### PR TITLE
Fix BBCode parsing to insert '<p></p>' instead of '<br />'

### DIFF
--- a/app/Libraries/BBCodeFromDB.php
+++ b/app/Libraries/BBCodeFromDB.php
@@ -251,7 +251,7 @@ class BBCodeFromDB
         $text = $this->parseYoutube($text);
         $text = $this->parseProfile($text);
 
-        $text = preg_replace('/\n/', "\n<br />", $text);
+        $text = preg_replace('/\n/', "\n<p></p>", $text);
         $text = CleanHTML::purify($text);
 
         return "<div class='bbcode'>{$text}</div>";

--- a/tests/Libraries/bbcode_examples/basic_color.html
+++ b/tests/Libraries/bbcode_examples/basic_color.html
@@ -1,4 +1,7 @@
 <span style="color:#FFFFFF;">Colored text! (name)</span>
-<br /><br /><span style="color:#ffffff;">Colored text! (code)</span>
-<br /><br /><span style="color:#FFFFFF;">Colored text! (uppercased hex)</span>
-<br /><br />[color=#fff]Failing at colored text! (unsupported hex)[/color]
+<p></p>
+<p></p><span style="color:#ffffff;">Colored text! (code)</span>
+<p></p>
+<p></p><span style="color:#FFFFFF;">Colored text! (uppercased hex)</span>
+<p></p>
+<p></p>[color=#fff]Failing at colored text! (unsupported hex)[/color]

--- a/tests/Libraries/bbcode_examples/basic_list.html
+++ b/tests/Libraries/bbcode_examples/basic_list.html
@@ -1,15 +1,15 @@
 <ol class="unordered"><li>Here
-<br /></li><li>be
-<br /></li><li>basic list
-<br /></li></ol><ol><li>Here
-<br /></li><li>be
-<br /></li><li>numbered list
-<br /></li></ol><ol class="unordered"><li>And
-<br /></li><li>here
-<br /><ol class="unordered"><li>is
-<br /></li><li>nested
-<br /></li></ol></li><li>list
-<br /></li><li>and
-<br /><ol><li>with
-<br /></li><li>number
-<br /></li></ol></li></ol>
+<p></p></li><li>be
+<p></p></li><li>basic list
+<p></p></li></ol><ol><li>Here
+<p></p></li><li>be
+<p></p></li><li>numbered list
+<p></p></li></ol><ol class="unordered"><li>And
+<p></p></li><li>here
+<p></p>  <ol class="unordered"><li>is
+<p></p>  </li><li>nested
+<p></p>  </li></ol></li><li>list
+<p></p></li><li>and
+<p></p>  <ol><li>with
+<p></p>  </li><li>number
+<p></p>  </li></ol></li></ol>

--- a/tests/Libraries/bbcode_examples/basic_quote.html
+++ b/tests/Libraries/bbcode_examples/basic_quote.html
@@ -1,3 +1,3 @@
 <blockquote>Basic
-<br />quote
-<br />tag</blockquote><h4>name wrote:</h4><blockquote>And with name</blockquote>
+<p></p>quote
+<p></p>tag</blockquote><h4>name wrote:</h4><blockquote>And with name</blockquote>

--- a/tests/Libraries/bbcode_examples/basic_size.html
+++ b/tests/Libraries/bbcode_examples/basic_size.html
@@ -1,3 +1,5 @@
 <span class="size-50">Tiny size</span>
-<br /><br /><span class="size-85">Small size</span>
-<br /><br /><span class="size-150">Large size</span>
+<p></p>
+<p></p><span class="size-85">Small size</span>
+<p></p>
+<p></p><span class="size-150">Large size</span>

--- a/tests/Libraries/bbcode_examples/basic_url.html
+++ b/tests/Libraries/bbcode_examples/basic_url.html
@@ -1,6 +1,7 @@
 <a rel="nofollow" href="http://osu.ppy.sh">http://osu.ppy.sh</a>
-<br /><a rel="nofollow" href="https://osu.ppy.sh">https://osu.ppy.sh</a>
-<br /><a rel="nofollow" href="ftp://ftp.openbsd.org">ftp://ftp.openbsd.org</a>
-<br /><br /><a rel="nofollow" href="http://store.ppy.sh">osu!store</a>
-<br /><a rel="nofollow" href="https://store.ppy.sh">osu!store (secure)</a>
-<br /><a rel="nofollow" href="ftp://ftp.openbsd.org">OpenBSD FTP</a>
+<p></p><a rel="nofollow" href="https://osu.ppy.sh">https://osu.ppy.sh</a>
+<p></p><a rel="nofollow" href="ftp://ftp.openbsd.org">ftp://ftp.openbsd.org</a>
+<p></p>
+<p></p><a rel="nofollow" href="http://store.ppy.sh">osu!store</a>
+<p></p><a rel="nofollow" href="https://store.ppy.sh">osu!store (secure)</a>
+<p></p><a rel="nofollow" href="ftp://ftp.openbsd.org">OpenBSD FTP</a>


### PR DESCRIPTION
Fix for ppy/osu-web#29.

![](http://up.ppy.sh/files/screenshot2015-09-03at8.13.44pm.png)