### PR TITLE
Feature/disallow double posts

### DIFF
--- a/app/Http/Controllers/Forum/TopicsController.php
+++ b/app/Http/Controllers/Forum/TopicsController.php
@@ -51,18 +51,6 @@ class TopicsController extends Controller
         ]]);
     }
 
-    private function isDoublePost($post)
-    {
-        $postTime = $post['post_time'];
-        $now = Carbon::now();
-        $diffSinceLastPost = $now->diffInDays($postTime);
-        if (! is_null(Auth::user()) && $post['poster_id'] == Auth::user()->user_id && $diffSinceLastPost < 3) {
-            return true;
-        }
-
-        return false;
-    }
-
     public function create($forum_id)
     {
         $forum = Forum::findOrFail($forum_id);
@@ -171,7 +159,7 @@ class TopicsController extends Controller
         }
 
         $postsPosition = $topic->postsPosition($posts);
-        $isDoublePost = $this->isDoublePost($posts[count($posts) - 1]);
+        $isDoublePost = Topic::isDoublePost($posts[count($posts) - 1]);
 
         Event::fire(new TopicWasViewed($topic, $posts->last(), Auth::user()));
 
@@ -185,7 +173,7 @@ class TopicsController extends Controller
         $topic = Topic::findOrFail($id);
         $posts = Post::where('post_id', $topic->topic_last_post_id)->get();
 
-        if ($this->isDoublePost($posts[count($posts) - 1])) {
+        if (Topic::isDoublePost($posts[count($posts) - 1])) {
             return 'not allowed';
         }
 

--- a/app/Http/Controllers/Forum/TopicsController.php
+++ b/app/Http/Controllers/Forum/TopicsController.php
@@ -51,11 +51,12 @@ class TopicsController extends Controller
         ]]);
     }
 
-    private function isDoublePost($post) {
+    private function isDoublePost($post)
+    {
         $postTime = $post['post_time'];
         $now = Carbon::now();
         $diffSinceLastPost = $now->diffInDays($postTime);
-        if (!is_null(Auth::user()) && $post['poster_id'] == Auth::user()->user_id && $diffSinceLastPost < 3) {
+        if (! is_null(Auth::user()) && $post['poster_id'] == Auth::user()->user_id && $diffSinceLastPost < 3) {
             return true;
         }
 
@@ -182,10 +183,10 @@ class TopicsController extends Controller
     public function reply(HttpRequest $request, $id)
     {
         $topic = Topic::findOrFail($id);
-        $posts = Post::where("post_id", $topic->topic_last_post_id)->get();
+        $posts = Post::where('post_id', $topic->topic_last_post_id)->get();
 
         if ($this->isDoublePost($posts[count($posts) - 1])) {
-            return "not allowed";
+            return 'not allowed';
         }
 
         $this->authorizePost($topic->forum, $topic);

--- a/app/Http/Controllers/Forum/TopicsController.php
+++ b/app/Http/Controllers/Forum/TopicsController.php
@@ -159,7 +159,7 @@ class TopicsController extends Controller
         }
 
         $postsPosition = $topic->postsPosition($posts);
-        $isDoublePost = $topic->isDoublePostBy(Auth::user()->user_id);
+        $isDoublePost = $topic->isDoublePostBy(Auth::user() ? Auth::user()->user_id : null);
 
         Event::fire(new TopicWasViewed($topic, $posts->last(), Auth::user()));
 

--- a/app/Http/Controllers/Forum/TopicsController.php
+++ b/app/Http/Controllers/Forum/TopicsController.php
@@ -159,7 +159,7 @@ class TopicsController extends Controller
         }
 
         $postsPosition = $topic->postsPosition($posts);
-        $isDoublePost = Topic::isDoublePost($posts[count($posts) - 1]);
+        $isDoublePost = $topic->isDoublePostBy(Auth::user()->user_id);
 
         Event::fire(new TopicWasViewed($topic, $posts->last(), Auth::user()));
 
@@ -173,7 +173,7 @@ class TopicsController extends Controller
         $topic = Topic::findOrFail($id);
         $posts = Post::where('post_id', $topic->topic_last_post_id)->get();
 
-        if (Topic::isDoublePost($posts[count($posts) - 1])) {
+        if ($topic->isDoublePostBy(Auth::user()->user_id)) {
             return 'not allowed';
         }
 

--- a/app/Models/Forum/Topic.php
+++ b/app/Models/Forum/Topic.php
@@ -70,18 +70,6 @@ class Topic extends Model
         return $topic;
     }
 
-    public static function isDoublePost($post)
-    {
-        $postTime = $post['post_time'];
-        $now = Carbon::now();
-        $diffSinceLastPost = $now->diffInDays($postTime);
-        if (! is_null(Auth::user()) && $post['poster_id'] == Auth::user()->user_id && $diffSinceLastPost < 3) {
-            return true;
-        }
-
-        return false;
-    }
-
     public function addPost($poster, $body, $notifyReplies)
     {
         DB::transaction(function () use ($poster, $body, $notifyReplies) {
@@ -207,6 +195,22 @@ class Topic extends Model
     {
         return $this->posts()->skip(intval($n) - 1)->first();
     }
+
+    public function isDoublePostBy($userId)
+    {
+        $post = $this->posts()->orderBy('post_id', 'desc')->first();
+        $postTime = $post['post_time'];
+        $now = Carbon::now();
+
+        $diffSinceLastPost = $now->diffInDays($postTime);
+
+        if (! is_null($userId) && $post['poster_id'] == $userId && $diffSinceLastPost < 3) {
+            return true;
+        }
+
+        return false;
+    }
+
 
     public function postPosition($postId)
     {

--- a/app/Models/Forum/Topic.php
+++ b/app/Models/Forum/Topic.php
@@ -24,6 +24,7 @@ namespace App\Models\Forum;
 use Carbon\Carbon;
 use DB;
 use Illuminate\Database\Eloquent\Model;
+use Auth;
 
 class Topic extends Model
 {
@@ -67,6 +68,18 @@ class Topic extends Model
         });
 
         return $topic;
+    }
+
+    public static function isDoublePost($post)
+    {
+        $postTime = $post['post_time'];
+        $now = Carbon::now();
+        $diffSinceLastPost = $now->diffInDays($postTime);
+        if (! is_null(Auth::user()) && $post['poster_id'] == Auth::user()->user_id && $diffSinceLastPost < 3) {
+            return true;
+        }
+
+        return false;
     }
 
     public function addPost($poster, $body, $notifyReplies)

--- a/app/Models/Forum/Topic.php
+++ b/app/Models/Forum/Topic.php
@@ -198,10 +198,10 @@ class Topic extends Model
     public function isDoublePostBy($userId)
     {
         $post = $this->posts()->orderBy('post_id', 'desc')->first();
-        $postTime = $post['post_time'];
-        $diffSinceLastPost = Carbon::now()->diffInDays($postTime);
+        $postTime = $post->post_time;
+        $daysSinceLastPost = Carbon::now()->diffInDays($postTime);
 
-        if (! is_null($userId) && $post['poster_id'] == $userId && $diffSinceLastPost < 3) {
+        if (! is_null($userId) && $post->poster_id == $userId && $daysSinceLastPost < 3) {
             return true;
         }
 

--- a/app/Models/Forum/Topic.php
+++ b/app/Models/Forum/Topic.php
@@ -24,7 +24,6 @@ namespace App\Models\Forum;
 use Carbon\Carbon;
 use DB;
 use Illuminate\Database\Eloquent\Model;
-use Auth;
 
 class Topic extends Model
 {
@@ -210,7 +209,6 @@ class Topic extends Model
 
         return false;
     }
-
 
     public function postPosition($postId)
     {

--- a/app/Models/Forum/Topic.php
+++ b/app/Models/Forum/Topic.php
@@ -199,9 +199,7 @@ class Topic extends Model
     {
         $post = $this->posts()->orderBy('post_id', 'desc')->first();
         $postTime = $post['post_time'];
-        $now = Carbon::now();
-
-        $diffSinceLastPost = $now->diffInDays($postTime);
+        $diffSinceLastPost = Carbon::now()->diffInDays($postTime);
 
         if (! is_null($userId) && $post['poster_id'] == $userId && $diffSinceLastPost < 3) {
             return true;

--- a/resources/assets/coffee/forum.coffee
+++ b/resources/assets/coffee/forum.coffee
@@ -113,7 +113,8 @@ class Forum
 
     if !showNext
       $(@endPost()).find('.delete-post-link').css(display: '')
-      $('#forum-topic-reply-box').css(display: 'block')
+      if !window.isDoublePost
+        $('#forum-topic-reply-box').css(display: 'block')
 
   refreshCounter: =>
     return if @_postsCounter.length == 0

--- a/resources/assets/coffee/forum/topic-ajax.coffee
+++ b/resources/assets/coffee/forum/topic-ajax.coffee
@@ -42,6 +42,11 @@ $(document).on 'ajax:success', '.delete-post-link', (_event, data) ->
 
 $(document).on 'ajax:success', '.reply-post-link', (e, data) ->
   data += '\n'
+  if window.isDoublePost
+    url = location.href
+    history.replaceState(null, null, url)
+    location.href = "#doublepost-box"
+    return
 
   $replyBox = $('#forum-topic-reply-box')
   $replyInput = $replyBox.find('[name=body]')
@@ -70,16 +75,30 @@ $(document).on 'ajax:success', '#forum-topic-reply-box', (_event, data) ->
     newPost = window.forum.endPost()
     newPost.classList.remove('js-forum-post__shrunk')
     newPost.scrollIntoView()
+    window.isDoublePost = true
+
+    $('#forum-topic-reply-box').hide()
+
+    doublepostBox = $("#doublepost-box")
+    editLastPostLink = doublepostBox.find("a")
+    lastPostId = $(".forum-post").last().attr("data-post-id")
+    previousLastPostId = editLastPostLink.attr("target")
+
+    editLastPostLink.attr("href", editLastPostLink.attr("href").replace(previousLastPostId, lastPostId))
+    editLastPostLink.attr("target", lastPostId)
+    doublepostBox.show()
+
   else
     osu.navigate $(data).find('.js-post-url').attr('href')
 
 
 $(document).on 'ajax:success', '.edit-post-link', (e, data, status, xhr) ->
+  targetId = $(e.target).attr("target");
+  $postBox = $("[data-post-id='"+targetId+"']")
+
   # ajax:complete needs to be triggered early because the link (target) is
   # removed in this callback.
   $(e.target).trigger('ajax:complete', [xhr, status])
-
-  $postBox = $(e.target).parents('.forum-post')
 
   $postBox
     .data 'originalPost', $postBox.html()

--- a/resources/assets/coffee/forum/topic-ajax.coffee
+++ b/resources/assets/coffee/forum/topic-ajax.coffee
@@ -40,13 +40,16 @@ $(document).on 'ajax:success', '.delete-post-link', (_event, data) ->
       $(document).trigger('osu:page:change')
 
 
-$(document).on 'ajax:success', '.reply-post-link', (e, data) ->
-  data += '\n'
+$(document).on 'ajax:before', '.reply-post-link', (e, data) ->
   if window.isDoublePost
     url = location.href
     history.replaceState(null, null, url)
     location.href = "#doublepost-box"
-    return
+    return false
+  return true
+
+$(document).on 'ajax:success', '.reply-post-link', (e, data) ->
+  data += '\n'
 
   $replyBox = $('#forum-topic-reply-box')
   $replyInput = $replyBox.find('[name=body]')
@@ -80,12 +83,12 @@ $(document).on 'ajax:success', '#forum-topic-reply-box', (_event, data) ->
     $('#forum-topic-reply-box').hide()
 
     doublepostBox = $("#doublepost-box")
-    editLastPostLink = doublepostBox.find("a")
+    editLastPostLink = doublepostBox.find("a.edit-post-link")
     lastPostId = $(".forum-post").last().attr("data-post-id")
-    previousLastPostId = editLastPostLink.attr("target")
+    previousLastPostId = editLastPostLink.attr("data-target-post-id")
 
     editLastPostLink.attr("href", editLastPostLink.attr("href").replace(previousLastPostId, lastPostId))
-    editLastPostLink.attr("target", lastPostId)
+    editLastPostLink.attr("data-target-post-id", lastPostId)
     doublepostBox.show()
 
   else
@@ -93,8 +96,8 @@ $(document).on 'ajax:success', '#forum-topic-reply-box', (_event, data) ->
 
 
 $(document).on 'ajax:success', '.edit-post-link', (e, data, status, xhr) ->
-  targetId = $(e.target).attr("target");
-  $postBox = $("[data-post-id='"+targetId+"']")
+  targetId = $(e.target).attr("data-target-post-id")
+  $postBox = $("[data-post-id='#{targetId}']")
 
   # ajax:complete needs to be triggered early because the link (target) is
   # removed in this callback.

--- a/resources/assets/less/colours.less
+++ b/resources/assets/less/colours.less
@@ -64,6 +64,8 @@
 // https://www.facebookbrand.com
 @facebook-colour: #3b5998;
 
+@dark-grey: #555555;
+
 .colours(@name) {
   @lighter: "@{name}-lighter";
   @light: "@{name}-light";

--- a/resources/assets/less/forum/base.less
+++ b/resources/assets/less/forum/base.less
@@ -936,10 +936,11 @@ body.community {
   padding: 0;
 
   p {
-    line-height: 22px;
+    align-self: center;
     margin: 0;
     padding: @grid-gutter-width/2;
   }
+
   .iconbox {
     background: @yellow-dark;
     padding: @grid-gutter-width/2;

--- a/resources/assets/less/forum/base.less
+++ b/resources/assets/less/forum/base.less
@@ -944,9 +944,7 @@ body.community {
   .iconbox {
     background: @yellow-dark;
     padding: @grid-gutter-width/2;
-    i {
-      font-size: 30px;
-    }
+    font-size: 30px;
   }
 }
 

--- a/resources/assets/less/forum/base.less
+++ b/resources/assets/less/forum/base.less
@@ -928,6 +928,27 @@ body.community {
   }
 }
 
+.forum-post-box-warning {
+  &:extend(.forum-post);
+  background: @dark-grey;
+  color: white;
+  min-height: 0;
+  padding: 0;
+
+  p {
+    line-height: 22px;
+    margin: 0;
+    padding: @grid-gutter-width/2;
+  }
+  .iconbox {
+    background: @yellow-dark;
+    padding: @grid-gutter-width/2;
+    i {
+      font-size: 30px;
+    }
+  }
+}
+
 .forum-posts-load-link {
   text-align: center;
   height: 40px;

--- a/resources/lang/en/forum.php
+++ b/resources/lang/en/forum.php
@@ -55,8 +55,8 @@ return [
         'reply_box_placeholder' => 'Type here to reply',
         'started_by' => 'by :user',
         'messages' => [
-            'doublepost' => 'You just posted. Please wait a bit or <a data-remote="1" data-target-post-id=":lastPostId" class="edit-post-link" href=":editPostLink">edit your previous post</a>.'
-        ]
+            'doublepost' => 'You just posted. Please wait a bit or <a data-remote="1" data-target-post-id=":lastPostId" class="edit-post-link" href=":editPostLink">edit your previous post</a>.',
+        ],
     ],
     'topics' => 'Topics',
 

--- a/resources/lang/en/forum.php
+++ b/resources/lang/en/forum.php
@@ -54,6 +54,9 @@ return [
         'post_reply' => 'Post',
         'reply_box_placeholder' => 'Type here to reply',
         'started_by' => 'by :user',
+        'messages' => [
+            'doublepost' => 'You just posted. Please wait a bit or <a data-remote="1" data-target-post-id=":lastPostId" class="edit-post-link" href=":editPostLink">edit your previous post</a>.'
+        ]
     ],
     'topics' => 'Topics',
 

--- a/resources/views/forum/topics/_doublepostbox.blade.php
+++ b/resources/views/forum/topics/_doublepostbox.blade.php
@@ -1,0 +1,30 @@
+{{--
+    Copyright 2015 ppy Pty. Ltd.
+
+    This file is part of osu!web. osu!web is distributed with the hope of
+    attracting more community contributions to the core ecosystem of osu!.
+
+    osu!web is free software: you can redistribute it and/or modify
+    it under the terms of the Affero GNU General Public License as published by
+    the Free Software Foundation, either version 3 of the License, or
+    (at your option) any later version.
+
+    osu!web is distributed WITHOUT ANY WARRANTY; without even the implied
+    warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+    See the GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with osu!web.  If not, see <http://www.gnu.org/licenses/>.
+--}}
+<?php
+$display = "inherit";
+
+if ($hide)
+    $display = "none";
+?>
+<div id="{{ $id }}" class="row-page flex-row forum-post-box-warning" style="display:{{ $display }}">
+    <div class="iconbox">
+        <i class="fa fa-info-circle"></i>
+    </div>
+    <p>You just posted. Please wait a bit or <a data-remote="1" target="{{ $lastPostId }}" class="edit-post-link" href="{{ route("forum.posts.edit", $lastPostId) }}">edit your previous post</a>.
+</div>

--- a/resources/views/forum/topics/_doublepostbox.blade.php
+++ b/resources/views/forum/topics/_doublepostbox.blade.php
@@ -17,7 +17,7 @@
     along with osu!web.  If not, see <http://www.gnu.org/licenses/>.
 --}}
 <?php
-$display = "inherit";
+$display = "";
 
 if ($hide)
     $display = "none";
@@ -26,5 +26,5 @@ if ($hide)
     <div class="iconbox">
         <i class="fa fa-info-circle"></i>
     </div>
-    <p>You just posted. Please wait a bit or <a data-remote="1" target="{{ $lastPostId }}" class="edit-post-link" href="{{ route("forum.posts.edit", $lastPostId) }}">edit your previous post</a>.
+    <p>You just posted. Please wait a bit or <a data-remote="1" data-target-post-id="{{ $lastPostId }}" class="edit-post-link" href="{{ route("forum.posts.edit", $lastPostId) }}">edit your previous post</a>.
 </div>

--- a/resources/views/forum/topics/_infobox.blade.php
+++ b/resources/views/forum/topics/_infobox.blade.php
@@ -16,13 +16,7 @@
     You should have received a copy of the GNU Affero General Public License
     along with osu!web.  If not, see <http://www.gnu.org/licenses/>.
 --}}
-<?php
-$display = "";
-
-if ($hide)
-    $display = "none";
-?>
-<div id="{{ $id }}" class="row-page flex-row forum-post-box-warning" style="display:{{ $display }}">
+<div id="{{ $id }}" class="row-page flex-row forum-post-box-warning" style="display:{{$hide ? 'none' : ''}}">
     <div class="iconbox">
         <i class="fa fa-info-circle"></i>
     </div>

--- a/resources/views/forum/topics/_infobox.blade.php
+++ b/resources/views/forum/topics/_infobox.blade.php
@@ -26,5 +26,5 @@ if ($hide)
     <div class="iconbox">
         <i class="fa fa-info-circle"></i>
     </div>
-    <p>You just posted. Please wait a bit or <a data-remote="1" data-target-post-id="{{ $lastPostId }}" class="edit-post-link" href="{{ route("forum.posts.edit", $lastPostId) }}">edit your previous post</a>.
+    <p>{!! $text !!}</p>
 </div>

--- a/resources/views/forum/topics/_post.blade.php
+++ b/resources/views/forum/topics/_post.blade.php
@@ -71,7 +71,7 @@
 
     <div class="post-viewer__actions">
         @if ($options["editLink"] === true)
-            <a href="{{ route("forum.posts.edit", $post) }}" class="post-viewer__action edit-post-link" data-remote="1">
+            <a href="{{ route("forum.posts.edit", $post) }}" class="post-viewer__action edit-post-link" data-remote="1" target="{{ $post->post_id }}">
                 <i class="fa fa-edit"></i>
             </a>
         @endif

--- a/resources/views/forum/topics/_post.blade.php
+++ b/resources/views/forum/topics/_post.blade.php
@@ -71,7 +71,7 @@
 
     <div class="post-viewer__actions">
         @if ($options["editLink"] === true)
-            <a href="{{ route("forum.posts.edit", $post) }}" class="post-viewer__action edit-post-link" data-remote="1" target="{{ $post->post_id }}">
+            <a href="{{ route("forum.posts.edit", $post) }}" class="post-viewer__action edit-post-link" data-remote="1" data-target-post-id="{{ $post->post_id }}">
                 <i class="fa fa-edit"></i>
             </a>
         @endif

--- a/resources/views/forum/topics/show.blade.php
+++ b/resources/views/forum/topics/show.blade.php
@@ -58,7 +58,7 @@
         <span><i class="fa fa-refresh fa-spin"></i></span>
     </div>
 
-    @if ($topic->canBeRepliedBy(Auth::user()))
+    @if ($topic->canBeRepliedBy(Auth::user()) && !$isDoublePost)
         {!! Form::open(["url" => route("forum.topics.reply", $topic->topic_id), "class" => "row row-blank post-editor post-editor--reply", "id" => "forum-topic-reply-box", "data-remote" => true]) !!}
             <div class="forum-small-row post-editor__main">
                 <div class="forum__avatar-container forum__avatar-container--reply hidden-xs">
@@ -77,6 +77,12 @@
             </div>
         {!! Form::close() !!}
     @endif
+
+    @include("forum.topics._doublepostbox",
+                ["text" => trans("forum.topic.doublepost_warning"),
+                "lastPostId" => $topic->topic_last_post_id,
+                "id" => "doublepost-box",
+                "hide" => !$isDoublePost])
 
     <div class="row-page row-blank fixed-bar-bottom">
         <div id="forum-topic-navigator" class="js-forum__topic-total-posts" data-total-count="{{ $topic->postsCount() }}">
@@ -111,5 +117,8 @@
 
     <script data-turbolinks-eval="always">
         window.postJumpTo = {{ $jumpTo }};
+        @if ($isDoublePost)
+            window.isDoublePost = true;
+        @endif
     </script>
 @endsection

--- a/resources/views/forum/topics/show.blade.php
+++ b/resources/views/forum/topics/show.blade.php
@@ -78,11 +78,14 @@
         {!! Form::close() !!}
     @endif
 
-    @include("forum.topics._doublepostbox",
-                ["text" => trans("forum.topic.doublepost_warning"),
-                "lastPostId" => $topic->topic_last_post_id,
-                "id" => "doublepost-box",
-                "hide" => !$isDoublePost])
+    @include("forum.topics._infobox",
+                ["text" => trans("forum.topic.messages.doublepost", [
+                    "lastPostId" => $topic->topic_last_post_id,
+                    "editPostLink" => route("forum.posts.edit", $topic->topic_last_post_id)
+                ]),
+                "hide" => !$isDoublePost,
+                "id" => "doublepost-box"
+                ])
 
     <div class="row-page row-blank fixed-bar-bottom">
         <div id="forum-topic-navigator" class="js-forum__topic-total-posts" data-total-count="{{ $topic->postsCount() }}">

--- a/resources/views/forum/topics/show.blade.php
+++ b/resources/views/forum/topics/show.blade.php
@@ -119,6 +119,8 @@
         window.postJumpTo = {{ $jumpTo }};
         @if ($isDoublePost)
             window.isDoublePost = true;
+        @else
+            window.isDoublePost = false;
         @endif
     </script>
 @endsection


### PR DESCRIPTION
PR for https://github.com/ppy/osu-web/issues/31

Man, this turned out to be a lot more difficult than I expected. While working on it I ran into more and more edge cases. In any way, here's what's done: 

- Style on mobile devices (still needs some edits) 
- Reply links will focus the infobox
- Posting results in the infobox to always show (because the doublepost box is only relevant for the last poster) 
- Clicking the 'edit your previous post' link will always edit the last post of the user

In any way, please let me know if changes are needed. 