### PR TITLE
Build and run on PHP 5.6 and 7, and try to fix travis PR issues

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,16 @@
-language: php
-php:
-  - hhvm
 addons:
   mariadb: 10.0
+
+language: php
+
+php:
+  - 5.6
+  - 7.0
+  - hhvm
+
 env:
   - DB_USERNAME=root
+
 before_install:
   - nvm install stable
   - nvm use stable


### PR DESCRIPTION
I contacted travis-ci, and they're fixing the pull request build issues (see https://github.com/travis-ci/travis-scheduler/commit/85688758392f362c4efc5f73b1fc59affda85b97).

This just adds 5.6 and 7.0 to the build matrix, which we should have parity with anyway.