### PR TITLE
parseInt must be called with radix parameter.

### DIFF
--- a/resources/assets/coffee/forum.coffee
+++ b/resources/assets/coffee/forum.coffee
@@ -78,7 +78,7 @@ class Forum
 
   totalPosts: =>
     return null if @_totalPostsDiv.length == 0
-    parseInt @_totalPostsDiv[0].getAttribute('data-total-count')
+    parseInt @_totalPostsDiv[0].getAttribute('data-total-count'), 10
 
   setTotalPosts: (n) =>
     @_totalPostsDiv[0].setAttribute('data-total-count', n)
@@ -95,7 +95,7 @@ class Forum
   endPost: => @posts[@posts.length - 1]
 
   lastPostLoaded: =>
-    parseInt(@endPost().getAttribute('data-post-position')) == @totalPosts()
+    parseInt(@endPost().getAttribute('data-post-position'), 10) == @totalPosts()
 
   refreshLoadMoreLinks: =>
     return if @posts.length == 0

--- a/resources/assets/coffee/forum/post-box.coffee
+++ b/resources/assets/coffee/forum/post-box.coffee
@@ -62,7 +62,7 @@ insert = (event, tagOpen, tagClose = '') ->
 
 $(document).on 'change', '.bbcode-size', (e) ->
   $select = $(e.target)
-  val = parseInt($select.val())
+  val = parseInt $select.val(), 10
 
   return if val == 100
 

--- a/resources/assets/coffee/forum/topic-ajax.coffee
+++ b/resources/assets/coffee/forum/topic-ajax.coffee
@@ -31,7 +31,7 @@ $(document).on 'ajax:success', '.delete-post-link', (_event, data) ->
       window.forum.setTotalPosts(window.forum.totalPosts() - 1)
 
       for post in window.forum.posts by -1
-        originalPosition = parseInt(post.getAttribute('data-post-position'))
+        originalPosition = parseInt post.getAttribute('data-post-position'), 10
 
         break if originalPosition < data.postPosition
 

--- a/resources/assets/coffee/store.coffee
+++ b/resources/assets/coffee/store.coffee
@@ -37,8 +37,8 @@ galleryArray = ->
     $el = $(el)
     {
       src: $el.attr('href')
-      w: parseInt $el.attr('data-size-w')
-      h: parseInt $el.attr('data-size-h')
+      w: parseInt $el.attr('data-size-w'), 10
+      h: parseInt $el.attr('data-size-h'), 10
     }
   .get()
 
@@ -67,7 +67,7 @@ openGallery = (index) ->
 
 $(document).on 'click', '#product-slides a', (e) ->
   e.preventDefault()
-  openGallery parseInt($(e.target).attr('data-index'))
+  openGallery parseInt($(e.target).attr('data-index'), 10)
 
 
 preventUsernameSubmission = ->


### PR DESCRIPTION
I missed the problem with string sometimes being parsed as something not in base 10 :(

https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/parseInt

Shouldn't* be a problem but a good practice anyway.

*until it is.