### PR TITLE
Extend price column in store cart view

### DIFF
--- a/resources/assets/less/store/base.less
+++ b/resources/assets/less/store/base.less
@@ -247,7 +247,7 @@
       }
 
       .subtotal {
-        flex: 0 0 100px;
+        flex: 0 0 150px;
         padding: 0px @grid-gutter-width/2;
       }
 


### PR DESCRIPTION
100px was too narrow, causing misalignment.