### PR TITLE
Cache bower_components for faster build times

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ cache:
   directories:
     - vendor
     - node_modules
+    - bower_components
 
 addons:
   mariadb: 10.0


### PR DESCRIPTION
Should cut another chunk out of global build times. I forgot this the first time.