### PR TITLE
Fix forum post link

### DIFF
--- a/app/Http/Controllers/Forum/PostsController.php
+++ b/app/Http/Controllers/Forum/PostsController.php
@@ -121,6 +121,6 @@ class PostsController extends Controller
 
         $this->authorizeView($post->forum);
 
-        return ujs_redirect(post_url($post->topic_id, $post->post_id));
+        return redirect(post_url($post->topic_id, $post->post_id));
     }
 }

--- a/resources/assets/coffee/forum.coffee
+++ b/resources/assets/coffee/forum.coffee
@@ -89,7 +89,7 @@ class Forum
     postId = currentPost.getAttribute('data-post-id')
 
     @_postsCounter[0].textContent = currentPostPosition
-    @_postsCounter[0].setAttribute 'href', "#{document.location.pathname}?start=#{postId}#forum-post-#{postId}"
+    @_postsCounter[0].setAttribute 'href', "#{window.canonicalUrl}?start=#{postId}#forum-post-#{postId}"
     @_postsProgress[0].setAttribute 'data-progress', Math.round(100 * currentPostPosition / @totalPosts())
 
   endPost: => @posts[@posts.length - 1]
@@ -258,7 +258,7 @@ $(document).on 'click', '.js-forum-posts-show-more', (e) ->
 
   $linkDiv.addClass 'loading'
 
-  $.get(document.location.pathname, options)
+  $.get(window.canonicalUrl, options)
   .done (data) ->
     if mode == 'previous'
       scrollReference = $refPost[0]

--- a/resources/assets/coffee/osu_common.coffee
+++ b/resources/assets/coffee/osu_common.coffee
@@ -26,11 +26,12 @@ along with osu!web.  If not, see <http://www.gnu.org/licenses/>.
 
   isMobile: -> ! window.matchMedia('(min-width: 920px)').matches
 
-  link: (url, text, classes = []) ->
+  link: (url, text, options = {}) ->
     el = document.createElement('a')
     el.setAttribute 'href', url
     el.setAttribute 'title', text
-    el.className = classes.join(' ')
+    el.setAttribute 'data-remote', true if options.isRemote
+    el.className = options.classNames.join(' ') if options.classNames
     el.textContent = text
     el.outerHTML
 

--- a/resources/assets/coffee/react/profile-page/kudosu.coffee
+++ b/resources/assets/coffee/react/profile-page/kudosu.coffee
@@ -53,8 +53,8 @@ class ProfilePage.Kudosu extends React.Component
                     dangerouslySetInnerHTML:
                       __html: Lang.get "users.show.extra.kudosu.entry.#{kudosu.action}",
                         amount: kudosu.amount
-                        giver: osu.link(kudosu.giver.url, kudosu.giver.name, ['kudosu-entries__link'])
-                        post: osu.link(kudosu.post.url, kudosu.post.title, ['kudosu-entries__link'])
+                        giver: osu.link(kudosu.giver.url, kudosu.giver.name, classNames: ['kudosu-entries__link'])
+                        post: osu.link(kudosu.post.url, kudosu.post.title, classNames: ['kudosu-entries__link'])
                 el 'div',
                   className: 'profile-extra-entries__time'
                   dangerouslySetInnerHTML: { __html: osu.timeago(kudosu.createdAt) }

--- a/resources/assets/coffee/react/profile-page/kudosu.coffee
+++ b/resources/assets/coffee/react/profile-page/kudosu.coffee
@@ -54,9 +54,7 @@ class ProfilePage.Kudosu extends React.Component
                       __html: Lang.get "users.show.extra.kudosu.entry.#{kudosu.action}",
                         amount: kudosu.amount
                         giver: osu.link(kudosu.giver.url, kudosu.giver.name, classNames: ['kudosu-entries__link'])
-                        post: osu.link kudosu.post.url, kudosu.post.title,
-                          classNames: ['kudosu-entries__link']
-                          isRemote: true
+                        post: osu.link(kudosu.post.url, kudosu.post.title, classNames: ['kudosu-entries__link'])
                 el 'div',
                   className: 'profile-extra-entries__time'
                   dangerouslySetInnerHTML: { __html: osu.timeago(kudosu.createdAt) }

--- a/resources/assets/coffee/react/profile-page/kudosu.coffee
+++ b/resources/assets/coffee/react/profile-page/kudosu.coffee
@@ -54,7 +54,9 @@ class ProfilePage.Kudosu extends React.Component
                       __html: Lang.get "users.show.extra.kudosu.entry.#{kudosu.action}",
                         amount: kudosu.amount
                         giver: osu.link(kudosu.giver.url, kudosu.giver.name, classNames: ['kudosu-entries__link'])
-                        post: osu.link(kudosu.post.url, kudosu.post.title, classNames: ['kudosu-entries__link'])
+                        post: osu.link kudosu.post.url, kudosu.post.title,
+                          classNames: ['kudosu-entries__link']
+                          isRemote: true
                 el 'div',
                   className: 'profile-extra-entries__time'
                   dangerouslySetInnerHTML: { __html: osu.timeago(kudosu.createdAt) }

--- a/resources/views/forum/topics/show.blade.php
+++ b/resources/views/forum/topics/show.blade.php
@@ -18,7 +18,8 @@
 --}}
 @extends("master", [
     "title" => "community / {$topic->topic_title}",
-    "body_additional_classes" => "forum-colour " . $topic->forum->categorySlug()
+    "body_additional_classes" => "forum-colour " . $topic->forum->categorySlug(),
+    'canonicalUrl' => route('forum.topics.show', $topic->topic_id),
 ])
 
 @section("content")

--- a/resources/views/layout/_global_variables.blade.php
+++ b/resources/views/layout/_global_variables.blade.php
@@ -23,6 +23,7 @@
     var page = "{{ $current_action }}";
     var logoutUrl = "{{ route("users.logout") }}";
     var helpUrl = "{{ route("wiki") }}";
+    var canonicalUrl = "{{ $canonicalUrl or '' }}";
 </script>
 
 @include ('layout._current_user')

--- a/resources/views/layout/metadata.blade.php
+++ b/resources/views/layout/metadata.blade.php
@@ -42,3 +42,7 @@
 @if (isset($rss))
     <link rel="alternate" type="application/rss+xml" title="RSS 2.0" href="{{ $rss }}">
 @endif
+
+@if (isset($canonicalUrl))
+    <link rel="canonical" href="{{ $canonicalUrl }}">
+@endif


### PR DESCRIPTION
First time the `/forum/p/:id` actually used (I think)... and turns out there's special care needed for it \o/

Or so it was. Made it a plain redirect.