### PR TITLE
Use sans-serif (OS/browser default) for forum post text.

### DIFF
--- a/resources/assets/less/forum/base.less
+++ b/resources/assets/less/forum/base.less
@@ -723,14 +723,17 @@ body.community {
 
     .post-body {
       order: 1;
-      font-family: sans-serif;
 
       @media @desktop {
         order: 2;
       }
 
       flex: 1 0 auto;
+
       font-size: 14px;
+      font-family: sans-serif;
+      color: #444;
+
       padding: @grid-gutter-width/4 0px @grid-gutter-width;
 
       &--small {

--- a/resources/assets/less/forum/base.less
+++ b/resources/assets/less/forum/base.less
@@ -723,6 +723,8 @@ body.community {
 
     .post-body {
       order: 1;
+      font-family: sans-serif;
+
       @media @desktop {
         order: 2;
       }


### PR DESCRIPTION
The custom font we have doesn't really work well for long prose sections.