### PR TITLE
Always expand post if jumpTo is not defined

### DIFF
--- a/resources/views/forum/topics/_posts.blade.php
+++ b/resources/views/forum/topics/_posts.blade.php
@@ -24,7 +24,7 @@
             "editLink" => $post->canBeEditedBy(Auth::user()),
             "postPosition" => $postsPosition[$post->post_id],
             "replyLink" => $topic->canBeRepliedBy(Auth::user()),
-            'expand' => $jumpTo !== null && $post->post_id >= $jumpTo,
+            'expand' => (! isset($jumpTo)) || ($jumpTo !== null && $post->post_id >= $jumpTo),
         ],
     ])
 @endforeach


### PR DESCRIPTION
I thought the render was done directly to the post view, not posts =[