### PR TITLE
Improved post targeting

### DIFF
--- a/resources/assets/coffee/forum.coffee
+++ b/resources/assets/coffee/forum.coffee
@@ -109,15 +109,19 @@ class Forum
 
     return unless post
 
-    postDim = post.getBoundingClientRect()
-    windowHeight = window.innerHeight
+    if post.getAttribute('data-post-position') == '1'
+      postTop = 0
+    else
+      postDim = post.getBoundingClientRect()
+      windowHeight = window.innerHeight
 
-    postTop = window.pageYOffset + postDim.top
+      postTop = window.pageYOffset + postDim.top
 
-    offset = (windowHeight - postDim.height) / 2
-    offset = Math.max(offset, 0)
+      offset = (windowHeight - postDim.height) / 2
+      # FIXME: compute height using new header target
+      offset = Math.max(offset, 60)
 
-    window.scrollTo 0, postTop - offset
+      window.scrollTo 0, postTop - offset
 
 
   postUrlClick: (e) =>


### PR DESCRIPTION
- First post link always goes to the top
- Topmost scroll offset limit is 60px instead of 0 to avoid it being covered by fixed header