### PR TITLE
Ability to change store orders from admin page

### DIFF
--- a/app/Http/Controllers/Store/Admin/OrdersController.php
+++ b/app/Http/Controllers/Store/Admin/OrdersController.php
@@ -1,0 +1,63 @@
+<?php
+
+namespace App\Http\Controllers\Store\Admin;
+
+use App\Http\Controllers\Controller;
+use App\Models\Store;
+use Auth;
+use Request;
+
+class OrdersController extends Controller
+{
+    protected $section = 'storeAdmin';
+
+    public function __construct()
+    {
+        $this->middleware('auth', ['only' => [
+            'index',
+            'show',
+            'update',
+        ]]);
+
+        return parent::__construct();
+    }
+
+    public function index()
+    {
+        return $this->show();
+    }
+
+    public function show($id = null)
+    {
+        if (!Auth::user()->isAdmin()) {
+            abort(403);
+        }
+
+        $orders = Store\Order::with('user', 'address', 'address.country', 'items.product');
+
+        if ($id) {
+            $orders->where('orders.order_id', $id);
+        } else {
+            $orders->where('orders.status', 'paid');
+        }
+
+        $ordersItemsQuantities = Store\Order::itemsQuantities($orders);
+        $orders = $orders->orderBy('created_at')->get();
+
+        return view('store.admin', compact('orders', 'ordersItemsQuantities'));
+    }
+
+    public function update($id)
+    {
+        if (!Auth::user()->isAdmin()) {
+            abort(403);
+        }
+
+        $order = Store\Order::findOrFail($id);
+        $order->unguard();
+        $order->update(Request::input('order'));
+        $order->save();
+
+        return ['message' => "order {$id} updated"];
+    }
+}

--- a/app/Http/Controllers/StoreController.php
+++ b/app/Http/Controllers/StoreController.php
@@ -36,8 +36,6 @@ class StoreController extends Controller
     public function __construct()
     {
         $this->middleware('auth', ['only' => [
-            'getAdmin',
-            'postAdmin',
             'getInvoice',
             'postUpdateCart',
             'postAddToCart',
@@ -63,40 +61,6 @@ class StoreController extends Controller
             ->with('skip_back_link', true)
             ->with('cart', $this->userCart())
             ->with('products', Store\Product::latest()->simplePaginate(30));
-    }
-
-    public function getAdmin($id = null)
-    {
-        if (!Auth::user()->isAdmin()) {
-            abort(403);
-        }
-
-        $orders = Store\Order::with('user', 'address', 'address.country', 'items.product');
-
-        if ($id) {
-            $orders->where('orders.order_id', $id);
-        } else {
-            $orders->where('orders.status', 'paid');
-        }
-
-        $ordersItemsQuantities = Store\Order::itemsQuantities($orders);
-        $orders = $orders->orderBy('created_at')->get();
-
-        return view('store.admin', compact('orders', 'ordersItemsQuantities'));
-    }
-
-    public function postAdmin()
-    {
-        if (!Auth::user()->isAdmin()) {
-            abort(403);
-        }
-
-        $order = Store\Order::findOrFail(Request::input('id'));
-        $order->unguard();
-        $order->update(Request::input('order'));
-        $order->save();
-
-        return ['message' => "order {$order->order_id} updated"];
     }
 
     public function getInvoice($id)

--- a/app/Http/routes.php
+++ b/app/Http/routes.php
@@ -89,6 +89,13 @@ Route::get('/wiki', ['as' => 'wiki', function () { return Redirect::to('https://
 Route::get('/help/support', ['as' => 'support', 'uses' => 'HelpController@getSupport']);
 Route::get('/help/faq', ['as' => 'faq', 'uses' => 'HelpController@getFaq']);
 
+// store admin
+Route::group(['prefix' => 'store/admin', 'namespace' => 'Store\Admin'], function () {
+    Route::resource('orders', 'OrdersController', ['only' => ['index', 'show', 'update']]);
+
+    Route::get('/', function () { return Redirect::route('store.admin.orders.index'); });
+});
+
 // catchall controllers
 Route::controller('/notifications', 'NotificationController');
 Route::controller('/store', 'StoreController');

--- a/resources/lang/en/layout.php
+++ b/resources/lang/en/layout.php
@@ -95,7 +95,6 @@ return [
             'getListing' => 'listing',
             'getCart' => 'cart',
 
-            'getAdmin' => 'admin',
             'getCheckout' => 'checkout',
             'getInvoice' => 'invoice',
             'getProduct' => 'product',
@@ -104,6 +103,10 @@ return [
             'home' => 'home',
             'index' => 'home',
             'thanks' => 'thanks',
+        ],
+        'storeAdmin' => [
+            '_' => 'store',
+            'index' => 'admin',
         ],
     ],
     'errors' => [

--- a/resources/views/store/admin.blade.php
+++ b/resources/views/store/admin.blade.php
@@ -57,8 +57,6 @@
     </div>
 
     @foreach ($orders as $o)
-    {!! Form::open(["url" => "store/admin", "data-remote" => true]) !!}
-    {!! Form::hidden('id', $o->order_id) !!}
     <div class="col-md-12">
 
         <div class="panel panel-default">
@@ -73,6 +71,7 @@
             </div>
             <div class="panel-body">
                 <div class='row'>
+                    {!! Form::open(['route' => ['store.admin.orders.update', $o->order_id], 'method' => 'put', 'data-remote' => true]) !!}
                     <div class='col-md-8'>
                         <div class="form-group">
                         @if ($o->status === 'paid' || $o->status === 'shipped')
@@ -93,6 +92,7 @@
 
                         </div>
                     </div>
+                    {!! Form::close() !!}
 
                     @include('store.objects.address', ['data' => $o->address])
                 </div>
@@ -115,7 +115,6 @@
             </table>
         </div>
     </div>
-    {!! Form::close() !!}
     @endforeach
 </div>
 @stop


### PR DESCRIPTION
This is a work in progress for ppy/osu-web#109

- [x] Ability to edit address.
  - [x] Changes should be saved instantly.
- [ ] Ability to change product to another product of same value (different size/design) using a dropdown.
  - [ ] Changes should be saved instantly.
- [ ] Should only be allowed for orders in a "paid" state. Shipped or Delivered orders should not be changeable.
- [ ] Remaining stock should be checked (products without stock shouldn't be shown in the dropdown)
  - [ ] and updated on change.