### PR TITLE
Add support for Docker as a provider for Vagrant.

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -25,8 +25,6 @@ cd /data/osu\!web/
 mkdir -p "public/uploads"
 chmod 777 "public/uploads"
 
-./bin/db_setup
-
 # replace mysql config vars to be reachable from vm host
 sed -i 's/bind-address/#bind-address/' /etc/mysql/my.cnf
 
@@ -38,5 +36,7 @@ sed -i 's/sendfile on/sendfile off/' /etc/nginx/nginx.conf
 service mysql restart
 service hhvm restart
 service nginx restart
+
+./bin/db_setup
 
 echo "Finished setup of daemons and servers"

--- a/vagrant/Dockerfile
+++ b/vagrant/Dockerfile
@@ -1,0 +1,17 @@
+FROM ubuntu:vivid
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+  openssh-server \
+  sudo \
+  && apt-get clean
+
+RUN mkdir /var/run/sshd
+EXPOSE 22
+
+RUN useradd vagrant --create-home --shell /bin/bash && echo -n 'vagrant:vagrant' | chpasswd
+RUN mkdir -p /home/vagrant/.ssh && chmod 700 /home/vagrant/.ssh
+RUN echo 'ssh-rsa AAAAB3NzaC1yc2EAAAABIwAAAQEA6NF8iallvQVp22WDkTkyrtvp9eWW6A8YVr+kz4TjGYe7gHzIw+niNltGEFHzD8+v1I2YJ6oXevct1YeS0o9HZyN1Q9qgCgzUFtdOKLv6IedplqoPkcmF0aYet2PkEDo3MlTBckFXPITAMzF8dJSIFo9D8HfdOV0IAdx4O7PtixWKn5y2hMNG0zQPyUecp4pzC6kivAIhyfHilFR61RGL+GPXQ2MWZWFYbAGjyiYJnAmCP3NOTd0jMZEnDkbUvxhMmBYSdETk1rRgm+R4LOzFUGaHqHDLKLX+FIPKcF96hrucXzcWyLbIbEgE98OHlnVYCzRdK8jlqm8tehUc9c9WhQ== vagrant insecure public key' >> /home/vagrant/.ssh/authorized_keys
+RUN chown -R vagrant: /home/vagrant
+RUN adduser vagrant sudo && echo '%sudo ALL=(ALL:ALL) NOPASSWD: ALL' > /etc/sudoers.d/sudo-nopasswd
+
+CMD /usr/sbin/sshd -D

--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -46,6 +46,15 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     vb.customize ["modifyvm", :id, "--natdnsproxy1", "off"]
   end
 
+  config.vm.provider :docker do |d, override|
+    override.vm.box = nil
+    d.name = "osu-web"
+    d.has_ssh = true
+    d.build_dir = "."
+    d.build_args = ["-t", "osu-web"]
+    d.create_args = ["--privileged"]
+  end
+
   config.vm.provision "shell", inline: $provisionScript
   config.vm.provision "shell", inline: "mount /data/osu!web/node_modules",
     run: "always"


### PR DESCRIPTION
Useful for development on Linux.

I'm not sure how the default provider is determined. The docs say that VirtualBox is always the default, but on my work machine, Vagrant automatically chooses Docker even if I don't explicitly pass `--provider docker` to `vagrant up`.

It could be that Vagrant detects that VirtualBox isn't installed and so tries the next provider?

Will need to test for compatibility before merge.