### PR TITLE
Fix undefined jump point

### DIFF
--- a/app/Http/Controllers/Forum/TopicsController.php
+++ b/app/Http/Controllers/Forum/TopicsController.php
@@ -130,7 +130,7 @@ class TopicsController extends Controller
         }
 
         if (!$skipLayout) {
-            foreach ([$postStartId, $postEndId, 0] as $jumpPoint) {
+            foreach ([$postStartId, $postEndId, $posts->first()->post_id] as $jumpPoint) {
                 if ($jumpPoint === null) {
                     continue;
                 }


### PR DESCRIPTION
Causing issues when loading threads without a start/end post specified.