### PR TITLE
Ignore invalid jumpTo instead of trying fixing it

### DIFF
--- a/app/Http/Controllers/Forum/TopicsController.php
+++ b/app/Http/Controllers/Forum/TopicsController.php
@@ -170,15 +170,6 @@ class TopicsController extends Controller
 
         $postsPosition = $topic->postsPosition($posts);
 
-        foreach ($postsPosition as $id => $_post) {
-            if ($id < $jumpTo) {
-                continue;
-            } else {
-                $jumpTo = $id;
-                break;
-            }
-        }
-
         Event::fire(new TopicWasViewed($topic, $posts->last(), Auth::user()));
 
         $template = $skipLayout ? '_posts' : 'show';

--- a/resources/views/forum/topics/show.blade.php
+++ b/resources/views/forum/topics/show.blade.php
@@ -167,7 +167,7 @@
                     forum-topic-nav__seek-bar
                     forum-colour__bg-link--{{ $topic->forum->categorySlug() }}
                 "
-                style="width: '{{ 100 * $postsPosition[$jumpTo] / $topic->postsCount() }}%';"
+                style="width: '{{ 100 * array_get($postsPosition, $jumpTo, 0) / $topic->postsCount() }}%';"
             >
             </div>
         </div>


### PR DESCRIPTION
Previous fix didn't fix case for invalid `end` parameter.