### PR TITLE
Change provisioning to not fail on chmod error for cache directories.

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -3,7 +3,9 @@
 set -u
 set -e
 
-chmod -R 777 storage bootstrap/cache
+# the user when provisioning is `vagrant`, but files are created by `www-data`
+# don't fail if permissions don't get set on all files (useful when reloading the container)
+chmod -R 777 storage bootstrap/cache || true
 
 if [ ! -d node_modules ]; then
   mkdir -p ~/node_modules


### PR DESCRIPTION
Once you have the site running, the `storage` folder is filled with files owned by `www-data`. Provisioning is done by the `vagrant` user, which doesn't have permission to `chmod` those files. If you run `vagrant reload` to update the container, the `chmod` step in `build.sh` can cause provisioning to fail.