### PR TITLE
Prioritise local images_json over masterProducts'.

### DIFF
--- a/app/Models/Store/Product.php
+++ b/app/Models/Store/Product.php
@@ -96,7 +96,7 @@ class Product extends Model
 
     public function images()
     {
-        if ($this->masterProduct) {
+        if (!$this->images_json && $this->masterProduct) {
             return $this->masterProduct->images();
         } else {
             if (!$this->images && $this->images_json) {


### PR DESCRIPTION
For the latest product addition, each sub-product has its own images_json definition. This allows those definitions to override the master_product's, when present.