### PR TITLE
Allow a custom_class to be defined but not exist.

### DIFF
--- a/resources/views/store/product.blade.php
+++ b/resources/views/store/product.blade.php
@@ -32,7 +32,7 @@
                 </div>
             </div>
 
-            @if($product->custom_class)
+            @if($product->custom_class && View::exists("store.products.{$product->custom_class}"))
 
                 <div class="row">
                     <div class="col-md-12">


### PR DESCRIPTION
I'm using custom_class in the fulfillment process to determind certain types of items. In the case of the new tournament banners, they don't (yet?) have a custom blade, but they do need a custom class. This allows that to be possible without error to face.

Needs to be merged ASAP.