### PR TITLE
Add ability to search by rank achieved

### DIFF
--- a/app/Http/Controllers/BeatmapController.php
+++ b/app/Http/Controllers/BeatmapController.php
@@ -67,15 +67,14 @@ class BeatmapController extends Controller
         ];
 
         $ranks = [
-            ['id' => null, 'name' => trans('beatmaps.rank.any')],
-            ['id' => 0, 'name' => trans('beatmaps.rank.silver-ss')],
-            ['id' => 1, 'name' => trans('beatmaps.rank.ss')],
-            ['id' => 2, 'name' => trans('beatmaps.rank.silver-s')],
-            ['id' => 3, 'name' => trans('beatmaps.rank.s')],
-            ['id' => 4, 'name' => trans('beatmaps.rank.a')],
-            ['id' => 5, 'name' => trans('beatmaps.rank.b')],
-            ['id' => 6, 'name' => trans('beatmaps.rank.c')],
-            ['id' => 7, 'name' => trans('beatmaps.rank.d')],
+            ['id' => 'XH', 'name' => trans('beatmaps.rank.silver-ss')],
+            ['id' => 'X', 'name' => trans('beatmaps.rank.ss')],
+            ['id' => 'SH', 'name' => trans('beatmaps.rank.silver-s')],
+            ['id' => 'S', 'name' => trans('beatmaps.rank.s')],
+            ['id' => 'A', 'name' => trans('beatmaps.rank.a')],
+            ['id' => 'B', 'name' => trans('beatmaps.rank.b')],
+            ['id' => 'C', 'name' => trans('beatmaps.rank.c')],
+            ['id' => 'D', 'name' => trans('beatmaps.rank.d')],
         ];
 
         $filters = ['data' => compact('modes', 'statuses', 'genres', 'languages', 'extras', 'ranks')];
@@ -97,7 +96,7 @@ class BeatmapController extends Controller
                 'genre' => Request::input('g'),
                 'language' => Request::input('l'),
                 'extra' => array_filter(explode('-', Request::input('e')), 'strlen'),
-                'rank' => Request::input('r'),
+                'rank' => array_filter(explode('-', Request::input('r')), 'strlen'),
                 'page' => Request::input('page'),
                 'sort' => explode('_', Request::input('sort')),
             ];

--- a/app/Http/Controllers/BeatmapController.php
+++ b/app/Http/Controllers/BeatmapController.php
@@ -25,7 +25,7 @@ use App\Models\Genre;
 use App\Models\Language;
 use League\Fractal\Manager;
 use League\Fractal\Resource\Collection;
-use App\Transformers\BeatmapTransformer;
+use App\Transformers\BeatmapSetTransformer;
 use Request;
 use Auth;
 
@@ -38,7 +38,7 @@ class BeatmapController extends Controller
         $fractal = new Manager();
         $languages = Language::listing();
         $genres = Genre::listing();
-        $data = new Collection(BeatmapSet::listing(), new BeatmapTransformer);
+        $data = new Collection(BeatmapSet::listing(), new BeatmapSetTransformer);
         $beatmaps = $fractal->createData($data)->toArray();
 
         // temporarily put filters here
@@ -118,7 +118,7 @@ class BeatmapController extends Controller
                 ARRAY_FILTER_USE_BOTH
             );
 
-            $data = new Collection(BeatmapSet::search($params), new BeatmapTransformer);
+            $data = new Collection(BeatmapSet::search($params), new BeatmapSetTransformer);
         }
 
         $fractal = new Manager();

--- a/app/Models/BeatmapSet.php
+++ b/app/Models/BeatmapSet.php
@@ -194,7 +194,6 @@ class BeatmapSet extends Model
         list($params['sort_field'], $params['sort_order']) = $params['sort'];
         unset($params['sort']);
 
-
         $valid_ranks = ['A', 'B', 'C', 'D', 'S', 'SH', 'X', 'XH'];
         foreach ($params['rank'] as $rank) {
             if (!in_array($rank, $valid_ranks)) {
@@ -299,14 +298,14 @@ class BeatmapSet extends Model
             'sort' => ['ranked', 'desc'],
         ];
 
-        BeatmapSet::sanitizeSearchParams($params);
+        self::sanitizeSearchParams($params);
 
-        $beatmap_ids = BeatmapSet::searchES($params);
+        $beatmap_ids = self::searchES($params);
         $beatmaps = [];
 
         if (count($beatmap_ids) > 0) {
             $ids = implode(',', $beatmap_ids);
-            $beatmaps = BeatmapSet::whereIn('beatmapset_id', $beatmap_ids)->orderByRaw(DB::raw("FIELD(beatmapset_id, {$ids})"))->get();
+            $beatmaps = self::whereIn('beatmapset_id', $beatmap_ids)->orderByRaw(DB::raw("FIELD(beatmapset_id, {$ids})"))->get();
         }
 
         return $beatmaps;
@@ -314,7 +313,7 @@ class BeatmapSet extends Model
 
     public static function listing()
     {
-        return BeatmapSet::search();
+        return self::search();
     }
 
     public function scopeSort($query)

--- a/app/Models/BeatmapSet.php
+++ b/app/Models/BeatmapSet.php
@@ -201,12 +201,10 @@ class BeatmapSet extends Model
             }
         }
 
-        if (presence($params['query']) != null) {
-            $params['query'] = preg_replace('/\s\s+/', ' ', $params['query']);
+        if ($params['query'] !== null) {
+            $params['query'] = preg_replace('/\s{2,}/', ' ', $params['query']);
             $params['query'] = trim($params['query']);
-        }
 
-        if (presence($params['query']) != null) {
             $query_parts = explode(' ', $params['query']);
             foreach ($query_parts as $key => $value) {
                 $query_parts[$key] = urlencode($value);
@@ -260,7 +258,7 @@ class BeatmapSet extends Model
             $matchParams[] = ['ids' => ['type' => 'beatmaps', 'values' => $scores]];
         }
 
-        if (presence($mode) != null && @presence($rank) == null) {
+        if (presence($mode) != null && presence($rank) == null) {
             $matchParams[] = ['match' => ['playmode' => (int) $mode]];
         }
 

--- a/app/Models/Score/Combined.php
+++ b/app/Models/Score/Combined.php
@@ -1,0 +1,33 @@
+<?php
+
+/**
+ *    Copyright 2015 ppy Pty. Ltd.
+ *
+ *    This file is part of osu!web. osu!web is distributed with the hope of
+ *    attracting more community contributions to the core ecosystem of osu!.
+ *
+ *    osu!web is free software: you can redistribute it and/or modify
+ *    it under the terms of the Affero GNU General Public License version 3
+ *    as published by the Free Software Foundation.
+ *
+ *    osu!web is distributed WITHOUT ANY WARRANTY; without even the implied
+ *    warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *    See the GNU Affero General Public License for more details.
+ *
+ *    You should have received a copy of the GNU Affero General Public License
+ *    along with osu!web.  If not, see <http://www.gnu.org/licenses/>.
+ */
+namespace App\Models\Score;
+
+class Combined extends Model
+{
+    public static function forUser(\App\Models\User $user)
+    {
+        $osu = Osu::forUser($user);
+        $taiko = Taiko::forUser($user);
+        $mania = Mania::forUser($user);
+        $fruits = Fruit::forUser($user);
+
+        return $osu->union($taiko)->union($mania)->union($fruits);
+    }
+}

--- a/app/Models/Score/Fruit.php
+++ b/app/Models/Score/Fruit.php
@@ -1,0 +1,25 @@
+<?php
+
+/**
+ *    Copyright 2015 ppy Pty. Ltd.
+ *
+ *    This file is part of osu!web. osu!web is distributed with the hope of
+ *    attracting more community contributions to the core ecosystem of osu!.
+ *
+ *    osu!web is free software: you can redistribute it and/or modify
+ *    it under the terms of the Affero GNU General Public License version 3
+ *    as published by the Free Software Foundation.
+ *
+ *    osu!web is distributed WITHOUT ANY WARRANTY; without even the implied
+ *    warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *    See the GNU Affero General Public License for more details.
+ *
+ *    You should have received a copy of the GNU Affero General Public License
+ *    along with osu!web.  If not, see <http://www.gnu.org/licenses/>.
+ */
+namespace App\Models\Score;
+
+class Fruit extends Model
+{
+    protected $table = 'osu_scores_fruits_high';
+}

--- a/app/Models/Score/Mania.php
+++ b/app/Models/Score/Mania.php
@@ -1,0 +1,25 @@
+<?php
+
+/**
+ *    Copyright 2015 ppy Pty. Ltd.
+ *
+ *    This file is part of osu!web. osu!web is distributed with the hope of
+ *    attracting more community contributions to the core ecosystem of osu!.
+ *
+ *    osu!web is free software: you can redistribute it and/or modify
+ *    it under the terms of the Affero GNU General Public License version 3
+ *    as published by the Free Software Foundation.
+ *
+ *    osu!web is distributed WITHOUT ANY WARRANTY; without even the implied
+ *    warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *    See the GNU Affero General Public License for more details.
+ *
+ *    You should have received a copy of the GNU Affero General Public License
+ *    along with osu!web.  If not, see <http://www.gnu.org/licenses/>.
+ */
+namespace App\Models\Score;
+
+class Mania extends Model
+{
+    protected $table = 'osu_scores_mania_high';
+}

--- a/app/Models/Score/Model.php
+++ b/app/Models/Score/Model.php
@@ -29,7 +29,7 @@ abstract class Model extends BaseModel
 
     public static function forUser(\App\Models\User $user)
     {
-        return static::where('user_id', (int)$user->user_id);
+        return static::where('user_id', (int) $user->user_id);
     }
 
     public static function getClass($game_mode)

--- a/app/Models/Score/Model.php
+++ b/app/Models/Score/Model.php
@@ -1,0 +1,55 @@
+<?php
+
+/**
+ *    Copyright 2015 ppy Pty. Ltd.
+ *
+ *    This file is part of osu!web. osu!web is distributed with the hope of
+ *    attracting more community contributions to the core ecosystem of osu!.
+ *
+ *    osu!web is free software: you can redistribute it and/or modify
+ *    it under the terms of the Affero GNU General Public License version 3
+ *    as published by the Free Software Foundation.
+ *
+ *    osu!web is distributed WITHOUT ANY WARRANTY; without even the implied
+ *    warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *    See the GNU Affero General Public License for more details.
+ *
+ *    You should have received a copy of the GNU Affero General Public License
+ *    along with osu!web.  If not, see <http://www.gnu.org/licenses/>.
+ */
+namespace App\Models\Score;
+
+use Illuminate\Database\Eloquent\Model as BaseModel;
+use App\Models\Beatmap;
+
+abstract class Model extends BaseModel
+{
+    protected $primaryKey = 'score_id';
+    public $timestamps = false;
+
+    public static function forUser(\App\Models\User $user)
+    {
+        return static::where('user_id', (int)$user->user_id);
+    }
+
+    public static function getClass($game_mode)
+    {
+        switch ($game_mode) {
+            case Beatmap::OSU:
+                return Osu::class;
+                break;
+
+            case Beatmap::TAIKO:
+                return Taiko::class;
+                break;
+
+            case Beatmap::CTB:
+                return Fruit::class;
+                break;
+
+            case Beatmap::MANIA:
+                return Mania::class;
+                break;
+        }
+    }
+}

--- a/app/Models/Score/Osu.php
+++ b/app/Models/Score/Osu.php
@@ -1,0 +1,25 @@
+<?php
+
+/**
+ *    Copyright 2015 ppy Pty. Ltd.
+ *
+ *    This file is part of osu!web. osu!web is distributed with the hope of
+ *    attracting more community contributions to the core ecosystem of osu!.
+ *
+ *    osu!web is free software: you can redistribute it and/or modify
+ *    it under the terms of the Affero GNU General Public License version 3
+ *    as published by the Free Software Foundation.
+ *
+ *    osu!web is distributed WITHOUT ANY WARRANTY; without even the implied
+ *    warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *    See the GNU Affero General Public License for more details.
+ *
+ *    You should have received a copy of the GNU Affero General Public License
+ *    along with osu!web.  If not, see <http://www.gnu.org/licenses/>.
+ */
+namespace App\Models\Score;
+
+class Osu extends Model
+{
+    protected $table = 'osu_scores_high';
+}

--- a/app/Models/Score/Taiko.php
+++ b/app/Models/Score/Taiko.php
@@ -1,0 +1,25 @@
+<?php
+
+/**
+ *    Copyright 2015 ppy Pty. Ltd.
+ *
+ *    This file is part of osu!web. osu!web is distributed with the hope of
+ *    attracting more community contributions to the core ecosystem of osu!.
+ *
+ *    osu!web is free software: you can redistribute it and/or modify
+ *    it under the terms of the Affero GNU General Public License version 3
+ *    as published by the Free Software Foundation.
+ *
+ *    osu!web is distributed WITHOUT ANY WARRANTY; without even the implied
+ *    warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *    See the GNU Affero General Public License for more details.
+ *
+ *    You should have received a copy of the GNU Affero General Public License
+ *    along with osu!web.  If not, see <http://www.gnu.org/licenses/>.
+ */
+namespace App\Models\Score;
+
+class Taiko extends Model
+{
+    protected $table = 'osu_scores_taiko_high';
+}

--- a/app/Transformers/BeatmapSetTransformer.php
+++ b/app/Transformers/BeatmapSetTransformer.php
@@ -19,9 +19,10 @@
  */
 namespace App\Transformers;
 
+use App\Models\BeatmapSet;
 use League\Fractal;
 
-class BeatmapTransformer extends Fractal\TransformerAbstract
+class BeatmapSetTransformer extends Fractal\TransformerAbstract
 {
     // beatmap difficulty grouping (for beatmap card display)
 
@@ -70,7 +71,7 @@ class BeatmapTransformer extends Fractal\TransformerAbstract
         return $difficulties;
     }
 
-    public function transform(array $beatmap)
+    public function transform(BeatmapSet $beatmap)
     {
         return [
             'beatmapset_id' => $beatmap['beatmapset_id'],
@@ -81,7 +82,7 @@ class BeatmapTransformer extends Fractal\TransformerAbstract
             'creator' => $beatmap['creator'],
             'user_id' => $beatmap['user_id'],
             'source' => $beatmap['source'],
-            'difficulties' => self::groupDifficulties($beatmap),
+            'difficulties' => [], //self::groupDifficulties($beatmap),
         ];
     }
 }

--- a/app/Transformers/GenreTransformer.php
+++ b/app/Transformers/GenreTransformer.php
@@ -27,7 +27,7 @@ class GenreTransformer extends Fractal\TransformerAbstract
     public function transform(Genre $genre)
     {
         return [
-            'id' => $genre->genre_id,
+            'id' => $genre->genre_id == 0 ? null : $genre->genre_id,
             'name' => trans('beatmaps.genre.'.str_replace(' ', '-', strtolower($genre->name))),
         ];
     }

--- a/app/Transformers/LanguageTransformer.php
+++ b/app/Transformers/LanguageTransformer.php
@@ -27,7 +27,7 @@ class LanguageTransformer extends Fractal\TransformerAbstract
     public function transform(Language $language)
     {
         return [
-            'id' => $language->language_id,
+            'id' => $language->language_id == 0 ? null : $language->language_id,
             'name' => trans('beatmaps.language.'.str_replace(' ', '-', strtolower($language->name))),
         ];
     }

--- a/resources/assets/coffee/react/beatmaps/search-filter.coffee
+++ b/resources/assets/coffee/react/beatmaps/search-filter.coffee
@@ -51,9 +51,16 @@ class @SearchFilter extends React.Component
         @setState { selected: [ i ] }, @triggerUpdate
 
   triggerUpdate: ->
+    if @props.multiselect
+      value = @state.selected.filter (n) ->
+        n != undefined
+      .join('-')
+    else
+      value = @state.selected[0]
+
     payload =
       name: @props.name
-      value: if @props.multiselect then @state.selected.join('-') else @state.selected[0]
+      value: value
     $(document).trigger 'beatmap:search:filtered', payload
 
   selected: (i) ->

--- a/resources/assets/coffee/react/beatmaps/search-filter.coffee
+++ b/resources/assets/coffee/react/beatmaps/search-filter.coffee
@@ -38,7 +38,7 @@ class @SearchFilter extends React.Component
     multiselect: React.PropTypes.bool
 
   select: (i, e) ->
-    e.preventDefault
+    e.preventDefault()
     if @selected(i)
       if @props.multiselect
         @setState { selected: _.without(@state.selected, i) }, @triggerUpdate

--- a/resources/assets/coffee/react/beatmaps/search-filter.coffee
+++ b/resources/assets/coffee/react/beatmaps/search-filter.coffee
@@ -69,7 +69,7 @@ class @SearchFilter extends React.Component
   render: ->
     selectors = []
     $.each @props.options, (i, e) =>
-      selectors.push a href:'#', className: ('active' if @selected(e['id'])), value: e['id'], key: i, onClick: @select.bind(@, e['id']), e['name']
+      selectors.push a href:'#', className: ('active' if @selected(e['id'])), value: e['id'], key: i, onMouseDown: @select.bind(@, e['id']), e['name']
 
     div id: @props.id, className: 'selector', 'data-name': @props.name,
       span className:'header', @props.title

--- a/resources/assets/coffee/react/beatmaps/search-panel.coffee
+++ b/resources/assets/coffee/react/beatmaps/search-panel.coffee
@@ -77,7 +77,7 @@ class @SearchPanel extends React.Component
         el(SearchFilter, name:'status', title: 'Rank Status', options: filters.statuses, default: 0)
 
         div className: 'more',
-          a className: 'toggle', href:'#', onClick: @show_more,
+          a className: 'toggle', href:'#', onMouseDown: @show_more,
             div {}, Lang.get('beatmaps.listing.search.options')
             div {}, i className:'fa fa-angle-down'
 

--- a/resources/assets/coffee/react/beatmaps/search-panel.coffee
+++ b/resources/assets/coffee/react/beatmaps/search-panel.coffee
@@ -85,4 +85,4 @@ class @SearchPanel extends React.Component
           el(SearchFilter, name: 'language', title: 'Language', options: filters.languages, default: filters.languages[0]['id'])
           el(SearchFilter, name: 'extra', title: 'Extra', options: filters.extras, multiselect: true)
           if currentUser.isSupporter
-            el(SearchFilter, name: 'rank', title: 'Rank Achieved', options: filters.ranks, default: null)
+            el(SearchFilter, name: 'rank', title: 'Rank Achieved', options: filters.ranks, multiselect: true)

--- a/resources/assets/coffee/react/beatmaps/search-sort.coffee
+++ b/resources/assets/coffee/react/beatmaps/search-sort.coffee
@@ -41,7 +41,6 @@ class @SearchSort extends React.Component
     options = [
       {id: 'title', name: 'title'},
       {id: 'artist', name: 'artist'},
-      {id: 'creator', name: 'creator'},
       {id: 'difficulty', name: 'difficulty'},
       {id: 'ranked', name: 'ranked'},
       {id: 'rating', name: 'rating'},

--- a/resources/assets/coffee/react/beatmaps/search-sort.coffee
+++ b/resources/assets/coffee/react/beatmaps/search-sort.coffee
@@ -51,7 +51,7 @@ class @SearchSort extends React.Component
       classes = []
       if @selected(e['id'])
         classes = ['active', @props.sorting.order]
-      selectors.push a href:'#', className: classes.join(' '), value: e['id'], key: i, onClick: @select.bind(@, e['id']), e['name']
+      selectors.push a href:'#', className: classes.join(' '), value: e['id'], key: i, onMouseDown: @select.bind(@, e['id']), e['name']
 
     div className: 'sorting',
       selectors


### PR DESCRIPTION
Now using DB + ElasticSearch to enable searching by rank achieved (supporter required)

Things still remaining:
- Search by rank status (for favourites, my maps, etc)
- Re-fix playmode/difficulty display
- Persist/restore state via URL
- Thumbnails
- \clean and optimize up all the codes/