### PR TITLE
Fix link parser

### DIFF
--- a/app/Libraries/BBCodeForDB.php
+++ b/app/Libraries/BBCodeForDB.php
@@ -148,14 +148,14 @@ class BBCodeForDB
         // www
         $text = preg_replace(
             "/{$spaces[0]}(www\.[^\s]+){$spaces[1]}/",
-            "\\1<!-- w --><a href='\\2' rel='nofollow'>\\2</a><!-- w -->\\3",
+            "\\1<!-- w --><a href='http://\\2' rel='nofollow'>\\2</a><!-- w -->\\3",
             $text
         );
 
         // emails
         $text = preg_replace(
             "/{$spaces[0]}([A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z-]+){$spaces[1]}/",
-            "\\1<!-- e --><a href='mailto:\\2' rel='nofollow'>\\2</a><!-- m -->\\3",
+            "\\1<!-- e --><a href='mailto:\\2' rel='nofollow'>\\2</a><!-- e -->\\3",
             $text
         );
 

--- a/tests/Libraries/bbcode_examples/autolink.base.txt
+++ b/tests/Libraries/bbcode_examples/autolink.base.txt
@@ -1,0 +1,5 @@
+ftp://ftp.example.com
+
+www.example.com
+
+user@example.com

--- a/tests/Libraries/bbcode_examples/autolink.db.txt
+++ b/tests/Libraries/bbcode_examples/autolink.db.txt
@@ -1,0 +1,5 @@
+<!-- m --><a href='ftp://ftp.example.com' rel='nofollow'>ftp://ftp.example.com</a><!-- m -->
+
+<!-- w --><a href='http://www.example.com' rel='nofollow'>www.example.com</a><!-- w -->
+
+<!-- e --><a href='mailto:user@example.com' rel='nofollow'>user@example.com</a><!-- e -->

--- a/tests/Libraries/bbcode_examples/autolink.html
+++ b/tests/Libraries/bbcode_examples/autolink.html
@@ -1,0 +1,5 @@
+<!-- m --><a href="ftp://ftp.example.com" rel="nofollow">ftp://ftp.example.com</a><!-- m -->
+
+<!-- w --><a href="http://www.example.com" rel="nofollow">www.example.com</a><!-- w -->
+
+<!-- e --><a href="mailto:user@example.com" rel="nofollow">user@example.com</a><!-- e -->


### PR DESCRIPTION
- missing scheme for www-type link
- wrong end tag for email
- there's a bug that newlines don't turn into `<br />` if written like the test. Unfortunately fixing it is a bit non-trivial

Fixes #271