### PR TITLE
Add unique and foreign key constraints to profile customization table

### DIFF
--- a/database/migrations/2016_01_12_074035_unique_user_customization_user_id.php
+++ b/database/migrations/2016_01_12_074035_unique_user_customization_user_id.php
@@ -1,0 +1,38 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+
+class UniqueUserCustomizationUserId extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        DB::statement('ALTER TABLE user_profile_customizations MODIFY user_id MEDIUMINT UNSIGNED NULL');
+
+        Schema::table('user_profile_customizations', function ($table) {
+            $table->foreign('user_id')->references('user_id')->on('phpbb_users');
+            $table->unique('user_id');
+            $table->dropIndex('user_profile_customizations_user_id_index');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('user_profile_customizations', function ($table) {
+            $table->index('user_id');
+            $table->dropUnique('user_profile_customizations_user_id_unique');
+            $table->dropForeign('user_profile_customizations_user_id_foreign');
+        });
+
+        DB::statement('ALTER TABLE user_profile_customizations MODIFY user_id INT NOT NULL');
+    }
+}


### PR DESCRIPTION
Raw SQL because there's no support for changing column type to `mediumint` :D

Oh and the table needs fixing as well since there seems to be some users having multiple customisations.

```sql
SELECT COUNT(1), user_id FROM user_profile_customizations GROUP BY user_id HAVING COUNT(1) > 1;
```