### PR TITLE
Hide tracking number until order has actually shipped.

### DIFF
--- a/resources/views/store/invoice.blade.php
+++ b/resources/views/store/invoice.blade.php
@@ -117,9 +117,11 @@
             <tr>
                 <td>{{{ $sentViaAddress->first_name }}} {{{ $sentViaAddress->last_name }}}</td>
                 <td>#{{{ $order->order_id }}}</td>
-                <td>EMS
-                @if($order->tracking_code)
-                    ({{ $order->tracking_code }})
+                <td>
+                @if(($order->status == 'shipped' || $order->status == 'delivered') && $order->tracking_code)
+                    EMS ({{ $order->tracking_code }})
+                @else
+                    N/A
                 @endif
                 </td>
                 <td>FOB Japan</td>


### PR DESCRIPTION
We quite often use the tracking code for notes before an order has shipped. The user doesn't need to see these notes, so let's not let them see it.