### PR TITLE
Red color take two

### DIFF
--- a/resources/assets/less/app.less
+++ b/resources/assets/less/app.less
@@ -20,7 +20,10 @@
 @node_root: "../../../node_modules";
 
 @import "@{node_root}/font-awesome/less/font-awesome";
+
 @import "@{node_root}/bootstrap/less/bootstrap";
+@import 'bootstrap-overrides';
+
 @import "@{node_root}/retina.js/src/retina";
 
 @import (inline) "@{bower_root}/ResponsiveSlides.js/responsiveslides.css";

--- a/resources/assets/less/bem/kudosu-entries.less
+++ b/resources/assets/less/bem/kudosu-entries.less
@@ -31,6 +31,6 @@
   &__amount {
     font-weight: inherit;
     font-style: italic;
-    color: @pink-darker;
+    color: @pink-text;
   }
 }

--- a/resources/assets/less/bem/profile-extra-entries.less
+++ b/resources/assets/less/bem/profile-extra-entries.less
@@ -106,7 +106,7 @@
     &--pp {
       font-size: 18px;
       font-weight: bold;
-      color: @pink-darker;
+      color: @pink-text;
     }
 
     &--time {

--- a/resources/assets/less/bem/profile-extra-tabs.less
+++ b/resources/assets/less/bem/profile-extra-tabs.less
@@ -58,7 +58,7 @@
     cursor: pointer;
 
     &:hover, &--active {
-      background-color: @pink-darker;
+      background-color: @pink-text;
     }
   }
 }

--- a/resources/assets/less/bem/store-cart-footer.less
+++ b/resources/assets/less/bem/store-cart-footer.less
@@ -58,7 +58,7 @@
     margin: 0;
 
     &--amount {
-      color: @pink-darker;
+      color: @pink-text;
       font-size: 140%;
     }
 

--- a/resources/assets/less/bootstrap-overrides.less
+++ b/resources/assets/less/bootstrap-overrides.less
@@ -1,0 +1,21 @@
+/**
+*    Copyright 2015 ppy Pty. Ltd.
+*
+*    This file is part of osu!web. osu!web is distributed with the hope of
+*    attracting more community contributions to the core ecosystem of osu!.
+*
+*    osu!web is free software: you can redistribute it and/or modify
+*    it under the terms of the Affero GNU General Public License version 3
+*    as published by the Free Software Foundation.
+*
+*    osu!web is distributed WITHOUT ANY WARRANTY; without even the implied
+*    warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+*    See the GNU Affero General Public License for more details.
+*
+*    You should have received a copy of the GNU Affero General Public License
+*    along with osu!web.  If not, see <http://www.gnu.org/licenses/>.
+*
+*/
+.modal.fade .modal-dialog {
+  transition-timing-function: cubic-bezier(0, 0, 0, 1);
+}

--- a/resources/assets/less/bootstrap-variables.less
+++ b/resources/assets/less/bootstrap-variables.less
@@ -35,7 +35,7 @@
 
 @line-height-base: 1.25; // 20/16
 
-@headings-color: @pink-darker;
+@headings-color: @pink-text;
 
 @padding-base-vertical: 5px;
 @padding-base-horizontal: 10px;

--- a/resources/assets/less/colours.less
+++ b/resources/assets/less/colours.less
@@ -28,7 +28,7 @@
 @pink-lighter: #ffddee;
 @pink-light: #ff99cc;
 @pink: #ff66aa;
-@pink-dark: #ee3399;
+@pink-dark: #cc5288;
 @pink-darker: #bb1177;
 
 @blue-lighter: #ddffff;
@@ -107,3 +107,10 @@
 .colours(~"blue");
 .colours(~"yellow");
 .colours(~"purple");
+
+@pink-text: @pink-dark;
+@green-text: @green-darker;
+@blue-text: @blue-darker;
+@yellow-text: @yellow-darker;
+@purple-text: @purple-darker;
+@gray-text: @gray-darker;

--- a/resources/assets/less/forum/base.less
+++ b/resources/assets/less/forum/base.less
@@ -605,7 +605,7 @@ body.community {
     }
 
     button {
-      color: @pink-darker;
+      color: @pink-text;
       display: flex;
       align-items: center;
       &, * { font-weight: bold; }

--- a/resources/assets/less/forum/colours.less
+++ b/resources/assets/less/forum/colours.less
@@ -45,21 +45,21 @@
 }
 
 .forum-colour {
-  .forum-colour-set(@gray, @gray-darker, @gray);
+  .forum-colour-set(@gray, @gray-text, @gray);
 
   &.category-osu {
-    .forum-colour-set(@pink, @pink-darker, @pink);
+    .forum-colour-set(@pink, @pink-text, @pink);
   }
 
   &.category-language-specific {
-    .forum-colour-set(@yellow, @yellow-darker, @yellow-dark);
+    .forum-colour-set(@yellow, @yellow-text, @yellow-dark);
   }
 
   &.category-other {
-    .forum-colour-set(@green, @green-darker, @green);
+    .forum-colour-set(@green, @green-text, @green);
   }
 
   &.category-beatmaps {
-    .forum-colour-set(@purple, @purple-darker, @purple);
+    .forum-colour-set(@purple, @purple-text, @purple);
   }
 }

--- a/resources/assets/less/functions.less
+++ b/resources/assets/less/functions.less
@@ -68,7 +68,7 @@
   color: @pink;
   text-decoration: none;
   &:hover {
-    color: @pink-darker;
+    color: @pink-text;
   }
 }
 

--- a/resources/assets/less/sections.less
+++ b/resources/assets/less/sections.less
@@ -56,29 +56,29 @@ body.home      { .section(@purple-lighter, @purple-light, @purple, @purple-dark,
 body.error     { .section(@pink-lighter, @pink-light, @pink, @pink-dark, @pink-darker); }
 body.user      { .section(@blue-lighter, @blue-light, @blue, @blue-dark, @blue-darker); }
 
-._section(~'beatmaps', @pink-darker);
-._section(~'store', @pink-darker);
-._section(~'ranking', @green-darker);
-._section(~'community', @pink-darker);
-._section(~'help', @yellow-darker);
-._section(~'home', @purple-darker);
-._section(~'error', @pink-darker);
-._section(~'user', @blue-darker);
+._section(~'beatmaps', @pink-darker, @pink-text);
+._section(~'store', @pink-darker, @pink-text);
+._section(~'ranking', @green-darker, @green-text);
+._section(~'community', @pink-darker, @pink-text);
+._section(~'help', @yellow-darker, @yellow-text);
+._section(~'home', @purple-darker, @purple-text);
+._section(~'error', @pink-darker, @pink-text);
+._section(~'user', @blue-darker, @blue-text);
 
-._section(@section-name, @colour) {
+._section(@section-name, @bg-colour, @text-colour) {
   .bg--@{section-name} {
-    background-color: @colour;
+    background-color: @bg-colour;
   }
 
   .colour--@{section-name} {
-    color: @colour;
+    color: @text-colour;
   }
 
   .colour-hover--@{section-name} {
     &:focus,
     &:hover,
     &:active {
-      color: @colour;
+      color: @text-colour;
     }
   }
 }

--- a/resources/assets/less/store/base.less
+++ b/resources/assets/less/store/base.less
@@ -93,7 +93,7 @@
   font-weight: 700;
 
   .price {
-    color: @pink-darker;
+    color: @pink-text;
     font-style: bold;
     font-size: 30px;
     margin-bottom: 0px;
@@ -221,7 +221,7 @@
 
   p {
     line-height: 12px;
-    &:nth-child(2) { font-size: 22px; color: @pink-darker }
+    &:nth-child(2) { font-size: 22px; color: @pink-text }
     &:nth-child(3) {
       color: @gray-light;
       font-size: 14px;

--- a/resources/assets/less/tournament.less
+++ b/resources/assets/less/tournament.less
@@ -31,12 +31,12 @@
   .title {
     font-weight: bold;
     font-size: 25px;
-    color: @pink-darker;
+    color: @pink-text;
   }
 
   .dates-tournament {
     font-weight: bold;
-    color: @pink-darker;
+    color: @pink-text;
   }
 
   .dates-reg {

--- a/resources/assets/less/users.less
+++ b/resources/assets/less/users.less
@@ -122,14 +122,14 @@
   color: @text-color;
 
   &:hover, &:active, &:focus {
-    color: @pink-darker;
+    color: @pink-text;
     text-decoration: none;
   }
 
   &--active {
-    color: @pink-darker;
+    color: @pink-text;
     font-weight: 900;
-    border-bottom-color: @pink-darker;
+    border-bottom-color: @pink-text;
   }
 }
 

--- a/resources/assets/less/variables.less
+++ b/resources/assets/less/variables.less
@@ -19,25 +19,25 @@
 @z-index--editor-zoom: 9999;
 
 @forum-category-colour--osu-bg: @pink;
-@forum-category-colour--osu-link: @pink-darker;
+@forum-category-colour--osu-link: @pink-text;
 @forum-category-colour--osu-link-hover: @pink;
 
 @forum-category-colour--language-specific-bg: @yellow;
-@forum-category-colour--language-specific-link: @yellow-darker;
+@forum-category-colour--language-specific-link: @yellow-text;
 @forum-category-colour--language-specific-link-hover: @yellow-dark;
 
 @forum-category-colour--other-bg: @green;
-@forum-category-colour--other-link: @green-darker;
+@forum-category-colour--other-link: @green-text;
 @forum-category-colour--other-link-hover: @green;
 
 @forum-category-colour--beatmaps-bg: @purple;
-@forum-category-colour--beatmaps-link: @purple-darker;
+@forum-category-colour--beatmaps-link: @purple-text;
 @forum-category-colour--beatmaps-link-hover: @purple;
 
 @forum-category-colour--osu-bg: @pink;
-@forum-category-colour--osu-link: @pink-darker;
+@forum-category-colour--osu-link: @pink-text;
 @forum-category-colour--osu-link-hover: @pink;
 
 @forum-category-colour--management-bg: @gray;
-@forum-category-colour--management-link: @gray-darker;
+@forum-category-colour--management-link: @gray-text;
 @forum-category-colour--management-link-hover: @gray;


### PR DESCRIPTION
I also noticed that attempting to mix in non-US English when the rest of libraries use US English results in useless confusion (variables, method names, etc).

Thereby I propose using US English for everything except as display text (e.g. values in `resources/lang/en`) ┐(･_･)┌