### PR TITLE
Add enabled state to store items.

### DIFF
--- a/app/Http/Controllers/StoreController.php
+++ b/app/Http/Controllers/StoreController.php
@@ -97,6 +97,9 @@ class StoreController extends Controller
         $cart = $this->userCart();
         $product = Store\Product::with('masterProduct')->findOrFail($id);
 
+        if (!$product->enabled)
+            abort(404);
+
         return view('store.product', compact('cart', 'product'));
     }
 

--- a/app/Models/Store/Order.php
+++ b/app/Models/Store/Order.php
@@ -172,6 +172,8 @@ class Order extends Model
 
                 if (!$product->inStock($item->quantity)) {
                     $result = [false, 'not enough stock'];
+                } elseif (!$item->enabled) {
+                    $result = [false, 'invalid item'];
                 } elseif ($item->quantity > $product->max_quantity) {
                     $result = [false, "you can only order {$product->max_quantity} of this item per order. visit your <a href='/store/cart'>shopping cart</a> to confirm your current order"];
                 } else {

--- a/app/Models/Store/Product.php
+++ b/app/Models/Store/Product.php
@@ -38,6 +38,7 @@ class Product extends Model
         'promoted' => 'boolean',
         'stock' => 'integer',
         'weight' => 'integer',
+        'enabled' => 'boolean'
     ];
 
     private $images;
@@ -111,6 +112,7 @@ class Product extends Model
     {
         return $query
             ->where('master_product_id', null)
+            ->where('enabled', true)
             ->with('masterProduct')
             ->orderBy('promoted', 'desc')
             ->orderBy('display_order', 'desc');

--- a/database/migrations/2016_01_26_194005_disable_products.php
+++ b/database/migrations/2016_01_26_194005_disable_products.php
@@ -1,0 +1,48 @@
+<?php
+
+/**
+ *    Copyright 2015 ppy Pty. Ltd.
+ *
+ *    This file is part of osu!web. osu!web is distributed in the hopes of
+ *    attracting more community contributions to the core ecosystem of osu!
+ *
+ *    osu!web is free software: you can redistribute it and/or modify
+ *    it under the terms of the Affero GNU General Public License version 3
+ *    as published by the Free Software Foundation.
+ *
+ *    osu!web is distributed WITHOUT ANY WARRANTY; without even the implied
+ *    warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *    See the GNU Affero General Public License for more details.
+ *
+ *    You should have received a copy of the GNU Affero General Public License
+ *    along with osu!web.  If not, see <http://www.gnu.org/licenses/>.
+ */
+use App\Models\Store;
+use Illuminate\Database\Migrations\Migration;
+
+class DisableProducts extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::connection('mysql-store')->table('products', function ($table) {
+            $table->boolean('enabled')->default(true);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::connection('mysql-store')->table('products', function ($table) {
+            $table->dropColumn(['enabled']);
+        });
+    }
+}


### PR DESCRIPTION
We need to be able to have hidden store items for internal use (tournament prizes for example) to generate invoices and tracking information. We also want to be able to hide items which are no longer relevant, such as the 2015 OWC banners.

This adds the basic ability to disable store products.