### PR TITLE
Chart fixes

### DIFF
--- a/app/Models/RankHistory.php
+++ b/app/Models/RankHistory.php
@@ -38,8 +38,8 @@ class RankHistory extends Model
     {
         $data = [];
 
-        $startOffset = Count::currentRankStart();
-        $end = $startOffset + 90;
+        $startOffset = Count::currentRankStart() + 1;
+        $end = $startOffset + 89;
 
         for ($i = $startOffset; $i < $end; $i++) {
             $column = 'r'.strval($i % 90);

--- a/resources/assets/coffee/react/profile-page/historical.coffee
+++ b/resources/assets/coffee/react/profile-page/historical.coffee
@@ -87,6 +87,8 @@ ProfilePage.Historical = React.createClass
 
 
   _rankHistory: ->
+    return unless @props.rankHistories
+
     data = @props.rankHistories.data
 
     startDate = moment().subtract(data.length, 'days')
@@ -113,17 +115,14 @@ ProfilePage.Historical = React.createClass
 
       h2 className: 'profile-extra__title', Lang.get('users.show.extra.historical.title')
 
-      if @props.rankHistories
-        [
-          h3
-            key: 'title'
-            className: 'profile-extra__title profile-extra__title--small'
-            Lang.get('users.show.extra.historical.rank_history.title')
-          div
-            key: 'area'
-            ref: 'chartArea'
-            className: 'chart'
-        ]
+      div
+        className: 'hidden' unless @props.rankHistories
+        h3
+          className: 'profile-extra__title profile-extra__title--small'
+          Lang.get('users.show.extra.historical.rank_history.title')
+        div
+          ref: 'chartArea'
+          className: 'chart'
 
       h3
         className: 'profile-extra__title profile-extra__title--small'


### PR DESCRIPTION
First day is removed for now so the furthest back is 89 days (not that anyone can tell yet because there's no tooltip). The heuristic in old site is... _nice try_.

Not fixing the rank scale because I can't think of better solution yet.

Here's another case of log vs linear:

![](https://puu.sh/n3j4g/eb83765051.png)

current idea is to check if difference between max and min rank is over an (or two) order of magnitude (coming soon™).