### PR TITLE
Cast twitch's ID to float, since int was overflowing.

### DIFF
--- a/app/Http/Controllers/CommunityController.php
+++ b/app/Http/Controllers/CommunityController.php
@@ -65,15 +65,15 @@ class CommunityController extends Controller
 
         $featuredStreamId = Cache::get('featuredStream');
         if ($featuredStreamId !== null) {
+            $featuredStreamId = floatval($featuredStreamId);
             foreach ($streams as $stream) {
-                if ($stream->_id !== $featuredStreamId) {
+                if (floatval($stream->_id) !== $featuredStreamId) {
                     continue;
                 }
                 $featuredStream = $stream;
                 break;
             }
         }
-
         return view('community.live', compact('streams', 'featuredStream'));
     }
 
@@ -84,7 +84,7 @@ class CommunityController extends Controller
         }
 
         if ($request->has('promote')) {
-            Cache::forever('featuredStream', intval($request->promote));
+            Cache::forever('featuredStream', floatval($request->promote));
         }
 
         if ($request->has('demote')) {

--- a/app/Http/Controllers/CommunityController.php
+++ b/app/Http/Controllers/CommunityController.php
@@ -74,6 +74,7 @@ class CommunityController extends Controller
                 break;
             }
         }
+
         return view('community.live', compact('streams', 'featuredStream'));
     }
 

--- a/app/Http/Controllers/CommunityController.php
+++ b/app/Http/Controllers/CommunityController.php
@@ -65,9 +65,9 @@ class CommunityController extends Controller
 
         $featuredStreamId = Cache::get('featuredStream');
         if ($featuredStreamId !== null) {
-            $featuredStreamId = (string)$featuredStreamId;
+            $featuredStreamId = (string) $featuredStreamId;
             foreach ($streams as $stream) {
-                if ((string)$stream->_id !== $featuredStreamId) {
+                if ((string) $stream->_id !== $featuredStreamId) {
                     continue;
                 }
                 $featuredStream = $stream;

--- a/app/Http/Controllers/CommunityController.php
+++ b/app/Http/Controllers/CommunityController.php
@@ -65,9 +65,9 @@ class CommunityController extends Controller
 
         $featuredStreamId = Cache::get('featuredStream');
         if ($featuredStreamId !== null) {
-            $featuredStreamId = floatval($featuredStreamId);
+            $featuredStreamId = (string)$featuredStreamId;
             foreach ($streams as $stream) {
-                if (floatval($stream->_id) !== $featuredStreamId) {
+                if ((string)$stream->_id !== $featuredStreamId) {
                     continue;
                 }
                 $featuredStream = $stream;


### PR DESCRIPTION
Fixes situation where certain streams weren't possible to be highlighted.