### PR TITLE
Correct migrations and update database dump

### DIFF
--- a/bin/db_dump
+++ b/bin/db_dump
@@ -11,6 +11,8 @@ _mysqldump() {
 
 _mysqldump osu \
   migrations \
+  forum_forum_covers \
+  forum_topic_covers \
   osu_achievements \
   osu_apikeys \
   osu_beatmaps \

--- a/database/db-osu-data.sql
+++ b/database/db-osu-data.sql
@@ -1,10 +1,11 @@
--- MySQL dump 10.15  Distrib 10.0.23-MariaDB, for debian-linux-gnu (x86_64)
+-- MySQL dump 10.13  Distrib 5.7.11, for Linux (i686)
 --
 -- Host: localhost    Database: osu
 -- ------------------------------------------------------
--- Server version	5.7.9-log
+-- Server version	5.7.11
 /*!40103 SET @OLD_TIME_ZONE=@@TIME_ZONE */;
 /*!40103 SET TIME_ZONE='+00:00' */;
+/*!40014 SET @OLD_UNIQUE_CHECKS=@@UNIQUE_CHECKS, UNIQUE_CHECKS=0 */;
 /*!40014 SET @OLD_FOREIGN_KEY_CHECKS=@@FOREIGN_KEY_CHECKS, FOREIGN_KEY_CHECKS=0 */;
 /*!40101 SET @OLD_SQL_MODE=@@SQL_MODE, SQL_MODE='NO_AUTO_VALUE_ON_ZERO' */;
 /*!40111 SET @OLD_SQL_NOTES=@@SQL_NOTES, SQL_NOTES=0 */;
@@ -13,28 +14,26 @@
 -- Dumping data for table `migrations`
 --
 
-INSERT INTO `migrations` VALUES ('2013_12_24_180249_create_notifications_table',1);
-INSERT INTO `migrations` VALUES ('2014_05_02_190748_add_shipping_rate_to_osu_countries_table',1);
-INSERT INTO `migrations` VALUES ('2015_01_23_114030_extend_products_table',2);
-INSERT INTO `migrations` VALUES ('2015_01_29_013313_add_last_order_tracking_state',3);
-INSERT INTO `migrations` VALUES ('2015_02_03_051509_record_cost_and_shipping_in_order',4);
-INSERT INTO `migrations` VALUES ('2015_02_04_165733_record_cost_and_shipping_in_order_populate',5);
-INSERT INTO `migrations` VALUES ('2015_05_01_013313_add_item_family',6);
-INSERT INTO `migrations` VALUES ('2015_06_04_083548_infinite_stock_products',7);
-INSERT INTO `migrations` VALUES ('2015_06_04_093340_custom_product_implementations',8);
-INSERT INTO `migrations` VALUES ('2015_06_18_022845_order_transaction_id',9);
-INSERT INTO `migrations` VALUES ('2015_06_19_050528_add_order_paid_at_column',10);
-INSERT INTO `migrations` VALUES ('2015_07_08_042238_create_tournaments_tables',11);
-INSERT INTO `migrations` VALUES ('2015_07_09_084235_create_user_profile_customizations_table',13);
-INSERT INTO `migrations` VALUES ('2015_07_09_091745_add_tournament_description_text',12);
-INSERT INTO `migrations` VALUES ('2015_07_09_105144_create_tournaments_registrations_table',12);
-INSERT INTO `migrations` VALUES ('2015_08_10_083016_add_slug_to_achievements',14);
-INSERT INTO `migrations` VALUES ('2015_11_16_065319_create_topic_covers_table',15);
-INSERT INTO `migrations` VALUES ('2015_11_20_122003_add_unique_index_to_forum_topic_covers_forum_id',16);
-INSERT INTO `migrations` VALUES ('2015_12_07_061307_create_forum_covers_table',17);
-INSERT INTO `migrations` VALUES ('2016_01_12_074035_unique_user_customization_user_id',18);
-INSERT INTO `migrations` VALUES ('2016_01_26_194005_disable_products',19);
-INSERT INTO `migrations` VALUES ('2016_01_29_090810_add_description_to_achievements',20);
+INSERT INTO `migrations` VALUES ('2015_01_23_114030_extend_products_table',1);
+INSERT INTO `migrations` VALUES ('2015_01_29_013313_add_last_order_tracking_state',1);
+INSERT INTO `migrations` VALUES ('2015_02_03_051509_record_cost_and_shipping_in_order',1);
+INSERT INTO `migrations` VALUES ('2015_02_04_165733_record_cost_and_shipping_in_order_populate',1);
+INSERT INTO `migrations` VALUES ('2015_05_01_013313_add_item_family',1);
+INSERT INTO `migrations` VALUES ('2015_06_04_083548_infinite_stock_products',1);
+INSERT INTO `migrations` VALUES ('2015_06_04_093340_custom_product_implementations',1);
+INSERT INTO `migrations` VALUES ('2015_06_18_022845_order_transaction_id',1);
+INSERT INTO `migrations` VALUES ('2015_06_19_050528_add_order_paid_at_column',1);
+INSERT INTO `migrations` VALUES ('2015_07_08_042238_create_tournaments_tables',1);
+INSERT INTO `migrations` VALUES ('2015_07_09_084235_create_user_profile_customizations_table',1);
+INSERT INTO `migrations` VALUES ('2015_07_09_091745_add_tournament_description_text',1);
+INSERT INTO `migrations` VALUES ('2015_07_09_105144_create_tournaments_registrations_table',1);
+INSERT INTO `migrations` VALUES ('2015_08_10_083016_add_slug_to_achievements',1);
+INSERT INTO `migrations` VALUES ('2015_11_16_065319_create_topic_covers_table',1);
+INSERT INTO `migrations` VALUES ('2015_11_20_122003_add_unique_index_to_forum_topic_covers_forum_id',1);
+INSERT INTO `migrations` VALUES ('2015_12_07_061307_create_forum_covers_table',1);
+INSERT INTO `migrations` VALUES ('2016_01_12_074035_unique_user_customization_user_id',1);
+INSERT INTO `migrations` VALUES ('2016_01_26_194005_disable_products',1);
+INSERT INTO `migrations` VALUES ('2016_01_29_090810_add_description_to_achievements',1);
 
 --
 -- Dumping data for table `osu_genres`
@@ -71,6 +70,7 @@ INSERT INTO `osu_languages` VALUES (11,'Italian',5);
 
 /*!40101 SET SQL_MODE=@OLD_SQL_MODE */;
 /*!40014 SET FOREIGN_KEY_CHECKS=@OLD_FOREIGN_KEY_CHECKS */;
+/*!40014 SET UNIQUE_CHECKS=@OLD_UNIQUE_CHECKS */;
 /*!40111 SET SQL_NOTES=@OLD_SQL_NOTES */;
 
--- Dump completed on 2016-01-04 19:33:22
+-- Dump completed on 2016-02-12 21:58:48

--- a/database/db-osu-structure.sql
+++ b/database/db-osu-structure.sql
@@ -1,8 +1,8 @@
--- MySQL dump 10.15  Distrib 10.0.23-MariaDB, for debian-linux-gnu (x86_64)
+-- MySQL dump 10.13  Distrib 5.7.11, for Linux (i686)
 --
 -- Host: localhost    Database: osu
 -- ------------------------------------------------------
--- Server version	5.7.9-log
+-- Server version	5.7.11
 
 /*!40101 SET @OLD_CHARACTER_SET_CLIENT=@@CHARACTER_SET_CLIENT */;
 /*!40101 SET @OLD_CHARACTER_SET_RESULTS=@@CHARACTER_SET_RESULTS */;
@@ -27,6 +27,52 @@ CREATE TABLE `migrations` (
   `batch` int(11) NOT NULL,
   PRIMARY KEY (`migration`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8 COLLATE=utf8_unicode_ci;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Table structure for table `forum_forum_covers`
+--
+
+DROP TABLE IF EXISTS `forum_forum_covers`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `forum_forum_covers` (
+  `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
+  `forum_id` mediumint(8) unsigned DEFAULT NULL,
+  `user_id` mediumint(8) unsigned DEFAULT NULL,
+  `hash` varchar(255) NOT NULL,
+  `ext` varchar(255) NOT NULL,
+  `created_at` timestamp NOT NULL DEFAULT '0000-00-00 00:00:00',
+  `updated_at` timestamp NOT NULL DEFAULT '0000-00-00 00:00:00',
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `forum_forum_covers_forum_id_unique` (`forum_id`),
+  KEY `forum_forum_covers_user_id_index` (`user_id`),
+  CONSTRAINT `forum_forum_covers_forum_id_foreign` FOREIGN KEY (`forum_id`) REFERENCES `phpbb_forums` (`forum_id`) ON DELETE SET NULL,
+  CONSTRAINT `forum_forum_covers_user_id_foreign` FOREIGN KEY (`user_id`) REFERENCES `phpbb_users` (`user_id`) ON DELETE SET NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+/*!40101 SET character_set_client = @saved_cs_client */;
+
+--
+-- Table structure for table `forum_topic_covers`
+--
+
+DROP TABLE IF EXISTS `forum_topic_covers`;
+/*!40101 SET @saved_cs_client     = @@character_set_client */;
+/*!40101 SET character_set_client = utf8 */;
+CREATE TABLE `forum_topic_covers` (
+  `id` bigint(20) unsigned NOT NULL AUTO_INCREMENT,
+  `topic_id` mediumint(8) unsigned DEFAULT NULL,
+  `user_id` mediumint(8) unsigned DEFAULT NULL,
+  `hash` varchar(255) NOT NULL,
+  `ext` varchar(255) NOT NULL,
+  `created_at` timestamp NOT NULL DEFAULT '0000-00-00 00:00:00',
+  `updated_at` timestamp NOT NULL DEFAULT '0000-00-00 00:00:00',
+  PRIMARY KEY (`id`),
+  UNIQUE KEY `forum_topic_covers_topic_id_unique` (`topic_id`),
+  KEY `forum_topic_covers_user_id_index` (`user_id`),
+  CONSTRAINT `forum_topic_covers_topic_id_foreign` FOREIGN KEY (`topic_id`) REFERENCES `phpbb_topics` (`topic_id`) ON DELETE SET NULL,
+  CONSTRAINT `forum_topic_covers_user_id_foreign` FOREIGN KEY (`user_id`) REFERENCES `phpbb_users` (`user_id`) ON DELETE SET NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
 /*!40101 SET character_set_client = @saved_cs_client */;
 
 --
@@ -1616,4 +1662,4 @@ CREATE TABLE `user_profile_customizations` (
 /*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;
 /*!40111 SET SQL_NOTES=@OLD_SQL_NOTES */;
 
--- Dump completed on 2016-01-04 19:33:15
+-- Dump completed on 2016-02-12 21:58:48

--- a/database/db-osu_store-structure.sql
+++ b/database/db-osu_store-structure.sql
@@ -1,8 +1,8 @@
--- MySQL dump 10.15  Distrib 10.0.23-MariaDB, for debian-linux-gnu (x86_64)
+-- MySQL dump 10.13  Distrib 5.7.11, for Linux (i686)
 --
 -- Host: localhost    Database: osu_store
 -- ------------------------------------------------------
--- Server version	5.7.9-log
+-- Server version	5.7.11
 
 /*!40101 SET @OLD_CHARACTER_SET_CLIENT=@@CHARACTER_SET_CLIENT */;
 /*!40101 SET @OLD_CHARACTER_SET_RESULTS=@@CHARACTER_SET_RESULTS */;
@@ -56,7 +56,7 @@ CREATE TABLE `order_items` (
   `created_at` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
   `deleted_at` timestamp NULL DEFAULT NULL,
   `updated_at` timestamp NULL DEFAULT NULL,
-  `cost` float(8,2) DEFAULT NULL,
+  `cost` double(8,2) DEFAULT NULL,
   `extra_info` varchar(255) DEFAULT NULL,
   PRIMARY KEY (`id`),
   UNIQUE KEY `order_id_product_id` (`order_id`,`product_id`),
@@ -83,7 +83,7 @@ CREATE TABLE `orders` (
   `deleted_at` timestamp NULL DEFAULT NULL,
   `updated_at` timestamp NULL DEFAULT NULL,
   `last_tracking_state` varchar(255) DEFAULT NULL,
-  `shipping` float(8,2) DEFAULT NULL,
+  `shipping` double(8,2) DEFAULT NULL,
   `transaction_id` varchar(255) DEFAULT NULL,
   PRIMARY KEY (`order_id`),
   KEY `user_id` (`user_id`),
@@ -137,4 +137,4 @@ CREATE TABLE `products` (
 /*!40101 SET COLLATION_CONNECTION=@OLD_COLLATION_CONNECTION */;
 /*!40111 SET SQL_NOTES=@OLD_SQL_NOTES */;
 
--- Dump completed on 2016-01-04 19:33:20
+-- Dump completed on 2016-02-12 21:58:48

--- a/database/migrations/2015_01_23_114030_extend_products_table.php
+++ b/database/migrations/2015_01_23_114030_extend_products_table.php
@@ -29,8 +29,8 @@ class ExtendProductsTable extends Migration
     public function up()
     {
         Schema::table('osu_store.products', function ($table) {
-            $table->boolean('promoted');
-            $table->integer('display_order');
+            $table->boolean('promoted')->default(false);
+            $table->integer('display_order')->default(0);
             $table->string('header_description');
             $table->string('header_image');
             $table->text('images_json');

--- a/database/migrations/2015_06_19_050528_add_order_paid_at_column.php
+++ b/database/migrations/2015_06_19_050528_add_order_paid_at_column.php
@@ -30,6 +30,7 @@ class AddOrderPaidAtColumn extends Migration
     {
         Schema::connection('mysql-store')->table('orders', function ($table) {
             $table->timestamp('paid_at')->nullable()->after('tracking_code');
+            $table->index('paid_at', 'paid_at');
         });
     }
 


### PR DESCRIPTION
Add `osu.forum_forum_covers` and `osu.forum_topic_covers` to `bin/db_dump`.

Fix some inconsistencies between the migrations and the database dump:
- `osu_store.products`: the columns `promoted` and `display_order` have default values in the dump but the migration doesn't specify them
- `osu_store.orders`: the database has `paid_at` as an index but the migration doesn't
- the two oldest migrations don't exist (anymore) so they shouldn't be be in `osu.migrations`

After these changes `php artisan migrate:refresh` works (again).
The dump was created after that command in the vagrant box.

Regarding the change from floats to doubles:
Apparently this is done intentionally by Laravel and there is no difference.
https://github.com/laravel/framework/issues/9103