### PR TITLE
Limit number of top played maps shown in user profile to 100.

### DIFF
--- a/app/Transformers/UserTransformer.php
+++ b/app/Transformers/UserTransformer.php
@@ -208,6 +208,7 @@ class UserTransformer extends Fractal\TransformerAbstract
         $beatmapPlaycounts = $user->beatmapPlaycounts()
             ->with('beatmap', 'beatmap.set')
             ->orderBy('playcount', 'desc')
+            ->limit(100)
             ->get()
             ->filter(function ($pc) {
                 return $pc->beatmap !== null && $pc->beatmap->set !== null;


### PR DESCRIPTION
Let's not return infinite results.