### PR TITLE
Stop targeting HHVM for now.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,6 @@ language: php
 
 php:
   - 7.0
-  - hhvm
 
 matrix:
   fast_finish: true


### PR DESCRIPTION
Because PHP 7 is looking pretty stable and more efficient for our particular environment. Also it runs composer/artisan much faster OOTB.