### PR TITLE
Add the missing extensions that certain Composer packages want

### DIFF
--- a/bootstrap.sh
+++ b/bootstrap.sh
@@ -30,8 +30,11 @@ apt-get install \
     php7.0-fpm \
     php7.0-gd \
     php7.0-json \
+    php7.0-mbstring \
     php7.0-mcrypt \
     php7.0-mysql \
+    php7.0-xml \
+    php7.0-zip \
     redis-server \
     tmux \
     vim \


### PR DESCRIPTION
Installing without the `mbstring` and `dom` (included in `php7.0-xml`) extensions results in errors when setting up using Vagrant. The `zip` extension was added to make Composer installs quicker.