### PR TITLE
Use regular expressions to pull out tracking codes specifically.

### DIFF
--- a/app/Console/Commands/StoreCheckOrderTrackingStatus.php
+++ b/app/Console/Commands/StoreCheckOrderTrackingStatus.php
@@ -17,7 +17,6 @@
  *    You should have received a copy of the GNU Affero General Public License
  *    along with osu!web.  If not, see <http://www.gnu.org/licenses/>.
  */
-
 namespace App\Console\Commands;
 
 use App\Models\Store;

--- a/app/Console/Commands/StoreCheckOrderTrackingStatus.php
+++ b/app/Console/Commands/StoreCheckOrderTrackingStatus.php
@@ -17,6 +17,7 @@
  *    You should have received a copy of the GNU Affero General Public License
  *    along with osu!web.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 namespace App\Console\Commands;
 
 use App\Models\Store;
@@ -72,7 +73,9 @@ class StoreCheckOrderTrackingStatus extends Command
             ++$i;
 
             try {
-                if (!strlen(trim($o->tracking_code)) || (strpos($o->tracking_code, 'EJ') !== 0 && strpos($o->tracking_code, 'RR') !== 0)) {
+                $trackingCodes = $o->trackingCodes();
+
+                if (!count($trackingCodes)) {
                     continue;
                 }
 
@@ -84,7 +87,6 @@ class StoreCheckOrderTrackingStatus extends Command
                 $orderStatuses = [];
                 $retainedCodes = [];
                 $deliveredCodes = [];
-                $trackingCodes = explode(',', $o->tracking_code);
 
                 //a single order may have multiple tracking numbers
                 foreach ($trackingCodes as $code) {

--- a/app/Models/Store/Order.php
+++ b/app/Models/Store/Order.php
@@ -17,7 +17,6 @@
  *    You should have received a copy of the GNU Affero General Public License
  *    along with osu!web.  If not, see <http://www.gnu.org/licenses/>.
  */
-
 namespace App\Models\Store;
 
 use DB;

--- a/app/Models/Store/Order.php
+++ b/app/Models/Store/Order.php
@@ -17,6 +17,7 @@
  *    You should have received a copy of the GNU Affero General Public License
  *    along with osu!web.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 namespace App\Models\Store;
 
 use DB;
@@ -50,6 +51,14 @@ class Order extends Model
     public function user()
     {
         return $this->belongsTo("App\Models\User");
+    }
+
+    public function trackingCodes()
+    {
+        $codes = [];
+        preg_match_all('/([A-Z]{2}[A-Z0-9]{9,11})/', $this->tracking_code, $codes);
+
+        return $codes[0];
     }
 
     public function getItemCount()

--- a/resources/views/store/invoice.blade.php
+++ b/resources/views/store/invoice.blade.php
@@ -167,7 +167,7 @@ window.onload = function() {
             </p>
         @elseif (($order->status == 'shipped' && ($order->last_tracking_state || !$order->tracking_code)) || $order->status == 'delivered')
             <p><strong>Your order has been shipped!</strong></p>
-            @if($order->tracking_code)
+            @if(count($order->trackingCodes()))
                 <p>
                     Tracking details follow:
                 </p>
@@ -188,8 +188,8 @@ window.onload = function() {
         @endif
     </div>
 
-    @if ($order->status == 'shipped' && $order->tracking_code)
-    @foreach(explode(',', $order->tracking_code) as $code)
+    @if ($order->status == 'shipped')
+    @foreach($order->trackingCodes() as $code)
     <div class='osu-layout__sub-row osu-layout__sub-row--with-separator'>
         <h4>Tracking for {{ $code }}</h4>
 

--- a/resources/views/store/invoice.blade.php
+++ b/resources/views/store/invoice.blade.php
@@ -173,7 +173,7 @@ window.onload = function() {
                 </p>
             @else
                 <p>
-                    We don't have tracking details as it was sent in a small envelope, but you can expect to receive it within 1-2 weeks at the most. If you have any concerns, please reply to the order confirmation email you received (or <a href='mailto:osustore@ppy.sh'>send us an email</a>).
+                    We don't have tracking details as we sent your package via Air Mail, but you can expect to receive it within 1-3 weeks. For Europe, sometimes customs can delay the order out of our control. If you have any concerns, please reply to the order confirmation email you received (or <a href='mailto:osustore@ppy.sh'>send us an email</a>).
                 </p>
             @endif
         @else
@@ -183,7 +183,7 @@ window.onload = function() {
             </p>
 
             <p>
-                We send all orders from Japan using EMS. This is the most efficient service available to us, and it should reach you in a very short time (3~14 days after we send it). For Europe, sometimes customs can delay the order out of our control.
+                We send all orders from Japan using a variety of shipping services depending on the weight and value. This area will update with specifics once we have shipped the order.
             </p>
         @endif
     </div>


### PR DESCRIPTION
Now that we are sending packages via airmail and other methods, the tracking code field can regularly contain notes for us and for the user which aren't valid tracking numbers.

This change matches tracking codes using the JP Post specification for them via regex.