### PR TITLE
Remove queue:restart from build script

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -21,7 +21,6 @@ php composer.phar config -g github-oauth.github.com 98cbc568911ef1e060a3a31623f2
 php composer.phar install
 
 php artisan migrate --force
-php artisan queue:restart
 php artisan lang:js resources/assets/js/messages.js
 
 npm install


### PR DESCRIPTION
This was running too early and restarting the workers with the old code. Added a seperate step to the auto-deployment system to do this instead.