### PR TITLE
Fixed user's 'more achievements' link not working

### DIFF
--- a/resources/assets/coffee/react/profile-page/recent-achievements.coffee
+++ b/resources/assets/coffee/react/profile-page/recent-achievements.coffee
@@ -22,7 +22,7 @@ class ProfilePage.RecentAchievements extends React.Component
   _showAllMedals: (e) =>
     e.preventDefault()
 
-    $.publish 'profilePageExtra:tab', 'medals'
+    $.publish 'profile:page:jump', 'medals'
 
 
   render: =>


### PR DESCRIPTION
Apparently the event name was left unchanged at some point.