### PR TITLE
Fix failing migrations

### DIFF
--- a/database/migrations/2016_02_29_081309_create_beatmap_discussion_posts.php
+++ b/database/migrations/2016_02_29_081309_create_beatmap_discussion_posts.php
@@ -39,6 +39,6 @@ class CreateBeatmapDiscussionPosts extends Migration
      */
     public function down()
     {
-        Schema::drop('beatmap_discussion_replies');
+        Schema::drop('beatmap_discussion_posts');
     }
 }

--- a/database/migrations/2016_04_11_071007_use_user_id_for_resolving_issue.php
+++ b/database/migrations/2016_04_11_071007_use_user_id_for_resolving_issue.php
@@ -46,6 +46,8 @@ class UseUserIdForResolvingIssue extends Migration
     public function down()
     {
         Schema::table('beatmap_discussions', function ($table) {
+            $table->dropForeign(['resolver_id']);
+
             $table->dropColumn('resolver_id');
         });
     }

--- a/database/migrations/2016_04_12_111756_add_last_editor_id_to_beatmap_discussion_posts.php
+++ b/database/migrations/2016_04_12_111756_add_last_editor_id_to_beatmap_discussion_posts.php
@@ -29,6 +29,8 @@ class AddLastEditorIdToBeatmapDiscussionPosts extends Migration
     public function down()
     {
         Schema::table('beatmap_discussion_posts', function ($table) {
+            $table->dropForeign(['last_editor_id']);
+
             $table->dropColumn('last_editor_id');
         });
     }


### PR DESCRIPTION
The migrations seem to be failing on rollback because of some missing drop foreign indexes instructions.