### PR TITLE
Generate simpler post url

### DIFF
--- a/resources/views/forum/topics/_post.blade.php
+++ b/resources/views/forum/topics/_post.blade.php
@@ -48,7 +48,7 @@
 
             <div class="forum-post__body">
                 <div class="forum-post__content forum-post__content--header">
-                    <a class="js-post-url link link--grey" href="{{ post_url($post->topic_id, $post->post_id) }}">
+                    <a class="js-post-url link link--grey" href="{{ route('forum.posts.show', $post->post_id) }}">
                         {!! trans("forum.post.posted_at", ["when" => timeago($post->post_time)]) !!}
                     </a>
                 </div>


### PR DESCRIPTION
`/forum/p/{post_id}` which will redirect to same previous url ¯\\\_(ツ)_/¯

Can use a visible hint of which post is it in the thread though.