### PR TITLE
Fix broken links on beatmap icons and mode tabs

### DIFF
--- a/resources/assets/coffee/react/beatmapset-page/contents-beatmap-icon.coffee
+++ b/resources/assets/coffee/react/beatmapset-page/contents-beatmap-icon.coffee
@@ -32,7 +32,7 @@ class BeatmapsetPage.ContentsBeatmapIcon extends React.Component
     a
       className: className
       onClick: @modeSwitch
-      href: BeatmapsetPageHash.generate mode: @props.beatmap.id, page: @props.currentPage
+      href: BeatmapsetPageHash.generate beatmapId: @props.beatmap.id, page: @props.currentPage
       el BeatmapIcon,
         beatmap: @props.beatmap
         showTitle: false

--- a/resources/assets/coffee/react/beatmapset-page/contents-tab.coffee
+++ b/resources/assets/coffee/react/beatmapset-page/contents-tab.coffee
@@ -31,7 +31,7 @@ class BeatmapsetPage.ContentsTab extends React.Component
     className += ' page-tabs__tab--disabled' if @props.disabled
 
     url = BeatmapsetPageHash.generate
-      mode: if active then @props.currentBeatmapId else @props.newBeatmapId
+      beatmapId: if active then @props.currentBeatmapId else @props.newBeatmapId
       page: @props.currentPage
 
     a


### PR DESCRIPTION
Right now they point at `/s/<set-id>#undefined`.