### PR TITLE
Beatmapset audio-preview overlay fixes and tweaks

### DIFF
--- a/resources/assets/coffee/react/beatmapset-page/header.coffee
+++ b/resources/assets/coffee/react/beatmapset-page/header.coffee
@@ -22,7 +22,8 @@ class BeatmapsetPage.Header extends React.Component
   onClick: (e) =>
     $.publish 'beatmapset:preview:toggle', !@props.isPreviewPlaying
 
-  doNothing: (e) =>
+  preventPropagation: (e) =>
+    # stops the audio from playing before we navigate away
     e.stopPropagation()
     return true
 
@@ -40,13 +41,13 @@ class BeatmapsetPage.Header extends React.Component
           div className: 'beatmapset-header__title',
             a
               href: laroute.route 'beatmapsets.index', q: @props.title
-              onClick: @doNothing
+              onClick: @preventPropagation
               @props.title
 
           div className: 'beatmapset-header__title beatmapset-header__title--small',
             a
               href: laroute.route 'beatmapsets.index', q: @props.artist
-              onClick: @doNothing
+              onClick: @preventPropagation
               @props.artist
 
         div className: 'beatmapset-header__title-box beatmapset-header__title-box--right',

--- a/resources/assets/coffee/react/beatmapset-page/header.coffee
+++ b/resources/assets/coffee/react/beatmapset-page/header.coffee
@@ -22,27 +22,32 @@ class BeatmapsetPage.Header extends React.Component
   onClick: (e) =>
     $.publish 'beatmapset:preview:toggle', !@props.isPreviewPlaying
 
+  doNothing: (e) =>
+    e.stopPropagation()
+    return true
+
   render: ->
     div className: 'osu-layout__row osu-layout__row--page-compact',
-      div className: 'beatmapset-header__preview-overlay',
-        div
-          className: 'beatmapset-header__preview-button'
-          onClick: @onClick
-          el Icon, name: if @props.isPreviewPlaying then 'pause' else 'play'
       div
         className: 'beatmapset-header',
+        onClick: @onClick,
         style:
           backgroundImage: "url(#{@props.cover})",
+        div
+          className: 'beatmapset-header__preview-button'
+          el Icon, name: if @props.isPreviewPlaying then 'pause' else 'play'
         div className: 'beatmapset-header__title-box beatmapset-header__title-box--left',
-          a
-            href: laroute.route 'beatmapsets.index', q: @props.title
-            className: 'beatmapset-header__title'
-            @props.title
+          div className: 'beatmapset-header__title',
+            a
+              href: laroute.route 'beatmapsets.index', q: @props.title
+              onClick: @doNothing
+              @props.title
 
-          a
-            href: laroute.route 'beatmapsets.index', q: @props.artist
-            className: 'beatmapset-header__title beatmapset-header__title--small'
-            @props.artist
+          div className: 'beatmapset-header__title beatmapset-header__title--small',
+            a
+              href: laroute.route 'beatmapsets.index', q: @props.artist
+              onClick: @doNothing
+              @props.artist
 
         div className: 'beatmapset-header__title-box beatmapset-header__title-box--right',
           div className: 'beatmapset-header__title beatmapset-header__title--stat',

--- a/resources/assets/coffee/react/beatmapset-page/main.coffee
+++ b/resources/assets/coffee/react/beatmapset-page/main.coffee
@@ -101,6 +101,7 @@ BeatmapsetPage.Main = React.createClass
       @audioPreview.play()
     else
       @audioPreview.pause()
+      @audioPreview.currentTime = 0;
 
   onPreviewEnded: ->
     @setState isPreviewPlaying: false

--- a/resources/assets/less/bem/beatmapset-header.less
+++ b/resources/assets/less/bem/beatmapset-header.less
@@ -26,6 +26,7 @@
 
   display: flex;
   flex-direction: row;
+  cursor: pointer;
 
   @media @desktop {
     padding-left: (@spacing * 4);
@@ -33,22 +34,22 @@
   }
 
   &__title {
-    font-size: 30px;
-    font-style: italic;
-    font-weight: 600;
-    color: @grey-f;
-    .default-text-shadow();
-
-    margin: 0;
-
-    &:hover, &:visited, &:link, &:active {
+    a {
+      font-size: 30px;
+      font-style: italic;
+      font-weight: 600;
       color: @grey-f;
-      text-decoration: none;
+      .default-text-shadow();
+
+      margin: 0;
+
+      &:hover, &:visited, &:link, &:active {
+        color: @grey-f;
+        text-decoration: none;
+      }
     }
 
-    &--small {
-      display: block;
-
+    &--small a {
       padding-top: 5px;
       font-size: 20px;
     }
@@ -57,6 +58,9 @@
       font-size: 18px;
       font-weight: 500;
       text-align: right;
+
+      color: @grey-f;
+      .default-text-shadow();
 
       overflow: hidden;
       white-space: nowrap;
@@ -89,28 +93,25 @@
     &--right {
       margin-left: auto;
     }
+
+    a {
+      z-index: @z-index--beatmapset-header + 1;
+    }
   }
 
-  &__preview-overlay {
-    position: absolute;
-    width: 100%;
-    height: 100%;
-
-    display: flex;
-    align-items: center;
-    justify-content: center;
-
-    z-index: @z-index--beatmapset-header + 1;
+  &:hover {
+    .beatmapset-header__preview-button {
+      opacity: 1;
+    }
   }
 
   &__preview-button {
     color: @grey-f;
     font-size: 80px;
-    opacity: 0;
+    opacity: 0.50;
+    position: absolute;
+    top: 64px;
+    left: 50%;
     cursor: pointer;
-
-    &:hover {
-      opacity: 1;
-    }
   }
 }


### PR DESCRIPTION
Fixes audio-preview overlay on the beatmapsets header making the title/artist links unclickable
Also tweaks the visual appearance a bit to always be visible and rewinds the preview when stopped

![](http://puu.sh/pcvlY/44269b66ac.png)