### PR TITLE
Display tweaks for Beatmapsets

### DIFF
--- a/resources/assets/coffee/react/_components/beatmapset-panel.coffee
+++ b/resources/assets/coffee/react/_components/beatmapset-panel.coffee
@@ -66,7 +66,7 @@ class @BeatmapsetPanel extends React.Component
       div className: 'beatmapset-panel__icons-box',
         a href: Url.beatmapDownload(beatmap.beatmapset_id), className: 'beatmapset-panel__icon',
           i className: 'fa fa-download'
-        a href: '#', className: 'beatmapset-panel__icon',
-          i className:'fa fa-heart'
+        # a href: '#', className: 'beatmapset-panel__icon',
+        #   i className:'fa fa-heart'
 
       div className: 'beatmapset-panel__difficulties', difficulties

--- a/resources/assets/less/bem/beatmapset-header.less
+++ b/resources/assets/less/bem/beatmapset-header.less
@@ -26,6 +26,7 @@
 
   display: flex;
   flex-direction: row;
+  justify-content: center;
   cursor: pointer;
 
   @media @desktop {
@@ -111,7 +112,6 @@
     opacity: 0.50;
     position: absolute;
     top: 64px;
-    left: 50%;
     cursor: pointer;
   }
 }

--- a/resources/assets/less/bem/beatmapset-panel.less
+++ b/resources/assets/less/bem/beatmapset-panel.less
@@ -32,8 +32,6 @@
   cursor: pointer;
 
   &:hover {
-    z-index: @z-index--beatmaps-panel;
-
     .beatmapset-panel__icons-box {
       opacity: 1 !important;
     }


### PR DESCRIPTION
Should (hopefully) improve performance on slower browsers when hovering the panels