### PR TITLE
Don't show title if it's blank

### DIFF
--- a/resources/assets/coffee/_classes/tooltip-default.coffee
+++ b/resources/assets/coffee/_classes/tooltip-default.coffee
@@ -25,6 +25,8 @@ class @TooltipDefault
     title = el.getAttribute 'title'
     el.removeAttribute 'title'
 
+    return if _.size(title) == 0
+
     $content = $('<span>').text(title)
 
     if el._tooltip


### PR DESCRIPTION
Broken when moving title content into its own element.