### PR TITLE
Turbolinks fixes

### DIFF
--- a/app/helpers.php
+++ b/app/helpers.php
@@ -127,7 +127,7 @@ function timeago($date)
     $display_date = $date->toRfc850String();
     $attribute_date = $date->toIso8601String();
 
-    return "<time class='timeago-raw timeago' datetime='{$attribute_date}'>{$display_date}</time>";
+    return "<time class='timeago' datetime='{$attribute_date}'>{$display_date}</time>";
 }
 
 function current_action()

--- a/resources/assets/coffee/_classes/forum-cover.coffee
+++ b/resources/assets/coffee/_classes/forum-cover.coffee
@@ -40,7 +40,7 @@ class @ForumCover
 
 
   closeModal: (e) =>
-    return unless @hasCoverEditor() && @header[0]._open
+    return unless @hasCoverEditor() && @isModalOpen()
 
     if e
       return if $(e.target).closest('.js-forum-cover--open-modal').length
@@ -51,7 +51,7 @@ class @ForumCover
     Fade.out $('.blackout')[0]
     @header[0].classList.remove 'forum-category-header--cover-modal'
 
-    @header[0]._open = false
+    @isModalOpen(false)
 
 
   hasCover: =>
@@ -62,23 +62,22 @@ class @ForumCover
     @uploadButton.length > 0
 
 
-  toggleModal: (e) =>
-    e.preventDefault()
+  isModalOpen: (isModalOpen) =>
+    return false if !@hasCoverEditor()
 
-    if @header[0]._open
-      @closeModal()
-    else
-      @openModal()
+    if isModalOpen?
+      @header[0].dataset.isModalOpen = if isModalOpen then '1' else ''
+
+    @header[0].dataset.isModalOpen == '1'
 
 
-  openModal: =>
-    Fade.in $('.blackout')[0]
-    @header[0]._open = true
-    @header[0].classList.add 'forum-category-header--cover-modal'
+  initFileupload: =>
+    return unless @isModalOpen()
+    return if @uploadButton[0]._initialized
+
+    @uploadButton[0]._initialized = true
 
     $dropZone = $('.js-forum-cover--modal')
-
-    return if @uploadButton[0]._initialized
 
     @$uploadButton().fileupload
       method: 'POST'
@@ -100,7 +99,22 @@ class @ForumCover
 
     @updateOptions()
 
-    @uploadButton[0]._initialized = true
+
+  toggleModal: (e) =>
+    e.preventDefault()
+
+    if @isModalOpen()
+      @closeModal()
+    else
+      @openModal()
+
+
+  openModal: =>
+    Fade.in $('.blackout')[0]
+    @isModalOpen(true)
+    @header[0].classList.add 'forum-category-header--cover-modal'
+
+    @initFileupload()
 
 
   setOverlay: (targetState) =>
@@ -158,3 +172,5 @@ class @ForumCover
     @header[0].style.backgroundImage = backgroundImage
 
     $('.js-forum-cover--remove').toggleClass('forum-post-actions__action--disabled', !@hasCover())
+
+    @initFileupload()

--- a/resources/assets/coffee/_classes/osu-layzr.coffee
+++ b/resources/assets/coffee/_classes/osu-layzr.coffee
@@ -1,0 +1,33 @@
+###
+# Copyright 2015-2016 ppy Pty. Ltd.
+#
+# This file is part of osu!web. osu!web is distributed with the hope of
+# attracting more community contributions to the core ecosystem of osu!.
+#
+# osu!web is free software: you can redistribute it and/or modify
+# it under the terms of the Affero GNU General Public License version 3
+# as published by the Free Software Foundation.
+#
+# osu!web is distributed WITHOUT ANY WARRANTY; without even the implied
+# warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with osu!web.  If not, see <http://www.gnu.org/licenses/>.
+###
+class @OsuLayzr
+  constructor: ->
+    @observer = new MutationObserver(@reinit)
+
+    $(document).on 'turbolinks:load', @init
+
+
+  init: =>
+    @layzr ?= Layzr()
+
+    @reinit()
+    @observer.observe document.body, childList: true, subtree: true
+
+
+  reinit: =>
+    @layzr.update().check().handlers(true)

--- a/resources/assets/coffee/_classes/timeago.coffee
+++ b/resources/assets/coffee/_classes/timeago.coffee
@@ -1,0 +1,28 @@
+###
+# Copyright 2015-2016 ppy Pty. Ltd.
+#
+# This file is part of osu!web. osu!web is distributed with the hope of
+# attracting more community contributions to the core ecosystem of osu!.
+#
+# osu!web is free software: you can redistribute it and/or modify
+# it under the terms of the Affero GNU General Public License version 3
+# as published by the Free Software Foundation.
+#
+# osu!web is distributed WITHOUT ANY WARRANTY; without even the implied
+# warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+# See the GNU Affero General Public License for more details.
+#
+# You should have received a copy of the GNU Affero General Public License
+# along with osu!web.  If not, see <http://www.gnu.org/licenses/>.
+###
+class @Timeago
+  constructor: ->
+    @observer = new MutationObserver (mutations) =>
+      mutations.forEach (mutation) =>
+        $nodes = $(mutation.addedNodes)
+        $nodes.find('.timeago').add($nodes.filter('.timeago')).timeago()
+
+
+    $(document).on 'turbolinks:load', =>
+      $('.timeago').timeago()
+      @observer.observe document.body, childList: true, subtree: true

--- a/resources/assets/coffee/_classes/tooltip-default.coffee
+++ b/resources/assets/coffee/_classes/tooltip-default.coffee
@@ -18,6 +18,10 @@
 class @TooltipDefault
   constructor: ->
     $(document).on 'mouseover', '[title]', @onMouseOver
+    $(document).on 'turbolinks:before-cache', @rollback
+
+    @tooltips = document.getElementsByClassName 'qtip'
+
 
   onMouseOver: (event) =>
     el = event.currentTarget
@@ -67,3 +71,11 @@ class @TooltipDefault
     el.setAttribute 'data-orig-title', title
 
     $(el).qtip options, event
+
+
+  rollback: =>
+    while @tooltips.length > 0
+      @tooltips[0].remove()
+
+    for el in document.querySelectorAll('[data-orig-title]')
+      el.setAttribute 'title', el.getAttribute('data-orig-title')

--- a/resources/assets/coffee/main.coffee
+++ b/resources/assets/coffee/main.coffee
@@ -26,6 +26,8 @@ $(document).on 'submit', 'form', LoadingOverlay.show
 
 @reactTurbolinks ||= new ReactTurbolinks
 @twitchPlayer ?= new TwitchPlayer
+@timeago ?= new Timeago
+@osuLayzr ?= new OsuLayzr
 
 reactTurbolinks.register 'user-card', UserCard
 
@@ -55,19 +57,6 @@ $(document).on 'ready turbolinks:load', =>
 
   @menu ||= new Menu
   @logoMenu ||= new LogoMenu
-
-  @layzr ||= Layzr()
-
-
-initPage = =>
-  osu.initTimeago()
-  @layzr.update().check().handlers(true)
-
-# Don't bother moving initPage to osu junk drawer and removing the
-# osu:page:change. It's intended to allow other scripts to attach
-# callbacks to osu:page:change.
-$(document).on 'ready turbolinks:load', initPage
-$(document).on 'osu:page:change', _.debounce(initPage, 500)
 
 
 $(document).on 'change', '.js-url-selector', (e) ->

--- a/resources/assets/coffee/osu_common.coffee
+++ b/resources/assets/coffee/osu_common.coffee
@@ -80,16 +80,13 @@ along with osu!web.  If not, see <http://www.gnu.org/licenses/>.
     regex = /(https?:\/\/(?:(?:[a-z0-9]\.|[a-z0-9][a-z0-9-]*[a-z0-9]\.)*[a-z][a-z0-9-]*[a-z0-9](?::\d+)?)(?:(?:(?:\/+(?:[a-z0-9$_\.\+!\*',;:@&=-]|%[0-9a-f]{2})*)*(?:\?(?:[a-z0-9$_\.\+!\*',;:@&=-]|%[0-9a-f]{2})*)?)?(?:#(?:[a-z0-9$_\.\+!\*',;:@&=-]|%[0-9a-f]{2})*)?)?)/ig
     return text.replace(regex, '<a href="$1" rel="nofollow">$1</a>')
 
+
   timeago: (time) ->
     el = document.createElement('time')
-    el.classList.add 'timeago-raw', 'timeago'
+    el.classList.add 'timeago'
     el.setAttribute 'datetime', time
     el.textContent = time
     el.outerHTML
-
-
-  initTimeago: ->
-    $('.timeago-raw').timeago().removeClass 'timeago-raw'
 
 
   reloadPage: (keepScroll = true) ->


### PR DESCRIPTION
Just realized yesterday that version 5 has one important change which obsoletes some of previously used techniques.

Namely it saves document using `cloneNode` so elements data and events are cleared out upon navigation. Storing element state using `el.someData = value` doesn't quite work anymore.

Reference: https://github.com/turbolinks/turbolinks/issues/30