### PR TITLE
Fix wrong check on overlay setter

### DIFF
--- a/resources/assets/coffee/_classes/forum-cover.coffee
+++ b/resources/assets/coffee/_classes/forum-cover.coffee
@@ -118,7 +118,7 @@ class @ForumCover
 
 
   setOverlay: (targetState) =>
-    return unless @header.length
+    return unless @hasCoverEditor()
 
     return if targetState == @overlay[0].getAttribute('data-state')
 


### PR DESCRIPTION
Previously checked class exists even though the upload button doesn't.