### PR TITLE
Fixes for contest entry system

### DIFF
--- a/app/Http/Controllers/ContestsController.php
+++ b/app/Http/Controllers/ContestsController.php
@@ -99,6 +99,10 @@ class ContestsController extends Controller
 
     private function userEntries($contest)
     {
+        if (!Auth::check()) {
+            return [];
+        }
+
         return fractal_api_serialize_collection(
             UserContestEntry::where(['contest_id' => $contest->id, 'user_id' => Auth::user()->user_id])->get(),
             new UserContestEntryTransformer

--- a/resources/lang/en/contest.php
+++ b/resources/lang/en/contest.php
@@ -23,6 +23,7 @@ return [
         'over' => 'Voting for this contest has ended',
     ],
     'entry' => [
+        'login_required' => 'You need to be logged in to enter.',
         'preparation' => 'We are current preparing this contest. Please wait patiently!',
         'over' => 'Thank you for your entries! Submissions have closed for this contest and voting will open soon.',
         'limit_reached' => 'You have reached the entry limit for this contest',

--- a/resources/lang/en/contest.php
+++ b/resources/lang/en/contest.php
@@ -23,7 +23,8 @@ return [
         'over' => 'Voting for this contest has ended',
     ],
     'entry' => [
-        'login_required' => 'You need to be logged in to enter.',
+        'login_required' => 'Please login to enter the contest.',
+        'silenced_or_restricted' => 'You cannot enter contests while restricted or silenced.',
         'preparation' => 'We are current preparing this contest. Please wait patiently!',
         'over' => 'Thank you for your entries! Submissions have closed for this contest and voting will open soon.',
         'limit_reached' => 'You have reached the entry limit for this contest',

--- a/resources/views/contests/enter.blade.php
+++ b/resources/views/contests/enter.blade.php
@@ -27,7 +27,11 @@
             <div class='contest__voting-ended'>{{trans('contest.entry.preparation')}}</div>
         @endif
     @else
-        <div class='js-react--userContestEntry'></div>
+        @if (!Auth::check())
+          <div class='contest__voting-ended'>{{trans('contest.entry.login_required')}}</div>
+        @else
+          <div class='js-react--userContestEntry'></div>
+        @endif
     @endif
 @endsection
 

--- a/resources/views/contests/enter.blade.php
+++ b/resources/views/contests/enter.blade.php
@@ -30,7 +30,11 @@
         @if (!Auth::check())
           <div class='contest__voting-ended'>{{trans('contest.entry.login_required')}}</div>
         @else
-          <div class='js-react--userContestEntry'></div>
+          @if (Auth::user()->isSilenced() || Auth::user()->isRestricted())
+            <div class='contest__voting-ended'>{{trans('contest.entry.silenced_or_restricted')}}</div>
+          @else
+            <div class='js-react--userContestEntry'></div>
+          @endif
         @endif
     @endif
 @endsection


### PR DESCRIPTION
Prevents entry page from exploding when user is not logged in and adds a message explaining that silenced/restricted users can't enter contest (instead of just failing on upload)