### PR TITLE
wrong text in translation

### DIFF
--- a/resources/lang/es/beatmaps.php
+++ b/resources/lang/es/beatmaps.php
@@ -81,7 +81,7 @@ return [
     'beatmapset' => [
         'show' => [
             'details' => [
-                'made-by' => 'creado por :user',
+                'made-by' => 'creado por ',
                 'submitted' => 'enviado el ',
                 'ranked' => 'rankeado el ',
                 'logged-out' => '¡Necesitas iniciar sesión para descargar beatmaps!',


### PR DESCRIPTION
there was a ':user' in this translation.