### PR TITLE
Add missing dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "d3": "^3.5.14",
     "font-awesome": "^4.5.0",
     "gulp": "^3.9.0",
+    "gulp-util": "^3.0.7",
     "jquery": "^2.2.0",
     "jquery-ui": "^1.12.0",
     "jquery-ujs": "^1.2.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1479,7 +1479,7 @@ constants-browserify@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/constants-browserify/-/constants-browserify-1.0.0.tgz#c20b96d8c617748aaf1c16021760cd27fcb8cb75"
 
-convert-source-map@1.X, convert-source-map@1.x, convert-source-map@^1.1.0:
+convert-source-map@1.x, convert-source-map@1.X, convert-source-map@^1.1.0:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-1.3.0.tgz#e9f3e9c6e2728efc2676696a70eb382f73106a67"
 
@@ -2606,7 +2606,7 @@ gulp-uglify@^1.5.1:
     uglify-save-license "^0.4.1"
     vinyl-sourcemaps-apply "^0.2.0"
 
-gulp-util@*, gulp-util@^3.0, gulp-util@^3.0.0, gulp-util@^3.0.1, gulp-util@^3.0.2, gulp-util@^3.0.6, gulp-util@^3.0.7:
+gulp-util, gulp-util@*, gulp-util@^3.0, gulp-util@^3.0.0, gulp-util@^3.0.1, gulp-util@^3.0.2, gulp-util@^3.0.6, gulp-util@^3.0.7:
   version "3.0.7"
   resolved "https://registry.yarnpkg.com/gulp-util/-/gulp-util-3.0.7.tgz#78925c4b8f8b49005ac01a011c557e6218941cbb"
   dependencies:


### PR DESCRIPTION
It's already dependency of another package(s) but since it's explicitly used in gulpfile, it should be listed as such.