### PR TITLE
Hours duration

### DIFF
--- a/resources/assets/coffee/_classes/beatmap-discussion-helper.coffee
+++ b/resources/assets/coffee/_classes/beatmap-discussion-helper.coffee
@@ -28,5 +28,10 @@ class @BeatmapDiscussionHelper
       suggestion: '&#xf10c;'
       problem: '&#xf06a;'
 
-  @formatTimestamp: (timestamp) =>
-    moment(timestamp).utcOffset(0).format('mm:ss.SSS')
+  @formatTimestamp: (value) =>
+    ms = value % 1000
+    s = Math.floor(value / 1000) % 60
+    # remaning duration goes here even if it's over an hour
+    m = Math.floor(value / 1000 / 60)
+
+    "#{_.padStart m, 2, 0}:#{_.padStart s, 2, 0}.#{_.padStart ms, 3, 0}"

--- a/resources/assets/coffee/react/_components/beatmap-basic-stats.coffee
+++ b/resources/assets/coffee/react/_components/beatmap-basic-stats.coffee
@@ -21,15 +21,14 @@ bn = 'beatmap-basic-stats'
 
 # value is in second
 formatDuration = (value) ->
-  duration = moment(value * 1000).utcOffset(0)
+  s = value % 60
+  m = Math.floor(value / 60) % 60
+  h = Math.floor(value / 3600)
 
-  format =
-    if duration.hours() > 0
-      'h:mm:ss'
-    else
-      'm:ss'
-
-  duration.format format
+  if h > 0
+    "#{h}:#{_.padStart m, 2, 0}:#{_.padStart s, 2, 0}"
+  else
+    "#{m}:#{_.padStart s, 2, 0}"
 
 
 @BeatmapBasicStats = ({beatmapset, beatmap}) ->

--- a/resources/assets/coffee/react/_components/beatmap-basic-stats.coffee
+++ b/resources/assets/coffee/react/_components/beatmap-basic-stats.coffee
@@ -19,6 +19,19 @@
 
 bn = 'beatmap-basic-stats'
 
+# value is in second
+formatDuration = (value) ->
+  duration = moment(value * 1000).utcOffset(0)
+
+  format =
+    if duration.hours() > 0
+      'h:mm:ss'
+    else
+      'm:ss'
+
+  duration.format format
+
+
 @BeatmapBasicStats = ({beatmapset, beatmap}) ->
   div
     className: bn
@@ -31,7 +44,7 @@ bn = 'beatmap-basic-stats'
 
       value =
         if stat == 'total_length'
-          moment(0).seconds(value).format 'm:ss'
+          formatDuration value
         else
           value.toLocaleString()
 

--- a/resources/assets/coffee/react/beatmap-discussions/new-discussion.coffee
+++ b/resources/assets/coffee/react/beatmap-discussions/new-discussion.coffee
@@ -160,7 +160,7 @@ BeatmapDiscussions.NewDiscussion = React.createClass
 
 
   parseTimestamp: ->
-    timestampRe = @state.message.match /\b(\d{2}):(\d{2})[:.](\d{3})\b/
+    timestampRe = @state.message.match /\b(\d{2,}):(\d{2})[:.](\d{3})\b/
 
     @setState timestamp:
       if timestampRe?


### PR DESCRIPTION
Beatmapset durations:
- 0:30 (or should it be 00:30?)
- 1:30
- 10:05
- 2:05:05 (or 02:...?)
- 10:05:05 (god why)

Modding timestamps:
- 00:00.000
- 01:20.300
- 70:10.000 (should it show 1:10:10.000 (or 01:...) instead?)
- 1000:00.000

Note that writing timestamp in hours format (01:01:01:001) still isn't supported.