### PR TITLE
Contest tweaks

### DIFF
--- a/resources/assets/less/bem/contest.less
+++ b/resources/assets/less/bem/contest.less
@@ -36,7 +36,7 @@
     > h1, h2, h3, h4, h5, h6 {
       color: white;
     }
-    & a {
+    a {
       color: #93b8c4;
     }
   }

--- a/resources/assets/less/bem/contest.less
+++ b/resources/assets/less/bem/contest.less
@@ -36,6 +36,9 @@
     > h1, h2, h3, h4, h5, h6 {
       color: white;
     }
+    & a {
+      color: #93b8c4;
+    }
   }
 
   &__voting-notice {

--- a/resources/views/contests/voting.blade.php
+++ b/resources/views/contests/voting.blade.php
@@ -28,12 +28,12 @@
         @else
             <div class='contest__accordion' id='contests-accordion'>
                 @foreach ($contests as $contest)
-                    <div class='panel contest__group{{ $loop->first ? ' panel-default' : '' }}'>
-                        <a href="#{{$contest->id}}" class='contest__group-heading' data-toggle='collapse' data-parent='#contests-accordion' aria-expanded='{{ $loop->first ? 'true' : 'false' }}'>
+                    <div class='panel contest__group'>
+                        <a href="#{{$contest->id}}" class='contest__group-heading' data-toggle='collapse' data-parent='#contests-accordion' aria-expanded='false'>
                             <span>{!! $contest->name !!}</span>
                             <i class="contest__section-toggle fa fa-fw fa-chevron-down"></i>
                         </a>
-                        <div class='contest__multi-panel collapse{{ $loop->first ? ' in' : '' }}' id="{{$contest->id}}">
+                        <div class='contest__multi-panel collapse' id="{{$contest->id}}">
                             @include('contests._voting-entrylist')
                         </div>
                     </div>


### PR DESCRIPTION
Makes links in the contest description box less blue.

Also collapses all sections within nested contests by default. Contests having lots of entries resulted in the other sections being pushed off-screen. This led to confusing UX as users may not see the other headings and realise they're expandable/collapsable...