### PR TITLE
Use priv_check to authorize access to profile page

### DIFF
--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -124,9 +124,9 @@ class UsersController extends Controller
 
     public function show($id)
     {
-        $user = User::lookup($id);
+        $user = User::lookup($id, null, true);
 
-        if ($user === null || !$user->hasProfile()) {
+        if ($user === null || !priv_check('UserShow', $user)->can()) {
             abort(404);
         }
 

--- a/app/Libraries/OsuAuthorize.php
+++ b/app/Libraries/OsuAuthorize.php
@@ -504,6 +504,21 @@ class OsuAuthorize
         return 'ok';
     }
 
+    public function checkUserShow($user, $owner)
+    {
+        $prefix = 'user.show.';
+
+        if ($user !== null && $user->user_id === $owner->user_id) {
+            return 'ok';
+        }
+
+        if ($owner->hasProfile()) {
+            return 'ok';
+        } else {
+            return $prefix.'no_access';
+        }
+    }
+
     public function ensureLoggedIn($user, $prefix = '')
     {
         if ($user === null) {


### PR DESCRIPTION
Different way to fix #216.

As global scope is available, it's actually possible to properly hide restricted user as well. Except I haven't figured out how to tell login system to remove the scope when looking for the user.

...closes #341?