### PR TITLE
Change resolve status behavior

### DIFF
--- a/app/Libraries/OsuAuthorize.php
+++ b/app/Libraries/OsuAuthorize.php
@@ -78,14 +78,6 @@ class OsuAuthorize
         return 'ok';
     }
 
-    public function checkBeatmapDiscussionPost($user, $discussion)
-    {
-        $this->ensureLoggedIn($user);
-        $this->ensureCleanRecord($user);
-
-        return 'ok';
-    }
-
     public function checkBeatmapDiscussionResolve($user, $discussion)
     {
         $prefix = 'beatmap_discussion.resolve.';
@@ -175,6 +167,14 @@ class OsuAuthorize
         if ($post->deleted_at === null) {
             return 'ok';
         }
+    }
+
+    public function checkBeatmapDiscussionPostStore($user, $discussion)
+    {
+        $this->ensureLoggedIn($user);
+        $this->ensureCleanRecord($user);
+
+        return 'ok';
     }
 
     public function checkBeatmapsetNominate($user, $beatmapset)

--- a/resources/assets/coffee/react/beatmap-discussions/new-reply.coffee
+++ b/resources/assets/coffee/react/beatmap-discussions/new-reply.coffee
@@ -35,7 +35,7 @@ BeatmapDiscussions.NewReply = React.createClass
 
   getInitialState: ->
     message: ''
-    resolveDiscussion: @canUpdate() && @props.discussion.resolved
+    resolveDiscussion: @props.discussion.resolved
 
 
   render: ->
@@ -69,7 +69,7 @@ BeatmapDiscussions.NewReply = React.createClass
                     className: 'osu-checkbox__input'
                     type: 'checkbox'
                     checked: @state.resolveDiscussion
-                    onChange: (e) => @setState resolveDiscussion: e.target.checked
+                    onChange: @toggleResolveDiscussion
 
                   span className: 'osu-checkbox__tick',
                     el Icon, name: 'check'
@@ -83,6 +83,14 @@ BeatmapDiscussions.NewReply = React.createClass
                 props:
                   disabled: !@validPost()
                   onClick: @throttledPost
+
+
+  canUpdate: ->
+    return false if !@props.currentUser.id?
+
+    @props.currentUser.isAdmin ||
+      @props.currentUser.id == @props.beatmapset.user_id ||
+      @props.currentUser.id == @props.discussion.user_id
 
 
   post: ->
@@ -114,20 +122,16 @@ BeatmapDiscussions.NewReply = React.createClass
     @setState message: e.target.value
 
 
-  canUpdate: ->
-    return false if !@props.currentUser.id?
-
-    @props.currentUser.isAdmin ||
-      @props.currentUser.id == @props.beatmapset.user_id ||
-      @props.currentUser.id == @props.discussion.user_id
-
-
-  validPost: ->
-    @state.message.length != 0
-
-
   submitIfEnter: (e) ->
     return if e.keyCode != 13
 
     e.preventDefault()
     @throttledPost()
+
+
+  toggleResolveDiscussion: (e) ->
+    @setState resolveDiscussion: e.target.checked
+
+
+  validPost: ->
+    @state.message.length != 0


### PR DESCRIPTION
Changing status (to resolved/unresolved) requires correct privilege (thread owner, beatmapset owner, or admin).

Currently it'll always reopen (unresolve) thread whenever anyone replies to it which doesn't sound right.