### PR TITLE
Wiki locales and margins

### DIFF
--- a/app/Libraries/LocaleMeta.php
+++ b/app/Libraries/LocaleMeta.php
@@ -71,6 +71,10 @@ class LocaleMeta
             'name' => 'Nederlands',
             'flag' => 'NL',
         ],
+        'no' => [
+            'name' => 'Norsk',
+            'flag' => 'NO',
+        ],
         'pl' => [
             'name' => 'Polski',
             'flag' => 'PL',

--- a/resources/assets/less/bem/wiki-content.less
+++ b/resources/assets/less/bem/wiki-content.less
@@ -28,6 +28,10 @@
     font-style: normal;
     color: @pink-light;
 
+    &:first-child {
+      margin-top: 0;
+    }
+
     &--2 {
       font-size: @font-size--header-wiki-2;
       margin: 80px -20px 10px;


### PR DESCRIPTION
I'm not sure if Norwegian should be just "Norsk" or "Norsk bokmål".