### PR TITLE
Don't override locale that's set in controller

### DIFF
--- a/app/Http/Middleware/SetLocale.php
+++ b/app/Http/Middleware/SetLocale.php
@@ -49,12 +49,6 @@ class SetLocale
 
         App::setLocale($locale);
 
-        $response = $next($request);
-
-        if (method_exists($response, 'withCookie')) {
-            return $response->withCookie(cookie()->forever('locale', $locale));
-        } else {
-            return $response;
-        }
+        return $next($request);
     }
 }


### PR DESCRIPTION
Should've been removed when moved to using controller instead of middleware.