### PR TITLE
Fix CJK font fallback

### DIFF
--- a/resources/assets/less/bootstrap-variables.less
+++ b/resources/assets/less/bootstrap-variables.less
@@ -29,7 +29,7 @@
 @link-color: @blue-darker;
 @link-hover-color: @blue;
 
-@font-family-sans-serif: "Exo 2", "Arial Grande",Tahoma,Helvetica,Arial,sans-serif;
+@font-family-sans-serif: "Exo 2", "Arial Grande",Tahoma,Helvetica,Arial,"Arial Unicode MS",sans-serif;
 
 @font-size-base: 16px;
 


### PR DESCRIPTION
Windows 10 Chrome (and possibly others?) sometimes doesn't fallback correctly to sans serif font for CJK text.