### PR TITLE
Fix starting mode when loading user profile page

### DIFF
--- a/resources/assets/coffee/_classes/profile-page-hash.coffee
+++ b/resources/assets/coffee/_classes/profile-page-hash.coffee
@@ -22,7 +22,9 @@ class @ProfilePageHash
 
   @parse: (hash) =>
     hash = hash.slice 1
-    if @noMode(hash)
+    if hash.length == 0
+      {}
+    else if @noMode(hash)
       page: hash
     else
       split = hash.split '/'


### PR DESCRIPTION
Splitting empty string results in single element array of empty string