### PR TITLE
Report unrecognized events to sentry

### DIFF
--- a/app/Models/Event.php
+++ b/app/Models/Event.php
@@ -20,6 +20,8 @@
 
 namespace App\Models;
 
+use Sentry;
+
 class Event extends Model
 {
     public $parsed = false;
@@ -110,6 +112,12 @@ class Event extends Model
 
     public function parseFailure()
     {
+        Sentry::captureMessage('Failed parsing event', ['log'], [
+            'extra' => [
+                'event' => $this->toArray(),
+            ],
+        ]);
+
         return ['parse_error' => true];
     }
 


### PR DESCRIPTION
Looks like there are some changes which broke current parser.