### PR TITLE
No more key from gpg server

### DIFF
--- a/bin/mysql_debian_install
+++ b/bin/mysql_debian_install
@@ -1,9 +1,8 @@
 #!/bin/sh
 
-apt-key adv --keyserver keys.gnupg.net --recv 5072E1F5
 echo mysql-apt-config mysql-apt-config/select-server select mysql-5.7 | debconf-set-selections
-wget https://dev.mysql.com/get/mysql-apt-config_0.8.1-1_all.deb
-dpkg --install mysql-apt-config_0.8.1-1_all.deb
+wget https://dev.mysql.com/get/mysql-apt-config_0.8.2-1_all.deb
+dpkg --install mysql-apt-config_0.8.2-1_all.deb
 apt-get update -q
 apt-get install -q -y -o Dpkg::Options::=--force-confnew mysql-server
 mysql_upgrade


### PR DESCRIPTION
Latest deb file contains latest key already. And the gpg server fails at random.

...except the new one also fetches key. Oh well, at least it's using a different server which hopefully is more stable than the other one.