### PR TITLE
fast_imagesize doesn't return false anymore.

### DIFF
--- a/app/Libraries/BBCodeFromDB.php
+++ b/app/Libraries/BBCodeFromDB.php
@@ -151,7 +151,7 @@ class BBCodeFromDB
             $imageTag = '';
 
             $imageSize = fast_imagesize($proxiedSrc);
-            if ($imageSize !== false && $imageSize[0] !== 0) {
+            if ($imageSize !== null && $imageSize[0] !== 0) {
                 $heightPercentage = ($imageSize[1] / $imageSize[0]) * 100;
 
                 $topClass = 'proportional-container';

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -505,11 +505,7 @@ function fast_imagesize($url)
         $data = curl_exec($curl);
         curl_close($curl);
 
-        try {
-            return read_image_properties_from_string($data);
-        } catch (Exception $_e) {
-            return [0, 0];
-        }
+        return read_image_properties_from_string($data);
     });
 }
 


### PR DESCRIPTION
And `null[0]` is apparently a valid php.