### PR TITLE
'Fix' timezone for Beatmapset datetime fields

### DIFF
--- a/app/Models/Beatmapset.php
+++ b/app/Models/Beatmapset.php
@@ -84,6 +84,22 @@ class Beatmapset extends Model
     const QUALIFICATIONS_PER_DAY = 6;
     const BUNDLED_IDS = [3756, 163112, 140662, 151878, 190390, 123593, 241526, 299224];
 
+    /*
+    |--------------------------------------------------------------------------
+    | Accesssors
+    |--------------------------------------------------------------------------
+    */
+
+    public function getApprovedDateAttribute($value)
+    {
+        return (new Carbon($value))->subHours(8);
+    }
+
+    public function getSubmitDateAttribute($value)
+    {
+        return (new Carbon($value))->subHours(8);
+    }
+
     // ranking functions for the set
 
     public function beatmapsetDiscussion()
@@ -452,16 +468,6 @@ class Beatmapset extends Model
                 ->orderByRaw('FIELD(beatmapset_id, '.db_array_bind($beatmap_ids).')', $beatmap_ids)
                 ->get()
             : [];
-    }
-
-    public function getApprovedDateAttribute($value)
-    {
-        return (new Carbon($value))->subHours(8);
-    }
-
-    public function getSubmitDateAttribute($value)
-    {
-        return (new Carbon($value))->subHours(8);
     }
 
     public static function latestRankedOrApproved($count = 5)

--- a/app/Models/Beatmapset.php
+++ b/app/Models/Beatmapset.php
@@ -454,6 +454,16 @@ class Beatmapset extends Model
             : [];
     }
 
+    public function getApprovedDateAttribute($value)
+    {
+        return (new Carbon($value))->subHours(8);
+    }
+
+    public function getSubmitDateAttribute($value)
+    {
+        return (new Carbon($value))->subHours(8);
+    }
+
     public static function latestRankedOrApproved($count = 5)
     {
         // TODO: add filtering by game mode after mode-toggle UI/UX happens


### PR DESCRIPTION
Currently they're stored as GMT+8, thanks to legacy stuff