### PR TITLE
Fix user ranking graphs with missing data

### DIFF
--- a/resources/assets/coffee/react/profile-page/header-extra.coffee
+++ b/resources/assets/coffee/react/profile-page/header-extra.coffee
@@ -205,11 +205,10 @@ class ProfilePage.HeaderExtra extends React.Component
       $.subscribe "fancy-chart:hover-#{options.hoverId}:end.#{@id}", @rankChartHover
 
     data = (@props.rankHistories?.data ? [])
-      .filter (rank) -> rank > 0
-
     data = data.map (rank, i) ->
       x: i - data.length + 1
       y: -rank
+    .filter (point) -> point.y < 0
 
     if data.length == 1
       data.unshift


### PR DESCRIPTION
Tiny fix for ranking graphs that don't have all data points set

See https://osu.ppy.sh/u/3666350 vs https://new.ppy.sh/u/3666350; the latter graph shows incorrectly shifted dates. This change fills the gap with a straight line