### PR TITLE
Fix mobile view for contest entry names and headers

### DIFF
--- a/resources/assets/less/bem/contest-list-item.less
+++ b/resources/assets/less/bem/contest-list-item.less
@@ -30,10 +30,10 @@
 
   border-right: 5px solid #323E41;
 
-  @media @mobile{
+  @media @mobile {
     height: 90px;
   }
- 
+
   &:active, &:focus, &:hover {
     color: white;
     text-decoration: none;
@@ -92,17 +92,14 @@
   }
 
   &__name {
-    font-size: 17px;
-    text-overflow: ellipsis;
-    overflow: hidden;
-    white-space: nowrap;
-    @media @mobile {
-      font-size: 14px;
-      text-overflow: initial;
-      overflow: initial;
-      white-space: initial;
-    }
+    font-size: 14px;
     padding-bottom: 5px;
+    @media @desktop {
+      font-size: 17px;
+      text-overflow: ellipsis;
+      overflow: hidden;
+      white-space: nowrap;
+    }
   }
 
   &__date {

--- a/resources/assets/less/bem/contest-list-item.less
+++ b/resources/assets/less/bem/contest-list-item.less
@@ -30,6 +30,10 @@
 
   border-right: 5px solid #323E41;
 
+  @media @mobile{
+    height: 90px;
+  }
+ 
   &:active, &:focus, &:hover {
     color: white;
     text-decoration: none;
@@ -94,6 +98,9 @@
     white-space: nowrap;
     @media @mobile {
       font-size: 14px;
+      text-overflow: initial;
+      overflow: initial;
+      white-space: initial;
     }
     padding-bottom: 5px;
   }
@@ -124,6 +131,7 @@
     float: left;
     @media @mobile {
       width: 50px;
+      height: 90px;
     }
   }
 }

--- a/resources/assets/less/bem/contest-list-legend.less
+++ b/resources/assets/less/bem/contest-list-legend.less
@@ -31,6 +31,7 @@
       text-overflow: ellipsis;
       overflow: hidden;
       white-space: nowrap;
+      font-size: 12px; 
 
       &:hover {
         flex: none;

--- a/resources/assets/less/bem/contest-list.less
+++ b/resources/assets/less/bem/contest-list.less
@@ -23,4 +23,7 @@
   font-weight: 300;
   padding: 20px;
   padding-top: 10px;
+  @media @mobile{
+   padding: 5px;
+  }
 }

--- a/resources/assets/less/bem/osu-page-header-v2.less
+++ b/resources/assets/less/bem/osu-page-header-v2.less
@@ -24,7 +24,7 @@
   padding: 20px;
   display: flex;
   flex-direction: column;
-  justify-content: flex-start;
+  justify-content: center;
 
   font-weight: 300;
   color: white;
@@ -67,6 +67,10 @@
     font-size: @font-size--new-header-subtitle;
     margin-bottom: 10px;
     margin-top: 5px;
+    
+    @media @mobile {
+      font-size: @font-size--new-header-subtitle-mobile;
+    }
   }
 
   &__title {
@@ -75,7 +79,8 @@
     font-style: italic;
 
     @media @mobile {
-      margin-top: 10px;
+      margin-top: 0;
+      font-size: @font-size--new-header-title-mobile;
     }
 
     &--artist {

--- a/resources/assets/less/bem/osu-page-header-v2.less
+++ b/resources/assets/less/bem/osu-page-header-v2.less
@@ -24,11 +24,15 @@
   padding: 20px;
   display: flex;
   flex-direction: column;
-  justify-content: center;
+  justify-content: flex-start;
 
   font-weight: 300;
   color: white;
   height: 100px;
+
+  @media @mobile {
+    justify-content: center;
+  }
 
   @media @desktop {
     padding-left: 40px;
@@ -67,7 +71,7 @@
     font-size: @font-size--new-header-subtitle;
     margin-bottom: 10px;
     margin-top: 5px;
-    
+
     @media @mobile {
       font-size: @font-size--new-header-subtitle-mobile;
     }

--- a/resources/assets/less/variables.less
+++ b/resources/assets/less/variables.less
@@ -110,6 +110,9 @@
 @font-size--new-header-title: 30px;
 @font-size--new-header-subtitle: 14px;
 
+@font-size--new-header-title-mobile: 26px;
+@font-size--new-header-subtitle-mobile: 12px;
+
 @font-size--forum-topic-entry-icon: 16px;
 @font-size--forum-topic-entry-icon-small: 10px;
 @font-size--forum-post-heading: 20px;


### PR DESCRIPTION
Styling changes to fix #797.
- applies when `@mobile`
  - ~~reset text-overflow, overflow, and white-space rules for contest entry name~~
  - increase entry item height to allow more text
  - (increase image height to match above)
  - decrease legend font-size
  - decrease contest list padding to give more space for text, image, border, etc.
  - reset heading top margin to 0
  - use new defined font-size for mobile header v2
  - issue: 3 lines max for both contest entry name and headers (or they will overflow when `@mobile`)
  - `justify-content: center;` for heading v2

_Left: this branch; Right: current_
![image](https://cloud.githubusercontent.com/assets/14264992/25551910/5d615d72-2c52-11e7-8195-68fcab03ee9e.png)
![image](https://cloud.githubusercontent.com/assets/14264992/25551911/7fc9596e-2c52-11e7-80f2-a6331ac92117.png)

