### PR TITLE
osu!wiki - increase margin-bottom for paragraph

### DIFF
--- a/resources/assets/less/bem/wiki-content.less
+++ b/resources/assets/less/bem/wiki-content.less
@@ -23,6 +23,10 @@
   font-size: @font-size--wiki;
   word-wrap: break-word;
 
+  p {
+    margin-bottom: 1em;
+  }
+
   &__header {
     font-family: @font-family-sans-serif;
     font-weight: bold;
@@ -63,10 +67,6 @@
       font-style: italic;
       margin-top: 20px;
     }
-  }
-
-  & p {
-    margin-bottom: 1em;
   }
 
   &__image {

--- a/resources/assets/less/bem/wiki-content.less
+++ b/resources/assets/less/bem/wiki-content.less
@@ -65,6 +65,10 @@
     }
   }
 
+  & p {
+    margin-bottom: 1em;
+  }
+
   &__image {
     max-width: 100%;
   }


### PR DESCRIPTION
_(Continued from #1109.)_ Increase `margin-bottom` for `<p/>` tags inside `.wiki-content` to `1em` (was `10px`).