### PR TITLE
Prevent viewing of unreleased artists

### DIFF
--- a/app/Http/Controllers/ArtistsController.php
+++ b/app/Http/Controllers/ArtistsController.php
@@ -20,10 +20,10 @@
 
 namespace App\Http\Controllers;
 
-use Auth;
 use App\Models\Artist;
 use App\Transformers\ArtistAlbumTransformer;
 use App\Transformers\ArtistTrackTransformer;
+use Auth;
 
 class ArtistsController extends Controller
 {

--- a/app/Http/Controllers/ArtistsController.php
+++ b/app/Http/Controllers/ArtistsController.php
@@ -20,6 +20,7 @@
 
 namespace App\Http\Controllers;
 
+use Auth;
 use App\Models\Artist;
 use App\Transformers\ArtistAlbumTransformer;
 use App\Transformers\ArtistTrackTransformer;
@@ -37,6 +38,11 @@ class ArtistsController extends Controller
     public function show($id)
     {
         $artist = Artist::with('label')->findOrFail($id);
+
+        $user = Auth::user();
+        if (!$artist->visible && ($user === null || !$user->isAdmin())) {
+            abort(404);
+        }
 
         $albums = $artist->albums()
             ->where('visible', true)

--- a/app/Http/Controllers/ArtistsController.php
+++ b/app/Http/Controllers/ArtistsController.php
@@ -31,15 +31,22 @@ class ArtistsController extends Controller
 
     public function index()
     {
+        $artists = Artist::with('label')->withCount('tracks');
+        $user = Auth::user();
+
+        if ($user === null || !$user->isAdmin()) {
+            $artists->where('visible', true);
+        }
+
         return view('artists.index')
-            ->with('artists', Artist::with('label')->withCount('tracks')->where('visible', true)->get());
+            ->with('artists', $artists->get());
     }
 
     public function show($id)
     {
         $artist = Artist::with('label')->findOrFail($id);
-
         $user = Auth::user();
+
         if (!$artist->visible && ($user === null || !$user->isAdmin())) {
             abort(404);
         }

--- a/resources/assets/less/bem/artist.less
+++ b/resources/assets/less/bem/artist.less
@@ -99,6 +99,20 @@
     }
   }
 
+  &__admin-note {
+    background-color: @yellow-dark;
+    color: black;
+    font-weight: bold;
+    padding: 20px;
+    margin-bottom: 10px;
+
+    text-align: center;
+
+    @media @desktop {
+      .default-box-shadow();
+    }
+  }
+
   &__album-title {
     padding: 10px;
     font-size: 2em;

--- a/resources/assets/less/bem/artist.less
+++ b/resources/assets/less/bem/artist.less
@@ -32,6 +32,10 @@
 
   &__box {
     margin: 10px;
+
+    &--hidden {
+      opacity: 0.25;
+    }
   }
 
   &__album {

--- a/resources/lang/en/artist.php
+++ b/resources/lang/en/artist.php
@@ -22,17 +22,24 @@ return [
     'page_description' => 'Featured artists on osu!',
     'title' => 'Featured Artists',
 
+    'admin' => [
+        'hidden' => 'ARTIST IS CURRENTLY HIDDEN',
+    ],
+
     'beatmaps' => [
         '_' => 'Beatmaps',
         'download' => 'Download Beatmap Template',
         'download-na' => 'Beatmap Template not yet available',
     ],
+
     'index' => [
         'description' => 'Featured artists are artists that we are working in collaboration with in order to bring new and original music to osu!. These artists and a selection of their tracks have been hand-picked by the osu! team as being awesomesauce and suitable for mapping. Some of these featured artists have also created exclusive new tracks for use in osu!.<br><br>All tracks in this section are provided as pre-timed .osz files and have been officially licensed for use in osu! and osu!-related content.',
     ],
+
     'links' => [
         'site' => 'Official Website',
     ],
+
     'songs' => [
         '_' => 'Songs',
         'count' => '1 song|:count songs',

--- a/resources/views/artists/index.blade.php
+++ b/resources/views/artists/index.blade.php
@@ -36,7 +36,7 @@
                 <div class="artist__description artist__description--index">{!! trans('artist.index.description') !!}</div>
                 <div class="artist__index">
                     @foreach ($artists as $artist)
-                        <div class="artist__box">
+                        <div class="artist__box{{$artist->visible ? '' : ' artist__box--hidden'}}">
                             <div class="artist__portrait-wrapper artist__portrait-wrapper--index">
                                 <a href="{{route('artist.show', ['id' => $artist->id])}}" class="artist__portrait artist__portrait--index" style="{{$artist->cover_url ? 'background-image: url(' . $artist->cover_url . ')' : ''}}"></a>
                                 @if($artist->label !== null)

--- a/resources/views/artists/show.blade.php
+++ b/resources/views/artists/show.blade.php
@@ -39,6 +39,9 @@
     <div class="osu-layout__row osu-layout__row--page-artist">
         <div class="page-contents page-contents--artist">
             <div class="page-contents__artist-left">
+                @if (!$artist->visible)
+                    <div class="artist__admin-note">{{ trans('artist.admin.hidden') }}</div>
+                @endif
                 <div class="artist__description">{!! Markdown::convertToHtml($artist->description) !!}</div>
                 @if (count($albums) > 0)
                     <div class="artist__albums">


### PR DESCRIPTION
Hides non-visible artists from being viewed (except to admins). Also adds the display of non-visible artists on the index for admins.

![](https://puu.sh/vDXOM/e73a89db77.png)