### PR TITLE
Update home.php [PT-BR]

### DIFF
--- a/resources/lang/pt-br/home.php
+++ b/resources/lang/pt-br/home.php
@@ -32,7 +32,7 @@ return [
         ],
 
         'slogan' => [
-            'main' => 'simulador de círculos grátis para jogar',
+            'main' => 'simulador de ritmo gratuito',
             'sub' => 'o ritmo está a um clique de distância',
         ],
     ],
@@ -51,7 +51,7 @@ return [
             ],
         ],
         'beatmaps' => [
-            'new' => 'Novos beapmaps aprovados',
+            'new' => 'Novos Beatmaps Aprovados',
             'popular' => 'Beatmaps populares',
         ],
         'buttons' => [

--- a/resources/lang/pt-br/home.php
+++ b/resources/lang/pt-br/home.php
@@ -51,7 +51,7 @@ return [
             ],
         ],
         'beatmaps' => [
-            'new' => 'Novos Beatmaps Aprovados',
+            'new' => 'Novos beatmaps aprovados',
             'popular' => 'Beatmaps populares',
         ],
         'buttons' => [


### PR DESCRIPTION
"simulador de ritmo gratuito" looks much better than "simulador de círculos grátis para jogar". The second option would be the english equivalent for "circle-clicking free game" and that's not suitable at all for reading, in my opinion. Plus, changed "beatmaps aprovados" into "Beatmaps Aprovados" for better capitalization.