### PR TITLE
Properly cancel turbolinks event

### DIFF
--- a/resources/assets/coffee/_classes/turbolinks-disable.coffee
+++ b/resources/assets/coffee/_classes/turbolinks-disable.coffee
@@ -38,4 +38,6 @@ class @TurbolinksDisable
 
   cancelIfExternal: (event) ->
     prefix = "#{document.location.protocol}//#{document.location.host}/"
-    RegExp("^(?:#{internal})(?:$|/)").test event.data.url.substr(prefix.length)
+
+    if RegExp("^(?:#{internal})(?:$|/)").test event.data.url.substr(prefix.length)
+      event.preventDefault()


### PR DESCRIPTION
Returning false isn't enough to cancel the event.