### PR TITLE
ranking.php bug-fix in portuguese

### DIFF
--- a/resources/lang/pt-br/ranking.php
+++ b/resources/lang/pt-br/ranking.php
@@ -19,7 +19,7 @@
  */
 
 return [
-    'header' => ':type Posição',
+    'header' => 'Classificação de :type',
     'type' => [
         'performance' => 'Desempenho',
         'charts' => 'Gráficos',


### PR DESCRIPTION
Thought 'header' and the contents on 'type' were two different words but they're actually a sentence. Turns out it looks really weird in portuguese.