### PR TITLE
Server-Side ACTION message handling

### DIFF
--- a/app/Transformers/API/Chat/MessageTransformer.php
+++ b/app/Transformers/API/Chat/MessageTransformer.php
@@ -38,7 +38,8 @@ class MessageTransformer extends Fractal\TransformerAbstract
             'target_type' => $message->target_type,
             'target_id' => $message->target_id,
             'timestamp' => json_time($message->timestamp),
-            'content' => $message->content,
+            'content' => preg_replace('/\x01ACTION |[\x00-\x1f\x7F]/', '', $message->content),
+            'is_action' => preg_match('/\x01ACTION\s.*\x01/', $message->content),
         ];
     }
 


### PR DESCRIPTION
Implement support for action messages in the server, this method does not require any modifications to the database.

I'll rewrite it if IRC-style encoded messages aren't wanted in the database, but from the looks of the system now, the database is probably already full of these.

Changes:
+ Strip all ASCII control characters from incoming and outgoing messages
+ Process ACTION messages and tag them with an is_action flag
+ Drop the maximum message length from 1024 characters to 1000 characters, This is done to leave room for the ACTION message tagging
+ Process incoming messages with is_action into ACTION messages

This pairs with ppy/osu#860