### PR TITLE
Fix cron

### DIFF
--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -61,7 +61,7 @@ class Kernel extends ConsoleKernel
             ->everyThirtyMinutes();
 
         $schedule->command('rankings:recalculate-country')
-            ->cron('25 */3+2 * * *');
+            ->cron('25 0,3,6,9,12,15,18,21 * * *');
     }
 
     protected function commands()


### PR DESCRIPTION
Laravel's cron doesn't support step values `¯\_(ツ)_/¯`