### PR TITLE
Fix missing ']' in store-supporter-tag querySelector.

### DIFF
--- a/resources/assets/coffee/_classes/store-supporter-tag.coffee
+++ b/resources/assets/coffee/_classes/store-supporter-tag.coffee
@@ -127,8 +127,8 @@ class @StoreSupporterTag
     @setUserInteraction(@user?)
 
   updateCostDisplay: =>
-    @el.querySelector('input[name="item[cost]"').value = @cost.price()
-    @el.querySelector('input[name="item[extra_data][duration]"').value = @cost.duration()
+    @el.querySelector('input[name="item[cost]"]').value = @cost.price()
+    @el.querySelector('input[name="item[extra_data][duration]"]').value = @cost.duration()
     @priceElement.textContent = "USD #{@cost.price()}"
     @durationElement.textContent = @cost.durationText()
     @discountElement.textContent = @cost.discountText()


### PR DESCRIPTION
Apparently, Safari was the only browser that cared about the missing `]` 