### PR TITLE
Increase the grabbable area of the supporter tag slider

### DIFF
--- a/resources/assets/less/bem/store-slider.less
+++ b/resources/assets/less/bem/store-slider.less
@@ -24,7 +24,7 @@
 
   &__fake-callout {
     position: absolute;
-    left: 5px;
+    left: @slider-handle-width / 2;
     padding: 0 32px @slider-callout--arrow-height 32px;
     transform: translateX(-50%);
     bottom: calc(100% ~'+' @slider-callout--arrow-gap);

--- a/resources/assets/less/bem/store-slider.less
+++ b/resources/assets/less/bem/store-slider.less
@@ -22,19 +22,22 @@
     font-weight: 600;
   }
 
-  &__callout {
+  &__fake-callout {
     position: absolute;
+    left: 5px;
+    padding: 0 32px @slider-callout--arrow-height 32px;
+    transform: translateX(-50%);
+    bottom: calc(100% ~'+' @slider-callout--arrow-gap);
+  }
+
+  &__callout {
     background-color: #333;
     color: #fff;
-    cursor: pointer;
     font-size: @font-size--normal;
     text-align: center;
     border-radius: 10px;
     padding: 6px;
     width: @slider-callout--width;
-    left: 5px;
-    transform: translateX(-50%);
-    bottom: calc(100% ~'+' @slider-callout--arrow-height + @slider-callout--arrow-gap);
 
     &:after, &:before {
       top: 100%;

--- a/resources/assets/less/bem/store-slider.less
+++ b/resources/assets/less/bem/store-slider.less
@@ -26,6 +26,7 @@
     position: absolute;
     background-color: #333;
     color: #fff;
+    cursor: pointer;
     font-size: @font-size--normal;
     text-align: center;
     border-radius: 10px;

--- a/resources/assets/less/bem/store-slider.less
+++ b/resources/assets/less/bem/store-slider.less
@@ -65,7 +65,7 @@
     font-size: 12px;
     margin: 4px;
     height: 20px;
-    width: 32px;
+    width: 36px;
     line-height: 19px;
     text-align: center;
     border-radius: 10px;

--- a/resources/assets/less/jquery-ui/slider.less
+++ b/resources/assets/less/jquery-ui/slider.less
@@ -17,8 +17,8 @@
     position: absolute;
     z-index: 2;
     cursor: pointer;
-    width: 10px;
-    height: 20px;
+    width: @slider-handle-width;
+    height: @slider-handle-height;
     border-radius: 30px;
     background-color: @pink-darker;
     outline: none;
@@ -34,11 +34,11 @@
 }
 
 .ui-slider-horizontal {
-  height: 10px;
+  height: @slider-height;
 
   .ui-slider-handle {
-    top: -5px;
-    margin-left: -5px;
+    top: -(@slider-handle-height - @slider-height) / 2;
+    margin-left: -@slider-handle-width / 2;
   }
 
   .ui-slider-range {

--- a/resources/assets/less/jquery-ui/slider.less
+++ b/resources/assets/less/jquery-ui/slider.less
@@ -16,7 +16,7 @@
   .ui-slider-handle {
     position: absolute;
     z-index: 2;
-    cursor: default;
+    cursor: pointer;
     width: 10px;
     height: 20px;
     border-radius: 30px;

--- a/resources/assets/less/jquery-ui/slider.less
+++ b/resources/assets/less/jquery-ui/slider.less
@@ -10,6 +10,7 @@
 
 .ui-slider {
   position: relative;
+  cursor: pointer;
   text-align: left;
 
   .ui-slider-handle {

--- a/resources/assets/less/variables.less
+++ b/resources/assets/less/variables.less
@@ -216,3 +216,8 @@
 @slider-callout--arrow-height: 12px;
 @slider-callout--arrow-gap: 2px;
 @slider-callout--width: 128px;
+@slider-handle-protrusion: 5px;
+@slider-handle-height: @slider-height + 2 * @slider-handle-protrusion;
+@slider-handle-width: 10px;
+@slider-height: 10px;
+

--- a/resources/views/store/products/supporter-tag.blade.php
+++ b/resources/views/store/products/supporter-tag.blade.php
@@ -50,10 +50,12 @@
     <div class="store-slider">
         <div class="js-slider ui-slider ui-slider-horizontal">
             <div class="ui-slider-handle">
-                <div class="store-slider__callout">
-                    <div class="js-price store-slider__bigtext"></div>
-                    <div class="js-duration"></div>
-                    <div class="js-discount store-slider__subtext"></div>
+                <div class="store-slider__fake-callout">
+                    <div class="store-slider__callout">
+                        <div class="js-price store-slider__bigtext"></div>
+                        <div class="js-duration"></div>
+                        <div class="js-discount store-slider__subtext"></div>
+                    </div>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
Makes the grabbable area of the callout slightly bigger than the callout visual itself.
Seems like we can't make the clickable area of the slider any larger, though, without making the slider itself larger. 🤔 

Also pointer cursors for everyone.