### PR TITLE
Always show accuracy in play-details

### DIFF
--- a/resources/assets/coffee/react/_components/play-detail.coffee
+++ b/resources/assets/coffee/react/_components/play-detail.coffee
@@ -74,7 +74,7 @@ el = React.createElement
                 else
                   score.score.toLocaleString()
             div
-              className: 'detail-row__detail-row detail-row__score-details'
+              className: 'detail-row__score-details'
               if score.weight
                 div
                   className: 'detail-row__text-score'

--- a/resources/assets/coffee/react/_components/play-detail.coffee
+++ b/resources/assets/coffee/react/_components/play-detail.coffee
@@ -73,14 +73,17 @@ el = React.createElement
                   osu.trans('users.show.extra.top_ranks.pp', amount: Math.round(score.pp))
                 else
                   score.score.toLocaleString()
+            if score.weight
+              div
+                className: 'detail-row__detail-row detail-row__detail-row--bottom'
+                span
+                  className: 'detail-row__text-score'
+                  osu.trans 'users.show.extra.top_ranks.weighted_pp',
+                    percentage: "#{Math.round(score.weight.percentage)}%"
+                    pp: osu.trans('users.show.extra.top_ranks.pp', amount: Math.round(score.weight.pp))
             div
               className: 'detail-row__detail-row detail-row__detail-row--bottom'
               span
                 className: 'detail-row__text-score'
-                if score.weight
-                  osu.trans 'users.show.extra.top_ranks.weighted_pp',
-                    percentage: "#{Math.round(score.weight.percentage)}%"
-                    pp: osu.trans('users.show.extra.top_ranks.pp', amount: Math.round(score.weight.pp))
-                else if !score.pp
-                  osu.trans 'users.show.extra.historical.recent_plays.accuracy',
-                    percentage: "#{(score.accuracy * 100).toFixed(2)}%"
+                osu.trans 'users.show.extra.historical.recent_plays.accuracy',
+                  percentage: "#{(score.accuracy * 100).toFixed(2)}%"

--- a/resources/assets/coffee/react/_components/play-detail.coffee
+++ b/resources/assets/coffee/react/_components/play-detail.coffee
@@ -73,17 +73,15 @@ el = React.createElement
                   osu.trans('users.show.extra.top_ranks.pp', amount: Math.round(score.pp))
                 else
                   score.score.toLocaleString()
-            if score.weight
-              div
-                className: 'detail-row__detail-row detail-row__detail-row--bottom'
-                span
+            div
+              className: 'detail-row__detail-row detail-row__score-details'
+              if score.weight
+                div
                   className: 'detail-row__text-score'
                   osu.trans 'users.show.extra.top_ranks.weighted_pp',
                     percentage: "#{Math.round(score.weight.percentage)}%"
                     pp: osu.trans('users.show.extra.top_ranks.pp', amount: Math.round(score.weight.pp))
-            div
-              className: 'detail-row__detail-row detail-row__detail-row--bottom'
-              span
+              div
                 className: 'detail-row__text-score'
                 osu.trans 'users.show.extra.historical.recent_plays.accuracy',
                   percentage: "#{(score.accuracy * 100).toFixed(2)}%"

--- a/resources/assets/less/bem/detail-row.less
+++ b/resources/assets/less/bem/detail-row.less
@@ -82,7 +82,7 @@
     }
 
     &--bottom {
-      min-height: 18px;
+      min-height: @detail-row--bottom-min-height;
       align-items: flex-start;
     }
   }
@@ -104,6 +104,13 @@
         order: 1;
       }
     }
+  }
+
+  &__score-details {
+    flex-direction: column;
+    align-items: flex-end;
+    margin-top: @detail-row--score-details-gap;
+    min-height: @detail-row--bottom-min-height - @detail-row--score-details-gap;
   }
 
   &__text-score {

--- a/resources/assets/less/bem/detail-row.less
+++ b/resources/assets/less/bem/detail-row.less
@@ -107,8 +107,7 @@
   }
 
   &__score-details {
-    flex-direction: column;
-    align-items: flex-end;
+    text-align: right;
     margin-top: @detail-row--score-details-gap;
     min-height: @detail-row--bottom-min-height - @detail-row--score-details-gap;
   }

--- a/resources/assets/less/variables.less
+++ b/resources/assets/less/variables.less
@@ -214,7 +214,7 @@
 
 // user profile detail-row
 @detail-row--bottom-min-height: 18px;
-@detail-row--score-details-gap: 3px;
+@detail-row--score-details-gap: 2px;
 
 // store slider
 @slider-callout--arrow-height: 12px;

--- a/resources/assets/less/variables.less
+++ b/resources/assets/less/variables.less
@@ -212,6 +212,10 @@
 @diff-insane: @purple;
 @diff-expert: #000;
 
+// user profile detail-row
+@detail-row--bottom-min-height: 18px;
+@detail-row--score-details-gap: 3px;
+
 // store slider
 @slider-callout--arrow-height: 12px;
 @slider-callout--arrow-gap: 2px;


### PR DESCRIPTION
resolves #1146 

There's already logic to show the accuracy if there's no `score.weight` or `score.pp`; this just makes it show all the time.
It might look kind of unbalanced, though?

![image](https://user-images.githubusercontent.com/1694544/27172523-862d6d0e-51f0-11e7-994d-d59ea03c3e8c.png)
