### PR TITLE
fixes #1256

### DIFF
--- a/resources/assets/less/bem/mod.less
+++ b/resources/assets/less/bem/mod.less
@@ -17,7 +17,7 @@
  */
 
 .mod {
-  flex: none;
+  position: absolute;
   width: 100%;
   height: 100%;
   background-size: contain;


### PR DESCRIPTION
Sets `min-height` so Safari doesn't consider it a 0 height block.