### PR TITLE
Remove user registration date formatting from UserTransformer

### DIFF
--- a/app/Transformers/UserTransformer.php
+++ b/app/Transformers/UserTransformer.php
@@ -51,7 +51,7 @@ class UserTransformer extends Fractal\TransformerAbstract
         return [
             'id' => $user->user_id,
             'username' => $user->username,
-            'joinDate' => display_regdate($user),
+            'join_date' => json_date($user->user_regdate),
             'country' => [
                 'code' => $user->country_acronym,
                 'name' => $user->countryName(),

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -77,6 +77,11 @@ function get_valid_locale($requestedLocale)
     );
 }
 
+function json_date($date)
+{
+    return json_time($date->startOfDay());
+}
+
 function json_time($time)
 {
     if ($time !== null) {
@@ -456,12 +461,14 @@ function display_regdate($user)
         return;
     }
 
+    $formattedDate = $user->user_regdate->formatLocalized('%B %Y');
+
     if ($user->user_regdate < Carbon\Carbon::createFromDate(2008, 1, 1)) {
-        return trans('users.show.first_members');
+        return "<div title='{$formattedDate}'>".trans('users.show.first_members').'</div>';
     }
 
     return trans('users.show.joined_at', [
-        'date' => '<strong>'.$user->user_regdate->formatLocalized('%B %Y').'</strong>',
+        'date' => "<strong>{$formattedDate}</strong>",
     ]);
 }
 

--- a/resources/assets/coffee/react/profile-page/header-extra.coffee
+++ b/resources/assets/coffee/react/profile-page/header-extra.coffee
@@ -79,10 +79,18 @@ class ProfilePage.HeaderExtra extends React.Component
                         age: rowValue osu.trans('users.show.age', age: @props.user.age)
 
           div className: "#{bn}__rows",
-            div
-              className: "#{bn}__row"
-              dangerouslySetInnerHTML:
-                __html: @props.user.joinDate
+            if moment(@props.user.join_date).isBefore moment('2008-01-01')
+              div
+                className: "#{bn}__row"
+                title: moment(@props.user.join_date).format('MMMM YYYY'),
+                  osu.trans 'users.show.first_members'
+            else
+              div
+                className: "#{bn}__row"
+                dangerouslySetInnerHTML:
+                  __html:
+                    osu.trans 'users.show.joined_at',
+                      date: rowValue moment(@props.user.join_date).format('MMMM YYYY')
             div
               className: "#{bn}__row"
               dangerouslySetInnerHTML:


### PR DESCRIPTION
Also adds a tooltip for users that have been here "since the beginning", showing the month+year they joined on hover.

Fixes #1254 
