### PR TITLE
Fix boolean operators breaking elasticsearch

### DIFF
--- a/app/helpers.php
+++ b/app/helpers.php
@@ -53,7 +53,7 @@ function es_query_and_words($words)
     $partsEscaped = [];
 
     foreach ($parts as $part) {
-        $partsEscaped[] = str_replace('-', '%2D', urlencode($part));
+        $partsEscaped[] = str_replace('-', '%2D', urlencode(strtolower($part)));
     }
 
     return implode(' AND ', $partsEscaped);


### PR DESCRIPTION
Searching with reserved keywords in terms (e.g, 'AND', 'OR', etc) will trigger an error from Elasticsearch. Converting terms to lowercase fixes this - search results shouldn't be affected because they're indexed case-insensitively.