### PR TITLE
Fix friends page if there is a friend with empty flag

### DIFF
--- a/resources/views/objects/_usercard.blade.php
+++ b/resources/views/objects/_usercard.blade.php
@@ -36,10 +36,12 @@
                         @if (isset($loading))
                             @include('objects._country_flag', ['country_code' => 'XX'])
                         @else
-                            @include('objects._country_flag', [
-                                'country_code' => $user->country->acronym,
-                                'country_name' => $user->country->name,
-                            ])
+                            @if (isset($user->country))
+                                @include('objects._country_flag', [
+                                    'country_code' => $user->country->acronym,
+                                    'country_name' => $user->country->name,
+                                ])
+                            @endif
                             @if ($user->isSupporter())
                                 <span class="usercard__supporter">
                                     <span class="fa fa-fw fa-heart"></span>


### PR DESCRIPTION
Currently there is _at least_ one [user](https://osu.ppy.sh/users/7705650) which flag acronym country supposedly is an empty string. This causes an exception in the friends page because in _usercard.blade.php was not handled the case of user->country being null.

