### PR TITLE
Condense difficulty icons when needed in the listing page

### DIFF
--- a/resources/assets/coffee/react/_components/beatmapset-panel.coffee
+++ b/resources/assets/coffee/react/_components/beatmapset-panel.coffee
@@ -52,23 +52,25 @@ class @BeatmapsetPanel extends React.PureComponent
 
     condenseDifficulties = beatmapset.beatmaps.length > maxDisplayedDifficulty
 
+    beatmapIcon = (beatmap, showTitle) ->
+      div
+        className: "#{'beatmapset-panel__difficulty-icon' if !condenseDifficulties}"
+        key: beatmap.id
+        el BeatmapIcon, beatmap: beatmap, showTitle: showTitle
+
     difficulties =
       for own mode, beatmaps of BeatmapHelper.group beatmapset.beatmaps
         if condenseDifficulties
           [..., hardestDiff] = beatmaps
-          span
-            key: mode
-            style: 
-              display: "flex"
-              alignItems: "center"
-            el BeatmapIcon, beatmap: hardestDiff, showTitle: false
-            span className: 'beatmapset-panel__difficulty-count', beatmaps.length
+          [
+            beatmapIcon hardestDiff, false
+            span
+              className: 'beatmapset-panel__difficulty-count'
+              key: "#{(hardestDiff.id)}-count", beatmaps.length
+          ]
         else
           for b in beatmaps
-            div
-              className: 'beatmapset-panel__difficulty-icon'
-              key: b.id
-              el BeatmapIcon, beatmap: b
+            beatmapIcon b, true
 
     div
       className: "beatmapset-panel #{'beatmapset-panel--previewing' if @state.preview != 'ended'}"

--- a/resources/assets/coffee/react/_components/beatmapset-panel.coffee
+++ b/resources/assets/coffee/react/_components/beatmapset-panel.coffee
@@ -52,25 +52,21 @@ class @BeatmapsetPanel extends React.PureComponent
 
     condenseDifficulties = beatmapset.beatmaps.length > maxDisplayedDifficulty
 
-    beatmapIcon = (beatmap, showTitle) ->
-      div
-        className: "#{'beatmapset-panel__difficulty-icon' if !condenseDifficulties}"
-        key: beatmap.id
-        el BeatmapIcon, beatmap: beatmap, showTitle: showTitle
-
     difficulties =
       for own mode, beatmaps of BeatmapHelper.group beatmapset.beatmaps
         if condenseDifficulties
-          [..., hardestDiff] = beatmaps
           [
-            beatmapIcon hardestDiff, false
+            el BeatmapIcon, key: "#{mode}-icon", beatmap: _.last(beatmaps), showTitle: false
             span
               className: 'beatmapset-panel__difficulty-count'
-              key: "#{(hardestDiff.id)}-count", beatmaps.length
+              key: "#{(mode)}-count", beatmaps.length
           ]
         else
           for b in beatmaps
-            beatmapIcon b, true
+            div
+              className: 'beatmapset-panel__difficulty-icon'
+              key: b.id
+              el BeatmapIcon, beatmap: b
 
     div
       className: "beatmapset-panel #{'beatmapset-panel--previewing' if @state.preview != 'ended'}"

--- a/resources/assets/coffee/react/_components/beatmapset-panel.coffee
+++ b/resources/assets/coffee/react/_components/beatmapset-panel.coffee
@@ -52,25 +52,23 @@ class @BeatmapsetPanel extends React.PureComponent
 
     condenseDifficulties = beatmapset.beatmaps.length > maxDisplayedDifficulty
 
-    beatmapIcon = (beatmap) ->
-      div
-        className: "#{'beatmapset-panel__difficulty-icon' if !condenseDifficulties}"
-        key: beatmap.id
-        el BeatmapIcon, beatmap: beatmap
-
     difficulties =
-      for own _mode, beatmaps of BeatmapHelper.group beatmapset.beatmaps
+      for own mode, beatmaps of BeatmapHelper.group beatmapset.beatmaps
         if condenseDifficulties
           [..., hardestDiff] = beatmaps
-          [ 
-            beatmapIcon hardestDiff
-            span 
-              className: 'beatmapset-panel__difficulty-count'
-              key: "#{(hardestDiff.id)}-count", "#{(beatmaps.length)}"
-          ]
+          span
+            key: mode
+            style: 
+              display: "flex"
+              alignItems: "center"
+            el BeatmapIcon, beatmap: hardestDiff, showTitle: false
+            span className: 'beatmapset-panel__difficulty-count', beatmaps.length
         else
           for b in beatmaps
-            beatmapIcon b         
+            div
+              className: 'beatmapset-panel__difficulty-icon'
+              key: b.id
+              el BeatmapIcon, beatmap: b
 
     div
       className: "beatmapset-panel #{'beatmapset-panel--previewing' if @state.preview != 'ended'}"

--- a/resources/assets/coffee/react/_components/beatmapset-panel.coffee
+++ b/resources/assets/coffee/react/_components/beatmapset-panel.coffee
@@ -50,16 +50,27 @@ class @BeatmapsetPanel extends React.PureComponent
     # arbitrary number
     maxDisplayedDifficulty = 10
 
-    difficulties =
-      for own _mode, beatmaps of BeatmapHelper.group beatmapset.beatmaps[..maxDisplayedDifficulty - 1]
-        for b in beatmaps
-          div
-            className: 'beatmapset-panel__difficulty-icon'
-            key: b.id
-            el BeatmapIcon, beatmap: b
+    condenseDifficulties = beatmapset.beatmaps.length > maxDisplayedDifficulty
 
-    if beatmapset.beatmaps.length > maxDisplayedDifficulty
-      difficulties.push span key: 'over', "+#{(beatmapset.beatmaps.length - maxDisplayedDifficulty)}"
+    beatmapIcon = (beatmap) ->
+      div
+        className: "#{'beatmapset-panel__difficulty-icon' if !condenseDifficulties}"
+        key: beatmap.id
+        el BeatmapIcon, beatmap: beatmap
+
+    difficulties =
+      for own _mode, beatmaps of BeatmapHelper.group beatmapset.beatmaps
+        if condenseDifficulties
+          [..., hardestDiff] = beatmaps
+          [ 
+            beatmapIcon hardestDiff
+            span 
+              className: 'beatmapset-panel__difficulty-count'
+              key: "#{(hardestDiff.id)}-count", "#{(beatmaps.length)}"
+          ]
+        else
+          for b in beatmaps
+            beatmapIcon b         
 
     div
       className: "beatmapset-panel #{'beatmapset-panel--previewing' if @state.preview != 'ended'}"

--- a/resources/assets/less/bem/beatmapset-panel.less
+++ b/resources/assets/less/bem/beatmapset-panel.less
@@ -58,8 +58,8 @@
   }
 
   &__difficulty-count {
-    margin-right: 8px;
-    margin-left: 2px;
+    margin-right: 10px;
+    margin-left: 3px;
     font-weight: bold;
   }
 

--- a/resources/assets/less/bem/beatmapset-panel.less
+++ b/resources/assets/less/bem/beatmapset-panel.less
@@ -57,6 +57,12 @@
     margin-right: 5px;
   }
 
+  &__difficulty-count {
+    margin-right: 8px;
+    margin-left: 2px;
+    font-weight: bold;
+  }
+
   &__header {
     .default-text-shadow();
     border-radius: @border-radius-base @border-radius-base 0 0;


### PR DESCRIPTION
If there are more than 10 diffs in the beatmap listing, condense them showing for each mode the icon of the hardest diff and the number of diffs of that mode.