### PR TITLE
Set CI to install yarn 0.27.5

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,6 @@ cache:
     - $HOME/.yarn-cache
 
 sudo: true
-dist: precise
 
 language: php
 
@@ -19,11 +18,13 @@ env:
   global:
     - DB_USERNAME=root
     - SLACK_ENDPOINT=http://myconan.net/null/
+    - PATH=$HOME/.yarn/bin:$PATH
 
 before_install:
   - sudo ./bin/mysql_debian_install
   - nvm install 6.11
   - nvm use 6.11
+  - curl -o- -L https://yarnpkg.com/install.sh | bash
   - ./bin/db_setup.sh
   - ./build.sh
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,7 +24,7 @@ before_install:
   - sudo ./bin/mysql_debian_install
   - nvm install 6.11
   - nvm use 6.11
-  - curl -o- -L https://yarnpkg.com/install.sh | bash
+  - curl -o- -L https://yarnpkg.com/install.sh | bash -s -- --version 0.27.5
   - ./bin/db_setup.sh
   - ./build.sh
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,7 @@ cache:
     - $HOME/.yarn-cache
 
 sudo: true
+dist: precise
 
 language: php
 


### PR DESCRIPTION
Travis is rolling out `Trusty` as the default environment: https://blog.travis-ci.com/2017-07-11-trusty-as-default-linux-is-coming

Except the base image comes with a much older version of yarn which breaks our CI build
https://github.com/travis-ci/travis-ci/issues/7951

Alternatively, we could install yarn on every build 🤷‍♂️ 