### PR TITLE
Fix beatmap discussion status

### DIFF
--- a/app/Models/BeatmapDiscussionPost.php
+++ b/app/Models/BeatmapDiscussionPost.php
@@ -112,9 +112,12 @@ class BeatmapDiscussionPost extends Model
             return trans('model_validation.beatmap_discussion_post.first_post');
         }
 
+        $time = Carbon::now();
+
         $this->update([
             'deleted_by_id' => $deletedBy->user_id ?? null,
-            'deleted_at' => Carbon::now(),
+            'deleted_at' => $time,
+            'updated_at' => $time,
         ]);
     }
 

--- a/resources/assets/coffee/react/beatmap-discussions/post.coffee
+++ b/resources/assets/coffee/react/beatmap-discussions/post.coffee
@@ -163,16 +163,6 @@ class BeatmapDiscussions.Post extends React.PureComponent
           dangerouslySetInnerHTML:
             __html: osu.timeago(@props.post.created_at)
 
-        if @props.post.updated_at != @props.post.created_at
-          span
-            className: "#{bn}__info #{bn}__info--edited"
-            dangerouslySetInnerHTML:
-              __html: osu.trans 'beatmaps.discussions.edited',
-                editor: osu.link laroute.route('users.show', user: @props.lastEditor.id),
-                  @props.lastEditor.username
-                  classNames: ["#{bn}__info-user"]
-                update_time: osu.timeago @props.post.updated_at
-
         if deleteModel.deleted_at?
           span
             className: "#{bn}__info #{bn}__info--edited"
@@ -182,6 +172,16 @@ class BeatmapDiscussions.Post extends React.PureComponent
                   @props.users[deleteModel.deleted_by_id].username
                   classNames: ["#{bn}__info-user"]
                 delete_time: osu.timeago @props.post.deleted_at
+
+        if @props.post.updated_at != @props.post.created_at && @props.post.updated_at != @props.post.deleted_at
+          span
+            className: "#{bn}__info #{bn}__info--edited"
+            dangerouslySetInnerHTML:
+              __html: osu.trans 'beatmaps.discussions.edited',
+                editor: osu.link laroute.route('users.show', user: @props.lastEditor.id),
+                  @props.lastEditor.username
+                  classNames: ["#{bn}__info-user"]
+                update_time: osu.timeago @props.post.updated_at
 
       div
         className: "#{bn}__actions"


### PR DESCRIPTION
Only show either deleted or edited but not both. Currently, deleting updates updated_at which causes edited status to show up as well.