### PR TITLE
Properly escape string for use with like search

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -174,8 +174,8 @@ class User extends Model implements AuthenticatableContract, Messageable
         $params['limit'] = clamp(get_int($rawParams['limit'] ?? null) ?? static::SEARCH_DEFAULTS['limit'], 1, 50);
         $params['page'] = max(1, get_int($rawParams['page'] ?? 1));
 
-        $query = static::where('username', 'LIKE', "{$params['query']}%")
-            ->where('username', 'NOT LIKE', '%_old')
+        $query = static::where('username', 'LIKE', mysql_escape_like($params['query']).'%')
+            ->where('username', 'NOT LIKE', '%\_old')
             ->default();
 
         return [

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -135,6 +135,11 @@ function locale_for_timeago($locale)
     return $locale;
 }
 
+function mysql_escape_like($string)
+{
+    return addcslashes($string, '%_\\');
+}
+
 function osu_url($key)
 {
     $url = config("osu.urls.{$key}");


### PR DESCRIPTION
Thankfully only two characters need to be escaped.