### PR TITLE
Replace direct calls to Lang.get with osu.trans

### DIFF
--- a/resources/assets/coffee/_classes/form-confirmation.coffee
+++ b/resources/assets/coffee/_classes/form-confirmation.coffee
@@ -56,4 +56,4 @@ class @FormConfirmation
     if inputMain == inputConfirmation
       return @formError.setOneError fields.confirmation, []
 
-    @formError.setOneError fields.confirmation, [Lang.get('model_validation.wrong_confirmation')]
+    @formError.setOneError fields.confirmation, [osu.trans 'model_validation.wrong_confirmation']

--- a/resources/assets/coffee/_classes/landing-hero.coffee
+++ b/resources/assets/coffee/_classes/landing-hero.coffee
@@ -30,5 +30,5 @@ class @LandingHero
 
     os = osu.getOS()
     others = osu.otherOS os
-    @el.platformCurrent[0].innerText = Lang.get('home.landing.download.for', os: os)
-    @el.platformOther[0].innerText = Lang.get('home.landing.download.other', os1: others[0], os2: others[1])
+    @el.platformCurrent[0].innerText = osu.trans 'home.landing.download.for', os: os
+    @el.platformOther[0].innerText = osu.trans 'home.landing.download.other', os1: others[0], os2: others[1]

--- a/resources/assets/coffee/_classes/landing-user-stats.coffee
+++ b/resources/assets/coffee/_classes/landing-user-stats.coffee
@@ -88,7 +88,7 @@ class @LandingUserStats
     @scaleY.domain [0, d3.max(@data, (d) -> d.y)]
 
     @svgPeakText
-      .text Lang.get('home.landing.peak', count: @maxElem.y.toLocaleString())
+      .text osu.trans('home.landing.peak', count: @maxElem.y.toLocaleString())
     @peakTextLength = @svgPeakText.node().getComputedTextLength()
 
 

--- a/resources/assets/coffee/_classes/store-supporter-tag.coffee
+++ b/resources/assets/coffee/_classes/store-supporter-tag.coffee
@@ -114,13 +114,13 @@ class @StoreSupporterTag
 
   updateSearchResult: =>
     if @searching
-      @inputFeedback.textContent = Lang.get('supporter_tag.user_search.searching')
+      @inputFeedback.textContent = osu.trans('supporter_tag.user_search.searching')
       return @setUserInteraction(false)
 
     [avatarUrl, text] = if @user
                           [@user.avatarUrl, '']
                         else
-                          ['', Lang.get("supporter_tag.user_search.not_found")]
+                          ['', osu.trans("supporter_tag.user_search.not_found")]
 
     @inputFeedback.textContent = text
     # Avoid setting value to undefined

--- a/resources/assets/coffee/_classes/user-verification.coffee
+++ b/resources/assets/coffee/_classes/user-verification.coffee
@@ -77,7 +77,7 @@ class @UserVerification
 
   prepareForRequest: (type) =>
     @request?.abort()
-    @setMessage Lang.get("user_verification.box.#{type}"), true
+    @setMessage osu.trans("user_verification.box.#{type}"), true
 
 
   reissue: (e) =>

--- a/resources/assets/coffee/react/mp-history/content.coffee
+++ b/resources/assets/coffee/react/mp-history/content.coffee
@@ -43,7 +43,7 @@ class MPHistory.Content extends React.Component
   render: ->
     if _.isEmpty @props.events
       div className: 'osu-layout__row osu-layout__row--page-mp-history',
-        Lang.get 'multiplayer.match.loading-events'
+        osu.trans 'multiplayer.match.loading-events'
     else
       div className: 'osu-layout__row osu-layout__row--page-mp-history js-mp-history--event-box',
         if !@props.full && @props.allEventsCount > 500
@@ -51,7 +51,7 @@ class MPHistory.Content extends React.Component
             a
               className: 'mp-history-content__show-more'
               href: laroute.route('matches.show', match: @props.id, full: true)
-              Lang.get 'multiplayer.match.more-events'
+              osu.trans 'multiplayer.match.more-events'
 
         div className: 'mp-history-events',
           for event, i in @props.events

--- a/resources/assets/coffee/react/mp-history/game-header.coffee
+++ b/resources/assets/coffee/react/mp-history/game-header.coffee
@@ -34,7 +34,7 @@ class MPHistory.GameHeader extends React.Component
     if @props.game.end_time
       timeString += "- #{timeEnd}"
     else
-      timeString += Lang.get 'multiplayer.match.in-progress'
+      timeString += osu.trans 'multiplayer.match.in-progress'
 
     a
       className: 'mp-history-game__header'
@@ -47,8 +47,8 @@ class MPHistory.GameHeader extends React.Component
 
       div className: 'mp-history-game__stats-box',
         span className: 'mp-history-game__stat', timeString
-        span className: 'mp-history-game__stat', Lang.get "beatmaps.mode.#{@props.game.mode}"
-        span className: 'mp-history-game__stat', Lang.get "multiplayer.game.scoring-type.#{@props.game.scoring_type}"
+        span className: 'mp-history-game__stat', osu.trans "beatmaps.mode.#{@props.game.mode}"
+        span className: 'mp-history-game__stat', osu.trans "multiplayer.game.scoring-type.#{@props.game.scoring_type}"
 
       div className: 'mp-history-game__metadata-box',
         h1 className: 'mp-history-game__metadata mp-history-game__metadata--title',
@@ -62,6 +62,6 @@ class MPHistory.GameHeader extends React.Component
 
       div
         className: 'mp-history-game__team-type'
-        title: Lang.get "multiplayer.match.team-types.#{@props.game.team_type}"
+        title: osu.trans "multiplayer.match.team-types.#{@props.game.team_type}"
         style:
           backgroundImage: "url(/images/badges/team-types/#{@props.game.team_type}.svg)"

--- a/resources/assets/coffee/react/mp-history/game.coffee
+++ b/resources/assets/coffee/react/mp-history/game.coffee
@@ -56,12 +56,12 @@ class MPHistory.Game extends React.Component
           div className: 'mp-history-game__team-scores',
             ['blue', 'red'].map (m) =>
               div className: "mp-history-game__team-score mp-history-game__team-score--#{m}", key: m,
-                span className: 'mp-history-game__team-score-text mp-history-game__team-score-text--name', Lang.get "multiplayer.match.teams.#{m}"
+                span className: 'mp-history-game__team-score-text mp-history-game__team-score-text--name', osu.trans "multiplayer.match.teams.#{m}"
                 span className: 'mp-history-game__team-score-text mp-history-game__team-score-text--score', @props.teamScores[m].toLocaleString()
 
           div className: 'mp-history-game__results',
-            span className: 'mp-history-game__results-text', Lang.get 'multiplayer.match.winner', team: Lang.get "multiplayer.match.teams.#{winningTeam}"
-            span className: 'mp-history-game__results-text mp-history-game__results-text--score', Lang.get 'multiplayer.match.difference', difference: difference.toLocaleString()
+            span className: 'mp-history-game__results-text', osu.trans 'multiplayer.match.winner', team: osu.trans "multiplayer.match.teams.#{winningTeam}"
+            span className: 'mp-history-game__results-text mp-history-game__results-text--score', osu.trans 'multiplayer.match.difference', difference: difference.toLocaleString()
 
   deletedBeatmap:
     id: null

--- a/resources/assets/coffee/react/mp-history/header.coffee
+++ b/resources/assets/coffee/react/mp-history/header.coffee
@@ -23,6 +23,6 @@ MPHistory.Header = (props) ->
     div className: 'osu-page-header osu-page-header--mp-history',
       div className: 'osu-page-header__title-box',
         h2 className: 'osu-page-header__title osu-page-header__title--small',
-          Lang.get 'multiplayer.match.header'
+          osu.trans 'multiplayer.match.header'
         h1 className: 'osu-page-header__title',
           props.name

--- a/resources/assets/coffee/react/mp-history/score.coffee
+++ b/resources/assets/coffee/react/mp-history/score.coffee
@@ -41,7 +41,7 @@ class MPHistory.Score extends React.Component
               user.username
 
             if !@props.score.multiplayer.pass
-              span className: 'mp-history-player-score__failed', Lang.get 'multiplayer.match.failed'
+              span className: 'mp-history-player-score__failed', osu.trans 'multiplayer.match.failed'
 
           el FlagCountry, country: user.country
 
@@ -65,7 +65,7 @@ class MPHistory.Score extends React.Component
                   @props.score.score.toLocaleString()
 
               div className: "mp-history-player-score__stat mp-history-player-score__stat--#{m}", key: m,
-                span className: 'mp-history-player-score__stat-label mp-history-player-score__stat-label--small', Lang.get "multiplayer.match.score.stats.#{m}"
+                span className: 'mp-history-player-score__stat-label mp-history-player-score__stat-label--small', osu.trans "multiplayer.match.score.stats.#{m}"
                 span className: "mp-history-player-score__stat-number mp-history-player-score__stat-number--#{modifier}", value
 
           div className: 'mp-history-player-score__stat-row',


### PR DESCRIPTION
This was causing some issues with locales that aren't fully translated. Some examples currently are multiplayer matches in Polish, and the supporter store page in Italian