### PR TITLE
Misc discussion fixes

### DIFF
--- a/app/Http/Controllers/BeatmapDiscussionPostsController.php
+++ b/app/Http/Controllers/BeatmapDiscussionPostsController.php
@@ -166,10 +166,11 @@ class BeatmapDiscussionPostsController extends Controller
     private function postParams($isNew = true)
     {
         $params = get_params(Request::all(), 'beatmap_discussion_post', ['message']);
-        $params['last_editor_id'] = Auth::user()->user_id;
 
         if ($isNew) {
             $params['user_id'] = Auth::user()->user_id;
+        } else {
+            $params['last_editor_id'] = Auth::user()->user_id;
         }
 
         return $params;

--- a/app/Transformers/BeatmapDiscussionPostTransformer.php
+++ b/app/Transformers/BeatmapDiscussionPostTransformer.php
@@ -35,7 +35,7 @@ class BeatmapDiscussionPostTransformer extends Fractal\TransformerAbstract
             'id' => $post->id,
             'beatmap_discussion_id' => $post->beatmap_discussion_id,
             'user_id' => $post->user_id,
-            'last_editor_id' => presence($post->last_editor_id, $post->user_id),
+            'last_editor_id' => $post->last_editor_id,
             'deleted_by_id' => $post->deleted_by_id,
 
             'system' => $post->system,

--- a/resources/assets/coffee/react/beatmap-discussions/post.coffee
+++ b/resources/assets/coffee/react/beatmap-discussions/post.coffee
@@ -125,7 +125,9 @@ class BeatmapDiscussions.Post extends React.PureComponent
 
 
   updatePost: =>
-    return if @state.message == @props.post.message
+    if @state.message == @props.post.message
+      @setState editing: false
+      return
 
     LoadingOverlay.show()
 

--- a/resources/assets/coffee/react/beatmap-discussions/post.coffee
+++ b/resources/assets/coffee/react/beatmap-discussions/post.coffee
@@ -187,7 +187,7 @@ class BeatmapDiscussions.Post extends React.PureComponent
                   classNames: ["#{bn}__info-user"]
                 delete_time: osu.timeago @props.post.deleted_at
 
-        if @props.post.updated_at != @props.post.created_at && @props.post.updated_at != @props.post.deleted_at
+        if @props.post.updated_at != @props.post.created_at && @props.post.updated_at != @props.post.deleted_at && @props.lastEditor?.id
           span
             className: "#{bn}__info #{bn}__info--edited"
             dangerouslySetInnerHTML:


### PR DESCRIPTION
Two little things:
- Fixes 'Last edited by <original poster>' always being shown after a deleted post is restored (even if it hadn't been edited)
- Hide the edit post interface when hitting 'save' with no changes (instead of just doing nothing)

