### PR TITLE
Correct event id

### DIFF
--- a/app/Transformers/EventTransformer.php
+++ b/app/Transformers/EventTransformer.php
@@ -30,7 +30,7 @@ class EventTransformer extends Fractal\TransformerAbstract
         $event->parse();
 
         return array_merge([
-            'id' => $event->id,
+            'id' => $event->getKey(),
             'createdAt' => json_time($event->date),
             'type' => $event->type,
         ], $event->details);


### PR DESCRIPTION
Should be `event_id` (or just `getKey()`). I thought I reverted this erroneous change but turned out I didn't.