### PR TITLE
User profile optimisation (stage 1)

### DIFF
--- a/app/Http/Controllers/FriendsController.php
+++ b/app/Http/Controllers/FriendsController.php
@@ -20,6 +20,7 @@
 
 namespace App\Http\Controllers;
 
+use App\Jobs\UpdateUserFollowerCountCache;
 use App\Models\User;
 use App\Models\UserRelation;
 use Auth;
@@ -80,6 +81,8 @@ class FriendsController extends Controller
                 'zebra_id' => $target_id,
                 'friend' => 1,
             ]);
+
+            dispatch(new UpdateUserFollowerCountCache($target_id));
         }
 
         return json_collection(
@@ -100,6 +103,8 @@ class FriendsController extends Controller
             'zebra_id' => $id,
             'friend' => 1,
         ])->delete();
+
+        dispatch(new UpdateUserFollowerCountCache($id));
 
         return json_collection(
             Auth::user()->relations()->friends()->withMutual()->get(),

--- a/app/Jobs/RegenerateBeatmapsetCover.php
+++ b/app/Jobs/RegenerateBeatmapsetCover.php
@@ -1,5 +1,23 @@
 <?php
 
+/**
+ *    Copyright 2015-2017 ppy Pty. Ltd.
+ *
+ *    This file is part of osu!web. osu!web is distributed with the hope of
+ *    attracting more community contributions to the core ecosystem of osu!.
+ *
+ *    osu!web is free software: you can redistribute it and/or modify
+ *    it under the terms of the Affero GNU General Public License version 3
+ *    as published by the Free Software Foundation.
+ *
+ *    osu!web is distributed WITHOUT ANY WARRANTY; without even the implied
+ *    warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *    See the GNU Affero General Public License for more details.
+ *
+ *    You should have received a copy of the GNU Affero General Public License
+ *    along with osu!web.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 namespace App\Jobs;
 
 use App\Exceptions\SilencedException;

--- a/app/Jobs/UpdateUserFollowerCountCache.php
+++ b/app/Jobs/UpdateUserFollowerCountCache.php
@@ -21,8 +21,6 @@
 namespace App\Jobs;
 
 use App\Models\User;
-use Cache;
-use Carbon\Carbon;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Queue\InteractsWithQueue;
@@ -49,13 +47,6 @@ class UpdateUserFollowerCountCache implements ShouldQueue
      */
     public function handle()
     {
-        $key = User::CACHING['follower_count']['key'];
-        $duration = User::CACHING['follower_count']['duration'];
-
-        Cache::put(
-            "{$key}:{$this->user_id}",
-            User::find($this->user_id)->uncachedFollowerCount(),
-            Carbon::now()->addHours($duration)
-        );
+        User::find($this->user_id)->cacheFollowerCount();
     }
 }

--- a/app/Jobs/UpdateUserFollowerCountCache.php
+++ b/app/Jobs/UpdateUserFollowerCountCache.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace App\Jobs;
+
+use App\Models\UserRelation;
+use Cache;
+use Carbon\Carbon;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Queue\SerializesModels;
+
+class UpdateUserFollowerCountCache implements ShouldQueue
+{
+    use InteractsWithQueue, Queueable, SerializesModels;
+    protected $user_id;
+
+    /**
+     * Create a new job instance.
+     *
+     * @return void
+     */
+    public function __construct($user_id)
+    {
+        $this->user_id = $user_id;
+    }
+
+    /**
+     * Execute the job.
+     *
+     * @return void
+     */
+    public function handle()
+    {
+        $count = UserRelation::where('zebra_id', $this->user_id)->where('friend', 1)->count();
+        Cache::put("friendCount:{$this->user_id}", $count, Carbon::now()->addDay(1));
+    }
+}

--- a/app/Jobs/UpdateUserFollowerCountCache.php
+++ b/app/Jobs/UpdateUserFollowerCountCache.php
@@ -18,20 +18,18 @@
  *    along with osu!web.  If not, see <http://www.gnu.org/licenses/>.
  */
 
- namespace App\Jobs;
+namespace App\Jobs;
 
 use App\Models\User;
-use App\Models\UserRelation;
 use Cache;
 use Carbon\Carbon;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Queue\InteractsWithQueue;
-use Illuminate\Queue\SerializesModels;
 
 class UpdateUserFollowerCountCache implements ShouldQueue
 {
-    use InteractsWithQueue, Queueable, SerializesModels;
+    use InteractsWithQueue, Queueable;
     protected $user_id;
 
     /**
@@ -51,7 +49,13 @@ class UpdateUserFollowerCountCache implements ShouldQueue
      */
     public function handle()
     {
-        $count = UserRelation::where('zebra_id', $this->user_id)->where('friend', 1)->count();
-        Cache::put(User::CACHE_KEYS['follower_count'].":{$this->user_id}", $count, Carbon::now()->addDay(1));
+        $key = User::CACHING['follower_count']['key'];
+        $duration = User::CACHING['follower_count']['duration'];
+
+        Cache::put(
+            "{$key}:{$this->user_id}",
+            User::find($this->user_id)->uncachedFollowerCount(),
+            Carbon::now()->addDay($duration)
+        );
     }
 }

--- a/app/Jobs/UpdateUserFollowerCountCache.php
+++ b/app/Jobs/UpdateUserFollowerCountCache.php
@@ -28,16 +28,16 @@ use Illuminate\Queue\InteractsWithQueue;
 class UpdateUserFollowerCountCache implements ShouldQueue
 {
     use InteractsWithQueue, Queueable;
-    protected $user_id;
+    protected $userId;
 
     /**
      * Create a new job instance.
      *
      * @return void
      */
-    public function __construct($user_id)
+    public function __construct($userId)
     {
-        $this->user_id = $user_id;
+        $this->userId = $userId;
     }
 
     /**
@@ -47,6 +47,6 @@ class UpdateUserFollowerCountCache implements ShouldQueue
      */
     public function handle()
     {
-        User::find($this->user_id)->cacheFollowerCount();
+        User::find($this->userId)->cacheFollowerCount();
     }
 }

--- a/app/Jobs/UpdateUserFollowerCountCache.php
+++ b/app/Jobs/UpdateUserFollowerCountCache.php
@@ -2,6 +2,7 @@
 
 namespace App\Jobs;
 
+use App\Models\User;
 use App\Models\UserRelation;
 use Cache;
 use Carbon\Carbon;
@@ -33,6 +34,6 @@ class UpdateUserFollowerCountCache implements ShouldQueue
     public function handle()
     {
         $count = UserRelation::where('zebra_id', $this->user_id)->where('friend', 1)->count();
-        Cache::put("friendCount:{$this->user_id}", $count, Carbon::now()->addDay(1));
+        Cache::put(User::CACHE_KEYS['follower_count'].":{$this->user_id}", $count, Carbon::now()->addDay(1));
     }
 }

--- a/app/Jobs/UpdateUserFollowerCountCache.php
+++ b/app/Jobs/UpdateUserFollowerCountCache.php
@@ -55,7 +55,7 @@ class UpdateUserFollowerCountCache implements ShouldQueue
         Cache::put(
             "{$key}:{$this->user_id}",
             User::find($this->user_id)->uncachedFollowerCount(),
-            Carbon::now()->addDay($duration)
+            Carbon::now()->addHours($duration)
         );
     }
 }

--- a/app/Jobs/UpdateUserFollowerCountCache.php
+++ b/app/Jobs/UpdateUserFollowerCountCache.php
@@ -1,6 +1,24 @@
 <?php
 
-namespace App\Jobs;
+/**
+ *    Copyright 2015-2017 ppy Pty. Ltd.
+ *
+ *    This file is part of osu!web. osu!web is distributed with the hope of
+ *    attracting more community contributions to the core ecosystem of osu!.
+ *
+ *    osu!web is free software: you can redistribute it and/or modify
+ *    it under the terms of the Affero GNU General Public License version 3
+ *    as published by the Free Software Foundation.
+ *
+ *    osu!web is distributed WITHOUT ANY WARRANTY; without even the implied
+ *    warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *    See the GNU Affero General Public License for more details.
+ *
+ *    You should have received a copy of the GNU Affero General Public License
+ *    along with osu!web.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+ namespace App\Jobs;
 
 use App\Models\User;
 use App\Models\UserRelation;

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -69,7 +69,7 @@ class User extends Model implements AuthenticatableContract, Messageable
     const CACHING = [
         'follower_count' => [
             'key' => 'followerCount',
-            'duration' => 12,
+            'duration' => 720, // 12 hours
         ],
     ];
 
@@ -817,13 +817,12 @@ class User extends Model implements AuthenticatableContract, Messageable
 
     public function cacheFollowerCount()
     {
-        $count = User::find($this->user_id)->uncachedFollowerCount();
-        $duration = self::CACHING['follower_count']['duration'];
+        $count = $this->uncachedFollowerCount();
 
         Cache::put(
-            self::CACHING['follower_count']['key'].":{$this->user_id}",
+            self::CACHING['follower_count']['key'].':'.$this->user_id,
             $count,
-            Carbon::now()->addHours($duration)
+            self::CACHING['follower_count']['duration']
         );
 
         return $count;
@@ -831,7 +830,7 @@ class User extends Model implements AuthenticatableContract, Messageable
 
     public function followerCount()
     {
-        return Cache::get(self::CACHING['follower_count']['key'].":{$this->user_id}") ?? $this->cacheFollowerCount();
+        return Cache::get(self::CACHING['follower_count']['key'].':'.$this->user_id) ?? $this->cacheFollowerCount();
     }
 
     public function foes()

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -806,6 +806,7 @@ class User extends Model implements AuthenticatableContract, Messageable
     public function cachedFollowerCount()
     {
         $user_id = $this->user_id;
+
         return Cache::remember("friendCount:{$this->user_id}", Carbon::now()->addDay(1), function () use ($user_id) {
             return UserRelation::where('zebra_id', $user_id)->where('friend', 1)->count();
         });

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -66,6 +66,10 @@ class User extends Model implements AuthenticatableContract, Messageable
         'page' => 1,
     ];
 
+    const CACHE_KEYS = [
+        'follower_count' => 'followerCount',
+    ];
+
     public $flags;
     private $groupIds;
     private $supportLength;
@@ -807,7 +811,7 @@ class User extends Model implements AuthenticatableContract, Messageable
     {
         $user_id = $this->user_id;
 
-        return Cache::remember("friendCount:{$this->user_id}", Carbon::now()->addDay(1), function () use ($user_id) {
+        return Cache::remember(self::CACHE_KEYS['follower_count'].":{$this->user_id}", Carbon::now()->addDay(1), function () use ($user_id) {
             return UserRelation::where('zebra_id', $user_id)->where('friend', 1)->count();
         });
     }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -24,6 +24,7 @@ use App\Interfaces\Messageable;
 use App\Libraries\BBCodeForDB;
 use App\Models\Chat\PrivateMessage;
 use App\Traits\UserAvatar;
+use Cache;
 use Carbon\Carbon;
 use DB;
 use Exception;
@@ -800,6 +801,14 @@ class User extends Model implements AuthenticatableContract, Messageable
         // 'cuz hasManyThrough is derp
 
         return self::whereIn('user_id', $this->relations()->friends()->pluck('zebra_id'));
+    }
+
+    public function cachedFollowerCount()
+    {
+        $user_id = $this->user_id;
+        return Cache::remember("friendCount:{$this->user_id}", Carbon::now()->addDay(1), function () use ($user_id) {
+            return UserRelation::where('zebra_id', $user_id)->where('friend', 1)->count();
+        });
     }
 
     public function foes()

--- a/app/Transformers/BeatmapCompactTransformer.php
+++ b/app/Transformers/BeatmapCompactTransformer.php
@@ -33,6 +33,8 @@ class BeatmapCompactTransformer extends Fractal\TransformerAbstract
     {
         return [
             'id' => $beatmap->beatmap_id,
+            'mode' => $beatmap->mode,
+            'difficulty_rating' => $beatmap->difficultyrating,
             'version' => $beatmap->version,
         ];
     }

--- a/app/Transformers/BeatmapPlaycountTransformer.php
+++ b/app/Transformers/BeatmapPlaycountTransformer.php
@@ -38,6 +38,7 @@ class BeatmapPlaycountTransformer extends Fractal\TransformerAbstract
     public function transform(BeatmapPlaycount $playcount)
     {
         return [
+            'beatmap_id' => $playcount->beatmap_id,
             'count' => $playcount->playcount,
         ];
     }
@@ -50,7 +51,7 @@ class BeatmapPlaycountTransformer extends Fractal\TransformerAbstract
 
         return $this->item(
             $playcount->beatmap,
-            new BeatmapTransformer()
+            new BeatmapCompactTransformer()
         );
     }
 
@@ -62,7 +63,7 @@ class BeatmapPlaycountTransformer extends Fractal\TransformerAbstract
 
         return $this->item(
             $playcount->beatmap->beatmapset,
-            new BeatmapsetTransformer()
+            new BeatmapsetCompactTransformer()
         );
     }
 }

--- a/app/Transformers/BeatmapsetCompactTransformer.php
+++ b/app/Transformers/BeatmapsetCompactTransformer.php
@@ -25,13 +25,27 @@ use League\Fractal;
 
 class BeatmapsetCompactTransformer extends Fractal\TransformerAbstract
 {
+    protected $availableIncludes = [
+        'beatmaps',
+    ];
+
     public function transform(Beatmapset $beatmapset)
     {
         return [
             'id' => $beatmapset->beatmapset_id,
             'title' => $beatmapset->title,
             'artist' => $beatmapset->artist,
+            'creator' => $beatmapset->creator,
+            'user_id' => $beatmapset->user_id,
             'covers' => $beatmapset->allCoverURLs(),
         ];
+    }
+
+    public function includeBeatmaps(Beatmapset $beatmapset)
+    {
+        return $this->collection(
+            $beatmapset->beatmaps,
+            new BeatmapCompactTransformer()
+        );
     }
 }

--- a/app/Transformers/ScoreTransformer.php
+++ b/app/Transformers/ScoreTransformer.php
@@ -75,7 +75,7 @@ class ScoreTransformer extends Fractal\TransformerAbstract
 
     public function includeBeatmapset($score)
     {
-        return $this->item($score->beatmapset, new BeatmapsetTransformer);
+        return $this->item($score->beatmapset, new BeatmapsetCompactTransformer);
     }
 
     public function includeWeight($score)

--- a/app/Transformers/UserTransformer.php
+++ b/app/Transformers/UserTransformer.php
@@ -147,7 +147,7 @@ class UserTransformer extends Fractal\TransformerAbstract
                 $scores = $user
                     ->scoresFirst($mode, true)
                     ->default()
-                    ->userBest(100, ['beatmapset', 'beatmap']);
+                    ->userBest(50, ['beatmapset', 'beatmap']);
 
                 $all[$mode] = json_collection($scores, new ScoreTransformer(), 'beatmap,beatmapset');
             }
@@ -165,7 +165,7 @@ class UserTransformer extends Fractal\TransformerAbstract
                     ->scoresBest($mode, true)
                     ->default()
                     ->orderBy('pp', 'DESC')
-                    ->userBest(100, ['beatmapset', 'beatmap']);
+                    ->userBest(50, ['beatmapset', 'beatmap']);
 
                 ScoreBestModel::fillInPosition($scores);
 
@@ -226,7 +226,7 @@ class UserTransformer extends Fractal\TransformerAbstract
         $beatmapPlaycounts = $user->beatmapPlaycounts()
             ->with('beatmap', 'beatmap.beatmapset')
             ->orderBy('playcount', 'desc')
-            ->limit(100)
+            ->limit(50)
             ->get()
             ->filter(function ($pc) {
                 return $pc->beatmap !== null && $pc->beatmap->beatmapset !== null;
@@ -258,8 +258,11 @@ class UserTransformer extends Fractal\TransformerAbstract
     public function includeFavouriteBeatmapsets(User $user)
     {
         return $this->collection(
-            $user->favouriteBeatmapsets()->with('beatmaps')->get(),
-            new BeatmapsetTransformer()
+            $user->favouriteBeatmapsets()
+                ->with('beatmaps')
+                ->limit(50)
+                ->get(),
+            new BeatmapsetCompactTransformer()
         );
     }
 

--- a/app/Transformers/UserTransformer.php
+++ b/app/Transformers/UserTransformer.php
@@ -102,7 +102,7 @@ class UserTransformer extends Fractal\TransformerAbstract
     public function includeFollowerCount(User $user)
     {
         return $this->item($user, function ($user) {
-            return [$user->cachedFollowerCount()];
+            return [$user->followerCount()];
         });
     }
 

--- a/app/Transformers/UserTransformer.php
+++ b/app/Transformers/UserTransformer.php
@@ -103,7 +103,7 @@ class UserTransformer extends Fractal\TransformerAbstract
     public function includeFollowerCount(User $user)
     {
         return $this->item($user, function ($user) {
-            return [UserRelation::where('zebra_id', $user->user_id)->where('friend', 1)->count()];
+            return [$user->cachedFollowerCount()];
         });
     }
 

--- a/app/Transformers/UserTransformer.php
+++ b/app/Transformers/UserTransformer.php
@@ -250,7 +250,7 @@ class UserTransformer extends Fractal\TransformerAbstract
     {
         return $this->collection(
             $user->beatmapsets()->rankedOrApproved()->active()->with('beatmaps')->get(),
-            new BeatmapsetTransformer()
+            new BeatmapsetCompactTransformer()
         );
     }
 

--- a/app/Transformers/UserTransformer.php
+++ b/app/Transformers/UserTransformer.php
@@ -23,7 +23,6 @@ namespace App\Transformers;
 use App\Models\Beatmap;
 use App\Models\Score\Best\Model as ScoreBestModel;
 use App\Models\User;
-use App\Models\UserRelation;
 use League\Fractal;
 
 class UserTransformer extends Fractal\TransformerAbstract


### PR DESCRIPTION
First phase reduces the amount of (unused) beatmapset json being sent initially to speed up downloading and parsing. (should reduce page size by ~50-60%)

In addition, caching has been added for user follower counts to ease the load from more popular players.

Also, the max displayed beatmaps in each section has been temporarily reduced to 50 for the time being.

More optimisations to come...