### PR TITLE
Maybe fix user searching on empty string

### DIFF
--- a/app/Libraries/Search.php
+++ b/app/Libraries/Search.php
@@ -102,7 +102,7 @@ class Search
         $key = __FUNCTION__.':'.$mode;
 
         if (!array_key_exists($key, $this->cache)) {
-            $this->cache[$key] = $class::search($this->params);
+            $this->cache[$key] = $this->hasQuery() ? $class::search($this->params) : [];
         }
 
         return $this->cache[$key];


### PR DESCRIPTION
reading `Search::urlParams()` triggers search which ends up calling `User::search()` with an empty string query

ᕕ( ᐛ )ᕗ