### PR TITLE
Fix profiles showing zeroed stats when defaulting to user's default playmode

### DIFF
--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -200,7 +200,7 @@ class UsersController extends Controller
         ];
 
         $statistics = json_item(
-            $user->statistics($mode),
+            $user->statistics($currentMode),
             'UserStatistics',
             ['rank', 'scoreRanks']
         );


### PR DESCRIPTION
fixes #1483