### PR TITLE
Wrong condition for vote rate limit

### DIFF
--- a/app/Libraries/OsuAuthorize.php
+++ b/app/Libraries/OsuAuthorize.php
@@ -142,7 +142,7 @@ class OsuAuthorize
         // rate limit
         $recentVotesCount = $user
             ->beatmapDiscussionVotes()
-            ->where('created_at', '<', Carbon::now()->subHour())
+            ->where('created_at', '>', Carbon::now()->subHour())
             ->count();
 
         if ($recentVotesCount > 10) {


### PR DESCRIPTION
Should be between an hour ago and now, not before an hour ago.

Fixes #1485.