### PR TITLE
Validate order item on saving

### DIFF
--- a/app/Exceptions/ValidationException.php
+++ b/app/Exceptions/ValidationException.php
@@ -1,0 +1,45 @@
+<?php
+
+/**
+ *    Copyright 2015-2017 ppy Pty. Ltd.
+ *
+ *    This file is part of osu!web. osu!web is distributed with the hope of
+ *    attracting more community contributions to the core ecosystem of osu!.
+ *
+ *    osu!web is free software: you can redistribute it and/or modify
+ *    it under the terms of the Affero GNU General Public License version 3
+ *    as published by the Free Software Foundation.
+ *
+ *    osu!web is distributed WITHOUT ANY WARRANTY; without even the implied
+ *    warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *    See the GNU Affero General Public License for more details.
+ *
+ *    You should have received a copy of the GNU Affero General Public License
+ *    along with osu!web.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace App\Exceptions;
+
+use App\Libraries\ValidationErrors;
+use Exception;
+
+class ValidationException extends Exception
+{
+    private $errors;
+
+    public function __construct(ValidationErrors $errors = null, Exception $previous = null)
+    {
+        $message = null;
+        if ($errors !== null) {
+            $message = implode("\n", $errors->allMessages());
+        }
+
+        parent::__construct($message, 0, $previous);
+        $this->errors = $errors;
+    }
+
+    public function getValidationErrors()
+    {
+        return $this->errors;
+    }
+}

--- a/app/Models/Store/Order.php
+++ b/app/Models/Store/Order.php
@@ -151,10 +151,10 @@ class Order extends Model
      * and a message.
      *
      * @param array $itemForm form parameters.
-     * @param bool $addNew whether the quantity should be added or replaced.
+     * @param bool $addToExisting whether the quantity should be added or replaced.
      * @return array [success, message]
      **/
-    public function updateItem(array $itemForm, $addNew = false)
+    public function updateItem(array $itemForm, $addToExisting = false)
     {
         $params = [
             'id' => array_get($itemForm, 'id'),
@@ -177,7 +177,7 @@ class Order extends Model
             if ($params['product']->allow_multiple) {
                 $item = $this->newOrderItem($params);
             } else {
-                $item = $this->updateOrderItem($params, $addNew);
+                $item = $this->updateOrderItem($params, $addToExisting);
             }
 
             $result = $this->validateBeforeSave($params['product'], $item);
@@ -313,7 +313,7 @@ class Order extends Model
         return $item;
     }
 
-    private function updateOrderItem(array $params, $addNew = false)
+    private function updateOrderItem(array $params, $addToExisting = false)
     {
         $product = $params['product'];
         $item = $this->items()->where('product_id', $product->product_id)->get()->first();
@@ -321,7 +321,7 @@ class Order extends Model
             return $this->newOrderItem($params);
         }
 
-        if ($addNew) {
+        if ($addToExisting) {
             $item->quantity += $params['quantity'];
         } else {
             $item->quantity = $params['quantity'];

--- a/app/Models/Store/Order.php
+++ b/app/Models/Store/Order.php
@@ -327,7 +327,7 @@ class Order extends Model
             $item->quantity = $params['quantity'];
         }
 
-        $item->cost = $item->quantity * $product->cost;
+        $item->cost = $product->cost;
 
         return $item;
     }

--- a/app/Models/Store/Order.php
+++ b/app/Models/Store/Order.php
@@ -327,8 +327,6 @@ class Order extends Model
             $item->quantity = $params['quantity'];
         }
 
-        $item->cost = $product->cost;
-
         return $item;
     }
 

--- a/app/Models/Store/Order.php
+++ b/app/Models/Store/Order.php
@@ -281,7 +281,7 @@ class Order extends Model
     private function newOrderItem(array $params)
     {
         if ($params['cost'] < 0) {
-            throw new \Exception('cute.');
+            $params['cost'] = 0;
         }
 
         $product = $params['product'];
@@ -299,16 +299,16 @@ class Order extends Model
                 // ignore received cost
                 $params['cost'] = $this->user->usernameChangeCost();
                 break;
+            default:
+                $params['cost'] = $product->cost ?? 0;
         }
 
         $item = new OrderItem();
         $item->quantity = $params['quantity'];
         $item->extra_info = $params['extraInfo'];
         $item->extra_data = $params['extraData'];
+        $item->cost = $params['cost'];
         $item->product()->associate($product);
-        if ($product->cost === null) {
-            $item->cost = $params['cost'];
-        }
 
         return $item;
     }
@@ -326,6 +326,8 @@ class Order extends Model
         } else {
             $item->quantity = $params['quantity'];
         }
+
+        $item->cost = $item->quantity * $product->cost;
 
         return $item;
     }

--- a/app/Models/Store/OrderItem.php
+++ b/app/Models/Store/OrderItem.php
@@ -20,8 +20,13 @@
 
 namespace App\Models\Store;
 
+use App\Exceptions\ValidationException;
+use App\Traits\Validatable;
+
 class OrderItem extends Model
 {
+    use Validatable;
+
     protected $primaryKey = 'id';
 
     protected $casts = [
@@ -32,6 +37,31 @@ class OrderItem extends Model
     //     'type' => 'custom-extra-info',
     //     ...additional fields
     // ]
+
+    public function isValid()
+    {
+        $this->validationErrors()->reset();
+
+        if ($this->quantity < 0) {
+            $this->validationErrors()->add('quantity', 'not_negative');
+        }
+
+        if ($this->cost < 0) {
+            $this->validationErrors()->add('cost', 'not_negative');
+        }
+
+        return $this->validationErrors()->isEmpty();
+    }
+
+    public function save(array $options = [])
+    {
+        if (!$this->isValid()) {
+            // FIXME: Simpler to just throw instead of fixing all the save() calls right now.
+            throw new ValidationException($this->validationErrors());
+        }
+
+        return parent::save($options);
+    }
 
     public function subtotal()
     {
@@ -76,5 +106,10 @@ class OrderItem extends Model
             default:
                 return $this->product->name.($this->extra_info !== null ? " ({$this->extra_info})" : '');
         }
+    }
+
+    public function validationErrorsTranslationPrefix()
+    {
+        return 'store.order_item';
     }
 }

--- a/resources/lang/en/model_validation.php
+++ b/resources/lang/en/model_validation.php
@@ -19,6 +19,7 @@
  */
 
 return [
+    'not_negative' => ':attribute cannot be negative.',
     'required' => ':attribute is required.',
     'wrong_confirmation' => 'Confirmation does not match.',
 


### PR DESCRIPTION
Why is model validation on save not a standard thing?  ಠ_ಠ

This also always forces `OrderItem` to always have a `cost` value when adding or updating the cart because right now, it doesn't.

