### PR TITLE
Fix sanitizing of double '.' in filenames

### DIFF
--- a/app/Http/Controllers/Admin/ContestsController.php
+++ b/app/Http/Controllers/Admin/ContestsController.php
@@ -69,7 +69,7 @@ class ContestsController extends Controller
                     mkdir($targetDir, 0755, true);
                 }
 
-                copy($entry->fileUrl(), "{$targetDir}/".sanitize_filename($entry->original_filename));
+                copy($entry->fileUrl(), $targetDir.sanitize_filename($entry->original_filename));
             }
 
             // zip 'em

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -760,8 +760,8 @@ function ci_file_search($fileName)
 
 function sanitize_filename($file)
 {
-    $file = mb_ereg_replace("([^\w\s\d\-_~,;\[\]\(\).])", '', $file);
-    $file = mb_ereg_replace("([\.]{2,})", '', $file);
+    $file = mb_ereg_replace('[^\w\s\d\-_~,;\[\]\(\).]', '', $file);
+    $file = mb_ereg_replace('[\.]{2,}', '.', $file);
 
     return $file;
 }


### PR DESCRIPTION
Would sanitize `file..png` into `filepng`, which would then be excluded by the `*.*` glob when creating the zip of entries...