### PR TITLE
Fix Pippi overflowing the landing-hero div

### DIFF
--- a/resources/assets/less/bem/osu-layout.less
+++ b/resources/assets/less/bem/osu-layout.less
@@ -133,6 +133,7 @@
     align-self: center;
     margin-left: auto;
     margin-right: auto;
+    line-height: 1;
 
     ._width;
     @media @desktop {


### PR DESCRIPTION
Solves issue #1593.
The `line-height: 1.25` property from the osu-layout__row div (inherited from html) was interfering with the positioning of the Pippi image directly below on some browsers.
Changing the line-height to 1 solved the issue, but made the header slightly shorter. Another option would be reducing Pippi's height by a few px.