### PR TITLE
Include final hitobjects in valid timestamp range

### DIFF
--- a/tests/Models/BeatmapDiscussionTest.php
+++ b/tests/Models/BeatmapDiscussionTest.php
@@ -31,7 +31,7 @@ class BeatmapDiscussionTest extends TestCase
         $otherBeatmapset = factory(Beatmapset::class)->create();
         $otherBeatmap = $otherBeatmapset->beatmaps()->save(factory(Beatmap::class)->make());
 
-        $invalidTimestamp = ($beatmap->total_length + 1) * 1000 + 1;
+        $invalidTimestamp = $beatmap->total_length * 1000 + 1;
 
         // blank everything not fine
         $discussion = $this->newDiscussion($beatmapset);


### PR DESCRIPTION
closes #1612 

lame solution for now; just allows a timestamp at 1 second past the beatmap length to include any objects in that final second