### PR TITLE
Disable newline in beatmap discussion

### DIFF
--- a/app/Models/BeatmapDiscussionPost.php
+++ b/app/Models/BeatmapDiscussionPost.php
@@ -69,7 +69,7 @@ class BeatmapDiscussionPost extends Model
         if ($this->system) {
             return json_decode($value, true);
         } else {
-            return $value;
+            return str_replace("\n", ' ', $value);
         }
     }
 
@@ -80,7 +80,7 @@ class BeatmapDiscussionPost extends Model
             $value = json_encode($value);
         }
 
-        $this->attributes['message'] = $value;
+        $this->attributes['message'] = str_replace("\n", ' ', $value);
     }
 
     public static function generateLogResolveChange($user, $resolved)

--- a/resources/assets/coffee/react/beatmap-discussions/new-discussion.coffee
+++ b/resources/assets/coffee/react/beatmap-discussions/new-discussion.coffee
@@ -64,6 +64,7 @@ class BeatmapDiscussions.NewDiscussion extends React.PureComponent
                 className: "#{bn}__message-area js-hype--input"
                 value: @state.message
                 onChange: @setMessage
+                onKeyDown: @ignoreEnter
                 placeholder: osu.trans 'beatmaps.discussions.message_placeholder'
             else
               osu.trans('beatmaps.discussions.require-login')
@@ -123,6 +124,12 @@ class BeatmapDiscussions.NewDiscussion extends React.PureComponent
                 el Icon, name: 'check'
 
               osu.trans('beatmap_discussions.nearby_posts.confirm')
+
+
+  ignoreEnter: (e) =>
+    return if e.keyCode != 13
+
+    e.preventDefault()
 
 
   nearbyPosts: =>
@@ -189,7 +196,7 @@ class BeatmapDiscussions.NewDiscussion extends React.PureComponent
 
 
   setMessage: (e) =>
-    message = e.currentTarget.value
+    message = e.currentTarget.value.replace /\n/g, ' '
     timestamp = @parseTimestamp(message) if @props.mode == 'timeline'
 
     @setState {message, timestamp}

--- a/resources/assets/coffee/react/beatmap-discussions/new-reply.coffee
+++ b/resources/assets/coffee/react/beatmap-discussions/new-reply.coffee
@@ -164,7 +164,7 @@ class BeatmapDiscussions.NewReply extends React.PureComponent
 
 
   setMessage: (e) =>
-    @setState message: e.target.value
+    @setState message: e.target.value.replace /\n/g, ' '
 
 
   submitIfEnter: (e) =>

--- a/resources/assets/coffee/react/beatmap-discussions/post.coffee
+++ b/resources/assets/coffee/react/beatmap-discussions/post.coffee
@@ -112,7 +112,7 @@ class BeatmapDiscussions.Post extends React.PureComponent
 
 
   messageInput: (e) =>
-    @setState message: e.target.value
+    @setState message: e.target.value.replace /\n/g, ' '
 
 
   submitIfEnter: (e) =>


### PR DESCRIPTION
Newline never happens on output and this ensures it's filtered on input as well. Fixes #1615.