### PR TITLE
Orders with no shippable items should be delivered immediately

### DIFF
--- a/app/Libraries/OrderCheckout.php
+++ b/app/Libraries/OrderCheckout.php
@@ -83,7 +83,7 @@ class OrderCheckout
             if ($order->status === 'incart') {
                 $order->status = 'checkout';
                 $order->saveorExplode();
-            } elseif (!in_array($order->status, ['paid', 'delivered'], true)) {
+            } elseif (!$order->isPaidOrDelivered()) {
                 // TODO: use validation errors instead?
                 throw new InvalidOrderStateException(
                     "`Order {$order->order_id}` in wrong state: `{$order->status}`"

--- a/app/Libraries/OrderCheckout.php
+++ b/app/Libraries/OrderCheckout.php
@@ -83,7 +83,7 @@ class OrderCheckout
             if ($order->status === 'incart') {
                 $order->status = 'checkout';
                 $order->saveorExplode();
-            } elseif ($order->status !== 'paid') {
+            } elseif (!in_array($order->status, ['paid', 'delivered'], true)) {
                 // TODO: use validation errors instead?
                 throw new InvalidOrderStateException(
                     "`Order {$order->order_id}` in wrong state: `{$order->status}`"

--- a/app/Libraries/Payments/XsollaPaymentProcessor.php
+++ b/app/Libraries/Payments/XsollaPaymentProcessor.php
@@ -116,7 +116,7 @@ class XsollaPaymentProcessor extends PaymentProcessor
             $this->validationErrors()->add('order.status', '.order.status.not_checkout', ['state' => $order->status]);
         }
 
-        if ($this->getNotificationType() === NotificationType::REFUND && $order->status !== 'paid') {
+        if ($this->getNotificationType() === NotificationType::REFUND && !$order->isPaidOrDelivered()) {
             $this->validationErrors()->add('order.status', '.order.status.not_paid', ['state' => $order->status]);
         }
 

--- a/app/Libraries/Payments/XsollaPaymentProcessor.php
+++ b/app/Libraries/Payments/XsollaPaymentProcessor.php
@@ -86,7 +86,7 @@ class XsollaPaymentProcessor extends PaymentProcessor
         }
 
         return $this->getNotificationType() === NotificationType::PAYMENT
-            && in_array($order->status, ['paid', 'delivered'], true);
+            && $order->isPaidOrDelivered();
     }
 
     public function validateTransaction()

--- a/app/Libraries/Payments/XsollaPaymentProcessor.php
+++ b/app/Libraries/Payments/XsollaPaymentProcessor.php
@@ -86,7 +86,7 @@ class XsollaPaymentProcessor extends PaymentProcessor
         }
 
         return $this->getNotificationType() === NotificationType::PAYMENT
-            && $order->status === 'paid';
+            && in_array($order->status, ['paid', 'delivered'], true);
     }
 
     public function validateTransaction()

--- a/app/Models/Store/Order.php
+++ b/app/Models/Store/Order.php
@@ -248,7 +248,7 @@ class Order extends Model
             $this->paid_at = Carbon::now();
         }
 
-        $this->status = 'paid';
+        $this->status = $this->requiresShipping() ? 'paid' : 'delivered';
         $this->saveOrExplode();
     }
 

--- a/app/Models/Store/Order.php
+++ b/app/Models/Store/Order.php
@@ -177,6 +177,11 @@ class Order extends Model
         return $this->getSubtotal() + $this->shipping;
     }
 
+    public function isPaidOrDelivered()
+    {
+        return in_array($this->status, ['paid', 'delivered'], true);
+    }
+
     public function removeInvalidItems()
     {
         $modified = false;


### PR DESCRIPTION
If nothing in an order required shipping, the order should immediately be marked as `delivered` instead of just sitting at `paid` once the payment is confirmed.

This make the invoice page show the appropriate text.