### PR TITLE
Add option to skip validation when renaming inactive users.

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -193,7 +193,8 @@ class User extends Model implements AuthenticatableContract, Messageable
             if (!$this->usernameChangeHistory()->save($history)) {
                 throw new ModelNotSavedException('failed saving model');
             }
-            $this->saveOrExplode();
+
+            $this->saveOrExplode(['inactive' => $type === 'inactive']);
         });
     }
 
@@ -1403,6 +1404,15 @@ class User extends Model implements AuthenticatableContract, Messageable
     public function validationErrorsTranslationPrefix()
     {
         return 'user';
+    }
+
+    public function save(array $options = [])
+    {
+        if ($options['inactive'] ?? false) {
+            return parent::save($options);
+        }
+
+        return $this->isValid() && parent::save($options);
     }
 
     /**

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -25,7 +25,6 @@ use App\Libraries\OsuAuthorize;
 use App\Models\BeatmapDiscussion;
 use App\Models\BeatmapDiscussionPost;
 use App\Models\Forum\PollVote as ForumPollVote;
-use App\Models\User;
 use Datadog;
 use Illuminate\Queue\Events\JobProcessed;
 use Illuminate\Support\ServiceProvider;

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -58,10 +58,6 @@ class AppServiceProvider extends ServiceProvider
             return $vote->isValid();
         });
 
-        User::saving(function ($user) {
-            return $user->isValid();
-        });
-
         Queue::after(function (JobProcessed $event) {
             if (config('datadog-helper.enabled')) {
                 Datadog::increment(config('datadog-helper.prefix').'.queue.run', 1, ['queue' => $event->job->getQueue()]);


### PR DESCRIPTION
Inactive user renaming can potentially set off too many errors.