### PR TITLE
Username change history should be paid type if cost > 0.

### DIFF
--- a/app/Libraries/Fulfillments/UsernameChangeFulfillment.php
+++ b/app/Libraries/Fulfillments/UsernameChangeFulfillment.php
@@ -33,8 +33,10 @@ class UsernameChangeFulfillment extends OrderFulfiller
     {
         $this->throwOnFail($this->validateRun());
 
+        $item = $this->getOrderItems()->first();
+        $type = $item['cost'] > 0 ? 'paid' : 'support';
         $user = $this->order->user;
-        $user->changeUsername($this->getNewUserName());
+        $user->changeUsername($this->getNewUserName(), $type);
         event("store.fulfillments.run.{$this->taggedName()}", new UsernameChanged($user, $this->order));
     }
 


### PR DESCRIPTION
Everything is being set to `support` now. This doesn't affect the cost of changes.