### PR TITLE
Include the validation error message when throwing ModelNotSavedException

### DIFF
--- a/app/Models/Model.php
+++ b/app/Models/Model.php
@@ -64,7 +64,11 @@ abstract class Model extends BaseModel
         $result = $this->save($options);
 
         if ($result === false) {
-            throw new ModelNotSavedException('failed saving model');
+            $message = method_exists($this, 'validationErrors') ?
+                implode("\n", $this->validationErrors()->allMessages()) :
+                'failed saving model';
+
+            throw new ModelNotSavedException($message);
         }
 
         return $result;


### PR DESCRIPTION
The generic message is not so useful when the user validation keeps being set off on users trying to change their username.