### PR TITLE
Skip field validations if field hasn't changed.

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -1392,9 +1392,11 @@ class User extends Model implements AuthenticatableContract, Messageable
         }
 
         foreach (self::MAX_FIELD_LENGTHS as $field => $limit) {
-            $val = $this->$field;
-            if ($val && mb_strlen($val) > $limit) {
-                $this->validationErrors()->add($field, '.too_long', ['limit' => $limit]);
+            if ($this->isDirty($field)) {
+                $val = $this->$field;
+                if ($val && mb_strlen($val) > $limit) {
+                    $this->validationErrors()->add($field, '.too_long', ['limit' => $limit]);
+                }
             }
         }
 


### PR DESCRIPTION
Username changes are failing because some users have existing field
values which no longer pass the validation.