### PR TITLE
Search adjustments

### DIFF
--- a/app/Models/Wiki/Page.php
+++ b/app/Models/Wiki/Page.php
@@ -66,14 +66,20 @@ class Page
             'bool' => [
                 'minimum_should_match' => 1,
                 'should' => [
-                    ['term' => [
-                            'locale' => [
-                                'value' => $params['locale'] ?? App::getLocale(),
-                                'boost' => 1000,
+                    ['constant_score' => [
+                        'boost' => 1000,
+                        'query' => [
+                            'match' => [
+                                'locale' => $params['locale'] ?? App::getLocale(),
                             ],
+                        ],
                     ]],
-                    ['term' => [
-                            'locale' => config('app.fallback_locale'),
+                    ['constant_score' => [
+                        'query' => [
+                            'match' => [
+                                'locale' => config('app.fallback_locale'),
+                            ],
+                        ],
                     ]],
                 ],
             ],

--- a/app/Models/Wiki/Page.php
+++ b/app/Models/Wiki/Page.php
@@ -66,14 +66,14 @@ class Page
             'bool' => [
                 'minimum_should_match' => 1,
                 'should' => [
-                    ['match' => [
-                        'locale' => [
-                            'query' => $params['locale'] ?? App::getLocale(),
-                            'boost' => 1000,
-                        ],
+                    ['term' => [
+                            'locale' => [
+                                'value' => $params['locale'] ?? App::getLocale(),
+                                'boost' => 1000,
+                            ],
                     ]],
-                    ['match' => [
-                        'locale' => config('app.fallback_locale'),
+                    ['term' => [
+                            'locale' => config('app.fallback_locale'),
                     ]],
                 ],
             ],


### PR DESCRIPTION
So TF, many IDF.

Fixes #1644. Maybe.

Ignore TF/IDF for locale matches. Otherwise incorrect result is generated from slight imbalance in document sharding.

References:
- https://www.elastic.co/guide/en/elasticsearch/guide/master/ignoring-tfidf.html
- https://www.elastic.co/guide/en/elasticsearch/guide/master/relevance-is-broken.html