### PR TITLE
Use correct value for username change store item validity response

### DIFF
--- a/resources/assets/coffee/store-username-change.coffee
+++ b/resources/assets/coffee/store-username-change.coffee
@@ -26,7 +26,7 @@ checkUsernameValidity = ->
 
   $.post '/users/check-username-availability', username: requestedUsername
   .done (data) ->
-    return unless data.username == requestedUsername
+    return unless data.username == $('#username.form-control').val()
 
     if data.available
       $('.js-store-add-to-cart').attr 'disabled', false


### PR DESCRIPTION
Resolves the issue where the validation result did not match the username entered.