### PR TITLE
Make Store notifications actually queueable.

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -101,6 +101,7 @@ PUSHER_SECRET=
 PAYMENT_SANDBOX=true
 
 STORE_NOTIFICATION_CHANNEL=test
+STORE_NOTIFICATIONS_QUEUE=store-notifications
 
 PAYPAL_URL=https://www.sandbox.paypal.com/cgi-bin/webscr
 PAYPAL_MERCHANT_ID=

--- a/app/Events/Fulfillments/FulfillmentValidationFailed.php
+++ b/app/Events/Fulfillments/FulfillmentValidationFailed.php
@@ -20,10 +20,20 @@
 
 namespace App\Events\Fulfillments;
 
+use App\Libraries\ValidationErrors;
+
 class FulfillmentValidationFailed extends ValidationFailedEvent implements HasOrder
 {
+    private $order;
+
+    public function __construct($sender, ValidationErrors $errors)
+    {
+        parent::__construct($sender, $errors);
+        $this->order = $sender->getOrder();
+    }
+
     public function getOrder()
     {
-        return $this->sender->getOrder();
+        return $this->order;
     }
 }

--- a/app/Events/Fulfillments/ValidationFailedEvent.php
+++ b/app/Events/Fulfillments/ValidationFailedEvent.php
@@ -29,8 +29,8 @@ class ValidationFailedEvent implements MessageableEvent
     use SerializesModels;
 
     protected $context = [];
-    private $errors;
-    private $senderClass;
+    protected $errors;
+    protected $senderClass;
 
     public function __construct($sender, ValidationErrors $errors)
     {

--- a/app/Events/Fulfillments/ValidationFailedEvent.php
+++ b/app/Events/Fulfillments/ValidationFailedEvent.php
@@ -22,9 +22,12 @@ namespace App\Events\Fulfillments;
 
 use App\Events\MessageableEvent;
 use App\Libraries\ValidationErrors;
+use Illuminate\Queue\SerializesModels;
 
 class ValidationFailedEvent implements MessageableEvent
 {
+    use SerializesModels;
+
     protected $context = [];
     private $errors;
     private $senderClass;

--- a/app/Events/Fulfillments/ValidationFailedEvent.php
+++ b/app/Events/Fulfillments/ValidationFailedEvent.php
@@ -25,13 +25,13 @@ use App\Libraries\ValidationErrors;
 
 class ValidationFailedEvent implements MessageableEvent
 {
-    protected $sender;
     protected $context = [];
     private $errors;
+    private $senderClass;
 
     public function __construct($sender, ValidationErrors $errors)
     {
-        $this->sender = $sender;
+        $this->senderClass = get_class_basename(get_class($sender));
         $this->errors = $errors;
     }
 
@@ -47,10 +47,9 @@ class ValidationFailedEvent implements MessageableEvent
 
     public function toMessage()
     {
-        $senderText = get_class_basename(get_class($this->sender));
         $className = get_class_basename(static::class);
         $messages = implode("\n\t", $this->getErrors()->allMessages());
 
-        return "`{$className}` from `{$senderText}`\n\t{$messages}";
+        return "`{$className}` from `{$this->senderClass}`\n\t{$messages}";
     }
 }

--- a/app/Libraries/Fulfillments/SupporterTagFulfillment.php
+++ b/app/Libraries/Fulfillments/SupporterTagFulfillment.php
@@ -105,7 +105,7 @@ class SupporterTagFulfillment extends OrderFulfiller
         $donationTotal = $this->getOrderItems()->sum('cost');
         Log::debug("total: {$donationTotal}, required: {$this->minimumRequired()}");
         if ($donationTotal < $this->minimumRequired()) {
-            $this->validationErrors()->addError(
+            $this->validationErrors()->add(
                 'order_total',
                 '.insufficient_paid',
                 ['expected' => $this->minimumRequired(), 'actual' => $donationTotal]

--- a/app/Notifications/Store/ErrorMessage.php
+++ b/app/Notifications/Store/ErrorMessage.php
@@ -37,6 +37,7 @@ class ErrorMessage extends Message
      */
     public function __construct($exception, $order)
     {
+        parent::__construct();
         $this->exceptionClass = get_class($exception);
 
         if ($exception instanceof PayPalConnectionException) {

--- a/app/Notifications/Store/ErrorMessage.php
+++ b/app/Notifications/Store/ErrorMessage.php
@@ -25,7 +25,9 @@ use PayPal\Exception\PayPalConnectionException;
 
 class ErrorMessage extends Message
 {
-    private $exception;
+    private $exceptionClass;
+    private $exceptionData;
+    private $exceptionMessage;
     private $order;
 
     /**
@@ -35,7 +37,13 @@ class ErrorMessage extends Message
      */
     public function __construct($exception, $order)
     {
-        $this->exception = $exception;
+        $this->exceptionClass = get_class($exception);
+
+        if ($exception instanceof PayPalConnectionException) {
+            $this->exceptionData = $exception->getData();
+        }
+
+        $this->exceptionMessage = $exception->getMessage();
         $this->order = $order;
     }
 
@@ -46,19 +54,18 @@ class ErrorMessage extends Message
             $content .= " | Order `{$this->order->getOrderNumber()}`";
         }
 
-        $className = get_class($this->exception);
-        $content .= "; `{$className}`";
+        $content .= "; `{$this->exceptionClass}`";
 
         return (new SlackMessage)
             ->to(config('payments.notification_channel'))
             ->error()
             ->content($content)
             ->attachment(function ($attachment) {
-                $attachment->content($this->exception->getMessage());
+                $attachment->content($this->exceptionMessage);
 
-                if ($this->exception instanceof PayPalConnectionException) {
+                if (isset($this->exceptionData)) {
                     $attachment->fields([
-                        'data' => $this->exception->getData(),
+                        'data' => $this->exceptionData,
                     ]);
                 }
             });
@@ -73,16 +80,16 @@ class ErrorMessage extends Message
     public function toArray($notifiable)
     {
         $array = [
-            'className' => get_class($this->exception),
-            'message' => $this->exception->getMessage(),
+            'className' => $this->exceptionClass,
+            'message' => $this->exceptionMessage,
         ];
 
         if ($this->order) {
             $array['orderId'] = $this->order->order_id;
         }
 
-        if ($this->exception instanceof PayPalConnectionException) {
-            $array['data'] = $this->exception->getData();
+        if (isset($this->exceptionData)) {
+            $array['data'] = $this->exceptionData;
         }
 
         return $array;

--- a/app/Notifications/Store/ErrorMessage.php
+++ b/app/Notifications/Store/ErrorMessage.php
@@ -50,7 +50,7 @@ class ErrorMessage extends Message
 
     public function toSlack($notifiable)
     {
-        $content = 'ERROR';
+        $content = "ERROR `{$this->notified_at}`";
         if ($this->order) {
             $content .= " | Order `{$this->order->getOrderNumber()}`";
         }

--- a/app/Notifications/Store/ErrorMessage.php
+++ b/app/Notifications/Store/ErrorMessage.php
@@ -58,6 +58,7 @@ class ErrorMessage extends Message
         $content .= "; `{$this->exceptionClass}`";
 
         return (new SlackMessage)
+            ->http(static::HTTP_OPTIONS)
             ->to(config('payments.notification_channel'))
             ->error()
             ->content($content)

--- a/app/Notifications/Store/Message.php
+++ b/app/Notifications/Store/Message.php
@@ -28,6 +28,11 @@ abstract class Message extends Notification implements ShouldQueue
 {
     use Queueable;
 
+    public function __construct()
+    {
+        $this->queue = 'store-notifications';
+    }
+
     /**
      * Get the notification's delivery channels.
      *

--- a/app/Notifications/Store/Message.php
+++ b/app/Notifications/Store/Message.php
@@ -20,6 +20,7 @@
 
 namespace App\Notifications\Store;
 
+use Carbon\Carbon;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Notifications\Notification;
@@ -28,9 +29,12 @@ abstract class Message extends Notification implements ShouldQueue
 {
     use Queueable;
 
+    protected $notified_at;
+
     public function __construct()
     {
         $this->queue = config('store.queue.notifications');
+        $this->notified_at = Carbon::now();
     }
 
     /**

--- a/app/Notifications/Store/Message.php
+++ b/app/Notifications/Store/Message.php
@@ -30,7 +30,7 @@ abstract class Message extends Notification implements ShouldQueue
 
     public function __construct()
     {
-        $this->queue = 'store-notifications';
+        $this->queue = config('store.queue.notifications');
     }
 
     /**

--- a/app/Notifications/Store/Message.php
+++ b/app/Notifications/Store/Message.php
@@ -21,6 +21,7 @@
 namespace App\Notifications\Store;
 
 use Carbon\Carbon;
+use GuzzleHttp\RequestOptions;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Notifications\Notification;
@@ -28,6 +29,11 @@ use Illuminate\Notifications\Notification;
 abstract class Message extends Notification implements ShouldQueue
 {
     use Queueable;
+
+    const HTTP_OPTIONS = [
+        RequestOptions::CONNECT_TIMEOUT => 5,
+        RequestOptions::TIMEOUT => 5,
+    ];
 
     protected $notified_at;
 

--- a/app/Notifications/Store/Message.php
+++ b/app/Notifications/Store/Message.php
@@ -21,9 +21,10 @@
 namespace App\Notifications\Store;
 
 use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Notifications\Notification;
 
-abstract class Message extends Notification
+abstract class Message extends Notification implements ShouldQueue
 {
     use Queueable;
 

--- a/app/Notifications/Store/OrderMessage.php
+++ b/app/Notifications/Store/OrderMessage.php
@@ -35,6 +35,7 @@ class OrderMessage extends Message
      */
     public function __construct($eventName, $order, $text)
     {
+        parent::__construct();
         $this->eventName = $eventName;
         $this->order = $order;
         $this->text = $text;

--- a/app/Notifications/Store/OrderMessage.php
+++ b/app/Notifications/Store/OrderMessage.php
@@ -43,7 +43,7 @@ class OrderMessage extends Message
 
     public function toSlack($notifiable)
     {
-        $content = "`{$this->eventName}` | Order `{$this->order->getOrderNumber()}`: {$this->text}";
+        $content = "`{$this->notified_at}` | `{$this->eventName}` | Order `{$this->order->getOrderNumber()}`: {$this->text}";
 
         return (new SlackMessage)
             ->to(config('payments.notification_channel'))

--- a/app/Notifications/Store/OrderMessage.php
+++ b/app/Notifications/Store/OrderMessage.php
@@ -46,6 +46,7 @@ class OrderMessage extends Message
         $content = "`{$this->notified_at}` | `{$this->eventName}` | Order `{$this->order->getOrderNumber()}`: {$this->text}";
 
         return (new SlackMessage)
+            ->http(static::HTTP_OPTIONS)
             ->to(config('payments.notification_channel'))
             ->content($content);
     }

--- a/app/Notifications/Store/StoreMessage.php
+++ b/app/Notifications/Store/StoreMessage.php
@@ -44,6 +44,7 @@ class StoreMessage extends Message
         $content = "`{$this->notified_at}` | `{$this->eventName}` | {$this->text}";
 
         return (new SlackMessage)
+            ->http(static::HTTP_OPTIONS)
             ->to(config('payments.notification_channel'))
             ->content($content);
     }

--- a/app/Notifications/Store/StoreMessage.php
+++ b/app/Notifications/Store/StoreMessage.php
@@ -34,6 +34,7 @@ class StoreMessage extends Message
      */
     public function __construct($eventName, $text)
     {
+        parent::__construct();
         $this->eventName = $eventName;
         $this->text = $text;
     }

--- a/app/Notifications/Store/StoreMessage.php
+++ b/app/Notifications/Store/StoreMessage.php
@@ -22,7 +22,7 @@ namespace App\Notifications\Store;
 
 use Illuminate\Notifications\Messages\SlackMessage;
 
-class StoreMessage extends Notification
+class StoreMessage extends Message
 {
     private $eventName;
     private $text;

--- a/app/Notifications/Store/StoreMessage.php
+++ b/app/Notifications/Store/StoreMessage.php
@@ -41,7 +41,7 @@ class StoreMessage extends Message
 
     public function toSlack($notifiable)
     {
-        $content = "`{$this->eventName}` | {$this->text}";
+        $content = "`{$this->notified_at}` | `{$this->eventName}` | {$this->text}";
 
         return (new SlackMessage)
             ->to(config('payments.notification_channel'))

--- a/app/Notifications/Store/ValidationMessage.php
+++ b/app/Notifications/Store/ValidationMessage.php
@@ -49,6 +49,7 @@ class ValidationMessage extends Message
         }
 
         return (new SlackMessage)
+            ->http(static::HTTP_OPTIONS)
             ->to(config('payments.notification_channel'))
             ->warning()
             ->content($content)

--- a/app/Notifications/Store/ValidationMessage.php
+++ b/app/Notifications/Store/ValidationMessage.php
@@ -43,7 +43,7 @@ class ValidationMessage extends Message
 
     public function toSlack($notifiable)
     {
-        $content = "`{$this->eventName}`";
+        $content = "`{$this->notified_at}` | `{$this->eventName}`";
         if ($this->event instanceof HasOrder) {
             $content .= " | Order `{$this->event->getOrder()->getOrderNumber()}`";
         }

--- a/app/Notifications/Store/ValidationMessage.php
+++ b/app/Notifications/Store/ValidationMessage.php
@@ -59,7 +59,7 @@ class ValidationMessage extends Message
                     ->markdown(['text', 'fields']);
 
                 if ($this->event instanceof HasOrder) {
-                    $attachment->title("Order {$this->event->getOrder()->order_id}");
+                    $attachment->title("Order {$this->event->getOrder()->getOrderNumber()}");
                 }
             });
     }

--- a/app/Notifications/Store/ValidationMessage.php
+++ b/app/Notifications/Store/ValidationMessage.php
@@ -36,6 +36,7 @@ class ValidationMessage extends Message
      */
     public function __construct($eventName, ValidationFailedEvent $event)
     {
+        parent::__construct();
         $this->eventName = $eventName;
         $this->event = $event;
     }

--- a/app/Traits/StoreNotifiable.php
+++ b/app/Traits/StoreNotifiable.php
@@ -60,7 +60,7 @@ trait StoreNotifiable
 
     private function tryNotify($message)
     {
-        // avoid failing if Slack fails :|
+        // avoid failing if calling notify fails for any reason.
         try {
             $this->notify($message);
         } catch (Exception $exception) {

--- a/config/store.php
+++ b/config/store.php
@@ -4,4 +4,7 @@ return [
     'order' => [
         'prefix' => presence(env('STORE_ORDER_PREFIX'), 'store'),
     ],
+    'queue' => [
+        'notifications' => presence(env('STORE_NOTIFICATIONS_QUEUE'), 'store-notifications'),
+    ]
 ];

--- a/config/store.php
+++ b/config/store.php
@@ -6,5 +6,5 @@ return [
     ],
     'queue' => [
         'notifications' => presence(env('STORE_NOTIFICATIONS_QUEUE'), 'store-notifications'),
-    ]
+    ],
 ];


### PR DESCRIPTION
Makes store notification serializable.
Try not to dump entire nested contents of `Order` object into queue.
Set a timeout when sending to Slack.
Also fix a wrong `addError` method call. 


The queue worker should be called with something like `--queue=store-notifications --delay=60 --tries=10` to prevent it from spamming retries forever.