### PR TITLE
Beatmapset search update

### DIFF
--- a/app/Http/Controllers/BeatmapsetsController.php
+++ b/app/Http/Controllers/BeatmapsetsController.php
@@ -61,7 +61,6 @@ class BeatmapsetsController extends Controller
             ['id' => 1, 'name' => trans('beatmaps.status.approved')],
             ['id' => 8, 'name' => trans('beatmaps.status.loved')],
             ['id' => 2, 'name' => trans('beatmaps.status.faves')],
-            ['id' => 3, 'name' => trans('beatmaps.status.modreqs')],
             ['id' => 4, 'name' => trans('beatmaps.status.pending')],
             ['id' => 5, 'name' => trans('beatmaps.status.graveyard')],
             ['id' => 6, 'name' => trans('beatmaps.status.my-maps')],

--- a/app/Models/Beatmapset.php
+++ b/app/Models/Beatmapset.php
@@ -81,20 +81,6 @@ class Beatmapset extends Model
         'loved' => 4,
     ];
 
-    const SEARCH_DEFAULTS = [
-        'query' => null,
-        'mode' => null,
-        'sort_order' => 'desc',
-        'sort_field' => 'approved_date',
-        'rank' => '',
-        'status' => 0,
-        'genre' => null,
-        'language' => null,
-        'extra' => '',
-        'limit' => 20,
-        'page' => 1,
-    ];
-
     const NOMINATIONS_PER_DAY = 3;
     const QUALIFICATIONS_PER_DAY = 6;
     const BUNDLED_IDS = [3756, 163112, 140662, 151878, 190390, 123593, 241526, 299224];

--- a/app/Models/Beatmapset.php
+++ b/app/Models/Beatmapset.php
@@ -270,6 +270,7 @@ class Beatmapset extends Model
             'ranked' => 'approved_date',
             'rating' => 'rating',
             'title' => 'title',
+            'updated' => 'last_update',
         ];
         $params['sort_field'] = $validSortFields[$sort[0] ?? null] ?? 'approved_date';
 

--- a/resources/assets/coffee/react/beatmaps/main.coffee
+++ b/resources/assets/coffee/react/beatmaps/main.coffee
@@ -219,6 +219,13 @@ class Beatmaps.Main extends React.PureComponent
   updateFilters: (_e, newFilters) =>
     newFilters = _.extend {}, @state.filters, newFilters
 
+    if @state.filters.status != newFilters.status
+      newFilters.sort =
+        if newFilters.status in [3, 4, 5]
+          'updated_desc'
+        else
+          'ranked_desc'
+
     if !_.isEqual @state.filters, newFilters
       @setState filters: newFilters, ->
         $(document).trigger 'beatmap:search:start'

--- a/resources/assets/coffee/react/beatmaps/search-sort.coffee
+++ b/resources/assets/coffee/react/beatmaps/search-sort.coffee
@@ -22,7 +22,7 @@ el = React.createElement
 class Beatmaps.SearchSort extends React.PureComponent
   render: =>
     div className: 'beatmapsets-sorting',
-      for field in ['title', 'artist', 'difficulty', 'ranked', 'rating', 'updated', 'plays']
+      for field in ['title', 'artist', 'difficulty', 'ranked', 'updated', 'rating', 'plays']
         selected = @selected(field)
 
         a

--- a/resources/assets/coffee/react/beatmaps/search-sort.coffee
+++ b/resources/assets/coffee/react/beatmaps/search-sort.coffee
@@ -22,7 +22,7 @@ el = React.createElement
 class Beatmaps.SearchSort extends React.PureComponent
   render: =>
     div className: 'beatmapsets-sorting',
-      for field in ['title', 'artist', 'difficulty', 'ranked', 'rating', 'plays']
+      for field in ['title', 'artist', 'difficulty', 'ranked', 'rating', 'updated', 'plays']
         selected = @selected(field)
 
         a


### PR DESCRIPTION
Add sort by updated option (and remove unused options).

Not smart enough to hide ranked/ranking/plays sort option (on non-ranked maps) and updated sort option (on ranked maps) at the moment.

That will require some fancy refactors.