### PR TITLE
Beatmap search results for 'Qualified' should be sorted by ranked time not last updated time by default

### DIFF
--- a/resources/assets/coffee/react/beatmaps/main.coffee
+++ b/resources/assets/coffee/react/beatmaps/main.coffee
@@ -221,7 +221,7 @@ class Beatmaps.Main extends React.PureComponent
 
     if @state.filters.status != newFilters.status
       newFilters.sort =
-        if newFilters.status in [3, 4, 5]
+        if newFilters.status in [4, 5]
           'updated_desc'
         else
           'ranked_desc'


### PR DESCRIPTION
Whoops, oversight.