### PR TITLE
Fix user lookups for numeric usernames

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -363,13 +363,10 @@ class User extends Model implements AuthenticatableContract, Messageable
 
             default:
                 if (is_numeric($username_or_id)) {
-                    $user = self::lookup($username_or_id, 'id', $find_all);
-                    if ($user !== null) {
-                        return $user;
-                    }
+                    $user = static::lookup($username_or_id, 'id', $find_all);
                 }
-                $user = self::where('username', $username_or_id)->orWhere('username_clean', '=', $username_or_id);
-                break;
+
+                return $user ?? static::lookup($username_or_id, 'string', $find_all);
         }
 
         if (!$find_all) {

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -363,10 +363,12 @@ class User extends Model implements AuthenticatableContract, Messageable
 
             default:
                 if (is_numeric($username_or_id)) {
-                    $user = self::where('user_id', $username_or_id);
-                } else {
-                    $user = self::where('username', $username_or_id)->orWhere('username_clean', '=', $username_or_id);
+                    $user = self::lookup($username_or_id, 'id', $find_all);
+                    if ($user !== null) {
+                        return $user;
+                    }
                 }
+                $user = self::where('username', $username_or_id)->orWhere('username_clean', '=', $username_or_id);
                 break;
         }
 


### PR DESCRIPTION
closes #1605 
fixes 404s when looking up numeric usernames (ex. "630" - [old site](https://osu.ppy.sh/u/630), [new site](https://osu.ppy.sh/users/630))

not sure if this is the best way to go about it