### PR TITLE
Ignore posts made by same user for duplicate check

### DIFF
--- a/resources/assets/coffee/react/beatmap-discussions/new-discussion.coffee
+++ b/resources/assets/coffee/react/beatmap-discussions/new-discussion.coffee
@@ -185,6 +185,10 @@ class BeatmapDiscussions.NewDiscussion extends React.PureComponent
       for post in @props.currentDiscussions.timeline
         continue if post.message_type not in ['suggestion', 'problem']
         continue if Math.abs(post.timestamp - @state.timestamp) > 5000
+
+        if post.user_id == @props.currentUser.id
+          continue if moment(post.updated_at).diff(moment(), 'hour') > -24
+
         posts.push(post)
 
       @cache.nearbyPosts =


### PR DESCRIPTION
For posts made/updated in last 24 hours (any longer should still be checked in case forgotten).

Fixes #1774.