### PR TITLE
Revert back to giving shorter length priority

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -319,7 +319,8 @@ class User extends Model implements AuthenticatableContract, Messageable
             'total' => $total,
             'over_limit' => $overLimit,
             'data' => $query
-                ->orderBy('user_id', 'ASC')
+                ->orderByRaw('LENGTH(username)')
+                ->orderBy('user_id')
                 ->limit($limit)
                 ->offset($offset)
                 ->get(),


### PR DESCRIPTION
Allow exact matches to come up first. And then sort by id.

Fixes #1788 but partially reverts #1269. Probably should be checked by @nekodex.