### PR TITLE
Add command to refresh topic cache to fix username change updating wrong field

### DIFF
--- a/app/Console/Commands/FixUsernameChangeTopicCache.php
+++ b/app/Console/Commands/FixUsernameChangeTopicCache.php
@@ -95,7 +95,11 @@ class FixUsernameChangeTopicCache extends Command
 
         $topicsFirstPoster->chunk(1000, function ($topics) use ($bar) {
             foreach ($topics as $topic) {
-                $topic->refreshCache();
+                $topic->setFirstPostCache();
+                if ($topic->isDirty()) {
+                    $topic->save();
+                }
+
                 $bar->advance();
             }
         });
@@ -104,7 +108,11 @@ class FixUsernameChangeTopicCache extends Command
 
         Topic::withTrashed()->whereIn('topic_id', $topicIds)->chunk(1000, function ($topics) use ($bar) {
             foreach ($topics as $topic) {
-                $topic->refreshCache();
+                $topic->setFirstPostCache();
+                if ($topic->isDirty()) {
+                    $topic->save();
+                }
+
                 $bar->advance();
             }
         });

--- a/app/Console/Commands/FixUsernameChangeTopicCache.php
+++ b/app/Console/Commands/FixUsernameChangeTopicCache.php
@@ -50,7 +50,7 @@ class FixUsernameChangeTopicCache extends Command
      */
     public function handle()
     {
-        $continue = $this->confirm('WARNING! This will refresh the cache for forum topics where the username has changed after 2017/08/09');
+        $continue = $this->confirm('WARNING! This will refresh the cache for forum topics effected by username changes after 2017/08/09');
 
         if (!$continue) {
             return $this->error('User aborted!');

--- a/app/Console/Commands/FixUsernameChangeTopicCache.php
+++ b/app/Console/Commands/FixUsernameChangeTopicCache.php
@@ -73,7 +73,11 @@ class FixUsernameChangeTopicCache extends Command
 
         // topics where they posted in - possible last posts.
         $this->info('Getting possible last poster counts...');
-        $topicIds = Post::withTrashed()->whereIn('poster_id', $ids)->distinct()->pluck('topic_id');
+        $topicIds = Post::withTrashed()
+            ->whereIn('poster_id', $ids)
+            ->whereNotIn('topic_id', (clone $topicsFirstPoster)->pluck('topic_id'))
+            ->distinct()
+            ->pluck('topic_id');
 
         $count += $topicIds->count();
         $this->warn("Total {$count}");

--- a/app/Console/Commands/FixUsernameChangeTopicCache.php
+++ b/app/Console/Commands/FixUsernameChangeTopicCache.php
@@ -1,0 +1,74 @@
+<?php
+
+/**
+ *    Copyright 2015-2017 ppy Pty. Ltd.
+ *
+ *    This file is part of osu!web. osu!web is distributed with the hope of
+ *    attracting more community contributions to the core ecosystem of osu!.
+ *
+ *    osu!web is free software: you can redistribute it and/or modify
+ *    it under the terms of the Affero GNU General Public License version 3
+ *    as published by the Free Software Foundation.
+ *
+ *    osu!web is distributed WITHOUT ANY WARRANTY; without even the implied
+ *    warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *    See the GNU Affero General Public License for more details.
+ *
+ *    You should have received a copy of the GNU Affero General Public License
+ *    along with osu!web.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace App\Console\Commands;
+
+use App\Models\Forum\Topic;
+use App\Models\UsernameChangeHistory;
+use Carbon\Carbon;
+use Illuminate\Console\Command;
+
+class FixUsernameChangeTopicCache extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'fix:username-change-topic-cache';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Refresh Topic cache from username changes changing wrong field';
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function handle()
+    {
+        $continue = $this->confirm('WARNING! This will refresh the cache for forum topics where the username has changed after 2017/08/09');
+
+        if (!$continue) {
+            $this->error('User aborted!');
+
+            return;
+        }
+
+        $ids = UsernameChangeHistory::where('timestamp', '>', Carbon::parse('2017/08/09'))
+            ->distinct()
+            ->pluck('user_id');
+
+        $topics = Topic::whereIn('topic_last_poster_id', $ids);
+        $bar = $this->output->createProgressBar($topics->count());
+        Topic::whereIn('topic_last_poster_id', $ids)->chunk(1000, function ($topics) use ($bar) {
+            foreach ($topics as $topic) {
+                $topic->refreshCache();
+                $bar->advance();
+            }
+        });
+
+        $bar->finish();
+    }
+}

--- a/app/Console/Commands/FixUsernameChangeTopicCache.php
+++ b/app/Console/Commands/FixUsernameChangeTopicCache.php
@@ -60,7 +60,7 @@ class FixUsernameChangeTopicCache extends Command
         $date = Carbon::parse('2017/08/09');
         $ids = UsernameChangeHistory::where('timestamp', '>', $date)
             ->distinct()
-            ->pluck('user_id');
+            ->pluck('user_id'); // pluck is faster than select for this.
 
         $userCount = count($ids);
         $this->warn("{$userCount} users effected");
@@ -75,9 +75,10 @@ class FixUsernameChangeTopicCache extends Command
         $this->info('Getting possible last poster counts...');
         $topicIds = Post::withTrashed()
             ->whereIn('poster_id', $ids)
-            ->whereNotIn('topic_id', (clone $topicsFirstPoster)->pluck('topic_id'))
+            ->whereNotIn('topic_id', (clone $topicsFirstPoster)->select('topic_id'))
             ->distinct()
-            ->pluck('topic_id');
+            ->select('topic_id') // select is faster than pluck for these.
+            ->get();
 
         $count += $topicIds->count();
         $this->warn("Total {$count}");

--- a/app/Console/Commands/FixUsernameChangeTopicCache.php
+++ b/app/Console/Commands/FixUsernameChangeTopicCache.php
@@ -22,6 +22,7 @@ namespace App\Console\Commands;
 
 use App\Models\Forum\Topic;
 use App\Models\Forum\Post;
+use App\Models\User;
 use App\Models\UsernameChangeHistory;
 use Carbon\Carbon;
 use Illuminate\Console\Command;
@@ -95,9 +96,9 @@ class FixUsernameChangeTopicCache extends Command
 
         $topicsFirstPoster->chunk(1000, function ($topics) use ($bar) {
             foreach ($topics as $topic) {
-                $topic->setFirstPostCache();
-                if ($topic->isDirty()) {
-                    $topic->save();
+                $username = User::select('username')->find($topic->topic_poster)->username;
+                if ($topic->topic_first_poster_name !== $username) {
+                    $topic->update(['topic_first_poster_name' => $username]);
                 }
 
                 $bar->advance();
@@ -108,9 +109,9 @@ class FixUsernameChangeTopicCache extends Command
 
         Topic::withTrashed()->whereIn('topic_id', $topicIds)->chunk(1000, function ($topics) use ($bar) {
             foreach ($topics as $topic) {
-                $topic->setFirstPostCache();
-                if ($topic->isDirty()) {
-                    $topic->save();
+                $username = User::select('username')->find($topic->topic_poster)->username;
+                if ($topic->topic_first_poster_name !== $username) {
+                    $topic->update(['topic_first_poster_name' => $username]);
                 }
 
                 $bar->advance();

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -47,6 +47,9 @@ class Kernel extends ConsoleKernel
 
         // moddingv2 kudosu recalculation
         Commands\KudosuRecalculateDiscussionsGrants::class,
+
+        // fix username change fail :D
+        Commands\FixUsernameChangeTopicCache::class,
     ];
 
     /**


### PR DESCRIPTION
turns out that getting the ids and then using `array_chunk` and selecting just the chunks is much faster than using Eloquent's `::chunk`