### PR TITLE
Shouldn't run username validation when reverting usernames.

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -193,7 +193,8 @@ class User extends Model implements AuthenticatableContract, Messageable
                 throw new ModelNotSavedException('failed saving model');
             }
 
-            $this->saveOrExplode(['inactive' => $type === 'inactive']);
+            $skipValidations = in_array($type, ['inactive', 'revert'], true);
+            $this->saveOrExplode(['skipValidations' => $skipValidations]);
         });
     }
 
@@ -1428,7 +1429,7 @@ class User extends Model implements AuthenticatableContract, Messageable
 
     public function save(array $options = [])
     {
-        if ($options['inactive'] ?? false) {
+        if ($options['skipValidations'] ?? false) {
             return parent::save($options);
         }
 


### PR DESCRIPTION
Because that would be silly.

Reverting to a username that was recently taken will be blocked by the unique constraint on `username_clean`