### PR TITLE
Add way to put outdated notice box in wiki page

### DIFF
--- a/app/Models/Wiki/Page.php
+++ b/app/Models/Wiki/Page.php
@@ -202,6 +202,11 @@ class Page
         }
     }
 
+    public function isOutdated()
+    {
+        return $this->page()['header']['outdated'] ?? false;
+    }
+
     public function page()
     {
         if (!array_key_exists('page', $this->cache)) {

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -405,7 +405,7 @@ function wiki_url($page = 'Welcome', $locale = null)
 {
     $params = compact('page');
 
-    if (present($locale) && $locale !== App::getLocale() && $locale !== config('app.fallback_locale')) {
+    if (present($locale) && $locale !== App::getLocale()) {
         $params['locale'] = $locale;
     }
 

--- a/resources/assets/less/bem-index.less
+++ b/resources/assets/less/bem-index.less
@@ -255,7 +255,7 @@
 @import "bem/usercard-list";
 @import "bem/userinfo-small";
 @import "bem/warning-box";
-@import "bem/wiki-fallback-locale";
+@import "bem/wiki-notice";
 @import "bem/wiki-page";
 @import "bem/wiki-toc";
 @import "bem/wiki-toc-list";

--- a/resources/assets/less/bem/wiki-notice.less
+++ b/resources/assets/less/bem/wiki-notice.less
@@ -16,7 +16,7 @@
  *    along with osu!web.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-.wiki-fallback-locale {
+.wiki-notice {
   padding: 10px 0;
 
   &__box {

--- a/resources/lang/en/wiki.php
+++ b/resources/lang/en/wiki.php
@@ -31,5 +31,10 @@ return [
             'link' => 'Show on GitHub',
             'refresh' => 'Refresh',
         ],
+
+        'outdated' => [
+            '_' => 'This page is outdated. Check :default for latest update and perhaps help translating it!',
+            'default' => 'English version',
+        ],
     ],
 ];

--- a/resources/lang/en/wiki.php
+++ b/resources/lang/en/wiki.php
@@ -33,7 +33,7 @@ return [
         ],
 
         'outdated' => [
-            '_' => 'This page is outdated. Check :default for latest update and perhaps help translating it!',
+            '_' => 'This page contains an outdated translation of the original content. Please check the :default for the most accurate information (and consider updating the translation if you are able to help out)!',
             'default' => 'English version',
         ],
     ],

--- a/resources/views/wiki/show.blade.php
+++ b/resources/views/wiki/show.blade.php
@@ -87,7 +87,7 @@
             <div class="wiki-notice">
                 <div class="wiki-notice__box">
                     {!! trans('wiki.show.outdated._', [
-                        'default' => '<a href="'.wiki_url($page->path, config('app.fallback_locale')).'">'.trans('wiki.show.outdated.default').'</a>',
+                        'default' => '<a href="'.e(wiki_url($page->path, config('app.fallback_locale'))).'">'.e(trans('wiki.show.outdated.default')).'</a>',
                     ]) !!}
                 </div>
             </div>

--- a/resources/views/wiki/show.blade.php
+++ b/resources/views/wiki/show.blade.php
@@ -76,9 +76,19 @@
 
     <div class="osu-page osu-page--wiki">
         @if ($page->page() !== null && $page->locale !== $page->requestedLocale)
-            <div class="wiki-fallback-locale">
-                <div class="wiki-fallback-locale__box">
+            <div class="wiki-notice">
+                <div class="wiki-notice__box">
                     {{ trans('wiki.show.fallback_translation', ['language' => locale_name($page->requestedLocale)]) }}
+                </div>
+            </div>
+        @endif
+
+        @if ($page->isOutdated())
+            <div class="wiki-notice">
+                <div class="wiki-notice__box">
+                    {!! trans('wiki.show.outdated._', [
+                        'default' => '<a href="'.wiki_url($page->path, config('app.fallback_locale')).'">'.trans('wiki.show.outdated.default').'</a>',
+                    ]) !!}
                 </div>
             </div>
         @endif


### PR DESCRIPTION
Just like news, put `outdated: true` in page metadata area

```
---
outdated: true
---
<content goes here>
```

Fixes #1827.