### PR TITLE
Link post with its resolve state change

### DIFF
--- a/app/Models/BeatmapDiscussion.php
+++ b/app/Models/BeatmapDiscussion.php
@@ -181,7 +181,9 @@ class BeatmapDiscussion extends Model
         $systemPosts = $this
             ->beatmapDiscussionPosts()
             ->withoutDeleted()
-            ->where('system', '=', true)->get();
+            ->where('system', '=', true)
+            ->orderBy('id', 'DESC')
+            ->get();
 
         foreach ($systemPosts as $post) {
             if ($post->message['type'] === 'resolved') {

--- a/app/Models/BeatmapDiscussion.php
+++ b/app/Models/BeatmapDiscussion.php
@@ -176,6 +176,22 @@ class BeatmapDiscussion extends Model
         });
     }
 
+    public function refreshResolved()
+    {
+        $systemPosts = $this
+            ->beatmapDiscussionPosts()
+            ->withoutDeleted()
+            ->where('system', '=', true)->get();
+
+        foreach ($systemPosts as $post) {
+            if ($post->message['type'] === 'resolved') {
+                return $this->update(['resolved' => $post->message['value']]);
+            }
+        }
+
+        return $this->update(['resolved' => false]);
+    }
+
     public function hasValidBeatmap()
     {
         return

--- a/resources/assets/coffee/react/beatmap-discussions/discussion.coffee
+++ b/resources/assets/coffee/react/beatmap-discussions/discussion.coffee
@@ -53,6 +53,8 @@ class BeatmapDiscussions.Discussion extends React.PureComponent
     lineClasses = "#{bn}__line"
     lineClasses += " #{bn}__line--resolved" if @props.discussion.resolved
 
+    lastResolvedState = false
+
     div
       className: topClasses
       'data-id': @props.discussion.id
@@ -82,7 +84,12 @@ class BeatmapDiscussions.Discussion extends React.PureComponent
           className: "#{bn}__expanded #{'hidden' if @state.collapsed}"
           div
             className: "#{bn}__replies"
-            @props.discussion.beatmap_discussion_posts.slice(1).map (reply) =>
+            for reply in @props.discussion.beatmap_discussion_posts.slice(1)
+              if reply.system && reply.message.type == 'resolved'
+                currentResolvedState = reply.message.value
+                continue if lastResolvedState == currentResolvedState
+                lastResolvedState = currentResolvedState
+
               @post reply, 'reply'
 
           el BeatmapDiscussions.NewReply,

--- a/resources/assets/coffee/react/beatmap-discussions/system-post.coffee
+++ b/resources/assets/coffee/react/beatmap-discussions/system-post.coffee
@@ -29,8 +29,11 @@ BeatmapDiscussions.SystemPost = (props) ->
           user: osu.link laroute.route('users.show', user: props.user.id), props.user.username,
             classNames: ["#{bn}__user"]
 
+  topClass = "#{bn} #{bn}--#{props.post.message.type}"
+  topClass += " #{bn}--deleted" if props.post.deleted_at
+
   div
-    className: "#{bn} #{bn}--#{props.post.message.type}"
+    className: topClass
     div
       className: "#{bn}__content"
       dangerouslySetInnerHTML:

--- a/resources/assets/less/bem/beatmap-discussion-system-post.less
+++ b/resources/assets/less/bem/beatmap-discussion-system-post.less
@@ -43,4 +43,10 @@
       margin-left: 10px;
     }
   }
+
+  // overrides all modifiers
+  &--deleted {
+    opacity: 0.75;
+    font-style: italic;
+  }
 }


### PR DESCRIPTION
~Side effect includes having a discussion to look like repeatedly reopened without any closing posts in between~. Now with fancy logic which hides resolved event indicator when no resolved state change.

Fixes #1835.

[//]: # (https://s.myconan.net/2017-11/firefox_2017-11-29_16-07-41.png)