### PR TITLE
Allow moderators to edit beatmap info description

### DIFF
--- a/app/Libraries/OsuAuthorize.php
+++ b/app/Libraries/OsuAuthorize.php
@@ -250,11 +250,11 @@ class OsuAuthorize
     {
         $this->ensureLoggedIn($user);
 
-        if ($user->user_id !== $beatmapset->user_id) {
-            return 'beatmapset_description.edit.not_owner';
+        if ($user->user_id === $beatmapset->user_id || $user->isGMT() || $user->isQAT()) {
+            return 'ok';
         }
 
-        return 'ok';
+        return 'beatmapset_description.edit.not_owner';
     }
 
     public function checkBeatmapsetDisqualify($user, $beatmapset)

--- a/resources/assets/coffee/react/beatmapset-page/info.coffee
+++ b/resources/assets/coffee/react/beatmapset-page/info.coffee
@@ -128,7 +128,7 @@ class BeatmapsetPage.Info extends React.Component
                 disabled: @state.isBusy
                 onChange: @onEditorChange
                 onSelectionUpdate: @onSelectionUpdate
-                rawValue: @state.description?.bbcode || @props.beatmapset.description.bbcode
+                rawValue: @state.description?.bbcode ? @props.beatmapset.description.bbcode
                 selection: @state.selection
 
       div className: 'beatmapset-info__box beatmapset-info__box--description',
@@ -141,7 +141,7 @@ class BeatmapsetPage.Info extends React.Component
         div
           className: 'beatmapset-info__description'
           dangerouslySetInnerHTML:
-            __html: @state.description?.description || @props.beatmapset.description.description
+            __html: @state.description?.description ? @props.beatmapset.description.description
 
       div className: 'beatmapset-info__box beatmapset-info__box--meta',
         if @props.beatmapset.source

--- a/resources/assets/coffee/react/beatmapset-page/info.coffee
+++ b/resources/assets/coffee/react/beatmapset-page/info.coffee
@@ -83,7 +83,7 @@ class BeatmapsetPage.Info extends React.Component
 
 
   withEdit: =>
-     window.currentUser.id == @props.beatmapset.user_id
+     @props.beatmapset.description.bbcode?
 
 
   renderChart: ->


### PR DESCRIPTION
fixes #1852
fixes #1855

Client-side just checks for existance of bbcode to decide whether to show the edit button to avoid adding more properties to the transformer, since the description bbcode is only sent if the user has edit permissions.