### PR TITLE
Skip blank data

### DIFF
--- a/resources/assets/coffee/_classes/changelog-chart.coffee
+++ b/resources/assets/coffee/_classes/changelog-chart.coffee
@@ -142,7 +142,7 @@ class @ChangelogChart
     return unless pos
 
     for el, i in @data
-      if y <= el[pos][1]
+      if y <= el[pos][1] && el[pos].data[el.key]?
         dataRow = i
         currentLabel = el.key
         labelModifier = @options.scales.class currentLabel


### PR DESCRIPTION
At mouse cursor `y=0`, first build/stream will always match because it must end at least at `y=0`. So make sure there's actual data before deciding that it's the correct build.