### PR TITLE
No count boolean

### DIFF
--- a/app/Models/UserRelation.php
+++ b/app/Models/UserRelation.php
@@ -46,7 +46,7 @@ class UserRelation extends Model
                 AND z.friend = 1
             ), 0)';
 
-        if (count(config('osu.user.super_friendly') > 0)) {
+        if (count(config('osu.user.super_friendly')) > 0) {
             $friendlyIds = implode(',', config('osu.user.super_friendly'));
             $raw = DB::raw(
                 "CASE WHEN phpbb_zebra.zebra_id IN ({$friendlyIds})


### PR DESCRIPTION
Ba dum tss.

Also it's currently impossible to be false anyway because `explode(' ', $something)` used for `config('osu.user.super_friendly')` will always return an array with at least 1 element, even on empty string.

```
>>> explode(' ', '')
=> [
     "",
   ]
```

```
>>> count(true)
=> 1
```