### PR TITLE
Fix tabbing when in news article previews

### DIFF
--- a/resources/views/home/_user_news_post_preview.blade.php
+++ b/resources/views/home/_user_news_post_preview.blade.php
@@ -19,6 +19,7 @@
 <div class="news-post-preview{{$collapsed ? ' news-post-preview--collapsed' : ''}}">
     <a
         class="news-post-preview__image"
+        tabindex="-1"
         href='{{ route('news.show', $post->getKey() )}}'
         {!! background_image($post->firstImage()) !!}
     ></a>


### PR DESCRIPTION
Prevent tabbing to the image to prevent the user from being able to tab both the image and the title text of the news article.