### PR TITLE
border-radius causes the left edge of textarea to disappear in Chrome…

### DIFF
--- a/resources/assets/less/bem/beatmap-discussion-post.less
+++ b/resources/assets/less/bem/beatmap-discussion-post.less
@@ -213,7 +213,6 @@
 
     &--editor {
       .reset-input();
-      .default-border-radius();
       width: 100%;
       resize: vertical;
 


### PR DESCRIPTION
...in some cases. wtf ಠ_ಠ

Should fix #1942