### PR TITLE
support qualified column name with model_pluck.

### DIFF
--- a/app/Models/Beatmapset.php
+++ b/app/Models/Beatmapset.php
@@ -400,7 +400,7 @@ class Beatmapset extends Model
                 $matchParams[] = ['match' => ['approved' => self::STATES['loved']]];
                 break;
             case 2: // Favourites
-                $favs = model_pluck($params['user']->favouriteBeatmapsets(), 'beatmapset_id');
+                $favs = model_pluck($params['user']->favouriteBeatmapsets(), 'beatmapset_id', self::class);
                 $matchParams[] = ['ids' => ['type' => 'beatmaps', 'values' => $favs]];
                 break;
             case 3: // Qualified

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -874,8 +874,12 @@ function array_rand_val($array)
  *
  * If need to pluck for all rows, just call `select()` on the class.
  */
-function model_pluck($builder, $key)
+function model_pluck($builder, $key, $class = null)
 {
+    if ($class) {
+        $key = (new $class)->getTable().'.'.$key;
+    }
+
     $result = [];
 
     foreach ($builder->select($key)->get() as $el) {


### PR DESCRIPTION
otherwise laravel will fail to select with joins on tables with the same
column names.

fixes search broken by #1999 

