### PR TITLE
Get first post id of topic faster

### DIFF
--- a/app/Http/Controllers/Forum/TopicsController.php
+++ b/app/Http/Controllers/Forum/TopicsController.php
@@ -256,7 +256,10 @@ class TopicsController extends Controller
 
         $firstPostId = $topic->posts()
             ->showDeleted($showDeleted)
-            ->min('post_id');
+            ->orderBy('post_id', 'asc')
+            ->select('post_id')
+            ->first()
+            ->post_id;
 
         $firstShownPostId = $posts->first()->post_id;
 


### PR DESCRIPTION
fixes https://github.com/ppy/osu-web/issues/1873#issuecomment-348544535

Apparently, mysql is fetching all the matching rows before applying min