### PR TITLE
Show 20 extra results per profile page pagination, rather than 5

### DIFF
--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -300,7 +300,7 @@ class UsersController extends Controller
         return [$friend, $friend->mutual ?? false];
     }
 
-    private function parsePaginationParams($perPage)
+    private function parsePaginationParams($firstPage, $perPage = 20)
     {
         $this->user = User::lookup(Request::route('user'), 'id');
         if ($this->user === null || !priv_check('UserShow', $this->user)->can()) {
@@ -316,6 +316,8 @@ class UsersController extends Controller
 
         if ($this->offset >= $this->maxResults) {
             $this->perPage = 0;
+        } else if ($this->offset === 0) {
+            $this->perPage = $firstPage;
         } else {
             $this->perPage = min($perPage, $this->maxResults - $this->offset);
         }

--- a/resources/assets/coffee/react/profile-page/show-more-link.coffee
+++ b/resources/assets/coffee/react/profile-page/show-more-link.coffee
@@ -25,9 +25,10 @@ class ProfilePage.ShowMoreLink extends React.PureComponent
 
     else
       firstLoad = !@props.pagination?
-      perPage = @props.perPage ? 5
+      firstPage = 5
+      perPage = @props.perPage ? 20
       maxResults = @props.maxResults ? 100
-      hasMore = (firstLoad && (!@props.collection? || @props.collection.length == perPage)) || @props.pagination?.hasMore
+      hasMore = (firstLoad && (!@props.collection? || @props.collection.length == firstPage)) || @props.pagination?.hasMore
 
       return null unless hasMore
 


### PR DESCRIPTION
The initial display is unchanged – only pagination is affected.

Closes #2010.