### PR TITLE
Include qualified beatmapsets on user profile page.

### DIFF
--- a/app/Models/Beatmapset.php
+++ b/app/Models/Beatmapset.php
@@ -301,7 +301,10 @@ class Beatmapset extends Model
 
     public function scopeRankedOrApproved($query)
     {
-        return $query->whereIn('approved', [self::STATES['ranked'], self::STATES['approved']]);
+        return $query->whereIn(
+            'approved',
+            [self::STATES['ranked'], self::STATES['approved'], self::STATES['qualified']]
+        );
     }
 
     public function scopeActive($query)


### PR DESCRIPTION
fixes #1875

Ended up not renaming the associated functions as that ended up cascading a lot of changes through, and changes the output of the transformers as well. Probably should do a refactor of the scope and transformer include methods to use a list of states to filter for, instead.