### PR TITLE
Reduce menu delay and auto resize menu

### DIFF
--- a/resources/assets/coffee/_classes/menu.coffee
+++ b/resources/assets/coffee/_classes/menu.coffee
@@ -129,5 +129,10 @@ class @Menu
         @$menuLink(menuId).removeClass('js-menu--active')
 
       else
+        last = $(menu).children('a:last')
+        bottom = last.position().top + last.height()
+        height = Math.max(250, bottom + 120)
+        $('.nav-popup').css('height', "#{height}px")
+
         Fade.in menu
         @$menuLink(menuId).addClass('js-menu--active')

--- a/resources/assets/coffee/_classes/menu.coffee
+++ b/resources/assets/coffee/_classes/menu.coffee
@@ -131,7 +131,7 @@ class @Menu
       else
         last = $(menu).children('a:last')
         bottom = last.position().top + last.height()
-        height = Math.max(250, bottom + 120)
+        height = Math.max(210, bottom + 110)
         $('.nav-popup').css('height', "#{height}px")
 
         Fade.in menu

--- a/resources/assets/coffee/_classes/nav.coffee
+++ b/resources/assets/coffee/_classes/nav.coffee
@@ -74,12 +74,12 @@ class @Nav
     return if @currentMode() == 'search'
 
     @clearTimeouts()
-    @hideTimeout = Timeout.set 250, @hidePopup
+    @hideTimeout = Timeout.set 50, @hidePopup
 
 
   delayedShowPopup: =>
     @clearTimeouts()
-    @showTimeout = Timeout.set 250, @showPopup
+    @showTimeout = Timeout.set 50, @showPopup
 
 
   floatPopup: (float) =>

--- a/resources/assets/less/bem/nav-popup.less
+++ b/resources/assets/less/bem/nav-popup.less
@@ -33,6 +33,7 @@
   @media @desktop {
     padding-left: (@padding-big - (@_menu-spacing / 2));
     min-height: @height--nav-popup;
+    transition: height 120ms;
   }
 
   &--main {

--- a/resources/assets/less/variables.less
+++ b/resources/assets/less/variables.less
@@ -29,7 +29,7 @@
 // ┐(ﾟ ヮﾟ)┌
 @padding-wiki-desktop: 40px;
 
-@height--nav-popup: 325px;
+@height--nav-popup: 250px; // min-height; actual height will be calculated by js.
 
 @navbar-mobile--content-height: @navbar-height - (@navbar-padding-vertical * 2);
 

--- a/resources/assets/less/variables.less
+++ b/resources/assets/less/variables.less
@@ -29,7 +29,7 @@
 // ┐(ﾟ ヮﾟ)┌
 @padding-wiki-desktop: 40px;
 
-@height--nav-popup: 250px; // min-height; actual height will be calculated by js.
+@height--nav-popup: 210px; // min-height; actual height will be calculated by js.
 
 @navbar-mobile--content-height: @navbar-height - (@navbar-padding-vertical * 2);
 


### PR DESCRIPTION
- Reduce the delay for showing and dismissing the navigation menu.
- hacky auto resize menu if the content for that sub menu exceeds a certain height (hi language menu).

fixes #2110 and eliminates need to keep updating the menu size when a new language gets added.
