### PR TITLE
Discussion timeline fix

### DIFF
--- a/app/Models/BeatmapDiscussion.php
+++ b/app/Models/BeatmapDiscussion.php
@@ -235,9 +235,17 @@ class BeatmapDiscussion extends Model
 
     public function hasValidTimestamp()
     {
+        if ($this->timestamp === null) {
+            return true;
+        }
+
+        // skip validation if not changed
+        if (!$this->isDirty('timestamp')) {
+            return true;
+        }
+
         return
-            ($this->timestamp === null) ||
-            ($this->beatmap_id !== null && $this->timestamp >= 0 && $this->timestamp <= ($this->beatmap->total_length) * 1000);
+            $this->beatmap_id !== null && $this->timestamp >= 0 && $this->timestamp <= ($this->beatmap->total_length) * 1000;
     }
 
     public function votesSummary()

--- a/app/Transformers/BeatmapDiscussionTransformer.php
+++ b/app/Transformers/BeatmapDiscussionTransformer.php
@@ -39,7 +39,7 @@ class BeatmapDiscussionTransformer extends Fractal\TransformerAbstract
 
         return [
             'id' => $discussion->id,
-            'beatmapset_discussion_id' => $discussion->beatmapset_discussion_id,
+            'beatmapset_id' => $discussion->beatmapset_id,
             'beatmap_id' => $discussion->beatmap_id,
             'user_id' => $discussion->user_id,
             'deleted_by_id' => $discussion->deleted_by_id,


### PR DESCRIPTION
- replace empty key with something more useful
- fix replying on timeline which map has been updated with shorter duration resulting in existing timestamp to exceed the new duration