### PR TITLE
Hotfix unranked beatmapset pages breaking

### DIFF
--- a/app/Transformers/BeatmapsetTransformer.php
+++ b/app/Transformers/BeatmapsetTransformer.php
@@ -210,7 +210,7 @@ class BeatmapsetTransformer extends Fractal\TransformerAbstract
 
                 $beatmap->playmode = $modeInt;
                 $beatmap->convert = true;
-                $beatmap->difficultyrating = $difficulty->diff_unified;
+                $beatmap->difficultyrating = $difficulty ? $difficulty->diff_unified : 0;
 
                 array_push($converts, $beatmap);
             }


### PR DESCRIPTION
Difficulty data is not populated for unranked beatmapsets, so the page explodes when trying to show the star difficulty.

Probably not the correct way to fix this, but it stops the page from exploding for now.

Fixes #2184
  