### PR TITLE
Only query for active Beatmapsets when indexing.

### DIFF
--- a/app/Models/Elasticsearch/BeatmapsetTrait.php
+++ b/app/Models/Elasticsearch/BeatmapsetTrait.php
@@ -44,6 +44,7 @@ trait BeatmapsetTrait
     {
         return static::on('mysql-readonly')
             ->withoutGlobalScopes()
+            ->active()
             ->with('beatmaps'); // note that the with query will run with the default scopes.
     }
 


### PR DESCRIPTION
Should fix the sorting by certain fields in ascending order when searching for Pending beatmapsets, after a clean index is created.

The issue was that beatmapsets that weren't set as active yet could have their records removed (instead of a soft delete) from elsewhere, which meant the change wouldn't be picked up on indexing.