### PR TITLE
composer require symfony/yaml

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,6 +15,7 @@
     }
   ],
   "require": {
+    "chaseconey/laravel-datadog-helper": "*",
     "doctrine/dbal": "*",
     "elasticsearch/elasticsearch": "~2.0",
     "ezyang/htmlpurifier": "*",
@@ -26,20 +27,20 @@
     "laravel/passport": "*",
     "laravel/tinker": "~1.0",
     "laravelcollective/html": "5.5.*",
+    "league/commonmark": "0.16.*",
     "league/flysystem-aws-s3-v3": "^1.0",
     "league/fractal": "*",
-    "league/commonmark": "0.16.*",
     "lord/laroute": "*",
     "maknz/slack": "dev-laravel-5.4",
     "mariuzzo/laravel-js-localization": "*",
+    "paypal/rest-api-sdk-php": "*",
     "predis/predis": "~1.0",
     "sentry/sentry-laravel": "*",
     "shift31/laravel-elasticsearch": "~2.0",
-    "webuni/commonmark-table-extension": "*",
-    "chaseconey/laravel-datadog-helper": "*",
+    "symfony/yaml": "^4.0",
     "tumblr/tumblr": "*",
-    "xsolla/xsolla-sdk-php": "*",
-    "paypal/rest-api-sdk-php": "*"
+    "webuni/commonmark-table-extension": "*",
+    "xsolla/xsolla-sdk-php": "*"
   },
   "require-dev": {
     "filp/whoops": "~2.0",

--- a/composer.json
+++ b/composer.json
@@ -37,7 +37,7 @@
     "predis/predis": "~1.0",
     "sentry/sentry-laravel": "*",
     "shift31/laravel-elasticsearch": "~2.0",
-    "symfony/yaml": "^4.0",
+    "symfony/yaml": "*",
     "tumblr/tumblr": "*",
     "webuni/commonmark-table-extension": "*",
     "xsolla/xsolla-sdk-php": "*"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "aaf0f4f782baecaaf31e4116d25b6be6",
+    "content-hash": "066f83facdd84287803f2187838ad7ed",
     "packages": [
         {
             "name": "aws/aws-sdk-php",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "content-hash": "5917b5be4b7cc7402b6343688cd7195e",
+    "content-hash": "aaf0f4f782baecaaf31e4116d25b6be6",
     "packages": [
         {
             "name": "aws/aws-sdk-php",
@@ -2746,7 +2746,7 @@
                 "slack"
             ],
             "support": {
-                "source": "https://github.com/nanaya/slack-php/tree/1.7.1"
+                "source": "https://github.com/nanaya/slack-php/tree/laravel-5.4"
             },
             "time": "2017-02-16T06:27:23+00:00"
         },
@@ -5413,6 +5413,64 @@
                 "dump"
             ],
             "time": "2018-01-03T17:14:19+00:00"
+        },
+        {
+            "name": "symfony/yaml",
+            "version": "v4.0.3",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/symfony/yaml.git",
+                "reference": "b84f646b9490d2101e2c25ddeec77ceefbda2eee"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/b84f646b9490d2101e2c25ddeec77ceefbda2eee",
+                "reference": "b84f646b9490d2101e2c25ddeec77ceefbda2eee",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1.3"
+            },
+            "conflict": {
+                "symfony/console": "<3.4"
+            },
+            "require-dev": {
+                "symfony/console": "~3.4|~4.0"
+            },
+            "suggest": {
+                "symfony/console": "For validating YAML files using the lint command"
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "4.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Symfony\\Component\\Yaml\\": ""
+                },
+                "exclude-from-classmap": [
+                    "/Tests/"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Fabien Potencier",
+                    "email": "fabien@symfony.com"
+                },
+                {
+                    "name": "Symfony Community",
+                    "homepage": "https://symfony.com/contributors"
+                }
+            ],
+            "description": "Symfony Yaml Component",
+            "homepage": "https://symfony.com",
+            "time": "2018-01-03T07:38:00+00:00"
         },
         {
             "name": "tedivm/jshrink",


### PR DESCRIPTION
Required to use `Symfony\Component\Yaml\Yaml`;
Used to be included implicitly by phpunit, not anymore.