### PR TITLE
change datadog prefix config key to get old tag prefixes back.

### DIFF
--- a/app/Libraries/Search.php
+++ b/app/Libraries/Search.php
@@ -109,7 +109,7 @@ class Search
 
             if (config('datadog-helper.enabled') && $mode !== 'beatmapset') {
                 $searchDuration = microtime(true) - $startTime;
-                Datadog::microtiming(config('datadog-helper.prefix').'.search', $searchDuration, 1, ['type' => $mode]);
+                Datadog::microtiming(config('datadog-helper.prefix_web').'.search', $searchDuration, 1, ['type' => $mode]);
             }
         }
 

--- a/app/Models/Beatmapset.php
+++ b/app/Models/Beatmapset.php
@@ -572,7 +572,7 @@ class Beatmapset extends Model
 
         if (config('datadog-helper.enabled')) {
             $searchDuration = microtime(true) - $startTime;
-            Datadog::microtiming(config('datadog-helper.prefix').'.search', $searchDuration, 1, ['type' => 'beatmapset']);
+            Datadog::microtiming(config('datadog-helper.prefix_web').'.search', $searchDuration, 1, ['type' => 'beatmapset']);
         }
 
         return [

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -54,7 +54,7 @@ class AppServiceProvider extends ServiceProvider
 
         Queue::after(function (JobProcessed $event) {
             if (config('datadog-helper.enabled')) {
-                Datadog::increment(config('datadog-helper.prefix').'.queue.run', 1, ['queue' => $event->job->getQueue()]);
+                Datadog::increment(config('datadog-helper.prefix_web').'.queue.run', 1, ['queue' => $event->job->getQueue()]);
             }
         });
     }

--- a/config/datadog-helper.php
+++ b/config/datadog-helper.php
@@ -21,7 +21,7 @@ return [
     | inside of your prefix. A common naming scheme is something like app.<app-name>.
     |
     */
-    'prefix' => env('DATADOG_PREFIX', 'osu.web'),
+    'prefix_web' => env('DATADOG_PREFIX', 'osu.web'), // different key to revert to manually prefixed tags
     'api_key' => env('DATADOG_API_KEY'),
     'application_key' => env('DATADOG_APP_KEY'),
     'datadog_host' => env('DATADOG_HOST', 'https://app.datadoghq.com'),


### PR DESCRIPTION
laravel-datadog-helper prefixes all tags by default now.