### PR TITLE
Fix broken url parsing in beatmapset discussions

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "retina.js": "^1.1.0",
     "timeago": "^1.5.0",
     "turbolinks": "^5.0.0-beta4",
-    "url-polyfill": "^1.0.7",
+    "url-polyfill": "^1.0.10",
     "webpack-sentry-plugin": "^1.9.2"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -6304,9 +6304,9 @@ url-parse@^1.1.8:
     querystringify "~1.0.0"
     requires-port "1.0.x"
 
-url-polyfill@^1.0.7:
-  version "1.0.7"
-  resolved "https://registry.yarnpkg.com/url-polyfill/-/url-polyfill-1.0.7.tgz#9dfd952aa6dcab8755c3eba7c4a3db5b41910ffd"
+url-polyfill@^1.0.10:
+  version "1.0.10"
+  resolved "https://registry.yarnpkg.com/url-polyfill/-/url-polyfill-1.0.10.tgz#097b81b3cf7556bfc396a3c8633044d410e36685"
 
 url-regex@^3.0.0:
   version "3.2.0"


### PR DESCRIPTION
...by updating url-polyfill

The polyfill provided `URL` couldn't handle the `window.location` object in the constructor, updating fixes this.

The polyfill also seems to be loading in Safari when it shouldn't be, which is a different issue.