### PR TITLE
Hide deleted beatmaps with no discussions

### DIFF
--- a/app/Http/Controllers/BeatmapsetWatchesController.php
+++ b/app/Http/Controllers/BeatmapsetWatchesController.php
@@ -56,7 +56,7 @@ class BeatmapsetWatchesController extends Controller
             }
         }
 
-        return $beatmapset->defaultJson();
+        return response([], 204);
     }
 
     public function destroy($beatmapsetId)
@@ -65,6 +65,6 @@ class BeatmapsetWatchesController extends Controller
 
         $beatmapset->watches()->where('user_id', '=', Auth::user()->getKey())->delete();
 
-        return $beatmapset->defaultJson();
+        return response([], 204);
     }
 }

--- a/resources/assets/coffee/react/beatmap-discussions/beatmap-list.coffee
+++ b/resources/assets/coffee/react/beatmap-discussions/beatmap-list.coffee
@@ -55,6 +55,8 @@ class BeatmapDiscussions.BeatmapList extends React.PureComponent
     menuItemClasses = "#{bn}__item"
     menuItemClasses += " #{bn}__item--current" if beatmap.id == @props.currentBeatmap.id
 
+    count = if beatmap.deleted_at? then null else @props.currentDiscussions.countsByBeatmap[beatmap.id]
+
     a
       href: BeatmapDiscussionHelper.hash beatmapId: beatmap.id
       className: menuItemClasses
@@ -64,7 +66,7 @@ class BeatmapDiscussions.BeatmapList extends React.PureComponent
       el BeatmapDiscussions.BeatmapListItem,
         beatmap: beatmap
         mode: 'version'
-        count: @props.currentDiscussions.countsByBeatmap[beatmap.id]
+        count: count
 
 
   hideSelector: (e) =>

--- a/resources/assets/coffee/react/beatmap-discussions/main.coffee
+++ b/resources/assets/coffee/react/beatmap-discussions/main.coffee
@@ -30,13 +30,10 @@ class BeatmapDiscussions.Main extends React.PureComponent
     @checkNewTimeoutMax = 60000
     @cache = {}
 
-    beatmaps = @groupBeatmaps props.initial.beatmapsetDiscussion
-
     @state =
       beatmapset: @props.initial.beatmapsetDiscussion.beatmapset
-      beatmaps: beatmaps
       beatmapsetDiscussion: @props.initial.beatmapsetDiscussion
-      currentBeatmap: BeatmapHelper.default(group: beatmaps)
+      currentBeatmap: null
       currentUser: currentUser
       userPermissions: @props.initial.userPermissions
       mode: 'timeline'
@@ -81,8 +78,8 @@ class BeatmapDiscussions.Main extends React.PureComponent
     div className: 'osu-layout osu-layout--full',
       el BeatmapDiscussions.Header,
         beatmapset: @state.beatmapset
-        beatmaps: @state.beatmaps
-        currentBeatmap: @state.currentBeatmap
+        beatmaps: @groupedBeatmaps()
+        currentBeatmap: @currentBeatmap()
         currentDiscussions: @currentDiscussions()
         currentUser: @state.currentUser
         currentFilter: @state.currentFilter
@@ -108,14 +105,14 @@ class BeatmapDiscussions.Main extends React.PureComponent
           el BeatmapDiscussions.NewDiscussion,
             beatmapset: @state.beatmapset
             currentUser: @state.currentUser
-            currentBeatmap: @state.currentBeatmap
+            currentBeatmap: @currentBeatmap()
             currentDiscussions: @currentDiscussions()
             mode: @state.mode
 
           el BeatmapDiscussions.Discussions,
             beatmapset: @state.beatmapset
             beatmapsetDiscussion: @state.beatmapsetDiscussion
-            currentBeatmap: @state.currentBeatmap
+            currentBeatmap: @currentBeatmap()
             currentDiscussions: @currentDiscussions()
             currentFilter: @state.currentFilter
             currentUser: @state.currentUser
@@ -126,7 +123,17 @@ class BeatmapDiscussions.Main extends React.PureComponent
 
 
   beatmaps: =>
-    @cache.beatmaps ?= _.keyBy @state.beatmapset.beatmaps, 'id'
+    return @cache.beatmaps if @cache.beatmaps?
+
+    hasDiscussion = {}
+    hasDiscussion[d.beatmap_id] = true for d in @state.beatmapsetDiscussion.beatmap_discussions
+
+    @cache.beatmaps ?=
+      _(@state.beatmapset.beatmaps)
+      .filter (beatmap) ->
+        !beatmap.deleted_at? || hasDiscussion[beatmap.id]
+      .keyBy 'id'
+      .value()
 
 
   checkNew: =>
@@ -156,6 +163,10 @@ class BeatmapDiscussions.Main extends React.PureComponent
       @nextTimeout = Math.min @nextTimeout, @checkNewTimeoutMax
 
       @checkNewTimeout = Timeout.set @nextTimeout, @checkNew
+
+
+  currentBeatmap: =>
+    @state.currentBeatmap ? BeatmapHelper.default(group: @groupedBeatmaps())
 
 
   currentDiscussions: =>
@@ -201,7 +212,7 @@ class BeatmapDiscussions.Main extends React.PureComponent
 
         mode =
           if d.beatmap_id?
-            if d.beatmap_id == @state.currentBeatmap.id
+            if d.beatmap_id == @currentBeatmap().id
               if d.timestamp?
                 'timeline'
               else
@@ -247,14 +258,10 @@ class BeatmapDiscussions.Main extends React.PureComponent
     @cache.currentDiscussions
 
 
-  groupBeatmaps: (discussionSet) =>
-    hasDiscussion = {}
-    hasDiscussion[d.beatmap_id] = true for d in discussionSet.beatmap_discussions
+  groupedBeatmaps: (discussionSet) =>
+    return @cache.groupedBeatmaps if @cache.groupedBeatmaps?
 
-    filteredBeatmaps = discussionSet.beatmapset.beatmaps.filter (beatmap) =>
-      !beatmap.deleted_at? || hasDiscussion[beatmap.id]
-
-    BeatmapHelper.group filteredBeatmaps
+    @cache.groupedBeatmaps = BeatmapHelper.group _.values(@beatmaps())
 
 
   jumpByHash: =>
@@ -266,7 +273,7 @@ class BeatmapDiscussions.Main extends React.PureComponent
     if target.mode == 'events'
       return @setMode null, mode: 'events'
 
-    target.beatmapId ?= @state.currentBeatmap.id
+    target.beatmapId ?= @currentBeatmap().id
     $.publish 'beatmap:select', id: target.beatmapId
 
 
@@ -332,12 +339,11 @@ class BeatmapDiscussions.Main extends React.PureComponent
     @setState
       beatmapsetDiscussion: beatmapsetDiscussion
       beatmapset: beatmapsetDiscussion.beatmapset
-      beatmaps: @groupBeatmaps beatmapsetDiscussion
       callback
 
   setCurrentBeatmapId: (_e, {id, callback}) =>
     return callback?() if !id?
-    return callback?() if id == @state.currentBeatmap.id
+    return callback?() if id == @currentBeatmap().id
 
     beatmap = @beatmaps()[id]
 
@@ -347,7 +353,7 @@ class BeatmapDiscussions.Main extends React.PureComponent
 
 
   setCurrentPlaymode: (_e, {mode}) =>
-    beatmap = BeatmapHelper.default items: @state.beatmaps[mode]
+    beatmap = BeatmapHelper.default items: @groupedBeatmaps()[mode]
     @setCurrentBeatmapId null, id: beatmap?.id
 
 

--- a/resources/assets/coffee/react/beatmap-discussions/subscribe.coffee
+++ b/resources/assets/coffee/react/beatmap-discussions/subscribe.coffee
@@ -47,7 +47,7 @@ class BeatmapDiscussions.Subscribe extends React.PureComponent
       type: if @props.beatmapset.is_watched then 'DELETE' else 'PUT'
       dataType: 'json'
     .done (data) =>
-      $.publish 'beatmapset:update', beatmapset: data
+      $.publish 'beatmapsetWatch:update', watching: !@props.beatmapset.is_watched
     .fail (xhr) =>
       osu.emitAjaxError() xhr
     .always =>


### PR DESCRIPTION
As beatmaps are now linked with discussions, remove beatmapset updater. It's already partly broken anyway because it doesn't usually contain deleted beatmaps. Its only user is watch function which is updated to simply toggle the watch state instead of passing the whole beatmapset.

Comes with bonus of hiding unresolved post count of deleted beatmaps.

On unrelated news, generating json of set with large discussions takes quite a long time... 🌈 