### PR TITLE
Prevent showing empty error message

### DIFF
--- a/resources/assets/coffee/osu_common.coffee
+++ b/resources/assets/coffee/osu_common.coffee
@@ -268,7 +268,7 @@
 
     message ?= xhr?.responseJSON?.error
 
-    if !message?
+    if !message? || message == ''
       errorKey = "errors.codes.http-#{xhr?.status}"
       message = osu.trans errorKey
       message = osu.trans 'errors.unknown' if message == errorKey


### PR DESCRIPTION
Laravel now passes error json as well with same key as existing ones. With default of empty string.

Fixes #2186.