### PR TITLE
Disable vote button initially; return more user-friendly error

### DIFF
--- a/app/Models/Forum/TopicVote.php
+++ b/app/Models/Forum/TopicVote.php
@@ -51,7 +51,7 @@ class TopicVote
             $this->validationErrors()->reset();
 
             if (!isset($this->params['option_ids']) || count($this->params['option_ids']) < 1) {
-                $this->validationErrors()->add('option_ids', 'required');
+                $this->validationErrors()->add('option_ids', '.required');
             }
 
             if (count($this->params['option_ids'] ?? []) > $this->topic->poll_max_options) {

--- a/resources/lang/en/model_validation.php
+++ b/resources/lang/en/model_validation.php
@@ -62,6 +62,7 @@ return [
         ],
 
         'topic_vote' => [
+            'required' => 'Select an option when voting.',
             'too_many' => 'Selected more options than allowed.',
         ],
     ],

--- a/resources/views/forum/topics/_poll.blade.php
+++ b/resources/views/forum/topics/_poll.blade.php
@@ -59,7 +59,7 @@
         @if (!priv_check('ForumTopicVote', $topic)->can())
             {{ priv_check('ForumTopicVote', $topic)->message() }}
         @else
-            <button class="btn-osu-lite btn-osu-lite--default js-checkbox-validation--submit">
+            <button class="btn-osu-lite btn-osu-lite--default js-checkbox-validation--submit" disabled>
                 {{ trans('forum.topics.show.poll.vote') }}
             </button>
         @endif


### PR DESCRIPTION
fixes #2288

In theory, the error message shouldn't appear anymore.
Of course, this means you can't click the button anymore if js isn't enabled, but then again, there's going to be problems with the rest of the site without js enabled :trollface: 