### PR TITLE
Allow starting discussion beyond last hit object

### DIFF
--- a/app/Models/BeatmapDiscussion.php
+++ b/app/Models/BeatmapDiscussion.php
@@ -323,8 +323,10 @@ class BeatmapDiscussion extends Model
             return true;
         }
 
+        // FIXME: total_length is only for existing hit objects.
+        // FIXME: The chart in discussion page will need to account this as well.
         return
-            $this->beatmap_id !== null && $this->timestamp >= 0 && $this->timestamp <= ($this->beatmap->total_length) * 1000;
+            $this->beatmap_id !== null && $this->timestamp >= 0 && $this->timestamp <= ($this->beatmap->total_length + 10) * 1000;
     }
 
     public function votesSummary()

--- a/tests/Models/BeatmapDiscussionTest.php
+++ b/tests/Models/BeatmapDiscussionTest.php
@@ -104,7 +104,8 @@ class BeatmapDiscussionTest extends TestCase
         $otherBeatmapset = factory(Beatmapset::class)->create();
         $otherBeatmap = $otherBeatmapset->beatmaps()->save(factory(Beatmap::class)->make());
 
-        $invalidTimestamp = $beatmap->total_length * 1000 + 1;
+        $validTimestamp = ($beatmap->total_length + 10) * 1000;
+        $invalidTimestamp = $validTimestamp + 1;
 
         // blank everything not fine
         $discussion = $this->newDiscussion($beatmapset);
@@ -130,17 +131,22 @@ class BeatmapDiscussionTest extends TestCase
 
         // complete data is fine as well
         $discussion = $this->newDiscussion($beatmapset);
+        $discussion->fill(['timestamp' => $validTimestamp, 'message_type' => 'praise', 'beatmap_id' => $beatmap->beatmap_id]);
+        $this->assertTrue($discussion->isValid());
+
+        // Including timestamp 0
+        $discussion = $this->newDiscussion($beatmapset);
         $discussion->fill(['timestamp' => 0, 'message_type' => 'praise', 'beatmap_id' => $beatmap->beatmap_id]);
         $this->assertTrue($discussion->isValid());
 
         // just timestamp is not valid
         $discussion = $this->newDiscussion($beatmapset);
-        $discussion->fill(['timestamp' => 0]);
+        $discussion->fill(['timestamp' => $validTimestamp]);
         $this->assertFalse($discussion->isValid());
 
         // nor is wrong beatmap_id
         $discussion = $this->newDiscussion($beatmapset);
-        $discussion->fill(['timestamp' => 0, 'message_type' => 'praise', 'beatmap_id' => $otherBeatmap->beatmap_id]);
+        $discussion->fill(['timestamp' => $validTimestamp, 'message_type' => 'praise', 'beatmap_id' => $otherBeatmap->beatmap_id]);
         $this->assertFalse($discussion->isValid());
 
         // nor is wrong timestamp


### PR DESCRIPTION
`total_duration` is only for the end of hit objects and not the end of the map/music.