### PR TITLE
Require title attribute for time tooltip

### DIFF
--- a/resources/assets/coffee/_classes/tooltip-default.coffee
+++ b/resources/assets/coffee/_classes/tooltip-default.coffee
@@ -18,7 +18,7 @@
 
 class @TooltipDefault
   constructor: ->
-    $(document).on 'mouseover', '[title]:not(iframe), .js-tooltip-time', @onMouseOver
+    $(document).on 'mouseover', '[title]:not(iframe)', @onMouseOver
     $(document).on 'mouseenter touchstart', '.u-ellipsis-overflow, .u-ellipsis-overflow-desktop', @autoAddTooltip
     $(document).on 'turbolinks:before-cache', @rollback
 
@@ -29,7 +29,7 @@ class @TooltipDefault
     title = el.getAttribute 'title'
     el.removeAttribute 'title'
 
-    return if _.size(title) == 0 && !el.classList.contains('js-tooltip-time')
+    return if _.size(title) == 0
 
     isTime = el.classList.contains('timeago') || el.classList.contains('js-tooltip-time')
 

--- a/resources/assets/coffee/react/_components/beatmapset-mapping.coffee
+++ b/resources/assets/coffee/react/_components/beatmapset-mapping.coffee
@@ -54,4 +54,5 @@ class @BeatmapsetMapping extends React.PureComponent
       time
         className: "#{bn}__date js-tooltip-time"
         dateTime: @props.beatmapset[attribute]
+        title: @props.beatmapset[attribute]
         moment(@props.beatmapset[attribute]).format dateFormat

--- a/resources/assets/coffee/react/beatmap-discussions/event.coffee
+++ b/resources/assets/coffee/react/beatmap-discussions/event.coffee
@@ -32,6 +32,7 @@ class BeatmapDiscussions.Event extends React.PureComponent
       time
         className: 'beatmapset-event__time js-tooltip-time'
         dateTime: @props.event.created_at
+        title: @props.event.created_at
         eventTime.format 'LT'
       div
         className: 'beatmapset-event__content'


### PR DESCRIPTION
Weird bug otherwise when the date is specified using `title`. Also prevent running the tooltip repeatedly on the specific class.