### PR TITLE
Scoreboard friend/self highlighting

### DIFF
--- a/resources/assets/coffee/osu_common.coffee
+++ b/resources/assets/coffee/osu_common.coffee
@@ -30,7 +30,7 @@
 
 
   currentUserIsFriendsWith: (user_id) ->
-    currentUser && _.find currentUser.friends, (o) -> o.target_id == user_id
+    _.find currentUser.friends, target_id: user_id
 
 
   executeAction: (element) =>

--- a/resources/assets/coffee/osu_common.coffee
+++ b/resources/assets/coffee/osu_common.coffee
@@ -29,6 +29,10 @@
     (body.scrollHeight - body.scrollTop) - body.clientHeight
 
 
+  currentUserIsFriendsWith: (user_id) ->
+    currentUser && _.find currentUser.friends, (o) -> o.target_id == user_id
+
+
   executeAction: (element) =>
     if !element?
       osu.reloadPage()

--- a/resources/assets/coffee/react/beatmapset-page/scoreboard-table.coffee
+++ b/resources/assets/coffee/react/beatmapset-page/scoreboard-table.coffee
@@ -49,6 +49,9 @@ BeatmapsetPage.ScoreboardTable = (props) ->
           if props.scoreboardType != 'friend' && osu.currentUserIsFriendsWith(score.user.id)
             rowClasses += " #{bn}__body-row--friend"
 
+          if score.user.id == currentUser.id
+            rowClasses += " #{bn}__body-row--self"
+
           tr
             className: rowClasses
             key: i,

--- a/resources/assets/coffee/react/beatmapset-page/scoreboard-table.coffee
+++ b/resources/assets/coffee/react/beatmapset-page/scoreboard-table.coffee
@@ -41,8 +41,16 @@ BeatmapsetPage.ScoreboardTable = (props) ->
 
       tbody className: "#{bn}__body",
         for score, i in props.scores
+          rowClasses = "#{bn}__body-row"
+
+          if i == 0
+            rowClasses += " #{bn}__body-row--first"
+
+          if props.scoreboardType != 'friend' && osu.currentUserIsFriendsWith(score.user.id)
+            rowClasses += " #{bn}__body-row--friend"
+
           tr
-            className: "#{bn}__body-row#{(if i == 0 then " #{bn}__body-row--first" else '')}"
+            className: rowClasses
             key: i,
 
             td className: "#{bn}__rank", "##{i+1}"

--- a/resources/assets/coffee/react/beatmapset-page/scoreboard.coffee
+++ b/resources/assets/coffee/react/beatmapset-page/scoreboard.coffee
@@ -102,6 +102,7 @@ class BeatmapsetPage.Scoreboard extends React.PureComponent
               scores: @props.scores
               countries: @props.countries
               hitTypeMapping: @hitTypeMapping()
+              scoreboardType: @props.type
 
         else if !@props.hasScores
           p

--- a/resources/assets/coffee/react/beatmapset-page/scoreboard.coffee
+++ b/resources/assets/coffee/react/beatmapset-page/scoreboard.coffee
@@ -93,7 +93,7 @@ class BeatmapsetPage.Scoreboard extends React.PureComponent
               div className: 'beatmap-scoreboard-top__item',
                 @scoreItem score: @props.scores[0], rank: 1, itemClass: 'ScoreTop'
 
-              if @props.userScore?
+              if @props.userScore? && @props.scores[0].user.id != @props.userScore.user.id
                 div className: 'beatmap-scoreboard-top__item',
                   @scoreItem score: @props.userScore, rank: @props.userScorePosition, itemClass: 'ScoreTop'
 

--- a/resources/assets/less/bem/beatmap-scoreboard-table.less
+++ b/resources/assets/less/bem/beatmap-scoreboard-table.less
@@ -114,6 +114,18 @@
         background-color: #ccc;
       }
     }
+
+    &--friend {
+      td {
+        background-color: lighten(@yellow-light, 20%) !important;
+      }
+
+      &:hover {
+        td {
+          background-color: @yellow-light !important;
+        }
+      }
+    }
   }
 
   &__mods {

--- a/resources/assets/less/bem/beatmap-scoreboard-table.less
+++ b/resources/assets/less/bem/beatmap-scoreboard-table.less
@@ -20,9 +20,26 @@
   @_top: beatmap-scoreboard-table;
   @row-height: 1.8em;
 
-
   width: 100%;
   overflow-x: auto;
+
+  .row-colour(@colour) {
+    td {
+      background-color: lighten(@colour, 20%);
+    }
+
+    &:nth-child(odd) {
+      td {
+        background-color: lighten(@colour, 20%);
+      }
+    }
+
+    &:hover {
+      td {
+        background-color: @colour;
+      }
+    }
+  }
 
   &__table {
     width: 100%;
@@ -90,13 +107,6 @@
   &__body-row {
     height: @row-height;
 
-    // styles applied to td instead of tr 'cuz firefox is a poop (can't do rounded corners on tr)
-    &:nth-child(odd) {
-      td {
-        background-color: #eee;
-      }
-    }
-
     td:first-child {
       // rounded corners for left side
       border-top-left-radius: 5px;
@@ -109,6 +119,13 @@
       padding-right: 10px;
     }
 
+    // styles applied to td instead of tr 'cuz firefox is a poop (can't do rounded corners on tr)
+    &:nth-child(odd) {
+      td {
+        background-color: #eee;
+      }
+    }
+
     &:hover {
       td {
         background-color: #ccc;
@@ -116,27 +133,11 @@
     }
 
     &--friend {
-      td {
-        background-color: lighten(@yellow-light, 20%) !important;
-      }
-
-      &:hover {
-        td {
-          background-color: @yellow-light !important;
-        }
-      }
+      .row-colour(@yellow-light);
     }
 
     &--self {
-      td {
-        background-color: lighten(@green-light, 20%) !important;
-      }
-
-      &:hover {
-        td {
-          background-color: @green-light !important;
-        }
-      }
+      .row-colour(@green-light);
     }
   }
 

--- a/resources/assets/less/bem/beatmap-scoreboard-table.less
+++ b/resources/assets/less/bem/beatmap-scoreboard-table.less
@@ -126,6 +126,18 @@
         }
       }
     }
+
+    &--self {
+      td {
+        background-color: lighten(@green-light, 20%) !important;
+      }
+
+      &:hover {
+        td {
+          background-color: @green-light !important;
+        }
+      }
+    }
   }
 
   &__mods {

--- a/resources/assets/less/bem/beatmap-scoreboard-table.less
+++ b/resources/assets/less/bem/beatmap-scoreboard-table.less
@@ -107,12 +107,12 @@
   &__body-row {
     height: @row-height;
 
-    td:first-child {
+    > td:first-child {
       // rounded corners for left side
       border-top-left-radius: 5px;
       border-bottom-left-radius: 5px;
     }
-    td:last-child {
+    > td:last-child {
       // ...and right side
       border-top-right-radius: 5px;
       border-bottom-right-radius: 5px;
@@ -121,13 +121,13 @@
 
     // styles applied to td instead of tr 'cuz firefox is a poop (can't do rounded corners on tr)
     &:nth-child(odd) {
-      td {
+      > td {
         background-color: #eee;
       }
     }
 
     &:hover {
-      td {
+      > td {
         background-color: #ccc;
       }
     }

--- a/resources/assets/less/bem/beatmap-scoreboard-table.less
+++ b/resources/assets/less/bem/beatmap-scoreboard-table.less
@@ -24,18 +24,18 @@
   overflow-x: auto;
 
   .row-colour(@colour) {
-    td {
+    > td {
       background-color: lighten(@colour, 20%);
     }
 
     &:nth-child(odd) {
-      td {
+      > td {
         background-color: lighten(@colour, 20%);
       }
     }
 
     &:hover {
-      td {
+      > td {
         background-color: @colour;
       }
     }


### PR DESCRIPTION
Adds highlighting of your own and your friends' scores on beatmap scoreboards.

(Also prevents double headers happening if you're at the top of a scoreboard)

fixes #2321