### PR TITLE
Don't include results that didn't match the username matchers

### DIFF
--- a/app/Models/Elasticsearch/UserTrait.php
+++ b/app/Models/Elasticsearch/UserTrait.php
@@ -141,6 +141,7 @@ trait UserTrait
 
         return [
             'bool' => [
+                'minimum_should_match' => 1,
                 'should' => [
                     ['match' => ['username.raw' => ['query' => $username, 'boost' => 5]]],
                     ['multi_match' => array_merge(['query' => $username], $lowercase_stick)],


### PR DESCRIPTION
Apparently having a filter context means "include everything" <_<

fixes #2349