### PR TITLE
Make "Leave Feedback" button able to be translated

### DIFF
--- a/resources/assets/coffee/react/beatmap-discussions/nominations.coffee
+++ b/resources/assets/coffee/react/beatmap-discussions/nominations.coffee
@@ -130,7 +130,7 @@ class BeatmapDiscussions.Nominations extends React.PureComponent
             div className: "#{bn}__row-right",
               el BigButton,
                 modifiers: ['full']
-                text: 'Leave Feedback'
+                text: osu.trans 'beatmaps.feedback.button',
                 icon: 'bullhorn'
                 props:
                   onClick: @focusNewDiscussion

--- a/resources/assets/coffee/react/beatmap-discussions/nominations.coffee
+++ b/resources/assets/coffee/react/beatmap-discussions/nominations.coffee
@@ -130,7 +130,7 @@ class BeatmapDiscussions.Nominations extends React.PureComponent
             div className: "#{bn}__row-right",
               el BigButton,
                 modifiers: ['full']
-                text: osu.trans 'beatmaps.feedback.button',
+                text: osu.trans 'beatmaps.feedback.button'
                 icon: 'bullhorn'
                 props:
                   onClick: @focusNewDiscussion

--- a/resources/lang/en/beatmaps.php
+++ b/resources/lang/en/beatmaps.php
@@ -128,6 +128,10 @@ return [
         'section_title' => 'Hype Train',
         'title' => 'Hype',
     ],
+   
+    'feedback' => [
+        'button' => 'Leave Feedback',
+    ],
 
     'nominations' => [
         'disqualification_prompt' => 'Reason for disqualification?',

--- a/resources/lang/en/beatmaps.php
+++ b/resources/lang/en/beatmaps.php
@@ -128,7 +128,7 @@ return [
         'section_title' => 'Hype Train',
         'title' => 'Hype',
     ],
-   
+
     'feedback' => [
         'button' => 'Leave Feedback',
     ],


### PR DESCRIPTION
Not sure if intentional but the button of "Leave Feedback" which appears in discussions of ranked/loved/graveyard mapsets was only displaying in English as there's no string in locale to translate it. This PR should fix that.