### PR TITLE
Fix discussion lastUpdate logic

### DIFF
--- a/resources/assets/coffee/react/beatmap-discussions/main.coffee
+++ b/resources/assets/coffee/react/beatmap-discussions/main.coffee
@@ -315,8 +315,8 @@ class BeatmapDiscussions.Main extends React.PureComponent
   lastUpdate: =>
     lastUpdate = _.max [
       @state.beatmapset.last_updated
-      _.maxBy @state.beatmapset.discussions, 'updated_at'
-      _.maxBy @state.beatmapset.events, 'updated_at'
+      _.maxBy(@state.beatmapset.discussions, 'updated_at')?.updated_at
+      _.maxBy(@state.beatmapset.events, 'created_at')?.created_at
     ]
 
     moment(lastUpdate) if lastUpdate?


### PR DESCRIPTION
It has been comparing between string, event object, and discussion object.

And it also has been checking nonexistent event attribute because it's not defined in transformer.

:rainbow: :horse: 