### PR TITLE
Unbreak safari

### DIFF
--- a/resources/assets/less/bem/account-edit-entry.less
+++ b/resources/assets/less/bem/account-edit-entry.less
@@ -64,6 +64,7 @@
 
     &::before {
       .full-size();
+      content: ' ';
       background-color: #000;
       opacity: 0;
       transition: all 120ms;

--- a/resources/assets/less/bem/account-edit.less
+++ b/resources/assets/less/bem/account-edit.less
@@ -40,6 +40,7 @@
     &::after {
       .inner-shadow-top();
       .full-size();
+      content: ' ';
       pointer-events: none;
     }
   }

--- a/resources/assets/less/bem/beatmap-discussion-new-float.less
+++ b/resources/assets/less/bem/beatmap-discussion-new-float.less
@@ -22,6 +22,7 @@
 
     &::before {
       .full-size();
+      content: ' ';
       background-color: fade(#000, 75%);
     }
   }

--- a/resources/assets/less/bem/beatmap-discussion-post.less
+++ b/resources/assets/less/bem/beatmap-discussion-post.less
@@ -55,6 +55,7 @@
   &--unread {
     &::before {
       .full-size();
+      content: ' ';
       background-color: @blue-darker;
       width: 5px;
     }

--- a/resources/assets/less/bem/beatmap-discussion.less
+++ b/resources/assets/less/bem/beatmap-discussion.less
@@ -43,6 +43,7 @@
     &--with-line {
       &::before {
         .full-size();
+        content: ' ';
         width: 1px;
         right: 100%;
         background-image: linear-gradient(to bottom, transparent, #ccc 50%, transparent);

--- a/resources/assets/less/bem/beatmap-icon.less
+++ b/resources/assets/less/bem/beatmap-icon.less
@@ -27,6 +27,7 @@
     .full-size();
     .icon-bg();
 
+    content: ' ';
     @margin: 2px;
     @size: calc(100% ~'-' (@margin * 2));
     height: auto;

--- a/resources/assets/less/bem/beatmapset-beatmap-picker.less
+++ b/resources/assets/less/bem/beatmapset-beatmap-picker.less
@@ -37,6 +37,7 @@
     &::before {
       .full-size();
       .default-border-radius();
+      content: ' ';
       background-color: fade(#000, 50%);
       width: calc(100% ~'-' @gutter);
       height: calc(100% ~'-' @gutter);

--- a/resources/assets/less/bem/beatmapset-panel.less
+++ b/resources/assets/less/bem/beatmapset-panel.less
@@ -175,6 +175,7 @@
 
     &::before {
       .full-size();
+      content: ' ';
       background-image: linear-gradient(to bottom, fade(#000, 10%), fade(#000, 70%));
     }
   }

--- a/resources/assets/less/bem/beatmapset-row.less
+++ b/resources/assets/less/bem/beatmapset-row.less
@@ -22,6 +22,7 @@
 
   &::before, &::after {
     .full-size();
+    content: ' ';
     will-change: opacity;
     transition: opacity 120ms;
     pointer-events: none;

--- a/resources/assets/less/bem/btn-circle.less
+++ b/resources/assets/less/bem/btn-circle.less
@@ -123,6 +123,7 @@
       &::before {
         .full-size();
         .circle(@btn-circle-diameter);
+        content: ' ';
         background-color: fade(#fff, 50%);
       }
     }

--- a/resources/assets/less/bem/btn-osu-big.less
+++ b/resources/assets/less/bem/btn-osu-big.less
@@ -65,6 +65,7 @@
 
     &::before {
       .full-size();
+      content: ' ';
       border-radius: inherit;
       background-color: fade(#fff, 50%);
     }

--- a/resources/assets/less/bem/changelog-build.less
+++ b/resources/assets/less/bem/changelog-build.less
@@ -55,7 +55,8 @@
     .thicker-box-shadow;
 
     &::before {
-      .full-size;
+      .full-size();
+      content: ' ';
       border-radius: @border-radius-base;
     }
   }

--- a/resources/assets/less/bem/detail-row.less
+++ b/resources/assets/less/bem/detail-row.less
@@ -27,6 +27,7 @@
 
   &::before {
     .full-size();
+    content: ' ';
     margin: 0 -10px;
     width: calc(100% ~'+' 20px);
     pointer-events: none;

--- a/resources/assets/less/bem/landing-hero.less
+++ b/resources/assets/less/bem/landing-hero.less
@@ -52,6 +52,7 @@
 
     &::after {
       .full-size();
+      content: ' ';
       background-color: fade(#000, 50%);
     }
   }

--- a/resources/assets/less/bem/loading-overlay.less
+++ b/resources/assets/less/bem/loading-overlay.less
@@ -42,6 +42,7 @@
 
   &::before {
     .full-size();
+    content: ' ';
     background-color: #000;
     will-change: opacity;
   }

--- a/resources/assets/less/bem/notification-banner.less
+++ b/resources/assets/less/bem/notification-banner.less
@@ -31,6 +31,7 @@
 
   &::before {
     .full-size();
+    content: ' ';
     height: 5px;
     background-image: url(/images/layout/caution-bar.png);
     background-position: top center;

--- a/resources/assets/less/bem/osu-page-header.less
+++ b/resources/assets/less/bem/osu-page-header.less
@@ -82,11 +82,12 @@
 
     &::before {
       .full-size();
+      content: ' ';
+
+      background-image: linear-gradient(to bottom, fade(#000, 25%), fade(#000, 75%));
+
       @media @desktop {
         background-image: linear-gradient(to bottom, fade(#000, 0%), fade(#000, 75%));
-      }
-      @media @mobile {
-        background-image: linear-gradient(to bottom, fade(#000, 25%), fade(#000, 75%));
       }
     }
 

--- a/resources/assets/less/bem/page-extra-tabs.less
+++ b/resources/assets/less/bem/page-extra-tabs.less
@@ -23,6 +23,7 @@
 
     &::before {
       .full-size();
+      content: ' ';
       background-color: fade(#000, 75%);
     }
   }

--- a/resources/assets/less/bem/product-box.less
+++ b/resources/assets/less/bem/product-box.less
@@ -36,6 +36,7 @@
 
   &::before, &::after {
     .full-size();
+    content: ' ';
     will-change: opacity;
     transition: opacity 120ms;
     pointer-events: none;

--- a/resources/assets/less/bem/profile-extra-entries.less
+++ b/resources/assets/less/bem/profile-extra-entries.less
@@ -42,6 +42,7 @@
 
       &::before {
         .full-size();
+        content: ' ';
         margin: 0 -10px;
         width: calc(100% ~'+' 20px);
         pointer-events: none;

--- a/resources/assets/less/bem/search-entry.less
+++ b/resources/assets/less/bem/search-entry.less
@@ -28,6 +28,7 @@
 
   &::after, &::before {
     .full-size();
+    content: ' ';
     will-change: opacity;
     transition: opacity 120ms;
     pointer-events: none;

--- a/resources/assets/less/bem/search-result.less
+++ b/resources/assets/less/bem/search-result.less
@@ -27,6 +27,7 @@
 
   &::before {
     .full-size();
+    content: ' ';
     width: 5px;
     border-top-left-radius: @border-radius-base;
     border-bottom-left-radius: @border-radius-base;

--- a/resources/assets/less/bem/support-osu-popup.less
+++ b/resources/assets/less/bem/support-osu-popup.less
@@ -74,8 +74,9 @@
     background: url("//s.ppy.sh/images/ty-pippi-heart.png");
     .own-layer();
 
-    &:before {
+    &::before {
       .full-size();
+      content: ' ';
       height: 200%;
       top: -100%;
       background: url("//s.ppy.sh/images/ty-pippi-heart.png");
@@ -93,8 +94,9 @@
     background: url("//s.ppy.sh/images/ty-pippi.jpg");
     .own-layer();
 
-    &:before {
+    &::before {
       .full-size();
+      content: ' ';
       height: 200%;
       top: -100%;
       background: url("//s.ppy.sh/images/ty-pippi.jpg");

--- a/resources/assets/less/forum/base.less
+++ b/resources/assets/less/forum/base.less
@@ -135,6 +135,7 @@ body.community {
 
     &::before, &::after {
       .full-size();
+      content: ' ';
       pointer-events: none;
       will-change: opacity;
       transition: all 25ms ease-out;

--- a/resources/assets/less/functions.less
+++ b/resources/assets/less/functions.less
@@ -44,6 +44,7 @@
 .default-header-overlay() {
   &::before {
     .full-size();
+    content: ' ';
     background-image: linear-gradient(fade(#000, 30%), fade(#000, 80%));
   }
 }
@@ -196,7 +197,6 @@
   top: 0;
   height: 100%;
   width: 100%;
-  content: ' ';
 }
 
 .btn-bg() {


### PR DESCRIPTION
Safari does something with `content: ' '` even when it's not in `::before`/`::after` ┐(' ヮ' )┌