### PR TITLE
Proper delete validation

### DIFF
--- a/app/Http/Controllers/AccountController.php
+++ b/app/Http/Controllers/AccountController.php
@@ -129,30 +129,23 @@ class AccountController extends Controller
         );
 
         try {
-            $ok = DB::transaction(function () use ($customizationParams, $userParams) {
+            DB::transaction(function () use ($customizationParams, $userParams) {
                 if (count($customizationParams) > 0) {
-                    if (!Auth::user()->profileCustomization()->update($customizationParams)) {
-                        throw new ModelNotSavedException('failed saving model');
-                    }
+                    Auth::user()
+                        ->profileCustomization()
+                        ->fill($customizationParams)
+                        ->saveOrExplode();
                 }
 
                 if (count($userParams) > 0) {
-                    if (!Auth::user()->update($userParams)) {
-                        throw new ModelNotSavedException('failed saving model');
-                    }
+                    Auth::user()->fill($userParams)->saveOrExplode();
                 }
-
-                return true;
             });
-        } catch (ModelNotSavedException $_e) {
-            $ok = false;
+        } catch (ModelNotSavedException $e) {
+            return error_popup($e->getMessage());
         }
 
-        if ($ok) {
-            return Auth::user()->defaultJson();
-        } else {
-            return error_popup(Auth::user()->validationErrors()->toSentence());
-        }
+        return Auth::user()->defaultJson();
     }
 
     public function updateEmail()

--- a/app/Http/Controllers/BeatmapDiscussionPostsController.php
+++ b/app/Http/Controllers/BeatmapDiscussionPostsController.php
@@ -48,11 +48,13 @@ class BeatmapDiscussionPostsController extends Controller
         $post = BeatmapDiscussionPost::whereNull('deleted_at')->findOrFail($id);
         priv_check('BeatmapDiscussionPostDestroy', $post)->ensureCan();
 
-        if ($post->softDelete(Auth::user())) {
-            return $post->beatmapset->defaultDiscussionJson();
-        } else {
-            return error_popup($post->validationErrors()->toSentence());
+        try {
+            $post->softDeleteOrExplode(Auth::user());
+        } catch (ModelNotSavedException $e) {
+            return error_popup($e->getMessage());
         }
+
+        return $post->beatmapset->defaultDiscussionJson();
     }
 
     public function index()

--- a/app/Http/Controllers/BeatmapDiscussionPostsController.php
+++ b/app/Http/Controllers/BeatmapDiscussionPostsController.php
@@ -48,12 +48,10 @@ class BeatmapDiscussionPostsController extends Controller
         $post = BeatmapDiscussionPost::whereNull('deleted_at')->findOrFail($id);
         priv_check('BeatmapDiscussionPostDestroy', $post)->ensureCan();
 
-        $error = $post->softDelete(Auth::user());
-
-        if ($error === null) {
+        if ($post->softDelete(Auth::user())) {
             return $post->beatmapset->defaultDiscussionJson();
         } else {
-            return error_popup($error);
+            return error_popup($post->validationErrors()->toSentence());
         }
     }
 

--- a/app/Http/Controllers/BeatmapDiscussionPostsController.php
+++ b/app/Http/Controllers/BeatmapDiscussionPostsController.php
@@ -142,7 +142,7 @@ class BeatmapDiscussionPostsController extends Controller
         }
 
         try {
-            $saved = DB::transaction(function () use ($posts, $discussion, $events, $resetNominations) {
+            DB::transaction(function () use ($posts, $discussion, $events, $resetNominations) {
                 $discussion->saveOrExplode();
 
                 foreach ($posts as $post) {
@@ -159,8 +159,6 @@ class BeatmapDiscussionPostsController extends Controller
                 if ($resetNominations) {
                     $discussion->beatmapset->refreshCache();
                 }
-
-                return true;
             });
         } catch (ModelNotSavedException $_e) {
             return error_popup(trans('beatmaps.discussion-posts.store.error'));

--- a/app/Http/Controllers/BeatmapDiscussionPostsController.php
+++ b/app/Http/Controllers/BeatmapDiscussionPostsController.php
@@ -163,28 +163,23 @@ class BeatmapDiscussionPostsController extends Controller
                 return true;
             });
         } catch (ModelNotSavedException $_e) {
-            $saved = false;
+            return error_popup(trans('beatmaps.discussion-posts.store.error'));
         }
 
         $postIds = array_pluck($posts, 'id');
+        $beatmapset = $discussion->beatmapset;
 
-        if ($saved === true) {
-            $beatmapset = $discussion->beatmapset;
+        BeatmapsetWatch::markRead($beatmapset, Auth::user());
+        NotifyBeatmapsetUpdate::dispatch([
+            'user' => Auth::user(),
+            'beatmapset' => $beatmapset,
+        ]);
 
-            BeatmapsetWatch::markRead($beatmapset, Auth::user());
-            NotifyBeatmapsetUpdate::dispatch([
-                'user' => Auth::user(),
-                'beatmapset' => $beatmapset,
-            ]);
-
-            return [
-                'beatmapset' => $posts[0]->beatmapset->defaultDiscussionJson(),
-                'beatmap_discussion_post_ids' => $postIds,
-                'beatmap_discussion_id' => $discussion->id,
-            ];
-        } else {
-            return error_popup(trans('beatmaps.discussion-posts.store.error'));
-        }
+        return [
+            'beatmapset' => $posts[0]->beatmapset->defaultDiscussionJson(),
+            'beatmap_discussion_post_ids' => $postIds,
+            'beatmap_discussion_id' => $discussion->id,
+        ];
     }
 
     public function update($id)

--- a/app/Http/Controllers/BeatmapDiscussionsController.php
+++ b/app/Http/Controllers/BeatmapDiscussionsController.php
@@ -44,11 +44,11 @@ class BeatmapDiscussionsController extends Controller
 
         try {
             $discussion->allowKudosu(Auth::user());
-
-            return $discussion->beatmapset->defaultDiscussionJson();
         } catch (ModelNotSavedException $e) {
             return error_popup($e->getMessage());
         }
+
+        return $discussion->beatmapset->defaultDiscussionJson();
     }
 
     public function denyKudosu($id)
@@ -58,11 +58,11 @@ class BeatmapDiscussionsController extends Controller
 
         try {
             $discussion->denyKudosu(Auth::user());
-
-            return $discussion->beatmapset->defaultDiscussionJson();
         } catch (ModelNotSavedException $e) {
             return error_popup($e->getMessage());
         }
+
+        return $discussion->beatmapset->defaultDiscussionJson();
     }
 
     public function destroy($id)

--- a/app/Http/Controllers/BeatmapDiscussionsController.php
+++ b/app/Http/Controllers/BeatmapDiscussionsController.php
@@ -70,12 +70,10 @@ class BeatmapDiscussionsController extends Controller
         $discussion = BeatmapDiscussion::whereNull('deleted_at')->findOrFail($id);
         priv_check('BeatmapDiscussionDestroy', $discussion)->ensureCan();
 
-        $error = $discussion->softDelete(Auth::user());
-
-        if ($error === null) {
+        if ($discussion->softDelete(Auth::user())) {
             return $discussion->beatmapset->defaultDiscussionJson();
         } else {
-            return error_popup($error);
+            return error_popup($discussion->validationErrors()->toSentence());
         }
     }
 

--- a/app/Http/Controllers/BeatmapDiscussionsController.php
+++ b/app/Http/Controllers/BeatmapDiscussionsController.php
@@ -70,11 +70,13 @@ class BeatmapDiscussionsController extends Controller
         $discussion = BeatmapDiscussion::whereNull('deleted_at')->findOrFail($id);
         priv_check('BeatmapDiscussionDestroy', $discussion)->ensureCan();
 
-        if ($discussion->softDelete(Auth::user())) {
-            return $discussion->beatmapset->defaultDiscussionJson();
-        } else {
-            return error_popup($discussion->validationErrors()->toSentence());
+        try {
+            $discussion->softDeleteOrExplode(Auth::user());
+        } catch (ModelNotSavedException $e) {
+            return error_popup($e->getMessage());
         }
+
+        return $discussion->beatmapset->defaultDiscussionJson();
     }
 
     public function index()

--- a/app/Http/Controllers/Forum/PostsController.php
+++ b/app/Http/Controllers/Forum/PostsController.php
@@ -62,8 +62,8 @@ class PostsController extends Controller
 
                 $topic->removePostOrExplode($post);
             });
-        } catch (ModelNotSavedException $_e) {
-            return error_popup($topic->validationErrors()->toSentence());
+        } catch (ModelNotSavedException $e) {
+            return error_popup($e->getMessage());
         }
 
         if ($topic->trashed()) {
@@ -130,8 +130,8 @@ class PostsController extends Controller
                     ])
                     ->saveOrExplode();
             });
-        } catch (ModelNotSavedException $_e) {
-            return error_popup($post->validationErrors()->toSentence());
+        } catch (ModelNotSavedException $e) {
+            return error_popup($e->getMessage());
         }
 
         $posts = collect([$post->fresh()]);

--- a/app/Http/Controllers/Forum/TopicsController.php
+++ b/app/Http/Controllers/Forum/TopicsController.php
@@ -335,8 +335,8 @@ class TopicsController extends Controller
 
         try {
             $topic = Topic::createNew($forum, $params, $poll ?? null);
-        } catch (ModelNotSavedException $_e) {
-            abort(422);
+        } catch (ModelNotSavedException $e) {
+            return error_popup($e->getMessage());
         }
 
         if (!app()->runningUnitTests()) {

--- a/app/Http/Controllers/Forum/TopicsController.php
+++ b/app/Http/Controllers/Forum/TopicsController.php
@@ -162,7 +162,7 @@ class TopicsController extends Controller
             'body' => 'required',
         ]);
 
-        $post = $topic->addPost(Auth::user(), Request::input('body'));
+        $post = $topic->addPostOrExplode(Auth::user(), Request::input('body'));
 
         if ($post->post_id !== null) {
             $posts = collect([$post]);

--- a/app/Models/BeatmapDiscussion.php
+++ b/app/Models/BeatmapDiscussion.php
@@ -573,10 +573,10 @@ class BeatmapDiscussion extends Model
 
             $timestamps = $this->timestamps;
             $this->timestamps = false;
-            $this->update([
+            $this->fill([
                 'deleted_by_id' => $deletedBy->user_id ?? null,
                 'deleted_at' => Carbon::now(),
-            ]);
+            ])->saveOrExplode();
             $this->timestamps = $timestamps;
             $this->refreshKudosu('delete');
 

--- a/app/Models/BeatmapDiscussion.php
+++ b/app/Models/BeatmapDiscussion.php
@@ -564,24 +564,26 @@ class BeatmapDiscussion extends Model
         return $ret;
     }
 
-    public function softDelete($deletedBy)
+    public function softDeleteOrExplode($deletedBy)
     {
-        return DB::transaction(function () use ($deletedBy) {
-            if ($deletedBy->getKey() !== $this->user_id) {
-                BeatmapsetEvent::log(BeatmapsetEvent::DISCUSSION_DELETE, $deletedBy, $this)->saveOrExplode();
-            }
+        $timestamps = $this->timestamps;
 
-            $timestamps = $this->timestamps;
-            $this->timestamps = false;
-            $this->fill([
-                'deleted_by_id' => $deletedBy->user_id ?? null,
-                'deleted_at' => Carbon::now(),
-            ])->saveOrExplode();
+        try {
+            DB::transaction(function () use ($deletedBy) {
+                if ($deletedBy->getKey() !== $this->user_id) {
+                    BeatmapsetEvent::log(BeatmapsetEvent::DISCUSSION_DELETE, $deletedBy, $this)->saveOrExplode();
+                }
+
+                $this->timestamps = false;
+                $this->fill([
+                    'deleted_by_id' => $deletedBy->user_id ?? null,
+                    'deleted_at' => Carbon::now(),
+                ])->saveOrExplode();
+                $this->refreshKudosu('delete');
+            });
+        } finally {
             $this->timestamps = $timestamps;
-            $this->refreshKudosu('delete');
-
-            return true;
-        });
+        }
     }
 
     public function trashed()

--- a/app/Models/Forum/Topic.php
+++ b/app/Models/Forum/Topic.php
@@ -89,7 +89,7 @@ class Topic extends Model
 
         DB::transaction(function () use ($forum, $topic, $params, $poll) {
             $topic->saveOrExplode();
-            $topic->addPost($params['user'], $params['body']);
+            $topic->addPostOrExplode($params['user'], $params['body']);
 
             if ($poll !== null) {
                 $topic->poll($poll)->save();
@@ -104,18 +104,19 @@ class Topic extends Model
         return $topic->fresh();
     }
 
-    public function addPost($poster, $body)
+    public function addPostOrExplode($poster, $body)
     {
         $post = new Post([
             'post_text' => $body,
             'post_username' => $poster->username,
             'poster_id' => $poster->user_id,
             'forum_id' => $this->forum_id,
+            'topic_id' => $this->getKey(),
             'post_time' => Carbon::now(),
         ]);
 
         DB::transaction(function () use ($post) {
-            $this->posts()->save($post);
+            $post->saveOrExplode();
 
             $this->refreshCache();
 

--- a/app/Models/Forum/Topic.php
+++ b/app/Models/Forum/Topic.php
@@ -137,9 +137,10 @@ class Topic extends Model
 
         return DB::transaction(function () use ($post) {
             if ($post->delete() === false) {
-                $this->validationErrors()->addTranslated('post', $post->validationErrors()->toSentence());
+                $message = $post->validationErrors()->toSentence();
+                $this->validationErrors()->addTranslated('post', $message);
 
-                throw new ModelNotSavedException('failed deleting post');
+                throw new ModelNotSavedException($message);
             }
 
             if ($this->posts()->exists() === true) {

--- a/tests/Models/BeatmapDiscussionTest.php
+++ b/tests/Models/BeatmapDiscussionTest.php
@@ -17,7 +17,6 @@
  *    You should have received a copy of the GNU Affero General Public License
  *    along with osu!web.  If not, see <http://www.gnu.org/licenses/>.
  */
-use App\Exceptions\ModelNotSavedException;
 use App\Models\Beatmap;
 use App\Models\BeatmapDiscussion;
 use App\Models\Beatmapset;

--- a/tests/Models/BeatmapDiscussionTest.php
+++ b/tests/Models/BeatmapDiscussionTest.php
@@ -17,6 +17,7 @@
  *    You should have received a copy of the GNU Affero General Public License
  *    along with osu!web.  If not, see <http://www.gnu.org/licenses/>.
  */
+use App\Exceptions\ModelNotSavedException;
 use App\Models\Beatmap;
 use App\Models\BeatmapDiscussion;
 use App\Models\Beatmapset;
@@ -150,7 +151,7 @@ class BeatmapDiscussionTest extends TestCase
         $this->assertFalse($discussion->isValid());
     }
 
-    public function testSoftDelete()
+    public function testSoftDeleteOrExplode()
     {
         $beatmapset = factory(Beatmapset::class)->create(['discussion_enabled' => true]);
         $beatmap = $beatmapset->beatmaps()->save(factory(Beatmap::class)->make());
@@ -165,7 +166,7 @@ class BeatmapDiscussionTest extends TestCase
         $this->assertFalse($discussion->trashed());
 
         // Soft delete.
-        $discussion->softDelete($user);
+        $discussion->softDeleteOrExplode($user);
         $discussion = $discussion->fresh();
         $this->assertTrue($discussion->trashed());
 
@@ -176,7 +177,7 @@ class BeatmapDiscussionTest extends TestCase
 
         // Soft delete with deleted beatmap.
         $beatmap->delete();
-        $discussion->softDelete($user);
+        $discussion->softDeleteOrExplode($user);
         $discussion = $discussion->fresh();
         $this->assertTrue($discussion->trashed());
 


### PR DESCRIPTION
Implement actual validation instead of using `null` check. And do some refactors on handling `ModelNotSaved`.

Can be simplified further by doing it at global exception handler for general cases (all of them at the moment). Maybe later (and not sure if good idea yet).

Fixes #2550.