### PR TITLE
Added username as possible entry for login

### DIFF
--- a/resources/lang/en/layout.php
+++ b/resources/lang/en/layout.php
@@ -232,7 +232,7 @@ return [
 
     'popup_login' => [
         'login' => [
-            'email' => 'email address',
+            'email' => 'username or email address',
             'forgot' => "I've forgotten my details",
             'password' => 'password',
             'title' => 'Sign In To Proceed',


### PR DESCRIPTION
It is now consistent with the error message for invalid credentials and I confirmed that it is indeed possible to login with username instead of email address.