### PR TITLE
Increase timeout for beatmap cover generation jobs

### DIFF
--- a/app/Jobs/RegenerateBeatmapsetCover.php
+++ b/app/Jobs/RegenerateBeatmapsetCover.php
@@ -38,6 +38,13 @@ class RegenerateBeatmapsetCover implements ShouldQueue
     protected $sizesToRegenerate;
 
     /**
+     * The number of seconds the job can run before timing out.
+     *
+     * @var int
+     */
+    public $timeout = 300;
+
+    /**
      * Create a new job instance.
      *
      * @return void

--- a/config/queue.php
+++ b/config/queue.php
@@ -39,37 +39,13 @@ return [
             'driver' => 'database',
             'table' => 'jobs',
             'queue' => 'default',
-            'retry_after' => 90,
-        ],
-
-        'beanstalkd' => [
-            'driver' => 'beanstalkd',
-            'host' => 'localhost',
-            'queue' => 'default',
-            'retry_after' => 90,
-        ],
-
-        'sqs' => [
-            'driver' => 'sqs',
-            'key' => 'your-public-key',
-            'secret' => 'your-secret-key',
-            'queue' => 'your-queue-url',
-            'region' => 'us-east-1',
-        ],
-
-        'iron' => [
-            'driver' => 'iron',
-            'host' => 'mq-aws-us-east-1.iron.io',
-            'token' => 'your-token',
-            'project' => 'your-project-id',
-            'queue' => 'your-queue-name',
-            'encrypt' => true,
+            'retry_after' => 305,
         ],
 
         'redis' => [
             'driver' => 'redis',
             'queue' => 'default',
-            'retry_after' => 90,
+            'retry_after' => 305, // our longest job timeout is 5m, plus 5s to allow time for workers to be killed
         ],
 
     ],
@@ -86,7 +62,8 @@ return [
     */
 
     'failed' => [
-        'database' => 'mysql', 'table' => 'failed_jobs',
+        'database' => 'mysql',
+        'table' => 'failed_jobs',
     ],
 
 ];


### PR DESCRIPTION
Default timeout is 60s and some runs have exceeded that and been killed (due to some combination of slow osz retrieval, large backgrounds, network latency spikes, etc)