### PR TITLE
Profile history graph date fix

### DIFF
--- a/app/Transformers/UserMonthlyPlaycountTransformer.php
+++ b/app/Transformers/UserMonthlyPlaycountTransformer.php
@@ -28,7 +28,7 @@ class UserMonthlyPlaycountTransformer extends Fractal\TransformerAbstract
     public function transform(UserMonthlyPlaycount $playcount)
     {
         return [
-            'start_date' => json_time($playcount->startDate()),
+            'start_date' => json_date($playcount->startDate()),
             'count' => $playcount->playcount,
         ];
     }

--- a/app/Transformers/UserReplaysWatchedCountTransformer.php
+++ b/app/Transformers/UserReplaysWatchedCountTransformer.php
@@ -28,7 +28,7 @@ class UserReplaysWatchedCountTransformer extends Fractal\TransformerAbstract
     public function transform(UserReplaysWatchedCount $count)
     {
         return [
-            'start_date' => json_time($count->startDate()),
+            'start_date' => json_date($count->startDate()),
             'count' => $count->count,
         ];
     }

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -190,16 +190,16 @@ function html_excerpt($body, $limit = 300)
     return e($body);
 }
 
-function json_date($date)
+function json_date(?DateTime $date)
 {
-    if ($date instanceof DateTime) {
+    if ($date !== null) {
         return $date->format('Y-m-d');
     }
 }
 
-function json_time($time)
+function json_time(?DateTime $time)
 {
-    if ($time instanceof DateTime) {
+    if ($time !== null) {
         return $time->format(DateTime::ATOM);
     }
 }

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -190,18 +190,14 @@ function html_excerpt($body, $limit = 300)
     return e($body);
 }
 
-function json_date(?DateTime $date)
+function json_date(?DateTime $date) : ?string
 {
-    if ($date !== null) {
-        return $date->format('Y-m-d');
-    }
+    return $date === null ? null : $date->format('Y-m-d');
 }
 
-function json_time(?DateTime $time)
+function json_time(?DateTime $time) : ?string
 {
-    if ($time !== null) {
-        return $time->format(DateTime::ATOM);
-    }
+    return $time === null ? null : $time->format(DateTime::ATOM);
 }
 
 function locale_flag($locale)

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -192,13 +192,15 @@ function html_excerpt($body, $limit = 300)
 
 function json_date($date)
 {
-    return json_time($date->startOfDay());
+    if ($date instanceof DateTime) {
+        return $date->format('Y-m-d');
+    }
 }
 
 function json_time($time)
 {
-    if ($time !== null) {
-        return $time->toIso8601String();
+    if ($time instanceof DateTime) {
+        return $time->format(DateTime::ATOM);
     }
 }
 

--- a/resources/assets/coffee/_classes/line-chart.coffee
+++ b/resources/assets/coffee/_classes/line-chart.coffee
@@ -60,7 +60,13 @@ class @LineChart
       .attr 'data-visibility', 'hidden'
 
     @tooltipContent = @tooltip.append 'div'
-      .classed 'chart__tooltip-content', true
+      .classed 'chart__tooltip-component chart__tooltip-component--content', true
+
+    @tooltip.append 'div'
+      .classed 'chart__tooltip-component chart__tooltip-component--arrow', true
+
+    @tooltip.append 'div'
+      .classed 'chart__tooltip-component chart__tooltip-component--circle', true
 
     @tooltipY = @tooltipContent.append 'div'
       .classed 'chart__tooltip-text chart__tooltip-text--y', true

--- a/resources/assets/less/bem/chart.less
+++ b/resources/assets/less/bem/chart.less
@@ -78,29 +78,29 @@
     flex-direction: column;
     align-items: center;
     width: 0;
+  }
 
-    &::before {
-      .circle(@_marker-radius * 2);
-      content: '';
-      order: 1;
-      background-color: #fff;
-      border: 3px solid @pink-darker;
-    }
+  &__tooltip-component {
+    flex: none;
 
-    &::after {
-      content: '';
+    &--arrow {
       border-left: 5px solid transparent;
       border-right: 5px solid transparent;
       border-top: 10px solid @pink-darker;
     }
-  }
 
-  &__tooltip-content {
-    .default-border-radius();
-    flex: none;
-    padding: 10px 20px;
-    background-color: @pink-darker;
-    color: #fff;
+    &--circle {
+      .circle(@_marker-radius * 2);
+      background-color: #fff;
+      border: 3px solid @pink-darker;
+    }
+
+    &--content {
+      .default-border-radius();
+      padding: 10px 20px;
+      background-color: @pink-darker;
+      color: #fff;
+    }
   }
 
   &__tooltip-text {


### PR DESCRIPTION
Use `json_date` and update the function to return date-only version of iso8601.

Also updated the helpers to be compatible with any `DateTime` while at it.

Not sure if should just call `moment.utc` when parsing instead ┐(°_° )┌

Fixes #2643.

Also includes fix for tooltip on [ie](https://github.com/philipwalton/flexbugs#flexbug-12) due to using `::before` and `::after` as flex element.