### PR TITLE
Unbreak discussion page nomination box (IE)

### DIFF
--- a/resources/assets/less/bem/beatmap-discussion-nomination.less
+++ b/resources/assets/less/bem/beatmap-discussion-nomination.less
@@ -31,7 +31,7 @@
     flex-direction: column;
 
     &--extended {
-      flex: 1;
+      flex: 1 0 auto;
     }
   }
 


### PR DESCRIPTION
Keep forgetting about IE overflowing instead of extending the box on `flex: 1`.