### PR TITLE
Fix success rate display for beatmaps

### DIFF
--- a/resources/assets/coffee/react/beatmapset-page/info.coffee
+++ b/resources/assets/coffee/react/beatmapset-page/info.coffee
@@ -209,10 +209,11 @@ class BeatmapsetPage.Info extends React.Component
 
             div
               className: 'beatmap-success-rate__percentage'
-              title: "#{@props.beatmap.passcount} / #{@props.beatmap.playcount}"
+              title: "#{@props.beatmap.passcount.toLocaleString()} / #{@props.beatmap.playcount.toLocaleString()}"
+              'data-tooltip-position': 'bottom center'
               style:
                 marginLeft: "#{percentage}%"
-              div null, "#{percentage}%"
+              "#{percentage}%"
 
             h3
               className: 'beatmap-success-rate__header'

--- a/resources/assets/coffee/react/beatmapset-page/info.coffee
+++ b/resources/assets/coffee/react/beatmapset-page/info.coffee
@@ -209,6 +209,7 @@ class BeatmapsetPage.Info extends React.Component
 
             div
               className: 'beatmap-success-rate__percentage'
+              title: "#{@props.beatmap.passcount} / #{@props.beatmap.playcount}"
               style:
                 marginLeft: "#{percentage}%"
               div null, "#{percentage}%"

--- a/resources/assets/coffee/react/beatmapset-page/info.coffee
+++ b/resources/assets/coffee/react/beatmapset-page/info.coffee
@@ -113,8 +113,6 @@ class BeatmapsetPage.Info extends React.Component
 
 
   render: ->
-    percentage = _.round (@props.beatmap.passcount / (@props.beatmap.playcount + @props.beatmap.passcount)) * 100
-
     tags = _(@props.beatmapset.tags)
       .split(' ')
       .filter((t) -> t? && t != '')
@@ -196,7 +194,8 @@ class BeatmapsetPage.Info extends React.Component
               '...' if tagsOverload
 
       div className: 'beatmapset-info__box beatmapset-info__box--success-rate',
-        if @props.beatmapset.has_scores
+        if @props.beatmapset.has_scores && @props.beatmap.playcount > 0
+          percentage = _.round((@props.beatmap.passcount / @props.beatmap.playcount) * 100, 1)
           div className: 'beatmap-success-rate',
             h3
               className: 'beatmap-success-rate__header'
@@ -211,7 +210,7 @@ class BeatmapsetPage.Info extends React.Component
             div
               className: 'beatmap-success-rate__percentage'
               style:
-                paddingLeft: "#{percentage}%"
+                marginLeft: "#{percentage}%"
               div null, "#{percentage}%"
 
             h3

--- a/resources/assets/less/bem/beatmap-success-rate.less
+++ b/resources/assets/less/bem/beatmap-success-rate.less
@@ -52,7 +52,7 @@
   }
 
   &__percentage {
-    .default-bar-transition(@property: padding-left);
+    .default-bar-transition(@property: margin-left);
     width: 0;
     display: flex;
     justify-content: center;


### PR DESCRIPTION
Previous calculation was dividing `passcount` by `playcount + passcount` for some reason.

Also adds a tooltip to the percentage to also show raw pass/play counts.

fixes #2652 