### PR TITLE
Add unweighted accuracy to score leaderboard

### DIFF
--- a/resources/lang/en/rankings.php
+++ b/resources/lang/en/rankings.php
@@ -28,6 +28,7 @@ return [
     ],
     'stat' => [
         'accuracy' => 'Accuracy',
+        'unweighted_accuracy' => 'Unweighted Acc.',
         'active_users' => 'Active Users',
         'country' => 'Country',
         'play_count' => 'Play Count',

--- a/resources/views/rankings/score.blade.php
+++ b/resources/views/rankings/score.blade.php
@@ -27,6 +27,9 @@
                     {{ trans('rankings.stat.accuracy') }}
                 </th>
                 <th class="ranking-page-table__heading">
+                    {{ trans('rankings.stat.unweighted_accuracy') }}
+                </th>
+                <th class="ranking-page-table__heading">
                     {{ trans('rankings.stat.play_count') }}
                 </th>
                 <th class="ranking-page-table__heading">
@@ -69,6 +72,9 @@
                     </td>
                     <td class="ranking-page-table__column ranking-page-table__column--dimmed">
                         {{ format_percentage($score->accuracy_new) }}
+                    </td>
+                    <td class="ranking-page-table__column ranking-page-table__column--dimmed">
+                        {{ format_percentage($score->accuracy, 4) }}
                     </td>
                     <td class="ranking-page-table__column ranking-page-table__column--dimmed">
                         {{ number_format($score->playcount) }}


### PR DESCRIPTION
resolves #2665 

![chrome_2018-03-10_22-36-17](https://user-images.githubusercontent.com/9954349/37250504-87e742dc-24b3-11e8-9876-e1438da6ccce.png)

need confirmation that `accuracy` is the correct field for the acc shown at https://osu.ppy.sh/p/playerranking