### PR TITLE
Null rank history if blank

### DIFF
--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -294,7 +294,7 @@ class UsersController extends Controller
             ->where('mode', Beatmap::modeInt($currentMode))
             ->first();
 
-        $rankHistory = $rankHistoryData ? json_item($rankHistoryData, 'RankHistory') : [];
+        $rankHistory = $rankHistoryData ? json_item($rankHistoryData, 'RankHistory') : null;
 
         if (Request::is('api/*')) {
             $userArray['statistics'] = $statistics;


### PR DESCRIPTION
Either that or fake it correctly and not just empty array? :man_shrugging: 

The only react component using it already does the null check.

The client doesn't like empty array :dancer: 