### PR TITLE
Rename beatmap job queue and split into priorities.

### DIFF
--- a/app/Http/Controllers/Admin/BeatmapsetsController.php
+++ b/app/Http/Controllers/Admin/BeatmapsetsController.php
@@ -41,7 +41,7 @@ class BeatmapsetsController extends Controller
     {
         $beatmapset = Beatmapset::findOrFail($id);
 
-        $job = (new RemoveBeatmapsetCover($beatmapset))->onQueue('beatmap_processor');
+        $job = (new RemoveBeatmapsetCover($beatmapset))->onQueue('beatmap_high');
         $this->dispatch($job);
 
         return response([], 204);
@@ -51,7 +51,7 @@ class BeatmapsetsController extends Controller
     {
         $beatmapset = Beatmapset::findOrFail($id);
 
-        $job = (new RegenerateBeatmapsetCover($beatmapset))->onQueue('beatmap_processor');
+        $job = (new RegenerateBeatmapsetCover($beatmapset))->onQueue('beatmap_high');
         $this->dispatch($job);
 
         return response([], 204);

--- a/app/Http/Controllers/LegacyInterOpController.php
+++ b/app/Http/Controllers/LegacyInterOpController.php
@@ -33,7 +33,7 @@ class LegacyInterOpController extends Controller
     {
         $beatmapset = Beatmapset::findOrFail($id);
 
-        $job = (new RegenerateBeatmapsetCover($beatmapset))->onQueue('beatmap_processor');
+        $job = (new RegenerateBeatmapsetCover($beatmapset))->onQueue('beatmap_default');
         $this->dispatch($job);
 
         return ['success' => true];


### PR DESCRIPTION
This will let us prioritise admin removal/regeneration jobs ahead of normal jobs.

Usually this is not an issue, but when there's a backlog (e.g. batch reprocessing), admin-initiated jobs can get held up.

Will require an update to the thumbnailer box to pick up jobs on the new queues