### PR TITLE
Fix client beatmap discussion failing to parse url with empty path components

### DIFF
--- a/resources/assets/coffee/_classes/beatmap-discussion-helper.coffee
+++ b/resources/assets/coffee/_classes/beatmap-discussion-helper.coffee
@@ -21,6 +21,9 @@ class @BeatmapDiscussionHelper
   @DEFAULT_MODE: 'timeline'
   @DEFAULT_FILTER: 'total'
 
+  @MODES = ['timeline', 'general', 'generalAll']
+  @FILTERS = ['deleted', 'hype', 'mapperNotes', 'mine', 'pending', 'praises', 'resolved', 'total']
+
   @discussionMode: (discussion) ->
     if discussion.beatmap_id?
       if discussion.timestamp?
@@ -155,8 +158,8 @@ class @BeatmapDiscussionHelper
       beatmapsetId: if isFinite(beatmapsetId) then beatmapsetId
       beatmapId: if isFinite(beatmapId) then beatmapId
       # empty path segments are ''
-      mode: mode || @DEFAULT_MODE
-      filter: filter || @DEFAULT_FILTER
+      mode: if _.includes(@MODES, mode) then mode else @DEFAULT_MODE
+      filter: if _.includes(@FILTERS, filter) then filter else @DEFAULT_FILTER
 
     if url.hash[1] == '/'
       discussionId = parseInt(url.hash[2..], 10)

--- a/resources/assets/coffee/_classes/beatmap-discussion-helper.coffee
+++ b/resources/assets/coffee/_classes/beatmap-discussion-helper.coffee
@@ -154,8 +154,9 @@ class @BeatmapDiscussionHelper
     ret =
       beatmapsetId: if isFinite(beatmapsetId) then beatmapsetId
       beatmapId: if isFinite(beatmapId) then beatmapId
-      mode: mode ? @DEFAULT_MODE
-      filter: filter ? @DEFAULT_FILTER
+      # empty path segments are ''
+      mode: mode || @DEFAULT_MODE
+      filter: filter || @DEFAULT_FILTER
 
     if url.hash[1] == '/'
       discussionId = parseInt(url.hash[2..], 10)

--- a/resources/assets/coffee/_classes/beatmap-discussion-helper.coffee
+++ b/resources/assets/coffee/_classes/beatmap-discussion-helper.coffee
@@ -21,7 +21,7 @@ class @BeatmapDiscussionHelper
   @DEFAULT_MODE: 'timeline'
   @DEFAULT_FILTER: 'total'
 
-  @MODES = ['timeline', 'general', 'generalAll', 'events']
+  @MODES = ['events', 'general', 'generalAll', 'timeline']
   @FILTERS = ['deleted', 'hype', 'mapperNotes', 'mine', 'pending', 'praises', 'resolved', 'total']
 
   @discussionMode: (discussion) ->

--- a/resources/assets/coffee/_classes/beatmap-discussion-helper.coffee
+++ b/resources/assets/coffee/_classes/beatmap-discussion-helper.coffee
@@ -21,7 +21,7 @@ class @BeatmapDiscussionHelper
   @DEFAULT_MODE: 'timeline'
   @DEFAULT_FILTER: 'total'
 
-  @MODES = ['timeline', 'general', 'generalAll']
+  @MODES = ['timeline', 'general', 'generalAll', 'events']
   @FILTERS = ['deleted', 'hype', 'mapperNotes', 'mine', 'pending', 'praises', 'resolved', 'total']
 
   @discussionMode: (discussion) ->


### PR DESCRIPTION
Fixes parse failing when url has a trailing `/` or one of the components is empty.
Also does whitelisting of `mode` and `filter` when parsing.

