### PR TITLE
Fix switching mode when clicking filter

### DIFF
--- a/resources/assets/coffee/react/beatmap-discussions/main.coffee
+++ b/resources/assets/coffee/react/beatmap-discussions/main.coffee
@@ -362,7 +362,7 @@ class BeatmapDiscussions.Main extends React.PureComponent
 
     if filter?
       if @state.currentMode == 'events'
-        mode = @lastMode ? BeatmapDiscussionHelper.DEFAULT_MODE
+        newState.currentMode = @lastMode ? BeatmapDiscussionHelper.DEFAULT_MODE
 
       if filter != @state.currentFilter
         newState.currentFilter = filter


### PR DESCRIPTION
Immediately set currentMode instead of pretending mode update.