### PR TITLE
Use full transformer instead of compact for beatmaps on user profiles

### DIFF
--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -408,26 +408,26 @@ class UsersController extends Controller
                     ->orderBy('beatmap_id', 'desc'); // for consistent sorting
                 break;
 
-            // BeatmapsetCompact
+            // Beatmapset
             case 'favouriteBeatmapsets':
-                $transformer = 'BeatmapsetCompact';
+                $transformer = 'Beatmapset';
                 $includes = ['beatmaps'];
                 $query = $user->profileBeatmapsetsFavourite();
                 break;
             case 'graveyardBeatmapsets':
-                $transformer = 'BeatmapsetCompact';
+                $transformer = 'Beatmapset';
                 $includes = ['beatmaps'];
                 $query = $user->profileBeatmapsetsGraveyard()
                     ->orderBy('last_update', 'desc');
                 break;
             case 'rankedAndApprovedBeatmapsets':
-                $transformer = 'BeatmapsetCompact';
+                $transformer = 'Beatmapset';
                 $includes = ['beatmaps'];
                 $query = $user->profileBeatmapsetsRankedAndApproved()
                     ->orderBy('approved_date', 'desc');
                 break;
             case 'unrankedBeatmapsets':
-                $transformer = 'BeatmapsetCompact';
+                $transformer = 'Beatmapset';
                 $includes = ['beatmaps'];
                 $query = $user->profileBeatmapsetsUnranked()
                     ->orderBy('last_update', 'desc');


### PR DESCRIPTION
The tiles rely on more info than the compact transformer provides and we've optimised the 'full' transformer to remove most of the slowness unless included anyway.

fixes #2704