### PR TITLE
Strip the UTF-8 BOM before attempting to parse .osu files

### DIFF
--- a/app/Models/BeatmapFile.php
+++ b/app/Models/BeatmapFile.php
@@ -27,6 +27,9 @@ class BeatmapFile
 
     public static function parse(string $content)
     {
+        // strip utf8 bom
+        $content = strip_utf8_bom($content);
+
         // check file 'header'
         if (!starts_with($content, 'osu file format v')) {
             return false;


### PR DESCRIPTION
otherwise header detection fails