### PR TITLE
Turbolinks, react, and navigation

### DIFF
--- a/resources/assets/coffee/react/beatmap-discussions/discussion.coffee
+++ b/resources/assets/coffee/react/beatmap-discussions/discussion.coffee
@@ -58,7 +58,6 @@ class BeatmapDiscussions.Discussion extends React.PureComponent
     div
       className: topClasses
       'data-id': @props.discussion.id
-      id: "/#{@props.discussion.id}"
       onClick: @emitSetHighlight
 
       div className: "#{bn}__timestamp hidden-xs",

--- a/resources/assets/coffee/react/beatmap-discussions/discussion.coffee
+++ b/resources/assets/coffee/react/beatmap-discussions/discussion.coffee
@@ -58,6 +58,7 @@ class BeatmapDiscussions.Discussion extends React.PureComponent
     div
       className: topClasses
       'data-id': @props.discussion.id
+      id: "/#{@props.discussion.id}"
       onClick: @emitSetHighlight
 
       div className: "#{bn}__timestamp hidden-xs",

--- a/resources/assets/coffee/react/beatmap-discussions/main.coffee
+++ b/resources/assets/coffee/react/beatmap-discussions/main.coffee
@@ -60,7 +60,7 @@ class BeatmapDiscussions.Main extends React.PureComponent
     $.subscribe 'beatmapDiscussionPost:markRead.beatmapDiscussions', @markPostRead
     $(document).on 'ajax:success.beatmapDiscussions', '.js-beatmapset-discussion-update', @ujsDiscussionUpdate
     $(document).on 'click.beatmapDiscussions', '.js-beatmap-discussion--jump', @jumpToClick
-    $(document).on 'turbolinks:before-cache', @saveStateToContainer
+    $(document).on 'turbolinks:before-cache.beatmapDiscussions', @saveStateToContainer
 
     @jumpToDiscussionByHash() if !@restoredState
     @timeouts.checkNew = Timeout.set @checkNewTimeoutDefault, @checkNew

--- a/resources/assets/coffee/react/beatmap-discussions/main.coffee
+++ b/resources/assets/coffee/react/beatmap-discussions/main.coffee
@@ -32,8 +32,9 @@ class BeatmapDiscussions.Main extends React.PureComponent
     @timeouts = {}
     @xhr = {}
     @state = JSON.parse(props.container.dataset.beatmapsetDiscussionState ? null)
+    @restoredState = @state?
 
-    if !@state?
+    if !@restoredState
       beatmapset = props.initial.beatmapset
 
       readPostIds = []
@@ -61,7 +62,7 @@ class BeatmapDiscussions.Main extends React.PureComponent
     $(document).on 'click.beatmapDiscussions', '.js-beatmap-discussion--jump', @jumpToClick
     $(document).on 'turbolinks:before-cache', @saveStateToContainer
 
-    @jumpToDiscussionByHash()
+    @jumpToDiscussionByHash() if !@restoredState
     @timeouts.checkNew = Timeout.set @checkNewTimeoutDefault, @checkNew
 
 

--- a/resources/assets/coffee/react/beatmapset-page.coffee
+++ b/resources/assets/coffee/react/beatmapset-page.coffee
@@ -16,8 +16,7 @@
 #    along with osu!web.  If not, see <http://www.gnu.org/licenses/>.
 ###
 
-propsFunction = =>
+reactTurbolinks.registerPersistent 'beatmapset-page', BeatmapsetPage.Main, true, (target) ->
   beatmapset: osu.parseJson('json-beatmapset')
   countries: _.keyBy osu.parseJson('json-countries'), 'code'
-
-reactTurbolinks.register 'beatmapset-page', BeatmapsetPage.Main, propsFunction
+  container: target

--- a/resources/assets/coffee/react/beatmapset-page/main.coffee
+++ b/resources/assets/coffee/react/beatmapset-page/main.coffee
@@ -23,40 +23,39 @@ class BeatmapsetPage.Main extends React.Component
   constructor: (props) ->
     super props
 
-    optionsHash = BeatmapsetPageHash.parse location.hash
-    @initialPage = optionsHash.page
-
-    beatmaps = _.concat props.beatmapset.beatmaps, props.beatmapset.converts
-    beatmaps = BeatmapHelper.group beatmaps
-
-    currentBeatmap = BeatmapHelper.find
-      group: beatmaps
-      id: optionsHash.beatmapId
-      mode: optionsHash.playmode
-
-    # fall back to the first mode that has beatmaps in this mapset
-    currentBeatmap ?= BeatmapHelper.default items: beatmaps[optionsHash.playmode]
-    currentBeatmap ?= BeatmapHelper.default group: beatmaps
-
     @scoreboardXhr = null
     @favouriteXhr = null
 
-    @state =
-      beatmaps: beatmaps
-      currentBeatmap: currentBeatmap
-      favcount: props.beatmapset.favourite_count
-      hasFavourited: props.beatmapset.has_favourited
-      loading: false
-      currentScoreboardType: 'global'
-      enabledMods: []
-      scores: []
-      userScore: null
-      userScorePosition: -1
+    @state = JSON.parse(@props.container.dataset.state ? 'null')
+    @restoredState = @state?
+    console.log 'restored state?', @restoredState
 
+    if !@restoredState
+      optionsHash = BeatmapsetPageHash.parse location.hash
 
-  setHash: =>
-    osu.setHash BeatmapsetPageHash.generate
-      beatmap: @state.currentBeatmap
+      beatmaps = _.concat props.beatmapset.beatmaps, props.beatmapset.converts
+      beatmaps = BeatmapHelper.group beatmaps
+
+      currentBeatmap = BeatmapHelper.find
+        group: beatmaps
+        id: optionsHash.beatmapId
+        mode: optionsHash.playmode
+
+      # fall back to the first mode that has beatmaps in this mapset
+      currentBeatmap ?= BeatmapHelper.default items: beatmaps[optionsHash.playmode]
+      currentBeatmap ?= BeatmapHelper.default group: beatmaps
+
+      @state =
+        beatmaps: beatmaps
+        currentBeatmap: currentBeatmap
+        favcount: props.beatmapset.favourite_count
+        hasFavourited: props.beatmapset.has_favourited
+        loading: false
+        currentScoreboardType: 'global'
+        enabledMods: []
+        scores: []
+        userScore: null
+        userScorePosition: -1
 
 
   setCurrentScoreboard: (_e, {
@@ -165,9 +164,10 @@ class BeatmapsetPage.Main extends React.Component
     $.subscribe 'beatmapset:hoveredbeatmap:set.beatmapsetPage', @setHoveredBeatmap
     $.subscribe 'beatmapset:favourite:toggle.beatmapsetPage', @toggleFavourite
     $.publish 'turbolinksDisqusReload'
+    $(document).on 'turbolinks:before-cache.beatmapsetPage', @saveStateToContainer
 
     @setHash()
-    @setCurrentScoreboard null, scoreboardType: 'global', resetMods: true
+    @setCurrentScoreboard(null, scoreboardType: 'global', resetMods: true) if !@restoredState
 
 
   componentWillUnmount: ->
@@ -210,3 +210,12 @@ class BeatmapsetPage.Main extends React.Component
             'data-turbolinks-disqus': JSON.stringify
               identifier: "beatmapset_#{@props.beatmapset.id}"
               title: "#{@props.beatmapset.artist} - #{@props.beatmapset.title} (mapped by #{@props.beatmapset.creator})"
+
+
+  saveStateToContainer: =>
+    @props.container.dataset.state = JSON.stringify(@state)
+
+
+  setHash: =>
+    osu.setHash BeatmapsetPageHash.generate
+      beatmap: @state.currentBeatmap

--- a/resources/assets/coffee/react/beatmapset-page/main.coffee
+++ b/resources/assets/coffee/react/beatmapset-page/main.coffee
@@ -28,7 +28,6 @@ class BeatmapsetPage.Main extends React.Component
 
     @state = JSON.parse(@props.container.dataset.state ? 'null')
     @restoredState = @state?
-    console.log 'restored state?', @restoredState
 
     if !@restoredState
       optionsHash = BeatmapsetPageHash.parse location.hash

--- a/resources/assets/coffee/react/beatmapset-page/main.coffee
+++ b/resources/assets/coffee/react/beatmapset-page/main.coffee
@@ -166,7 +166,9 @@ class BeatmapsetPage.Main extends React.Component
     $(document).on 'turbolinks:before-cache.beatmapsetPage', @saveStateToContainer
 
     @setHash()
-    @setCurrentScoreboard(null, scoreboardType: 'global', resetMods: true) if !@restoredState
+
+    if !@restoredState || @state.loading
+      @setCurrentScoreboard null, scoreboardType: 'global', resetMods: true
 
 
   componentWillUnmount: ->

--- a/resources/assets/coffee/react/profile-page.coffee
+++ b/resources/assets/coffee/react/profile-page.coffee
@@ -16,7 +16,7 @@
 #    along with osu!web.  If not, see <http://www.gnu.org/licenses/>.
 ###
 
-reactTurbolinks.register 'profile-page', ProfilePage.Main, ->
+reactTurbolinks.registerPersistent 'profile-page', ProfilePage.Main, true, (target) ->
   user = osu.parseJson('json-user')
 
   user: user
@@ -29,3 +29,4 @@ reactTurbolinks.register 'profile-page', ProfilePage.Main, ->
   achievements: _.keyBy osu.parseJson('json-achievements'), 'id'
   perPage: osu.parseJson('json-perPage')
   extras: osu.parseJson('json-extras')
+  container: target

--- a/resources/assets/coffee/turbolinks-overrides.coffee
+++ b/resources/assets/coffee/turbolinks-overrides.coffee
@@ -50,3 +50,8 @@ Turbolinks.Controller.prototype.advanceHistory = (url) ->
   @cacheSnapshot()
   @lastRenderedLocation = Turbolinks.Location.wrap(url)
   @pushHistoryWithLocationAndRestorationIdentifier url, Turbolinks.uuid()
+
+
+# Ignore anchor check on loading snapshot to prevent repeating requesting page
+# when the target doesn't exist.
+Turbolinks.Snapshot.prototype.hasAnchor = -> true


### PR DESCRIPTION
Should fix part of #2696. Need more checks. There are some components not yet updated to `registerPersistent` thingy.

- unmount after replacing the page
- save state on `before-cache` to where the component is attached to
- disable anchor existence check in turbolinks because some of the anchors used don't exist which causes page fetch on history navigation