### PR TITLE
Prevent user profiles from breaking when scores exist for (soft) deleted beatmaps

### DIFF
--- a/app/Models/Score/Best/Model.php
+++ b/app/Models/Score/Best/Model.php
@@ -279,6 +279,7 @@ abstract class Model extends BaseModel
     public function scopeDefault($query)
     {
         return $query
+            ->whereHas('beatmap')
             ->whereHas('user', function ($userQuery) {
                 $userQuery->default();
             });


### PR DESCRIPTION
Scores should be deleted when their associated beatmap is deleted (but they're not being in some cases right now), so this handles that case as a precaution.