### PR TITLE
Move site-switcher JS file hash to config var

### DIFF
--- a/config/osu.php
+++ b/config/osu.php
@@ -73,6 +73,7 @@ return [
             'user' => 100,
         ],
     ],
+    'site-switcher-js-hash' => env('SITE_SWITCHER_JS_HASH', ''),
     'support' => [
         'video_url' => env('SUPPORT_OSU_VIDEO_URL', 'https://assets.ppy.sh/media/osu-direct-demo.mp4'),
     ],

--- a/resources/views/layout/metadata.blade.php
+++ b/resources/views/layout/metadata.blade.php
@@ -71,7 +71,7 @@
 <script src="{{ mix("js/app-deps.js") }}" data-turbolinks-track="reload"></script>
 <script src="{{ mix("js/app.js") }}" data-turbolinks-track="reload"></script>
 <script src="/vendor/js/timeago-locales/jquery.timeago.{{ locale_for_timeago(Lang::getLocale()) }}.js" data-turbolinks-track="reload"></script>
-<script src="//assets.ppy.sh/js/site-switcher.min.js?{{ENV('SITE_SWITCHER_JS_HASH', '6a1de058')}}" async></script>
+<script src="//assets.ppy.sh/js/site-switcher.min.js?{{config('osu.site-switcher-js-hash')}}" async></script>
 
 @if (($momentLocale = locale_for_moment(Lang::getLocale())) !== null)
     <script src="/vendor/js/moment-locales/{{ $momentLocale }}.js" data-turbolinks-track="reload"></script>


### PR DESCRIPTION
env() helper returns nulls when combined with cached configs