### PR TITLE
Prevent duplicate voting to same discussion

### DIFF
--- a/database/migrations/2018_04_06_081112_unique_beatmapset_discussion_votes.php
+++ b/database/migrations/2018_04_06_081112_unique_beatmapset_discussion_votes.php
@@ -1,0 +1,31 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\Schema;
+
+class UniqueBeatmapsetDiscussionVotes extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('beatmap_discussion_votes', function ($table) {
+            $table->unique(['beatmap_discussion_id', 'user_id']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('beatmap_discussion_votes', function ($table) {
+            $table->dropUnique('beatmap_discussion_votes_beatmap_discussion_id_user_id_unique');
+        });
+    }
+}


### PR DESCRIPTION
Forgot a unique index =)

Fixes #2923.

Useful stuff:

```php
DB::table('beatmap_discussion_votes')->groupBy(['user_id','beatmap_discussion_id'])->having('count(*)', '>', 1)->selectRaw('count(*), max(id), max(score), min(score), beatmap_discussion_id, user_id')->get();

// clean up
$a = DB::table('beatmap_discussion_votes')->groupBy(['user_id','beatmap_discussion_id'])->having('count(*)', '>', 1)->selectRaw('count(*), max(id), max(score), min(score), beatmap_discussion_id, user_id')->get()->pluck('max(id)')->toArray();
BeatmapDiscussionVote::whereIn('id', $a)->get()->each->delete();
php artisan kudosu:recalculate-discussions-grants
```