### PR TITLE
use simple_query_string instead of query_string

### DIFF
--- a/app/Libraries/Elasticsearch/QueryHelper.php
+++ b/app/Libraries/Elasticsearch/QueryHelper.php
@@ -43,7 +43,7 @@ class QueryHelper
     }
 
     /**
-     * Helper method that creates the query_string query.
+     * Helper method that creates the simple_query_string query.
      *
      * @param string $query The query string.
      * @param array $fields The fields to search; Use an empty array to search all fields.
@@ -53,7 +53,7 @@ class QueryHelper
     public static function queryString(string $query, array $fields = []) : array
     {
         return [
-            'query_string' => [
+            'simple_query_string' => [
                 'query' => $query,
                 'fields' => $fields,
             ],


### PR DESCRIPTION
`simple_query_string` discards the invalid parts of `query_string` instead of letting Lucene explode on badly formed queries.

tbh, neither should be used for public facing queries