### PR TITLE
Supporter status page fixes

### DIFF
--- a/app/Http/Controllers/HomeController.php
+++ b/app/Http/Controllers/HomeController.php
@@ -209,10 +209,14 @@ class HomeController extends Controller
                     ->pluck('timestamp')
                     ->first();
 
+                if ($lastTagPurchaseDate === null) {
+                    $lastTagPurchaseDate = $expiration->copy()->subMonths(1);
+                }
+
                 $total = $expiration->diffInDays($lastTagPurchaseDate);
                 $used = $lastTagPurchaseDate->diffInDays();
 
-                $supporterStatus['usedRatio'] = 100 - round(($used / $total) * 100, 2);
+                $supporterStatus['remainingRatio'] = 100 - round(($used / $total) * 100, 2);
             }
         }
 

--- a/resources/views/home/support-the-game.blade.php
+++ b/resources/views/home/support-the-game.blade.php
@@ -66,23 +66,25 @@
                 </div>
                 <div class="stg-status__flex-container-inner">
                     <div class="stg-status__progress-bar">
-                        <div class="stg-status__progress-bar-fill" style="width: {{$supporterStatus['usedRatio'] ?? 0}}%;"></div>
+                        <div class="stg-status__progress-bar-fill" style="width: {{$supporterStatus['remainingRatio'] ?? 0}}%;"></div>
                     </div>
-                    @if ($supporterStatus['tags'] > 0)
+                    @if ($supporterStatus['expiration'] !== null)
                     <div class="stg-status__text stg-status__text--first">
                         {!! trans('community.support.supporter_status.'.($supporterStatus['current'] ? 'valid_until' : 'was_valid_until'), [
                             'date' => '<strong>'.timeago($supporterStatus['expiration']).'</strong>'
                         ]) !!}
                     </div>
+                    @else
+                    <div class="stg-status__text">
+                        {!! trans('community.support.supporter_status.not_yet') !!}
+                    </div>
+                    @endif
+                    @if ($supporterStatus['tags'] > 0)
                     <div class="stg-status__text">
                         {!! trans('community.support.supporter_status.contribution', [
                             'dollars' => "<strong>{$supporterStatus['dollars']}</strong>",
                             'tags' => "<strong>{$supporterStatus['tags']}</strong>"
                         ]) !!}
-                    </div>
-                    @else
-                    <div class="stg-status__text">
-                        {!! trans('community.support.supporter_status.not_yet') !!}
                     </div>
                     @endif
                     @if ($supporterStatus['giftedTags'] > 0)


### PR DESCRIPTION
Fixes:
 - Supporter status page breaking when missing purchase data for tags.
 - Expiration date being hidden for people who've been gifted tags but never purchased any.
 - Misnamed variable (`used` was actually `remaining`)