### PR TITLE
Reset size selector on select and load (browser form saving)

### DIFF
--- a/resources/assets/coffee/forum/post-box.coffee
+++ b/resources/assets/coffee/forum/post-box.coffee
@@ -62,8 +62,13 @@ insert = (event, tagOpen, tagClose = '') ->
     insert e, openTag, closeTag
 
 
+$(document).on 'turbolinks:load', ->
+  $('.js-bbcode-btn--size').val('')
+
+
 $(document).on 'change', '.js-bbcode-btn--size', (e) ->
   $select = $(e.target)
   val = parseInt $select.val(), 10
+  $select.val('')
 
   insert e, "[size=#{val}]", '[/size]'

--- a/resources/assets/coffee/react/_components/bbcode-editor.coffee
+++ b/resources/assets/coffee/react/_components/bbcode-editor.coffee
@@ -21,6 +21,7 @@ el = React.createElement
 
 class @BBCodeEditor extends React.Component
   componentDidMount: =>
+    @sizeSelect.value = ''
     @body.focus()
 
 
@@ -61,7 +62,7 @@ class @BBCodeEditor extends React.Component
                 select
                   className: 'bbcode-size-select__select js-bbcode-btn--size'
                   disabled: @props.disabled
-                  defaultValue: '100'
+                  ref: @setSizeSelect
                   option value: '50', osu.trans('bbcode.size.tiny')
                   option value: '85', osu.trans('bbcode.size.small')
                   option value: '100', osu.trans('bbcode.size.normal')
@@ -94,6 +95,10 @@ class @BBCodeEditor extends React.Component
 
   setBody: (element) =>
     @body = element
+
+
+  setSizeSelect: (element) =>
+    @sizeSelect = element
 
 
   onKeyDown: (e) =>


### PR DESCRIPTION
Fixes #2970.

Couldn't find a way to tell react to not select anything hence the dumb workaround ಠ_ಠ