### PR TITLE
Define React and friends as externals in webpack

### DIFF
--- a/webpack.mix.js
+++ b/webpack.mix.js
@@ -79,6 +79,11 @@ vendor.forEach(function (script) {
 
 
 let webpackConfig = {
+  externals: {
+    "react": "React",
+    "react-dom": "ReactDOM",
+    "prop-types": "PropTypes",
+  },
   plugins: [
     new webpack.DefinePlugin({
       'process.env.PAYMENT_SANDBOX': JSON.stringify(paymentSandbox),


### PR DESCRIPTION
2 copies of React and friends were being served ( ﾟ ヮﾟ)