### PR TITLE
Put back popup template

### DIFF
--- a/resources/views/master.blade.php
+++ b/resources/views/master.blade.php
@@ -92,6 +92,7 @@
 
         @include("layout._global_variables")
         @include('layout._loading_overlay')
+        @include('layout.popup-container')
 
         @yield("script")
     </body>


### PR DESCRIPTION
Previously included in header template for some reason ┐(' ヮ' )┌