### PR TITLE
Virtualize beatmap listing

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "react-autosize-textarea": "*",
     "react-dom": "^16.2.0",
     "react-dom-factories": "^1.0.0",
+    "react-virtual-list": "^2.2.4",
     "require-dir": "^0.3.2",
     "retina.js": "^1.1.0",
     "timeago": "^1.5.0",

--- a/resources/assets/coffee/react/beatmaps/main.coffee
+++ b/resources/assets/coffee/react/beatmaps/main.coffee
@@ -67,8 +67,7 @@ class Beatmaps.Main extends React.PureComponent
 
 
   columnCount: () ->
-    # see @screen-sm-min
-    if window.innerWidth < 900 then 1 else 2
+    if osu.isDesktop() then 2 else 1
 
 
   updateColumnCount: () =>

--- a/resources/assets/coffee/react/beatmaps/main.coffee
+++ b/resources/assets/coffee/react/beatmaps/main.coffee
@@ -53,7 +53,6 @@ class Beatmaps.Main extends React.PureComponent
     @state = prevState.state if prevState.url == location.href
     @state ?= _.extend
       beatmaps: @props.beatmaps
-      columnCount: @columnCount()
       paging:
         page: 1
         url: laroute.route('beatmapsets.search')
@@ -63,6 +62,8 @@ class Beatmaps.Main extends React.PureComponent
       filters: null
       isExpanded: null
       @stateFromUrl()
+
+    @state.columnCount = @columnCount()
 
 
   columnCount: () ->

--- a/resources/assets/coffee/react/beatmaps/main.coffee
+++ b/resources/assets/coffee/react/beatmaps/main.coffee
@@ -18,6 +18,25 @@
 
 {div} = ReactDOMFactories
 el = React.createElement
+VirtualList = window.VirtualList
+
+ListRender = ({ virtual, itemHeight }) ->
+  console.log virtual.style
+  style = _.extend {}, virtual.style
+  div
+    style: style
+    div
+      className: 'beatmapsets__items'
+      virtual.items.map (item) ->
+        div
+          className: 'beatmapsets__item'
+          style:
+            height: 205
+          key: item.id
+          el BeatmapsetPanel, beatmap: item
+
+BeatmapList = VirtualList()(ListRender)
+
 
 class Beatmaps.Main extends React.PureComponent
   constructor: (props) ->
@@ -77,13 +96,10 @@ class Beatmaps.Main extends React.PureComponent
           div
             className: 'beatmapsets__content'
             if @state.beatmaps.length > 0
-              div
-                className: 'beatmapsets__items'
-                for beatmap in @state.beatmaps
-                  div
-                    className: 'beatmapsets__item'
-                    key: beatmap.id
-                    el BeatmapsetPanel, beatmap: beatmap
+              el BeatmapList,
+                items: @state.beatmaps
+                itemBuffer: 0
+                itemHeight: 205
 
             else
               div className: 'beatmapsets__empty',

--- a/resources/assets/less/bem/beatmapsets.less
+++ b/resources/assets/less/bem/beatmapsets.less
@@ -52,4 +52,9 @@
     display: flex;
     flex-wrap: wrap;
   }
+
+  &__items-row {
+    display: flex;
+    width: 100%;
+  }
 }

--- a/resources/assets/less/bootstrap-variables.less
+++ b/resources/assets/less/bootstrap-variables.less
@@ -53,7 +53,7 @@
 @input-color: @gray-dark;
 @input-border-focus: @pink;
 
-@screen-sm-min: 900px; // sync with osu.isDesktop
+@screen-sm-min: 900px; // sync with osu.isDesktop, react/beatmaps/main.coffee
 @screen-lg-min: 1300px;
 @screen-md-min: @screen-sm-min;
 

--- a/resources/assets/less/bootstrap-variables.less
+++ b/resources/assets/less/bootstrap-variables.less
@@ -53,7 +53,7 @@
 @input-color: @gray-dark;
 @input-border-focus: @pink;
 
-@screen-sm-min: 900px; // sync with osu.isDesktop, react/beatmaps/main.coffee
+@screen-sm-min: 900px; // sync with osu.isDesktop
 @screen-lg-min: 1300px;
 @screen-md-min: @screen-sm-min;
 

--- a/resources/assets/lib/import-shims.coffee
+++ b/resources/assets/lib/import-shims.coffee
@@ -21,9 +21,11 @@
 import { StoreCheckout } from 'store-checkout'
 import Promise from 'promise-polyfill'
 import TextareaAutosize from 'react-autosize-textarea'
+import VirtualList from 'react-virtual-list'
 
 # polyfill non-Edge IE
 window.Promise ?= Promise
 
 window.StoreCheckout = StoreCheckout
 window.TextareaAutosize = TextareaAutosize
+window.VirtualList = VirtualList

--- a/yarn.lock
+++ b/yarn.lock
@@ -5079,6 +5079,14 @@ promise@^7.1.1:
   dependencies:
     asap "~2.0.3"
 
+prop-types@^15.5.10:
+  version "15.6.1"
+  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.1.tgz#36644453564255ddda391191fb3a125cbdf654ca"
+  dependencies:
+    fbjs "^0.8.16"
+    loose-envify "^1.3.1"
+    object-assign "^4.1.1"
+
 prop-types@^15.5.6, prop-types@^15.6.0:
   version "15.6.0"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.0.tgz#ceaf083022fc46b4a35f69e13ef75aed0d639856"
@@ -5215,6 +5223,12 @@ react-dom@^16.2.0:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
     prop-types "^15.6.0"
+
+react-virtual-list@^2.2.4:
+  version "2.2.4"
+  resolved "https://registry.yarnpkg.com/react-virtual-list/-/react-virtual-list-2.2.4.tgz#bbeb4938436f80ddbff4f8724f43de2117085691"
+  dependencies:
+    prop-types "^15.5.10"
 
 react@^16.2.0:
   version "16.2.0"


### PR DESCRIPTION
sort of fixes #2117

Virtualizes the beatmap listing to keep it fast after scrolling through many pages. 

I gave up on using `react-virtualized` and opted to fork`react-virtual-list` to make it work with our flexbox layout on the page instead, since:
- it required way too many changes to work
- didn't do a very good job of restoring the scroll position when navigating back in history.
- this option turned out to be massively simpler ( ﾟ ヮﾟ)

It doesn't eject the already loaded data yet