### PR TITLE
Allow activity text on user profile page to wrap

### DIFF
--- a/resources/assets/less/bem/profile-extra-entries.less
+++ b/resources/assets/less/bem/profile-extra-entries.less
@@ -27,8 +27,7 @@
     justify-content: space-between;
     align-items: center;
     margin-bottom: 5px;
-    height: @item-height;
-    white-space: nowrap;
+    min-height: @item-height;
 
     &--top-ranks {
       height: auto;


### PR DESCRIPTION
fixes #2794

also causes other text like the kudosu history to wrap