### PR TITLE
Prevent overlapping button and status icons

### DIFF
--- a/resources/assets/less/bem/beatmapset-panel.less
+++ b/resources/assets/less/bem/beatmapset-panel.less
@@ -160,7 +160,12 @@
     text-transform: uppercase;
 
     .fade-element(@hover-transition-duration);
+
     .@{top}:hover & {
+      opacity: 0;
+    }
+
+    .@{top}--previewing & {
       opacity: 0;
     }
   }


### PR DESCRIPTION
Hide the status icons when previewing.

Fixes #2706.