### PR TITLE
Use mb_strtolower in OsuMarkdownProcessor.

### DIFF
--- a/app/Libraries/OsuMarkdownProcessor.php
+++ b/app/Libraries/OsuMarkdownProcessor.php
@@ -234,7 +234,7 @@ class OsuMarkdownProcessor implements DocumentProcessorInterface, ConfigurationA
         }
 
         $title = $this->getText($this->node);
-        $slug = presence(strtolower(str_replace(' ', '-', $title))) ?? 'page';
+        $slug = presence(mb_strtolower(str_replace(' ', '-', $title))) ?? 'page';
 
         if (array_key_exists($slug, $this->tocSlugs)) {
             $this->tocSlugs[$slug] += 1;


### PR DESCRIPTION
Should fix cases where `json_encode` fails due to `strtolower` deciding the text is ascii.
Also less environment dependent ಠ_ಠ

```
>>> strtolower('かなAAmĄkA')
=> b"ÒüïÒü¬aamõäka"
>>> mb_strtolower('かなAAmĄkA')
=> "かなaamąka"

>> strtolower('欢迎来到')
=> "欢迎来到"
>>> mb_strtolower('欢迎来到')
=> "欢迎来到"
>>> strtolower('欢迎来到Ą')
=> b"µ¼óÞ┐ÄµØÑÕê░õä"
>>> mb_strtolower('欢迎来到Ą')
=> "欢迎来到ą"
```