### PR TITLE
Use '100%' instead of 'cover' for .badge-rank

### DIFF
--- a/resources/assets/less/bem/badge-rank.less
+++ b/resources/assets/less/bem/badge-rank.less
@@ -20,7 +20,7 @@
   @size: 100%;
   width: @size;
   height: @size;
-  background-size: cover;
+  background-size: 100%;
   background-position: center;
   background-repeat: no-repeat;
 


### PR DESCRIPTION
fixes #2589 
