### PR TITLE
Reverse conditional on username change history display

### DIFF
--- a/app/Models/UsernameChangeHistory.php
+++ b/app/Models/UsernameChangeHistory.php
@@ -30,6 +30,6 @@ class UsernameChangeHistory extends Model
 
     public function scopeVisible($query)
     {
-        $query->whereNotIn('type', ['admin', 'revert']);
+        $query->whereIn('type', ['support', 'paid']);
     }
 }


### PR DESCRIPTION
Matches scope in `User->usernameChangeCost` (we may want to combine these two?)

Fixes (system-controlled) inactive changes showing up.