### PR TITLE
Improved cursor position on edit start

### DIFF
--- a/resources/assets/coffee/react/_components/bbcode-editor.coffee
+++ b/resources/assets/coffee/react/_components/bbcode-editor.coffee
@@ -22,6 +22,7 @@ el = React.createElement
 class @BBCodeEditor extends React.Component
   componentDidMount: =>
     @sizeSelect.value = ''
+    @body.selectionEnd = 0
     @body.focus()
 
 


### PR DESCRIPTION
Ensure it's always at the beginning. Also current behavior is different between firefox and chrome.

Fixes #3014.

<sup><sup><sup>not sure if it's actually better</sup></sup></sup>