### PR TITLE
Eagerload beatmaps.

### DIFF
--- a/app/Http/Controllers/BeatmapsetsController.php
+++ b/app/Http/Controllers/BeatmapsetsController.php
@@ -145,7 +145,10 @@ class BeatmapsetsController extends Controller
                 }
             );
 
-            return Beatmapset::whereIn('beatmapset_id', $ids)->orderByField('beatmapset_id', $ids)->get();
+            return Beatmapset::whereIn('beatmapset_id', $ids)
+                ->orderByField('beatmapset_id', $ids)
+                ->with('beatmaps')
+                ->get();
         }, config('datadog-helper.prefix_web').'.search', ['type' => 'beatmapset']);
 
         return json_collection(


### PR DESCRIPTION
Went missing when page output caching was reverted to beatmapset id
caching