### PR TITLE
Load bold and italic versions of Noto Sans

### DIFF
--- a/resources/views/layout/metadata.blade.php
+++ b/resources/views/layout/metadata.blade.php
@@ -33,7 +33,7 @@
 @endif
 
 <link href='//fonts.googleapis.com/css?family=Exo+2:300,300italic,200,200italic,400,400italic,500,500italic,600,600italic,700,700italic,900' rel='stylesheet' type='text/css'>
-<link href='https://fonts.googleapis.com/css?family=Noto+Sans' rel='stylesheet' type='text/css'>
+<link href='https://fonts.googleapis.com/css?family=Noto+Sans:400,400i,700,700i' rel='stylesheet' type='text/css'>
 
 <link rel="stylesheet" media="all" href="{{ mix("css/app.css") }}" data-turbolinks-track="reload">
 <link rel="stylesheet" media="all" href="/vendor/_photoswipe-default-skin/default-skin.css">


### PR DESCRIPTION
I guess forum posts haven't had proper bold or italics since we changed to Noto Sans?