### PR TITLE
Use correct user for rendering post info in editor

### DIFF
--- a/resources/views/forum/topics/_post_edit.blade.php
+++ b/resources/views/forum/topics/_post_edit.blade.php
@@ -29,7 +29,7 @@
         ></div>
     @endif
 
-    @include("forum.topics._post_info", ["user" => $post->user])
+    @include("forum.topics._post_info", ["user" => $post->userNormalized()])
 
     <div class="forum-post__body">
         <div class="forum-post__content">


### PR DESCRIPTION
Currently explodes when editing post of a deleted user.