### PR TITLE
Allow redirecting wiki paths more than one level deep

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -354,7 +354,7 @@ route_redirect('s/{beatmapset}', 'beatmapsets.show');
 route_redirect('u/{user}', 'users.show');
 route_redirect('forum', 'forum.forums.index');
 route_redirect('mp/{match}', 'matches.show');
-route_redirect('wiki/{page?}', 'wiki.show');
+route_redirect('wiki/{page?}', 'wiki.show')->where('page', '.+');
 
 // status
 if (Config::get('app.debug')) {


### PR DESCRIPTION
Currenty the redirect only works for wiki paths one level deep:
`/wiki/Welcome` -> `/help/wiki/Welcome`

This fixes the redirects for anything deeper:
`/wiki/Mascots/Gallery` -> `/help/wiki/Mascots/Gallery`
`/wiki/we/need/to/go/deeper` -> `/help/wiki/we/need/to/go/deeper`