### PR TITLE
Right align the news preview post date if it happens to wrap

### DIFF
--- a/resources/assets/less/bem/news-post-preview.less
+++ b/resources/assets/less/bem/news-post-preview.less
@@ -54,6 +54,7 @@
     color: @pink-light;
     padding-right: 10px;
     overflow: hidden;
+    text-align: right;
 
     .@{top}--collapsed & {
       flex-direction: row;


### PR DESCRIPTION
![](https://user-images.githubusercontent.com/14264992/39552967-27d653ae-4e31-11e8-9b55-df9833e4feb5.png) ![](https://user-images.githubusercontent.com/14264992/39553096-9e5440e0-4e31-11e8-9276-4f7b16c01645.png)

Unless it should always be wrapped, or not...?