### PR TITLE
Override trans to ignore empty strings

### DIFF
--- a/app/Models/Store/OrderItem.php
+++ b/app/Models/Store/OrderItem.php
@@ -121,7 +121,7 @@ class OrderItem extends Model
                 $duration = (int) $this->extra_data['duration'];
                 $text = SupporterTag::getDurationText($duration);
 
-                return __('store.order.item.display_name.supporter_tag', [
+                return trans('store.order.item.display_name.supporter_tag', [
                     'name' => $this->product->name,
                     // test data didn't include username, so ?? ''
                     'username' => $this->extra_data['username'] ?? '',

--- a/app/framework_helper_overrides.php
+++ b/app/framework_helper_overrides.php
@@ -10,13 +10,55 @@ function e($value)
     return htmlspecialchars($value, ENT_QUOTES, 'UTF-8', true);
 }
 
-function trans_choice($key, $number, array $replace = [], $locale = null)
+function trans($key = null, $replace = [], $locale = null)
 {
     $translator = app('translator');
 
-    if ($translator->hasForLocale($key, $locale)) {
-        return $translator->transChoice($key, $number, $replace, $locale);
-    } else {
-        return $translator->transChoice($key, $number, $replace, config('app.fallback_locale'));
+    if (is_null($key)) {
+        return $translator;
     }
+
+    $locale ?? $locale = $translator->getLocale();
+
+    $translated = null;
+
+    if ($translator->hasForLocale($key, $locale)) {
+        $translated = presence($translator->get($key, $replace, $locale, false));
+    }
+
+    if ($translated === null) {
+        $fallbackLocale = config('app.fallback_locale');
+
+        if ($locale === $fallbackLocale) {
+            $translated = $key;
+        } else {
+            $translated = $translator->get($key, $replace, $fallbackLocale, false);
+        }
+    }
+
+    return $translated;
+}
+
+function trans_choice($key, $number, array $replace = [], $locale = null)
+{
+    $translator = app('translator');
+    $locale ?? $locale = $translator->getLocale();
+
+    $translated = null;
+
+    if ($translator->hasForLocale($key, $locale)) {
+        $translated = presence($translator->transChoice($key, $number, $replace, $locale));
+    }
+
+    if ($translated === null) {
+        $fallbackLocale = config('app.fallback_locale');
+
+        if ($locale === $fallbackLocale) {
+            $translated = $key;
+        } else {
+            $translated = $translator->transChoice($key, $number, $replace, $fallbackLocale);
+        }
+    }
+
+    return $translated;
 }

--- a/resources/assets/coffee/_classes/store-supporter-tag-price.coffee
+++ b/resources/assets/coffee/_classes/store-supporter-tag-price.coffee
@@ -70,9 +70,9 @@ class @StoreSupporterTagPrice
     texts = []
 
     if duration.years > 0
-      texts.push Lang.choice('common.count.years', duration.years)
+      texts.push osu.transChoice('common.count.years', duration.years)
 
     if duration.months > 0
-      texts.push Lang.choice('common.count.months', duration.months)
+      texts.push osu.transChoice('common.count.months', duration.months)
 
     texts.join(', ')

--- a/resources/assets/coffee/main.coffee
+++ b/resources/assets/coffee/main.coffee
@@ -18,7 +18,6 @@
 
 @polyfills ?= new Polyfills
 Lang.setLocale(currentLocale)
-Lang.setFallback(fallbackLocale)
 jQuery.timeago.settings.allowFuture = true
 
 # loading animation overlay

--- a/resources/assets/coffee/osu_common.coffee
+++ b/resources/assets/coffee/osu_common.coffee
@@ -234,8 +234,22 @@
     $('#overlay').is(':visible')
 
 
-  trans: (key, replacements) ->
-    Lang.get key, replacements
+  presence: (string) ->
+    if string? && string != '' then string else null
+
+
+  trans: (key, replacements, locale) ->
+    if locale?
+      initialLocale = Lang.getLocale()
+      Lang.setLocale locale
+      translated = Lang.get(key, replacements)
+      Lang.setLocale initialLocale
+
+      translated
+    else
+      translated = Lang.get(key, replacements) if Lang.has(key)
+
+      osu.presence(translated) ? osu.trans(key, replacements, fallbackLocale)
 
 
   transArray: (array, key = 'common.array_and') ->
@@ -250,8 +264,18 @@
         "#{array[...-1].join(osu.trans("#{key}.words_connector"))}#{osu.trans("#{key}.last_word_connector")}#{_.last(array)}"
 
 
-  transChoice: (key, count, replacements) ->
-    Lang.choice key, count, replacements
+  transChoice: (key, count, replacements, locale) ->
+    if locale?
+      initialLocale = Lang.getLocale()
+      Lang.setLocale locale
+      translated = Lang.choice(key, count, replacements)
+      Lang.setLocale initialLocale
+
+      translated
+    else
+      translated = Lang.choice(key, count, replacements) if Lang.has(key)
+
+      osu.presence(translated) ? osu.transChoice(key, count, replacements, fallbackLocale)
 
 
   uuid: ->

--- a/resources/assets/coffee/store-username-change.coffee
+++ b/resources/assets/coffee/store-username-change.coffee
@@ -54,9 +54,9 @@ $(document).on 'input', '.js-username-change #username.form-control', ->
   preventUsernameSubmission()
 
   if requestedUsername.length == 0
-    $status.text Lang.get('store.username_change.check')
+    $status.text osu.trans('store.username_change.check')
   else
-    $status.text Lang.get('store.username_change.checking', username: requestedUsername)
+    $status.text osu.trans('store.username_change.checking', username: requestedUsername)
     debouncedCheckUsernameValidity()
 
 $(document).on 'turbolinks:load', ->

--- a/resources/assets/less/bem/simple-form.less
+++ b/resources/assets/less/bem/simple-form.less
@@ -61,9 +61,6 @@
 
   &__input-group-label {
     font-weight: normal;
-    &--prefix {
-      margin-right: 5px;
-    }
 
     &--suffix {
       margin-left: 5px;

--- a/resources/lang/en/forum.php
+++ b/resources/lang/en/forum.php
@@ -147,7 +147,6 @@ return [
 
             'poll' => [
                 'length' => 'Run poll for',
-                'length_days_prefix' => '',
                 'length_days_suffix' => 'days',
                 'length_info' => 'Leave blank for a never ending poll',
                 'max_options' => 'Options per user',

--- a/resources/views/accounts/_edit_playstyle_checkbox.blade.php
+++ b/resources/views/accounts/_edit_playstyle_checkbox.blade.php
@@ -17,7 +17,7 @@
 --}}
 <label class="account-edit-entry js-account-edit js-account-edit-playstyle" data-playstyle="{{ $field }}">
     <div class="account-edit-entry__label">
-        @lang('accounts.playstyles.'.$field)
+        {{ trans('accounts.playstyles.'.$field) }}
     </div>
 
     <div class="osu-checkbox">

--- a/resources/views/forum/topics/_create_poll.blade.php
+++ b/resources/views/forum/topics/_create_poll.blade.php
@@ -54,9 +54,6 @@
             <p class="simple-form__info">{{ trans('forum.topics.create.poll.length_info') }}</p>
         </div>
         <div class="simple-form__input-group">
-            <span class="simple-form__input-group-label simple-form__input-group-label--prefix">
-                {{ trans('forum.topics.create.poll.length_days_prefix') }}
-            </span>
             <input class="simple-form__input simple-form__input--small simple-form__input--centered" name="forum_topic_poll[length_days]" />
             <span class="simple-form__input-group-label simple-form__input-group-label--suffix">
                 {{ trans('forum.topics.create.poll.length_days_suffix') }}

--- a/resources/views/home/_search_results.blade.php
+++ b/resources/views/home/_search_results.blade.php
@@ -18,7 +18,7 @@
 <div class="search-result search-result--{{ $mode }}">
     @if ($search->total() === 0)
         <div class="search-result__row search-result__row--notice">
-            @lang('home.search.empty_result')
+            {{ trans('home.search.empty_result') }}
         </div>
     @else
         <div class="search-result__row search-result__row--entries-container">
@@ -39,7 +39,7 @@
                 class="search-result__row search-result__row--more"
                 href="{{ route('search', ['mode' => $mode, 'query' => request('query')]) }}"
             >
-                @lang("home.search.{$mode}.more_simple")
+                {{ trans("home.search.{$mode}.more_simple") }}
             </a>
         @else
             @if (request('mode') === 'user' && $search->overLimit())

--- a/resources/views/home/search.blade.php
+++ b/resources/views/home/search.blade.php
@@ -68,7 +68,7 @@
                 @else
                     <div class="search-result">
                         <div class="search-result__row search-result__row--notice">
-                            @lang('home.search.missing_query', ['n' => config('osu.search.minimum_length')])
+                            {{ trans('home.search.missing_query', ['n' => config('osu.search.minimum_length')]) }}
                         </div>
                     </div>
                 @endif

--- a/resources/views/packs/index.blade.php
+++ b/resources/views/packs/index.blade.php
@@ -37,9 +37,9 @@
                             '<span class="beatmap-packs__scary">' . trans('beatmappacks.index.blurb.note.scary') . '</span>',
                         ];
                     @endphp
-                    <p class="beatmap-packs__important">@lang('beatmappacks.index.blurb.important')</p>
-                    <p>@lang('beatmappacks.index.blurb.instruction._', ['scary' => $scaryTexts[0]])</p>
-                    <p>@lang('beatmappacks.index.blurb.note._', ['scary' => $scaryTexts[1]])</p>
+                    <p class="beatmap-packs__important">{{ trans('beatmappacks.index.blurb.important') }}</p>
+                    <p>{{ trans('beatmappacks.index.blurb.instruction._', ['scary' => $scaryTexts[0]]) }}</p>
+                    <p>{{ trans('beatmappacks.index.blurb.note._', ['scary' => $scaryTexts[1]]) }}</p>
                 </div>
             </div>
             <ul class="page-mode">

--- a/resources/views/store/checkout.blade.php
+++ b/resources/views/store/checkout.blade.php
@@ -31,7 +31,7 @@
             @if (session()->has('checkout.error.message') || $hasErrors)
                 <div class="alert alert-danger">
                     <p>
-                        @lang('store.checkout.error')
+                        {{ trans('store.checkout.error') }}
                     </p>
                     <p>
                         {{ session('checkout.error.message') }}
@@ -53,8 +53,8 @@
                 @endphp
                 <div class="alert alert-danger">
                     <p>
-                        @lang('store.checkout.pending_checkout.line_1')<br>
-                        @lang('store.checkout.pending_checkout.line_2', ['link' => $cancelLink])
+                        {{ trans('store.checkout.pending_checkout.line_1') }}<br>
+                        {{ trans('store.checkout.pending_checkout.line_2', ['link' => $cancelLink]) }}
                     </p>
                 </div>
             @endif
@@ -108,9 +108,9 @@
                 @if ($hasErrors)
                     {{-- Remove checkout options if there are cart errors --}}
                     <div class="store-checkout-text--error">
-                        <p>@lang('store.checkout.cart_problems')</p>
+                        <p>{{ trans('store.checkout.cart_problems') }}</p>
                         <p>
-                            <a href="{{ route('store.cart.show') }}">@lang('store.checkout.cart_problems_edit')</a>
+                            <a href="{{ route('store.cart.show') }}">{{ trans('store.checkout.cart_problems_edit') }}</a>
                         </p>
                     </div>
                 @else

--- a/resources/views/store/products/supporter-tag.blade.php
+++ b/resources/views/store/products/supporter-tag.blade.php
@@ -61,7 +61,7 @@
             </div>
         </div>
         <div class="grid grid--xs grid--right store-slider__presets">
-            <span class="store-slider__presets-blurb">@lang('supporter_tag.months')</span>
+            <span class="store-slider__presets-blurb">{{ trans('supporter_tag.months') }}</span>
             @foreach([1, 2, 4, 6, 12, 18, 24] as $months)
                 <div class="js-slider-preset store-slider__preset" data-months="{{$months}}">{{$months}}</div>
             @endforeach

--- a/resources/views/store/products/username-change.blade.php
+++ b/resources/views/store/products/username-change.blade.php
@@ -35,7 +35,7 @@
             {!! Form::text('item[extra_info]', '', ['id' => 'username', 'class' => 'form-control', 'placeholder' => 'Requested Username', 'autocomplete' => 'off']) !!}
         </div>
         <strong>
-            <div id="username-check-status">@lang('store.username_change.check')</div>
+            <div id="username-check-status">{{ trans('store.username_change.check') }}</div>
         </strong>
         <div>Your current username is "<i>{{ Auth::user()->username }}</i>".</div>
     </div>

--- a/resources/views/users/posts.blade.php
+++ b/resources/views/users/posts.blade.php
@@ -46,7 +46,7 @@
                 <div class="search-result search-result--forum_post">
                     @if ($search->total() === 0)
                         <div class="search-result__row search-result__row--notice">
-                            @lang('home.search.empty_result')
+                            {{ trans('home.search.empty_result') }}
                         </div>
                     @else
                         <div class="search-result__row search-result__row--entries-container">

--- a/tests/LocaleTest.php
+++ b/tests/LocaleTest.php
@@ -1,0 +1,72 @@
+<?php
+
+/**
+ *    Copyright 2015-2017 ppy Pty. Ltd.
+ *
+ *    This file is part of osu!web. osu!web is distributed with the hope of
+ *    attracting more community contributions to the core ecosystem of osu!.
+ *
+ *    osu!web is free software: you can redistribute it and/or modify
+ *    it under the terms of the Affero GNU General Public License version 3
+ *    as published by the Free Software Foundation.
+ *
+ *    osu!web is distributed WITHOUT ANY WARRANTY; without even the implied
+ *    warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *    See the GNU Affero General Public License for more details.
+ *
+ *    You should have received a copy of the GNU Affero General Public License
+ *    along with osu!web.  If not, see <http://www.gnu.org/licenses/>.
+ */
+class LocaleTest extends TestCase
+{
+    public function testAll()
+    {
+        $fallbackLocale = 'en';
+        trans()->addLines([
+            'key_1.simple' => 'test',
+            'key_1.simple_empty' => 'test 2',
+            'key_1.simple_missing' => 'test 3',
+            'key_1.keyed' => 'test: :value',
+            'key_1.keyed_empty' => 'test 2: :value',
+            'key_1.keyed_missing' => 'test 3: :value',
+            'key_1.choice' => ':count unit|:count units',
+            'key_1.choice_empty' => ':count item|:count items',
+            'key_1.choice_missing' => ':count entity|:count entities',
+        ], $fallbackLocale);
+
+        App::setLocale($fallbackLocale);
+        $this->assertSame('key_1.missing', trans('key_1.missing'));
+        $this->assertSame('test', trans('key_1.simple'));
+        $this->assertSame('test: stuff', trans('key_1.keyed', ['value' => 'stuff']));
+        $this->assertSame('1 unit', trans_choice('key_1.choice', 1));
+        $this->assertSame('2 units', trans_choice('key_1.choice', 2));
+
+        $incompleteLocale = 'ja';
+        trans()->addLines([
+            'key_1.simple' => 'テスト',
+            'key_1.simple_empty' => '',
+            'key_1.keyed' => 'テスト: :value',
+            'key_1.keyed_empty' => '',
+            'key_1.choice' => ':count個',
+            'key_1.choice_empty' => '',
+        ], $incompleteLocale);
+
+        app('translator')->setFallback($fallbackLocale);
+        App::setLocale($incompleteLocale);
+        $this->assertSame('key_1.missing', trans('key_1.missing'));
+        $this->assertSame('テスト', trans('key_1.simple'));
+        $this->assertSame('test 2', trans('key_1.simple_empty'));
+        $this->assertSame('test 3', trans('key_1.simple_missing'));
+
+        $this->assertSame('テスト: stuff', trans('key_1.keyed', ['value' => 'stuff']));
+        $this->assertSame('test 2: stuff', trans('key_1.keyed_empty', ['value' => 'stuff']));
+        $this->assertSame('test 3: stuff', trans('key_1.keyed_missing', ['value' => 'stuff']));
+
+        $this->assertSame('1個', trans_choice('key_1.choice', 1));
+        $this->assertSame('2個', trans_choice('key_1.choice', 2));
+        $this->assertSame('1 item', trans_choice('key_1.choice_empty', 1));
+        $this->assertSame('2 items', trans_choice('key_1.choice_empty', 2));
+        $this->assertSame('1 entity', trans_choice('key_1.choice_missing', 1));
+        $this->assertSame('2 entities', trans_choice('key_1.choice_missing', 2));
+    }
+}


### PR DESCRIPTION
To work with crowdin. Fix `Lang.choice` and do minor cleanup while at it.

- only use `trans()` and `trans_choice()` for php
- only use `osu.trans()` and `osu.transChoice()` for javascript
  - add `osu.presence` helper to allow chaining
  - don't set fallback locale
  - as it turned out the library hasn't been updated with plural rule bug fix