### PR TITLE
Fix mode switching in discussion

### DIFF
--- a/resources/assets/coffee/_classes/beatmap-helper.coffee
+++ b/resources/assets/coffee/_classes/beatmap-helper.coffee
@@ -19,7 +19,7 @@
 class @BeatmapHelper
   @default: ({group, items, mode}) =>
     if items?
-      return _.findLast items, (i) -> !i.deleted_at?
+      return _.findLast(items, (i) -> !i.deleted_at?) ? _.last(items)
 
     return unless group?
 


### PR DESCRIPTION
Allow switching to mode which all maps are deleted by falling back to plain `_.last` when there's no active maps available.

Fixes #3197.