### PR TITLE
Synchronize account saving behavior

### DIFF
--- a/resources/assets/coffee/_classes/account-edit-playstyle.coffee
+++ b/resources/assets/coffee/_classes/account-edit-playstyle.coffee
@@ -28,6 +28,7 @@ class @AccountEditPlaystyle
     target = e.currentTarget
     target.dataset.playstyleUpdating = '1'
 
+    @xhr?.abort()
     @setState 'saving'
     @debouncedUpdate()
 
@@ -61,7 +62,6 @@ class @AccountEditPlaystyle
       checkbox = field.getElementsByTagName('input')[0]
       arr.push field.dataset.playstyle if checkbox.checked
 
-    @xhr?.abort()
     @xhr = $.ajax laroute.route('account.update'),
       method: 'PUT'
       data:

--- a/resources/assets/coffee/_classes/account-edit.coffee
+++ b/resources/assets/coffee/_classes/account-edit.coffee
@@ -31,6 +31,7 @@ class @AccountEdit
     return if form.dataset.accountEditAutoSubmit != '1'
 
     @abortUpdate form
+    @saving form
     form.debouncedUpdate ?= _.debounce @update, 1000
     form.debouncedUpdate form
 
@@ -78,11 +79,9 @@ class @AccountEdit
 
     prevValue = form.dataset.lastValue
 
-    return if value == prevValue
+    return @clearState(form) if value == prevValue
 
     form.dataset.lastValue = value
-
-    @saving form
 
     form.updating = $.ajax laroute.route('account.update'),
       method: 'PUT'


### PR DESCRIPTION
On update, immediately:
- abort previous request
- show spinner

Fixes #3258.