### PR TITLE
Return json on error for a json request

### DIFF
--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -108,7 +108,7 @@ class Handler extends ExceptionHandler
         } else {
             $message = $this->exceptionMessage($e);
 
-            if ($request->ajax() || $request->wantsJson()) {
+            if ($request->expectsJson()) {
                 $response = response(['error' => $message]);
             } else {
                 $response = response()->view('layout.error', ['exceptionMessage' => $message]);
@@ -120,7 +120,7 @@ class Handler extends ExceptionHandler
 
     protected function unauthenticated($request, AuthenticationException $exception)
     {
-        if ($request->wantsJson()) {
+        if ($request->expectsJson()) {
             return response(['authentication' => 'basic'], 401);
         }
 

--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -108,7 +108,7 @@ class Handler extends ExceptionHandler
         } else {
             $message = $this->exceptionMessage($e);
 
-            if ($request->ajax()) {
+            if ($request->ajax() || $request->wantsJson()) {
                 $response = response(['error' => $message]);
             } else {
                 $response = response()->view('layout.error', ['exceptionMessage' => $message]);
@@ -120,7 +120,7 @@ class Handler extends ExceptionHandler
 
     protected function unauthenticated($request, AuthenticationException $exception)
     {
-        if ($request->expectsJson()) {
+        if ($request->wantsJson()) {
             return response(['authentication' => 'basic'], 401);
         }
 


### PR DESCRIPTION
`ajax` only covers requests with `X-Requested-With=XMLHttpRequest`.
And change `expectsJson` to `wantsJson`. The former also includes `ajax` requests.