### PR TITLE
Remove overlapping `last` function

### DIFF
--- a/app/Models/Forum/Post.php
+++ b/app/Models/Forum/Post.php
@@ -284,11 +284,6 @@ class Post extends Model implements AfterCommit
         return bbcode_for_editor($this->post_text, $this->bbcode_uid);
     }
 
-    public function scopeLast($query)
-    {
-        return $query->orderBy('post_id', 'desc')->limit(1);
-    }
-
     public function scopeShowDeleted($query, $showDeleted)
     {
         if ($showDeleted) {

--- a/app/Models/Forum/Topic.php
+++ b/app/Models/Forum/Topic.php
@@ -659,7 +659,7 @@ class Topic extends Model implements AfterCommit
 
     public function setLastPostCache()
     {
-        $lastPost = $this->posts()->last()->first();
+        $lastPost = $this->posts()->last();
 
         if ($lastPost === null) {
             $this->topic_last_post_id = 0;

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -1273,7 +1273,7 @@ class User extends Model implements AuthenticatableContract, Messageable
             $newPostsCount = $this->forumPosts()->whereIn('forum_id', Forum\Authorize::postsCountedForums($this))->count();
         }
 
-        $lastPost = $this->forumPosts()->last()->select('post_time')->first();
+        $lastPost = $this->forumPosts()->select('post_time')->last();
 
         // FIXME: not null column, hence default 0. Change column to allow null
         $lastPostTime = $lastPost !== null ? $lastPost->post_time : 0;


### PR DESCRIPTION
The old one was a scope which was made before `macro` was created, causing broken stuff when real `last` function/macro is created.