### PR TITLE
Use user's playmode when searching for recommended difficulties.

### DIFF
--- a/app/Libraries/Search/BeatmapsetSearch.php
+++ b/app/Libraries/Search/BeatmapsetSearch.php
@@ -134,7 +134,7 @@ class BeatmapsetSearch extends RecordSearch
     {
         if ($this->params->showRecommended && $this->params->user !== null) {
             // TODO: index convert difficulties and handle them.
-            $mode = Beatmap::modeStr($this->params->mode ?? Beatmap::MODES['osu']);
+            $mode = Beatmap::modeStr($this->params->mode) ?? $this->params->user->playmode;
             $difficulty = $this->params->user->recommendedStarDifficulty($mode);
             $query->filter([
                 'range' => [


### PR DESCRIPTION
When searching for recommended difficulties of any mode type, it should default to the
user's playmode instead of using `osu`.

fixes #3302