### PR TITLE
Unjustify changelog change text.

### DIFF
--- a/resources/assets/less/bem/changelog-change.less
+++ b/resources/assets/less/bem/changelog-change.less
@@ -20,7 +20,7 @@
   display: flex;
   flex-direction: row;
   flex-grow: 1;
-  align-items: center;
+  align-items: baseline;
 
   padding: 5px 0;
 
@@ -57,7 +57,6 @@
 
   &__right {
     font-size: @font-size--normal-2;
-    text-align: justify;
 
     @media @mobile {
       text-align: center;

--- a/resources/assets/less/bem/changelog-change.less
+++ b/resources/assets/less/bem/changelog-change.less
@@ -58,10 +58,6 @@
   &__right {
     font-size: @font-size--normal-2;
 
-    @media @mobile {
-      text-align: center;
-    }
-
     &--major {
       font-size: 16px;
       color: @purple-dark;


### PR DESCRIPTION
fixes #3323 

Also align items to baseline which has the side-effect of aligning the text on mobile to the left instead of centre.