### PR TITLE
Faster topic cache update

### DIFF
--- a/app/Jobs/UpdateUserForumCache.php
+++ b/app/Jobs/UpdateUserForumCache.php
@@ -1,7 +1,7 @@
 <?php
 
 /**
- *    Copyright 2015-2017 ppy Pty. Ltd.
+ *    Copyright 2015-2018 ppy Pty. Ltd.
  *
  *    This file is part of osu!web. osu!web is distributed with the hope of
  *    attracting more community contributions to the core ecosystem of osu!.

--- a/app/Jobs/UpdateUserForumCache.php
+++ b/app/Jobs/UpdateUserForumCache.php
@@ -1,0 +1,53 @@
+<?php
+
+/**
+ *    Copyright 2015-2017 ppy Pty. Ltd.
+ *
+ *    This file is part of osu!web. osu!web is distributed with the hope of
+ *    attracting more community contributions to the core ecosystem of osu!.
+ *
+ *    osu!web is free software: you can redistribute it and/or modify
+ *    it under the terms of the Affero GNU General Public License version 3
+ *    as published by the Free Software Foundation.
+ *
+ *    osu!web is distributed WITHOUT ANY WARRANTY; without even the implied
+ *    warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *    See the GNU Affero General Public License for more details.
+ *
+ *    You should have received a copy of the GNU Affero General Public License
+ *    along with osu!web.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace App\Jobs;
+
+use App\Models\User;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Queue\InteractsWithQueue;
+
+class UpdateUserForumCache implements ShouldQueue
+{
+    use InteractsWithQueue, Queueable;
+
+    protected $userId;
+
+    /**
+     * Create a new job instance.
+     *
+     * @return void
+     */
+    public function __construct($userId)
+    {
+        $this->userId = $userId;
+    }
+
+    /**
+     * Execute the job.
+     *
+     * @return void
+     */
+    public function handle()
+    {
+        optional(User::find($this->userId))->refreshForumCache();
+    }
+}

--- a/app/Models/Elasticsearch/PostTrait.php
+++ b/app/Models/Elasticsearch/PostTrait.php
@@ -82,4 +82,9 @@ trait PostTrait
     {
         return 'posts';
     }
+
+    public function esShouldIndex()
+    {
+        return $this->forum->enable_indexing && !$this->trashed();
+    }
 }

--- a/app/Models/Elasticsearch/TopicTrait.php
+++ b/app/Models/Elasticsearch/TopicTrait.php
@@ -75,4 +75,9 @@ trait TopicTrait
     {
         return Post::esType();
     }
+
+    public function esShouldIndex()
+    {
+        return $this->forum->enable_indexing && !$this->trashed();
+    }
 }

--- a/app/Models/Forum/Post.php
+++ b/app/Models/Forum/Post.php
@@ -20,7 +20,6 @@
 
 namespace App\Models\Forum;
 
-use App\Jobs\EsDeleteDocument;
 use App\Jobs\EsIndexDocument;
 use App\Libraries\BBCodeForDB;
 use App\Libraries\BBCodeFromDB;
@@ -293,11 +292,7 @@ class Post extends Model implements AfterCommit
 
     public function afterCommit()
     {
-        if ($this->forum->enable_indexing && !$this->trashed()) {
-            dispatch(new EsIndexDocument($this));
-        } else {
-            dispatch(new EsDeleteDocument($this));
-        }
+        dispatch(new EsIndexDocument($this));
     }
 
     public function markRead($user)

--- a/app/Models/Forum/Topic.php
+++ b/app/Models/Forum/Topic.php
@@ -21,8 +21,8 @@
 namespace App\Models\Forum;
 
 use App\Exceptions\ModelNotSavedException;
-use App\Jobs\EsDeleteDocument;
 use App\Jobs\EsIndexDocument;
+use App\Jobs\UpdateUserForumCache;
 use App\Libraries\BBCodeForDB;
 use App\Libraries\Transactions\AfterCommit;
 use App\Models\Beatmapset;
@@ -84,6 +84,7 @@ class Topic extends Model implements AfterCommit
     {
         $topic = new static([
             'forum_id' => $forum->forum_id,
+            'forum' => $forum,
             'topic_time' => Carbon::now(),
             'topic_title' => $params['title'] ?? null,
             'topic_poster' => $params['user']->user_id,
@@ -91,7 +92,7 @@ class Topic extends Model implements AfterCommit
             'topic_first_poster_colour' => $params['user']->user_colour,
         ]);
 
-        DB::transaction(function () use ($forum, $topic, $params, $poll) {
+        $this->getConnection()->transaction(function () use ($forum, $topic, $params, $poll) {
             $topic->saveOrExplode();
             $topic->addPostOrExplode($params['user'], $params['body']);
 
@@ -119,14 +120,11 @@ class Topic extends Model implements AfterCommit
             'post_time' => Carbon::now(),
         ]);
 
-        DB::transaction(function () use ($post) {
+        $this->getConnection()->transaction(function () use ($post) {
             $post->saveOrExplode();
 
-            $this->refreshCache();
-
-            if ($this->forum !== null) {
-                $this->forum->refreshCache();
-            }
+            $this->postsAdded(1);
+            optional($this->forum)->postsAdded(1);
 
             if ($post->user !== null) {
                 $post->user->refreshForumCache($this->forum, 1);
@@ -140,7 +138,7 @@ class Topic extends Model implements AfterCommit
     {
         $this->validationErrors()->reset();
 
-        return DB::transaction(function () use ($post) {
+        return $this->getConnection()->transaction(function () use ($post) {
             if ($post->delete() === false) {
                 $message = $post->validationErrors()->toSentence();
                 $this->validationErrors()->addTranslated('post', $message);
@@ -149,14 +147,13 @@ class Topic extends Model implements AfterCommit
             }
 
             if ($this->posts()->exists() === true) {
-                $this->refreshCache();
+                $this->postsAdded(-1);
             } else {
                 $this->delete();
+                optional($this->forum)->topicsAdded(-1);
             }
 
-            if ($this->forum !== null) {
-                $this->forum->refreshCache();
-            }
+            optional($this->forum)->postsAdded(-1);
 
             if ($post->user !== null) {
                 $post->user->refreshForumCache($this->forum, -1);
@@ -168,22 +165,17 @@ class Topic extends Model implements AfterCommit
 
     public function restorePost($post)
     {
-        DB::transaction(function () use ($post) {
+        $this->getConnection()->transaction(function () use ($post) {
             $post->restore();
+
+            $this->postsAdded(1);
+            optional($this->forum)->postsAdded(1);
 
             if ($this->trashed()) {
                 $this->restore();
             }
 
-            $this->refreshCache();
-
-            if ($this->forum !== null) {
-                $this->forum->refreshCache();
-            }
-
-            if ($post->user !== null) {
-                $post->user->refreshForumCache($this->forum, 1);
-            }
+            optional($post->user)->refreshForumCache($this->forum, 1);
         });
 
         return true;
@@ -199,33 +191,31 @@ class Topic extends Model implements AfterCommit
             return false;
         }
 
-        return DB::transaction(function () use ($destinationForum) {
+        return $this->getConnection()->transaction(function () use ($destinationForum) {
             $originForum = $this->forum;
             $this->forum()->associate($destinationForum);
             $this->save();
 
-            $posts = $this->posts()->withTrashed()->with(['forum', 'topic'])->get();
-            $posts->each(function ($post) use ($destinationForum) {
-                $post->forum()->associate($destinationForum);
-                $post->save();
-            });
+            $this->posts()->withTrashed()->update(['forum_id' => $this->forum_id]);
 
             $this->logs()->update(['forum_id' => $destinationForum->forum_id]);
             $this->userTracks()->update(['forum_id' => $destinationForum->forum_id]);
 
-            if ($originForum !== null) {
-                $originForum->refreshCache();
-            }
+            $visiblePostsCount = $this->posts()->count();
+            optional($originForum)->topicsAdded(-1);
+            optional($originForum)->postsAdded($visiblePostsCount * -1);
+            optional($this->forum)->topicsAdded(1);
+            optional($this->forum)->postsAdded($visiblePostsCount);
 
-            if ($this->forum !== null) {
-                $this->forum->refreshCache();
-            }
-
-            $users = User::whereIn('user_id', model_pluck($this->posts(), 'poster_id'))->get();
-
-            foreach ($users as $user) {
-                $user->refreshForumCache();
-            }
+            $this
+                ->posts()
+                ->withTrashed()
+                // this relies on dispatcher always reloading the model
+                ->select(['poster_id', 'post_id'])
+                ->each(function ($post) {
+                    dispatch(new UpdateUserForumCache($post->poster_id));
+                    dispatch(new EsIndexDocument($post));
+                });
 
             return true;
         });
@@ -384,7 +374,19 @@ class Topic extends Model implements AfterCommit
             return false;
         }
 
-        return parent::save($options);
+        return $this->getConnection()->transaction(function () use ($options) {
+            // creating new topic
+            if (!$this->exists && $this->forum !== null) {
+                $this->forum->topicsAdded(1);
+            }
+
+            // restoring topic
+            if ($this->isDirty('deleted_at') && $this->deleted_at === null) {
+                $this->forum->topicsAdded(1);
+            }
+
+            return parent::save($options);
+        });
     }
 
     public function isValid()
@@ -621,9 +623,23 @@ class Topic extends Model implements AfterCommit
         return in_array($this->forum_id, config('osu.forum.help_forum_ids'), true);
     }
 
+    public function postsAdded($count)
+    {
+        $this->getConnection()->transaction(function () use ($count) {
+            $this->fill([
+                'topic_replies' => db_unsigned_increment('topic_replies', $count),
+                'topic_replies_real' => db_unsigned_increment('topic_replies_real', $count),
+            ]);
+            $this->setFirstPostCache();
+            $this->setLastPostCache();
+
+            $this->save();
+        });
+    }
+
     public function refreshCache()
     {
-        DB::transaction(function () {
+        $this->getConnection()->transaction(function () {
             $this->setPostsCountCache();
             $this->setFirstPostCache();
             $this->setLastPostCache();
@@ -815,10 +831,6 @@ class Topic extends Model implements AfterCommit
 
     public function afterCommit()
     {
-        if ($this->forum->enable_indexing && !$this->trashed()) {
-            dispatch(new EsIndexDocument($this));
-        } else {
-            dispatch(new EsDeleteDocument($this));
-        }
+        dispatch(new EsIndexDocument($this));
     }
 }

--- a/app/Models/Forum/Topic.php
+++ b/app/Models/Forum/Topic.php
@@ -92,7 +92,7 @@ class Topic extends Model implements AfterCommit
             'topic_first_poster_colour' => $params['user']->user_colour,
         ]);
 
-        $this->getConnection()->transaction(function () use ($forum, $topic, $params, $poll) {
+        $topic->getConnection()->transaction(function () use ($forum, $topic, $params, $poll) {
             $topic->saveOrExplode();
             $topic->addPostOrExplode($params['user'], $params['body']);
 

--- a/app/Models/Forum/Topic.php
+++ b/app/Models/Forum/Topic.php
@@ -83,14 +83,13 @@ class Topic extends Model implements AfterCommit
     public static function createNew($forum, $params, $poll = null)
     {
         $topic = new static([
-            'forum_id' => $forum->forum_id,
-            'forum' => $forum,
             'topic_time' => Carbon::now(),
             'topic_title' => $params['title'] ?? null,
             'topic_poster' => $params['user']->user_id,
             'topic_first_poster_name' => $params['user']->username,
             'topic_first_poster_colour' => $params['user']->user_colour,
         ]);
+        $topic->forum()->associate($forum);
 
         $topic->getConnection()->transaction(function () use ($forum, $topic, $params, $poll) {
             $topic->saveOrExplode();

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -1279,8 +1279,7 @@ class User extends Model implements AuthenticatableContract, Messageable
                 $postsChangeCount = 0;
             }
 
-            // In case user_posts is 0 and $postsChangeCount is -1.
-            $newPostsCount = DB::raw("GREATEST(CAST(user_posts AS SIGNED) + {$postsChangeCount}, 0)");
+            $newPostsCount = db_unsigned_increment('user_posts', $postsChangeCount);
         } else {
             $newPostsCount = $this->forumPosts()->whereIn('forum_id', Forum\Authorize::postsCountedForums($this))->count();
         }

--- a/app/Traits/EsIndexable.php
+++ b/app/Traits/EsIndexable.php
@@ -67,6 +67,10 @@ trait EsIndexable
 
     public function esIndexDocument(array $options = [])
     {
+        if (method_exists($this, 'esShouldIndex') && !$this->esShouldIndex()) {
+            return $this->esDeleteDocument($options);
+        }
+
         $document = array_merge([
             'index' => static::esIndexName(),
             'type' => static::esType(),

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -66,6 +66,18 @@ function datadog_timing(callable $callable, $stat, array $tag = null)
     return $result;
 }
 
+function db_unsigned_increment($column, $count)
+{
+    if ($count >= 0) {
+        $value = "{$column} + {$count}";
+    } else {
+        $change = -$count;
+        $value = "IF({$column} < {$change}, 0, {$column} - {$change})";
+    }
+
+    return DB::raw($value);
+}
+
 function es_query_and_words($words)
 {
     $parts = preg_split("/\s+/", $words, null, PREG_SPLIT_NO_EMPTY);


### PR DESCRIPTION
- update `DB::transaction` to `$this->getConnection()` in some models
- directly increment/decrement cache counts
- queue heavy updates
- still need to be checked further