### PR TITLE
Prevent navigation background from vertically repeating

### DIFF
--- a/resources/assets/less/bem/nav2-header.less
+++ b/resources/assets/less/bem/nav2-header.less
@@ -59,5 +59,6 @@
     .full-size();
     background-image: url('/images/layout/nav2-background.png');
     background-position: bottom center;
+    background-repeat: repeat-x;
   }
 }


### PR DESCRIPTION
- fixes #3395

caused by rounding of layout values.

---

Stops the top of the navigation bar's background from leaking through the bottom