### PR TITLE
Disable add friend button instead of hiding

### DIFF
--- a/resources/assets/coffee/react/_components/friend-button.coffee
+++ b/resources/assets/coffee/react/_components/friend-button.coffee
@@ -86,6 +86,16 @@ class @FriendButton extends React.PureComponent
 
     blockClass = bn
 
+    isFriendLimit = currentUser.friends.length >= currentUser.max_friends
+    title = if @state.friend
+              osu.trans('friends.buttons.remove')
+            else if isFriendLimit
+              osu.trans('friends.too_many')
+            else
+              osu.trans('friends.buttons.add')
+
+    disabled = @state.loading || isFriendLimit && !@state.friend
+
     if @state.friend && !@state.loading
       if @state.friend.mutual
         blockClass += " #{bn}--mutual"
@@ -97,8 +107,8 @@ class @FriendButton extends React.PureComponent
       className: blockClass
       onClick: @clicked
       ref: (el) => @button = el
-      title: if @state.friend then osu.trans('friends.buttons.remove') else osu.trans('friends.buttons.add')
-      disabled: @state.loading
+      title: title
+      disabled: disabled
       if @state.loading
         el Spinner
       else

--- a/resources/assets/coffee/react/_components/friend-button.coffee
+++ b/resources/assets/coffee/react/_components/friend-button.coffee
@@ -131,7 +131,7 @@ class @FriendButton extends React.PureComponent
                 i className: 'fas fa-user'
           ]
         else
-          i className: 'fas fa-user-plus'
+          i className: if isFriendLimit then 'fas fa-user' else 'fas fa-user-plus'
 
 
   isVisible: =>

--- a/resources/assets/coffee/react/_components/friend-button.coffee
+++ b/resources/assets/coffee/react/_components/friend-button.coffee
@@ -127,10 +127,8 @@ class @FriendButton extends React.PureComponent
   isVisible: =>
     # - not a guest
     # - not viewing own card
-    # - already a friend or can add more friends
     # - not blocked
     currentUser.id? &&
       _.isFinite(@props.user_id) &&
       @props.user_id != currentUser.id &&
-      (@state.friend || currentUser.friends.length < currentUser.max_friends) &&
       !_.find(currentUser.blocks, target_id: @props.user_id)

--- a/resources/lang/en/friends.php
+++ b/resources/lang/en/friends.php
@@ -32,5 +32,5 @@ return [
     'title' => 'Friends',
     'title_compact' => 'friends',
 
-    'too_many' => 'Friend limit reached.',
+    'too_many' => 'Friend limit reached',
 ];


### PR DESCRIPTION
fixes #3346

---

Shows the add friend button and disables it instead of hiding it when the friend limit is reached.