### PR TITLE
Fix datetime datatype for osu_beatmapsets

### DIFF
--- a/app/Models/Beatmapset.php
+++ b/app/Models/Beatmapset.php
@@ -90,32 +90,6 @@ class Beatmapset extends Model implements AfterCommit
     const MINIMUM_DAYS_FOR_RANKING = 7;
     const BUNDLED_IDS = [3756, 163112, 140662, 151878, 190390, 123593, 241526, 299224];
 
-    /*
-    |--------------------------------------------------------------------------
-    | Accesssors
-    |--------------------------------------------------------------------------
-    */
-
-    public function getApprovedDateAttribute($value)
-    {
-        return (new Carbon($value))->subHours(8);
-    }
-
-    public function setApprovedDateAttribute($value)
-    {
-        $this->attributes['approved_date'] = $value !== null ? parse_time_to_carbon($value)->addHours(8) : null;
-    }
-
-    public function getSubmitDateAttribute($value)
-    {
-        return (new Carbon($value))->subHours(8);
-    }
-
-    public function setSubmitDateAttribute($value)
-    {
-        $this->attributes['submit_date'] = parse_time_to_carbon($value)->addHours(8);
-    }
-
     public function beatmapDiscussions()
     {
         return $this->hasMany(BeatmapDiscussion::class, 'beatmapset_id', 'beatmapset_id');

--- a/database/migrations/2018_06_25_072709_update_beatmapset_datetimes_datatype.php
+++ b/database/migrations/2018_06_25_072709_update_beatmapset_datetimes_datatype.php
@@ -20,9 +20,9 @@ class UpdateBeatmapsetDatetimesDatatype extends Migration
         ');
         // some of the times were in UTC+8
         DB::statement('UPDATE osu_beatmapsets SET
-            approved_date = IF(approved_date IS NULL, NULL, DATE_SUB(approved_date, INTERVAL 8 HOUR)),
-            submit_date = IF(submit_date IS NULL, NULL, DATE_SUB(submit_date, INTERVAL 8 HOUR)),
-            thread_icon_date = IF(thread_icon_date IS NULL, NULL, DATE_SUB(thread_icon_date, INTERVAL 8 HOUR))
+            approved_date = DATE_SUB(approved_date, INTERVAL 8 HOUR),
+            submit_date = DATE_SUB(submit_date, INTERVAL 8 HOUR),
+            thread_icon_date = DATE_SUB(thread_icon_date, INTERVAL 8 HOUR)
         ');
     }
 
@@ -41,9 +41,9 @@ class UpdateBeatmapsetDatetimesDatatype extends Migration
             MODIFY COLUMN queued_at DATETIME DEFAULT NULL
         ');
         DB::statement('UPDATE osu_beatmapsets SET
-            approved_date = IF(approved_date IS NULL, NULL, DATE_ADD(approved_date, INTERVAL 8 HOUR)),
-            submit_date = IF(submit_date IS NULL, NULL, DATE_ADD(submit_date, INTERVAL 8 HOUR)),
-            thread_icon_date = IF(thread_icon_date IS NULL, NULL, DATE_ADD(thread_icon_date, INTERVAL 8 HOUR))
+            approved_date = DATE_ADD(approved_date, INTERVAL 8 HOUR),
+            submit_date = DATE_ADD(submit_date, INTERVAL 8 HOUR),
+            thread_icon_date = DATE_ADD(thread_icon_date, INTERVAL 8 HOUR)
         ');
     }
 }

--- a/database/migrations/2018_06_25_072709_update_beatmapset_datetimes_datatype.php
+++ b/database/migrations/2018_06_25_072709_update_beatmapset_datetimes_datatype.php
@@ -12,17 +12,17 @@ class UpdateBeatmapsetDatetimesDatatype extends Migration
     public function up()
     {
         DB::statement('ALTER TABLE osu_beatmapsets
-            MODIFY COLUMN approved_date TIMESTAMP,
-            MODIFY COLUMN submit_date TIMESTAMP,
-            MODIFY COLUMN thread_icon_date TIMESTAMP,
-            MODIFY COLUMN cover_updated_at TIMESTAMP,
-            MODIFY COLUMN queued_at TIMESTAMP
+            MODIFY COLUMN approved_date TIMESTAMP DEFAULT NULL,
+            MODIFY COLUMN submit_date TIMESTAMP DEFAULT NULL,
+            MODIFY COLUMN thread_icon_date TIMESTAMP DEFAULT NULL,
+            MODIFY COLUMN cover_updated_at TIMESTAMP DEFAULT NULL,
+            MODIFY COLUMN queued_at TIMESTAMP DEFAULT NULL
         ');
         // some of the times were in UTC+8
         DB::statement('UPDATE osu_beatmapsets SET
-            approved_date = DATE_SUB(approved_date, INTERVAL 8 HOUR),
-            submit_date = DATE_SUB(submit_date, INTERVAL 8 HOUR),
-            thread_icon_date = DATE_SUB(thread_icon_date, INTERVAL 8 HOUR)
+            approved_date = IF(approved_date IS NULL, NULL, DATE_SUB(approved_date, INTERVAL 8 HOUR)),
+            submit_date = IF(submit_date IS NULL, NULL, DATE_SUB(submit_date, INTERVAL 8 HOUR)),
+            thread_icon_date = IF(thread_icon_date IS NULL, NULL, DATE_SUB(thread_icon_date, INTERVAL 8 HOUR))
         ');
     }
 
@@ -34,16 +34,16 @@ class UpdateBeatmapsetDatetimesDatatype extends Migration
     public function down()
     {
         DB::statement('ALTER TABLE osu_beatmapsets
-            MODIFY COLUMN approved_date DATETIME,
-            MODIFY COLUMN submit_date DATETIME,
-            MODIFY COLUMN thread_icon_date DATETIME,
-            MODIFY COLUMN cover_updated_at DATETIME,
-            MODIFY COLUMN queued_at DATETIME
+            MODIFY COLUMN approved_date DATETIME DEFAULT NULL,
+            MODIFY COLUMN submit_date DATETIME DEFAULT NULL,
+            MODIFY COLUMN thread_icon_date DATETIME DEFAULT NULL,
+            MODIFY COLUMN cover_updated_at DATETIME DEFAULT NULL,
+            MODIFY COLUMN queued_at DATETIME DEFAULT NULL
         ');
         DB::statement('UPDATE osu_beatmapsets SET
-            approved_date = DATE_ADD(approved_date, INTERVAL 8 HOUR),
-            submit_date = DATE_ADD(submit_date, INTERVAL 8 HOUR),
-            thread_icon_date = DATE_ADD(thread_icon_date, INTERVAL 8 HOUR)
+            approved_date = IF(approved_date IS NULL, NULL, DATE_ADD(approved_date, INTERVAL 8 HOUR)),
+            submit_date = IF(submit_date IS NULL, NULL, DATE_ADD(submit_date, INTERVAL 8 HOUR)),
+            thread_icon_date = IF(thread_icon_date IS NULL, NULL, DATE_ADD(thread_icon_date, INTERVAL 8 HOUR))
         ');
     }
 }

--- a/database/migrations/2018_06_25_072709_update_beatmapset_datetimes_datatype.php
+++ b/database/migrations/2018_06_25_072709_update_beatmapset_datetimes_datatype.php
@@ -1,0 +1,49 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+
+class UpdateBeatmapsetDatetimesDatatype extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        DB::statement('ALTER TABLE osu_beatmapsets
+            MODIFY COLUMN approved_date TIMESTAMP,
+            MODIFY COLUMN submit_date TIMESTAMP,
+            MODIFY COLUMN thread_icon_date TIMESTAMP,
+            MODIFY COLUMN cover_updated_at TIMESTAMP,
+            MODIFY COLUMN queued_at TIMESTAMP
+        ');
+        // some of the times were in UTC+8
+        DB::statement('UPDATE osu_beatmapsets SET
+            approved_date = DATE_SUB(approved_date, INTERVAL 8 HOUR),
+            submit_date = DATE_SUB(submit_date, INTERVAL 8 HOUR),
+            thread_icon_date = DATE_SUB(thread_icon_date, INTERVAL 8 HOUR)
+        ');
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        DB::statement('ALTER TABLE osu_beatmapsets
+            MODIFY COLUMN approved_date DATETIME,
+            MODIFY COLUMN submit_date DATETIME,
+            MODIFY COLUMN thread_icon_date DATETIME,
+            MODIFY COLUMN cover_updated_at DATETIME,
+            MODIFY COLUMN queued_at DATETIME
+        ');
+        DB::statement('UPDATE osu_beatmapsets SET
+            approved_date = DATE_ADD(approved_date, INTERVAL 8 HOUR),
+            submit_date = DATE_ADD(submit_date, INTERVAL 8 HOUR),
+            thread_icon_date = DATE_ADD(thread_icon_date, INTERVAL 8 HOUR)
+        ');
+    }
+}

--- a/database/migrations/2018_06_25_072709_update_beatmapset_datetimes_datatype.php
+++ b/database/migrations/2018_06_25_072709_update_beatmapset_datetimes_datatype.php
@@ -12,11 +12,11 @@ class UpdateBeatmapsetDatetimesDatatype extends Migration
     public function up()
     {
         DB::statement('ALTER TABLE osu_beatmapsets
-            MODIFY COLUMN approved_date TIMESTAMP DEFAULT NULL,
-            MODIFY COLUMN submit_date TIMESTAMP DEFAULT NULL,
-            MODIFY COLUMN thread_icon_date TIMESTAMP DEFAULT NULL,
-            MODIFY COLUMN cover_updated_at TIMESTAMP DEFAULT NULL,
-            MODIFY COLUMN queued_at TIMESTAMP DEFAULT NULL
+            MODIFY COLUMN approved_date TIMESTAMP NULL DEFAULT NULL,
+            MODIFY COLUMN submit_date TIMESTAMP NULL DEFAULT NULL,
+            MODIFY COLUMN thread_icon_date TIMESTAMP NULL DEFAULT NULL,
+            MODIFY COLUMN cover_updated_at TIMESTAMP NULL DEFAULT NULL,
+            MODIFY COLUMN queued_at TIMESTAMP NULL DEFAULT NULL
         ');
         // some of the times were in UTC+8
         DB::statement('UPDATE osu_beatmapsets SET
@@ -34,11 +34,11 @@ class UpdateBeatmapsetDatetimesDatatype extends Migration
     public function down()
     {
         DB::statement('ALTER TABLE osu_beatmapsets
-            MODIFY COLUMN approved_date DATETIME DEFAULT NULL,
-            MODIFY COLUMN submit_date DATETIME DEFAULT NULL,
-            MODIFY COLUMN thread_icon_date DATETIME DEFAULT NULL,
-            MODIFY COLUMN cover_updated_at DATETIME DEFAULT NULL,
-            MODIFY COLUMN queued_at DATETIME DEFAULT NULL
+            MODIFY COLUMN approved_date DATETIME NULL DEFAULT NULL,
+            MODIFY COLUMN submit_date DATETIME NULL DEFAULT NULL,
+            MODIFY COLUMN thread_icon_date DATETIME NULL DEFAULT NULL,
+            MODIFY COLUMN cover_updated_at DATETIME NULL DEFAULT NULL,
+            MODIFY COLUMN queued_at DATETIME NULL DEFAULT NULL
         ');
         DB::statement('UPDATE osu_beatmapsets SET
             approved_date = DATE_ADD(approved_date, INTERVAL 8 HOUR),


### PR DESCRIPTION
The last two columns (`cover_updated_at` and `queued_at`) are assigned from new web and doesn't have timezone adjustment so it's been stored in UTC. The rest were assigned from old web which uses UTC+8 and thus readjusted because conversion is done in UTC timezone.

Fixes #3399.

---