### PR TITLE
Fix changelog listing showing no legacy entries

### DIFF
--- a/app/Models/Build.php
+++ b/app/Models/Build.php
@@ -72,9 +72,10 @@ class Build extends Model
         return $this->belongsTo(UpdateStream::class, 'stream_id', 'stream_id');
     }
 
+    // FIXME: Need to match stream_id as well. It's currently checked in transformer.
     public function changelogs()
     {
-        return $this->hasMany(Changelog::class, 'build', 'version')->where('stream_id', '=', $this->stream_id);
+        return $this->hasMany(Changelog::class, 'build', 'version');
     }
 
     public function defaultChangelogs()

--- a/app/Transformers/BuildTransformer.php
+++ b/app/Transformers/BuildTransformer.php
@@ -54,7 +54,9 @@ class BuildTransformer extends Fractal\TransformerAbstract
     {
         $legacyEntries = $build
             ->defaultChangelogs
-            ->map(function ($item) {
+            ->filter(function ($item) use ($build) {
+                return $item->stream_id === $build->stream_id;
+            })->map(function ($item) {
                 return ChangelogEntry::convertLegacy($item);
             });
 


### PR DESCRIPTION
Filtering in model relation doesn't work when combined with eager load because $this is null for eager load.

---
