### PR TITLE
Corrected origin_country

### DIFF
--- a/resources/lang/fr/users.php
+++ b/resources/lang/fr/users.php
@@ -112,7 +112,7 @@ return [
         'missingtext' => 'Vous avez peut-être fait une faute de frappe ! (ou l\'utilisateur est banni)',
         'origin_age' => ':age',
         'origin_country_age' => ':age ans et de :country',
-        'origin_country' => 'Depuis :country',
+        'origin_country' => 'De :country',
         'page_description' => 'osu! - Tout ce que vous devez savoir à propos de :username!',
         'previous_usernames' => 'Anciennement connu en tant que',
         'plays_with' => 'Joue avec :devices',


### PR DESCRIPTION
"De" is more correct than "Depuis" in that case.

Add any details pertaining to developers above the break.

- [ ] Depends on #PR
- Closes #ISSUE

---

Add a sentence or two describing this change in plain english. This will be displayed on the [changelog](https://osu.ppy.sh/home/changelog). A single screenshot or short gif is also welcomed.