### PR TITLE
Show different text for users that were never seen

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -626,6 +626,11 @@ class User extends Model implements AuthenticatableContract, Messageable
         return $this->user_lastvisit > Carbon::now()->subMinutes(config('osu.user.online_window'));
     }
 
+    public function isNeverOnline()
+    {
+        return Carbon::createFromTimestampUTC(0)->diffInSeconds($this->user_lastvisit) === 0;
+    }
+
     public function isPrivileged()
     {
         return $this->isAdmin()

--- a/resources/assets/coffee/osu_common.coffee
+++ b/resources/assets/coffee/osu_common.coffee
@@ -158,9 +158,14 @@
 
   timeago: (time) ->
     el = document.createElement('time')
-    el.classList.add 'timeago'
-    el.setAttribute 'datetime', time
-    el.textContent = time
+
+    if moment(0).isSame(time)
+      el.textContent = osu.trans('common.time.never')
+    else
+      el.classList.add 'timeago'
+      el.setAttribute 'datetime', time
+      el.textContent = time
+
     el.outerHTML
 
 

--- a/resources/lang/en/common.php
+++ b/resources/lang/en/common.php
@@ -102,6 +102,7 @@ return [
     'time' => [
         'days_ago' => ':count day ago|:count days ago',
         'hours_ago' => ':count hour ago|:count hours ago',
+        'never' => 'Never',
         'now' => 'now',
         'remaining' => 'Time Remaining',
     ],

--- a/resources/views/objects/_usercard.blade.php
+++ b/resources/views/objects/_usercard.blade.php
@@ -94,7 +94,7 @@
             </div>
             <div class="usercard__status-bar usercard__status-bar--{{!isset($loading) && $user->isOnline() ? 'online' : 'offline'}}">
                 <span class="far fa-fw fa-circle usercard__status-icon"></span>
-                <span class="usercard__status-message" title="{{isset($loading) || $user->isOnline() ? '' : ($user->user_lastvisit ? trans('users.show.lastvisit', ['date' => $user->user_lastvisit->diffForHumans()]) : '')}}">
+                <span class="usercard__status-message" title="{{isset($loading) || $user->isOnline() || $user->isNeverOnline() ? '' : ($user->user_lastvisit ? trans('users.show.lastvisit', ['date' => $user->user_lastvisit->diffForHumans()]) : '')}}">
                     {{!isset($loading) && $user->isOnline() ? trans('users.status.online') : trans('users.status.offline')}}
                 </span>
             </div>


### PR DESCRIPTION
fixes #3357

- removes the tooltip is `user_lastvisit` is `0`
- shows `Never` if time is start of epoch

![image](https://user-images.githubusercontent.com/1694544/42492970-02cc916c-8456-11e8-8734-27ce2bc9c915.png)

---
