### PR TITLE
Add caching fallback for GitHub pages

### DIFF
--- a/app/Http/Controllers/Payments/XsollaController.php
+++ b/app/Http/Controllers/Payments/XsollaController.php
@@ -32,7 +32,6 @@ use Exception;
 use Illuminate\Http\Request as HttpRequest;
 use Log;
 use Request;
-use Sentry;
 use Xsolla\SDK\API\PaymentUI\TokenRequest;
 use Xsolla\SDK\API\XsollaClient;
 

--- a/app/Http/Controllers/Payments/XsollaController.php
+++ b/app/Http/Controllers/Payments/XsollaController.php
@@ -106,10 +106,7 @@ class XsollaController extends Controller
         } catch (XsollaUserNotFoundException $exception) {
             return $this->errorResponse('INVALID_USER', 'INVALID_USER', 404);
         } catch (Exception $exception) {
-            Log::error($exception);
-            if (config('sentry.dsn')) {
-                Sentry::captureException($exception);
-            }
+            log_error($exception);
 
             // status code needs to be a 4xx code to make Xsolla an error to the user.
             return $this->errorResponse('Something went wrong.', 'FATAL_ERROR', 422);

--- a/app/Models/News/Index.php
+++ b/app/Models/News/Index.php
@@ -86,7 +86,7 @@ class Index
 
     public static function index()
     {
-        return Cache::remember(
+        return cache_remember_with_fallback(
             static::cacheKey(),
             static::CACHE_DURATION,
             function () {

--- a/app/Models/News/Index.php
+++ b/app/Models/News/Index.php
@@ -58,7 +58,10 @@ class Index
                 continue;
             }
 
-            $posts[] = new Post(Post::nameId($file['name']), $files);
+            $post = new Post(Post::nameId($file['name']), $files);
+            if ($post->page() !== null) {
+                $posts[] = $post;
+            }
         }
 
         if ($start > 0) {

--- a/app/Models/News/Post.php
+++ b/app/Models/News/Post.php
@@ -164,14 +164,8 @@ class Post
         }
 
         if (!array_key_exists('page', $this->cache)) {
-            $page = Cache::get($this->cacheKey());
-
-            if ($page === null) {
-                try {
-                    $rawPage = OsuWiki::fetchContent('news/'.$this->filename());
-                } catch (GitHubNotFoundException $_e) {
-                    return;
-                }
+            $this->cache['page'] = cache_remember_with_fallback($this->cacheKey(), static::CACHE_DURATION, function () {
+                $rawPage = OsuWiki::fetchContent('news/'.$this->filename());
 
                 $page = OsuMarkdownProcessor::process($rawPage, [
                     'html_input' => 'allow',
@@ -181,10 +175,8 @@ class Post
 
                 $page['header']['date'] = Carbon::parse($page['header']['date'] ?? null);
 
-                Cache::put($this->cacheKey(), $page, static::CACHE_DURATION);
-            }
-
-            $this->cache['page'] = $page;
+                return $page;
+            });
         }
 
         return $this->cache['page'];

--- a/app/Models/News/Post.php
+++ b/app/Models/News/Post.php
@@ -20,7 +20,6 @@
 
 namespace App\Models\News;
 
-use App\Exceptions\GitHubNotFoundException;
 use App\Libraries\OsuMarkdownProcessor;
 use App\Libraries\OsuWiki;
 use Cache;

--- a/app/Models/Wiki/Image.php
+++ b/app/Models/Wiki/Image.php
@@ -50,7 +50,7 @@ class Image
     public function data()
     {
         if (!array_key_exists('data', $this->cache)) {
-            $this->cache['data'] = Cache::remember($this->cacheKeyData(), static::CACHE_DURATION, function () {
+            $this->cache['data'] = cache_remember_with_fallback($this->cacheKeyData(), static::CACHE_DURATION, function () {
                 try {
                     $data = OsuWiki::fetchContent('wiki/'.$this->path);
                     $type = image_type_to_mime_type(

--- a/app/Models/Wiki/Image.php
+++ b/app/Models/Wiki/Image.php
@@ -22,7 +22,6 @@ namespace App\Models\Wiki;
 
 use App\Exceptions\GitHubNotFoundException;
 use App\Libraries\OsuWiki;
-use Cache;
 
 class Image
 {

--- a/app/Models/Wiki/Page.php
+++ b/app/Models/Wiki/Page.php
@@ -30,6 +30,7 @@ use App\Libraries\OsuWiki;
 use App\Libraries\Search\BasicSearch;
 use Carbon\Carbon;
 use Es;
+use Exception;
 
 class Page
 {
@@ -207,7 +208,11 @@ class Page
                 if ($fetch) {
                     try {
                         $body = OsuWiki::fetchContent('wiki/'.$this->pagePath());
-                    } catch (GitHubNotFoundException $_e) {
+                    } catch (Exception $e) {
+                        if (!$e instanceof GitHubNotFoundException) {
+                            log_error($e);
+                        }
+
                         $body = null;
                     }
 

--- a/app/Models/Wiki/Page.php
+++ b/app/Models/Wiki/Page.php
@@ -210,6 +210,8 @@ class Page
                         $body = OsuWiki::fetchContent('wiki/'.$this->pagePath());
                     } catch (Exception $e) {
                         if (!$e instanceof GitHubNotFoundException) {
+                            $index = false;
+
                             log_error($e);
                         }
 
@@ -225,7 +227,7 @@ class Page
 
                 $this->cache['page'] = $page;
 
-                if ($fetch) {
+                if ($fetch && ($index ?? true)) {
                     dispatch(new EsIndexDocument($this));
                 }
 

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -243,6 +243,15 @@ function locale_for_timeago($locale)
     return $locale;
 }
 
+function log_error($exception)
+{
+    Log::error($exception);
+
+    if (config('sentry.dsn')) {
+        Sentry::captureException($exception);
+    }
+}
+
 function mysql_escape_like($string)
 {
     return addcslashes($string, '%_\\');

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -52,6 +52,31 @@ function beatmap_timestamp_format($ms)
     return sprintf('%02d:%02d.%03d', $m, $s, $ms);
 }
 
+/**
+ * Like Cache::remember but always save for one month or 10 * $minutes (whichever is longer)
+ * and return old value if failed getting the value after it expires.
+ */
+function cache_remember_with_fallback($key, $minutes, $callback)
+{
+    $data = Cache::get($key);
+
+    if ($data === null || $data['expires_at']->isPast()) {
+        try {
+            $data = [
+                'expires_at' => Carbon\Carbon::now()->addMinutes($minutes),
+                'value' => $callback(),
+            ];
+
+            Cache::put($key, $data, max(60 * 24 * 30, $minutes * 10));
+        } catch (Exception $e) {
+            // Log and continue with data from the first ::get.
+            log_error($e);
+        }
+    }
+
+    return $data['value'] ?? null;
+}
+
 function datadog_timing(callable $callable, $stat, array $tag = null)
 {
     $start = microtime(true);

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -58,7 +58,9 @@ function beatmap_timestamp_format($ms)
  */
 function cache_remember_with_fallback($key, $minutes, $callback)
 {
-    $data = Cache::get($key);
+    $fullKey = "{$key}:with_fallback";
+
+    $data = Cache::get($fullKey);
 
     if ($data === null || $data['expires_at']->isPast()) {
         try {
@@ -67,7 +69,7 @@ function cache_remember_with_fallback($key, $minutes, $callback)
                 'value' => $callback(),
             ];
 
-            Cache::put($key, $data, max(60 * 24 * 30, $minutes * 10));
+            Cache::put($fullKey, $data, max(60 * 24 * 30, $minutes * 10));
         } catch (Exception $e) {
             // Log and continue with data from the first ::get.
             log_error($e);

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -58,6 +58,8 @@ function beatmap_timestamp_format($ms)
  */
 function cache_remember_with_fallback($key, $minutes, $callback)
 {
+    static $oneMonthInMinutes = 30 * 24 * 60;
+
     $fullKey = "{$key}:with_fallback";
 
     $data = Cache::get($fullKey);
@@ -69,7 +71,7 @@ function cache_remember_with_fallback($key, $minutes, $callback)
                 'value' => $callback(),
             ];
 
-            Cache::put($fullKey, $data, max(60 * 24 * 30, $minutes * 10));
+            Cache::put($fullKey, $data, max($oneMonthInMinutes, $minutes * 10));
         } catch (Exception $e) {
             // Log and continue with data from the first ::get.
             log_error($e);


### PR DESCRIPTION
Covers a bit more than #3493 which misses handler for news pages which are also needed for home page (and wiki pages).

Fixes #3193.

closes #3493

---