### PR TITLE
Retrieve first posts for forum search using a separate query

### DIFF
--- a/app/Libraries/Search/ForumSearch.php
+++ b/app/Libraries/Search/ForumSearch.php
@@ -27,7 +27,6 @@ use App\Libraries\Elasticsearch\Hit;
 use App\Libraries\Elasticsearch\QueryHelper;
 use App\Libraries\Elasticsearch\Search;
 use App\Libraries\Elasticsearch\SearchResponse;
-use App\Libraries\Elasticsearch\Sort;
 use App\Models\Forum\Post;
 use App\Models\Forum\Topic;
 use App\Models\User;

--- a/app/Libraries/Search/ForumSearch.php
+++ b/app/Libraries/Search/ForumSearch.php
@@ -123,6 +123,8 @@ class ForumSearch extends Search
                     ->filter(['terms' => ['post_id' => $ids]])
             )->source(['topic_id', 'search_content']);
 
+        $search->loggingTag = get_called_class().'-firstPosts';
+
         $map = [];
         foreach ($search->response() as $post) {
             $map[$post->source('topic_id')] = $post;

--- a/resources/views/home/_search_result_forum_post.blade.php
+++ b/resources/views/home/_search_result_forum_post.blade.php
@@ -18,17 +18,15 @@
 {{-- more code than template in this view :best: --}}
 @php
     $users = $search->users()->select('user_id', 'username', 'user_avatar')->get();
+    $firstPostsMap = $search->firstPostsMap();
 @endphp
 
 @foreach ($search->data() as $entry)
     @php
         // $entry should be of type App\Libraries\Elasticsearch\Hit
         $innerHits = $entry->innerHits('posts');
-        $firstPost = $entry->innerHits('first_post'); // instance of App\Libraries\Elasticsearch\SearchResponse
         $firstPostUrl = route('forum.topics.show', $entry->source('topic_id'));
-        $excerpt = implode('', array_map(function ($post) {
-            return html_excerpt($post->source('search_content'));
-        }, iterator_to_array($firstPost)));
+        $excerpt = html_excerpt($firstPostsMap[$entry->source('topic_id')]->source('search_content'));
 
         $user = $users->where('user_id', $entry->source('poster_id'))->first() ?? new App\Models\DeletedUser();
     @endphp


### PR DESCRIPTION
Avoids using has_child to get the first post in a forum search. This particular portion of the query seems excessively expensive.

---
