### PR TITLE
Fix missing user best performance

### DIFF
--- a/app/Libraries/Elasticsearch/Search.php
+++ b/app/Libraries/Elasticsearch/Search.php
@@ -249,6 +249,6 @@ abstract class Search implements Queryable
     private function isSearchWindowExceeded()
     {
         // compare using the fixed value for MAX_RESULTS, not the overridable one.
-        return $this->getQuerySize() <= 0;
+        return $this->getQuerySize() < 0;
     }
 }


### PR DESCRIPTION
Don't consider the search window as exceeded if query size is 0, otherwise aggregations and other queries that don't require any hits won't run.

fixes breakage from #3500 

---

whoops