### PR TITLE
Add unique token filter to post text analyzer

### DIFF
--- a/config/schemas/posts.json
+++ b/config/schemas/posts.json
@@ -42,7 +42,8 @@
         "analyzer": {
           "post_text_analyzer": {
             "filter": [
-              "lowercase"
+              "lowercase",
+              "unique"
             ],
             "char_filter": [
               "html_filter"


### PR DESCRIPTION
Removes duplicate tokens from the `search_content` token stream when indexing.
Speeds up searching and scoring the `search_content` field on `posts` index.

The `posts` index should be recreated to apply the updated analyzer

---

