### PR TITLE
Don't index topics that were moved to a new topic

### DIFF
--- a/app/Models/Elasticsearch/TopicTrait.php
+++ b/app/Models/Elasticsearch/TopicTrait.php
@@ -78,6 +78,8 @@ trait TopicTrait
 
     public function esShouldIndex()
     {
-        return $this->forum->enable_indexing && !$this->trashed();
+        return $this->forum->enable_indexing
+            && !$this->trashed()
+            && $this->topic_moved_id === 0;
     }
 }

--- a/resources/views/home/_search_result_forum_post.blade.php
+++ b/resources/views/home/_search_result_forum_post.blade.php
@@ -26,7 +26,7 @@
         // $entry should be of type App\Libraries\Elasticsearch\Hit
         $innerHits = $entry->innerHits('posts');
         $firstPostUrl = route('forum.topics.show', $entry->source('topic_id'));
-        $excerpt = html_excerpt($firstPostsMap[$entry->source('topic_id')]->source('search_content'));
+        $excerpt = html_excerpt(optional($firstPostsMap[$entry->source('topic_id')] ?? null)->source('search_content'));
 
         $user = $users->where('user_id', $entry->source('poster_id'))->first() ?? new App\Models\DeletedUser();
     @endphp


### PR DESCRIPTION
Topics moved to a new topic shouldn't be indexed as they have no post content.
Also handle a case when showing results that haven't finished propagating through the index (`topic` updated but `post` is still waiting)

---

