### PR TITLE
Use paid orders in fulfillment tests

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -182,6 +182,7 @@ class User extends Model implements AuthenticatableContract, Messageable
             $history = new UsernameChangeHistory();
             $history->username = $newUsername;
             $history->username_last = $oldUsername;
+            $history->timestamp = Carbon::now();
             $history->type = $type;
 
             if (!$this->usernameChangeHistory()->save($history)) {

--- a/database/factories/OrderFactory.php
+++ b/database/factories/OrderFactory.php
@@ -8,6 +8,17 @@ $factory->define(App\Models\Store\Order::class, function (Faker\Generator $faker
     ];
 });
 
+$factory->defineAs(App\Models\Store\Order::class, 'paid', function (Faker\Generator $faker) use ($factory) {
+    $raw = $factory->raw(App\Models\Store\Order::class);
+    $date = Carbon\Carbon::now();
+
+    return array_merge($raw, [
+        'paid_at' => $date,
+        'status' => 'paid',
+        'transaction_id' => "test-{$date->timestamp}",
+    ]);
+});
+
 $factory->state(App\Models\Store\Order::class, 'incart', function (Faker\Generator $faker) {
     return [
         'status' => 'incart',

--- a/tests/Libraries/Fulfillments/BannerFulfillmentTest.php
+++ b/tests/Libraries/Fulfillments/BannerFulfillmentTest.php
@@ -43,9 +43,8 @@ class BannerFulfillmentTest extends TestCase
             'osu_subscriptionexpiry' => Carbon::now(),
         ]);
 
-        $this->order = factory(Order::class)->create([
+        $this->order = factory(Order::class, 'paid')->create([
             'user_id' => $this->user->user_id,
-            'transaction_id' => 'test-'.time(),
         ]);
 
         // crap test

--- a/tests/Libraries/Fulfillments/SupporterTagFulfillmentTest.php
+++ b/tests/Libraries/Fulfillments/SupporterTagFulfillmentTest.php
@@ -43,9 +43,8 @@ class SupporterTagFulfillmentTest extends TestCase
             'osu_subscriptionexpiry' => Carbon::today(),
         ]);
 
-        $this->order = factory(Order::class)->create([
+        $this->order = factory(Order::class, 'paid')->create([
             'user_id' => $this->user->user_id,
-            'transaction_id' => 'test-'.time(),
         ]);
     }
 

--- a/tests/Libraries/Fulfillments/UsernameChangeFulfillmentTest.php
+++ b/tests/Libraries/Fulfillments/UsernameChangeFulfillmentTest.php
@@ -34,7 +34,7 @@ class UsernameChangeFulfillmentTest extends TestCase
         parent::setUp();
 
         $this->user = factory(User::class)->create();
-        $this->order = factory(Order::class)->create(['user_id' => $this->user->user_id]);
+        $this->order = factory(Order::class, 'paid')->create(['user_id' => $this->user->user_id]);
     }
 
     public function testRun()


### PR DESCRIPTION
- use orders that are in a paid state when running fulfillment tests
- explicitly set `UsernameChangeHistory` timestamp instead of `null`.

---

