### PR TITLE
Feature/search require login placeholder

### DIFF
--- a/resources/assets/coffee/react/beatmaps/search-panel.coffee
+++ b/resources/assets/coffee/react/beatmaps/search-panel.coffee
@@ -52,14 +52,19 @@ class Beatmaps.SearchPanel extends React.PureComponent
 
   renderGuest: =>
     div
-      className: 'osu-page-header osu-page-header--beatmapsets-header-guest'
+      className: 'beatmapsets-search'
       div
         className: 'osu-page-header__background'
         style:
           backgroundImage: "url(#{@props.background})"
-      h1
-        className: 'osu-page-header__title'
-        'Beatmaps'
+      div className: 'fancy-search fancy-search--beatmapsets',
+        input
+          className: 'fancy-search__input'
+          type: 'textbox'
+          disabled: true
+          placeholder: osu.trans('beatmaps.listing.search.login_required')
+        div className: 'fancy-search__icon',
+          i className: 'fas fa-search'
 
 
   renderUser: =>

--- a/resources/assets/coffee/react/beatmaps/search-panel.coffee
+++ b/resources/assets/coffee/react/beatmaps/search-panel.coffee
@@ -57,11 +57,10 @@ class Beatmaps.SearchPanel extends React.PureComponent
         className: 'osu-page-header__background'
         style:
           backgroundImage: "url(#{@props.background})"
-      div className: 'fancy-search fancy-search--beatmapsets',
+      div className: 'fancy-search fancy-search--beatmapsets js-user-link',
         input
           className: 'fancy-search__input'
           type: 'textbox'
-          disabled: true
           placeholder: osu.trans('beatmaps.listing.search.login_required')
         div className: 'fancy-search__icon',
           i className: 'fas fa-search'

--- a/resources/lang/en/beatmaps.php
+++ b/resources/lang/en/beatmaps.php
@@ -172,6 +172,7 @@ return [
     'listing' => [
         'search' => [
             'prompt' => 'type in keywords...',
+            'login_required' => 'Sign in to search.',
             'options' => 'More Search Options',
             'supporter_filter' => 'Filtering by :filters requires an active osu!supporter tag',
             'not-found' => 'no results',


### PR DESCRIPTION
This was discussed a while ago with @arflyte when implementing one of the previous items for the beatmap search page, that we'd put a placeholder search box for the time being until #2592 is ready.

closes #3279

---

