### PR TITLE
Fix supporter expiration display

### DIFF
--- a/app/Http/Controllers/HomeController.php
+++ b/app/Http/Controllers/HomeController.php
@@ -153,7 +153,7 @@ class HomeController extends Controller
             $user = Auth::user();
 
             // current status
-            $expiration = $user->osu_subscriptionexpiry->addDays(1);
+            $expiration = optional($user->osu_subscriptionexpiry)->addDays(1);
             $current = $expiration !== null ? $expiration->isFuture() : false;
 
             // purchased

--- a/app/Http/Controllers/HomeController.php
+++ b/app/Http/Controllers/HomeController.php
@@ -153,7 +153,7 @@ class HomeController extends Controller
             $user = Auth::user();
 
             // current status
-            $expiration = $user->osu_subscriptionexpiry;
+            $expiration = $user->osu_subscriptionexpiry->addDays(1);
             $current = $expiration !== null ? $expiration->isFuture() : false;
 
             // purchased

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -518,7 +518,7 @@ class User extends Model implements AuthenticatableContract, Messageable
     public function getOsuSubscriptionexpiryAttribute($value)
     {
         if (present($value)) {
-            return Carbon::parse($value);
+            return Carbon::parse($value)->addDays(1);
         }
     }
 

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -518,7 +518,7 @@ class User extends Model implements AuthenticatableContract, Messageable
     public function getOsuSubscriptionexpiryAttribute($value)
     {
         if (present($value)) {
-            return Carbon::parse($value)->addDays(1);
+            return Carbon::parse($value);
         }
     }
 

--- a/resources/views/home/support-the-game.blade.php
+++ b/resources/views/home/support-the-game.blade.php
@@ -71,7 +71,7 @@
                     @if ($supporterStatus['expiration'] !== null)
                     <div class="stg-status__text stg-status__text--first">
                         {!! trans('community.support.supporter_status.'.($supporterStatus['current'] ? 'valid_until' : 'was_valid_until'), [
-                            'date' => '<strong>'.timeago($supporterStatus['expiration']).'</strong>'
+                            'date' => '<strong>'.i18n_date($supporterStatus['expiration']).'</strong>'
                         ]) !!}
                     </div>
                     @else


### PR DESCRIPTION
Supporter expires the day after `osu_subscriptionexpiry`, so this is reflected in the display now.

This also changes the expiration shown to be an absolute date instead of a relative datetime. Having a time doesn't make sense when `osu_subscriptionexpiry` is only of day granularity and not guaranteed to expire at a specific time.

fixes #3527

---