### PR TITLE
Fix news refresh logic

### DIFF
--- a/app/Models/News/Index.php
+++ b/app/Models/News/Index.php
@@ -21,7 +21,6 @@
 namespace App\Models\News;
 
 use App\Libraries\OsuWiki;
-use Cache;
 use Illuminate\Pagination\LengthAwarePaginator;
 
 class Index
@@ -79,7 +78,7 @@ class Index
 
     public static function cacheClear()
     {
-        Cache::forget(static::cacheKey());
+        cache_forget_with_fallback(static::cacheKey());
     }
 
     public static function cacheKey()

--- a/app/Models/News/Post.php
+++ b/app/Models/News/Post.php
@@ -22,7 +22,6 @@ namespace App\Models\News;
 
 use App\Libraries\OsuMarkdownProcessor;
 use App\Libraries\OsuWiki;
-use Cache;
 use Carbon\Carbon;
 
 class Post
@@ -58,7 +57,7 @@ class Post
 
     public function cacheClear()
     {
-        Cache::forget($this->cacheKey());
+        cache_forget_with_fallback($this->cacheKey());
     }
 
     public function cacheKey()

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -81,6 +81,12 @@ function cache_remember_with_fallback($key, $minutes, $callback)
     return $data['value'] ?? null;
 }
 
+// Just normal Cache::forget but with the suffix.
+function cache_forget_with_fallback($key)
+{
+    return Cache::forget("{$key}:with_fallback");
+}
+
 function datadog_timing(callable $callable, $stat, array $tag = null)
 {
     $uid = uniqid($stat);


### PR DESCRIPTION
Probably should be a bit smarter by updating expiration date to `now()` instead?

---