### PR TITLE
Update multiplayer games mods column datatype

### DIFF
--- a/database/migrations/2015_01_01_133337_multiplayer_base_tables.php
+++ b/database/migrations/2015_01_01_133337_multiplayer_base_tables.php
@@ -64,7 +64,7 @@ class MultiplayerBaseTables extends Migration
             $table->unsignedTinyInteger('match_type')->nullable();
             $table->unsignedTinyInteger('scoring_type')->nullable();
             $table->unsignedTinyInteger('team_type')->nullable();
-            $table->unsignedMediumInteger('mods')->nullable();
+            $table->unsignedBigInteger('mods')->nullable();
 
             $table->index('match_id', 'match_lookup');
         });


### PR DESCRIPTION
mediumint isn't enough to hold mania mods data. Live database has been updated to match this change.

Fixes #3537. Kind of.

---