### PR TITLE
Force image dimensions to be rechecked when contests are made live

### DIFF
--- a/app/Models/Contest.php
+++ b/app/Models/Contest.php
@@ -30,6 +30,7 @@ class Contest extends Model
     protected $dates = ['entry_starts_at', 'entry_ends_at', 'voting_starts_at', 'voting_ends_at'];
     protected $casts = [
         'extra_options' => 'json',
+        'visible' => 'boolean',
     ];
 
     public function entries()

--- a/app/Transformers/ContestEntryTransformer.php
+++ b/app/Transformers/ContestEntryTransformer.php
@@ -60,7 +60,12 @@ class ContestEntryTransformer extends Fractal\TransformerAbstract
         }
 
         return $this->item($entry, function ($entry) {
-            $size = fast_imagesize($entry->entry_url);
+            // suffix urls when contests are made live to ensure image dimensions are forcibly rechecked
+            if ($entry->contest->visible) {
+                $urlSuffix = str_contains($entry->entry_url, '?') ? '&live' : '?live';
+            }
+
+            $size = fast_imagesize($entry->entry_url.($urlSuffix ?? ''));
             $thumb = $entry->entry_url;
 
             if (present(config('osu.assets.mini_url')) && present(config('osu.assets.mini_url'))) {


### PR DESCRIPTION
Resolves an issue where images (that were not yet uploaded prior to the contest page being accessed for the first time) were being cached as a 404, which resulted in having no image dimension metadata (which broke the javascript image viewer relying on this metadata).

---
