### PR TITLE
Remove explicit database name in TournamentRegistration table definition

### DIFF
--- a/app/Models/TournamentRegistration.php
+++ b/app/Models/TournamentRegistration.php
@@ -22,7 +22,7 @@ namespace App\Models;
 
 class TournamentRegistration extends Model
 {
-    protected $table = 'osu.tournament_registrations';
+    protected $table = 'tournament_registrations';
     protected $primaryKey = 'registration_id';
 
     public function getDates()

--- a/app/Models/TournamentRegistration.php
+++ b/app/Models/TournamentRegistration.php
@@ -22,7 +22,6 @@ namespace App\Models;
 
 class TournamentRegistration extends Model
 {
-    protected $table = 'tournament_registrations';
     protected $primaryKey = 'registration_id';
 
     public function getDates()


### PR DESCRIPTION
Noticed this when `TableTest::testTableExistence()` failed while running on a test database that wasn't named `osu`.

---
