### PR TITLE
Disable tooltip auto hiding

### DIFF
--- a/resources/assets/coffee/_classes/tooltip-beatmap.coffee
+++ b/resources/assets/coffee/_classes/tooltip-beatmap.coffee
@@ -21,7 +21,7 @@ class @TooltipBeatmap
       '<div class="tooltip-beatmap__text tooltip-beatmap__text--<%- difficulty %>"><%- stars %> <i class="fas fa-star" aria-hidden="true"></i></div>'
 
   constructor: ->
-    $(document).on 'mouseover', '.js-beatmap-tooltip', @onMouseOver
+    $(document).on 'mouseover touchstart', '.js-beatmap-tooltip', @onMouseOver
 
   onMouseOver: (event) =>
     el = event.currentTarget
@@ -50,13 +50,14 @@ class @TooltipBeatmap
       show:
         event: event.type
         ready: true
-      hide:
-        inactive: 3000
       style:
         classes: 'qtip tooltip-beatmap'
         tip:
           width: 10
           height: 9
+
+    if event.type == 'touchstart'
+      options['hide'] = inactive: 3000
 
     $(el).qtip options, event
 

--- a/resources/assets/coffee/_classes/tooltip-beatmap.coffee
+++ b/resources/assets/coffee/_classes/tooltip-beatmap.coffee
@@ -57,7 +57,7 @@ class @TooltipBeatmap
           height: 9
 
     if event.type == 'touchstart'
-      options['hide'] = inactive: 3000
+      options.hide = inactive: 3000
 
     $(el).qtip options, event
 

--- a/resources/assets/coffee/_classes/tooltip-default.coffee
+++ b/resources/assets/coffee/_classes/tooltip-default.coffee
@@ -76,7 +76,7 @@ class @TooltipDefault
           height: 8
 
     if event.type == 'touchstart'
-      options['hide'] = inactive: 3000
+      options.hide = inactive: 3000
 
     # if enabled, prevents tooltip from changing position
     if el.dataset.tooltipPinPosition

--- a/resources/assets/coffee/_classes/tooltip-default.coffee
+++ b/resources/assets/coffee/_classes/tooltip-default.coffee
@@ -18,7 +18,7 @@
 
 class @TooltipDefault
   constructor: ->
-    $(document).on 'mouseover', '[title]:not(iframe)', @onMouseOver
+    $(document).on 'mouseover touchstart', '[title]:not(iframe)', @onMouseOver
     $(document).on 'mouseenter touchstart', '.u-ellipsis-overflow, .u-ellipsis-overflow-desktop', @autoAddTooltip
     $(document).on 'turbolinks:before-cache', @rollback
 
@@ -69,13 +69,14 @@ class @TooltipDefault
       show:
         event: event.type
         ready: true
-      hide:
-        inactive: 3000
       style:
         classes: classes
         tip:
           width: 10
           height: 8
+
+    if event.type == 'touchstart'
+      options['hide'] = inactive: 3000
 
     # if enabled, prevents tooltip from changing position
     if el.dataset.tooltipPinPosition


### PR DESCRIPTION
if not triggered by touch.

Browser doesn't send touch events? TOO BAD. (looking at you Edge)

closes #3343

---

