### PR TITLE
Hide tooltip on click

### DIFF
--- a/resources/assets/coffee/_classes/tooltip-beatmap.coffee
+++ b/resources/assets/coffee/_classes/tooltip-beatmap.coffee
@@ -50,6 +50,8 @@ class @TooltipBeatmap
       show:
         event: event.type
         ready: true
+      hide:
+        event: 'click mouseleave'
       style:
         classes: 'qtip tooltip-beatmap'
         tip:

--- a/resources/assets/coffee/_classes/tooltip-default.coffee
+++ b/resources/assets/coffee/_classes/tooltip-default.coffee
@@ -69,6 +69,8 @@ class @TooltipDefault
       show:
         event: event.type
         ready: true
+      hide:
+        event: 'click mouseleave'
       style:
         classes: classes
         tip:


### PR DESCRIPTION
Adds `click` as a trigger to hide qtip2.

Seems like many things can cause qtip2 to not trigger the default `mouseleave` handler to hide the qtip, such as: modifying the element's properties, modifying the element's children, moving the cursor out too fast after clicking, breathing on it, displaying another element over the current element.

closes #3571

---
