### PR TITLE
Upgrade docker's elasticsearch to latest version

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,7 +31,7 @@ services:
   redis:
     image: redis:latest
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch-oss:6.2.1
+    image: docker.elastic.co/elasticsearch/elasticsearch:6.3.2
     volumes:
       - elasticsearch:/usr/share/elasticsearch/data
     environment:


### PR DESCRIPTION
The older version was causing issues when seeding forum posts.

---

Fixes issues arising in the development environment, irrelevant to the live website itself.