### PR TITLE
Fix beatmap processor not using mirrors listed in config

### DIFF
--- a/app/Models/BeatmapMirror.php
+++ b/app/Models/BeatmapMirror.php
@@ -52,6 +52,11 @@ class BeatmapMirror extends Model
         return self::randomUsable()->first();
     }
 
+    public static function getRandomFromList(array $mirrorIds)
+    {
+        return self::whereIn('mirror_id', $mirrorIds)->randomUsable()->first();
+    }
+
     public static function getRandomForRegion($region = null)
     {
         if (presence($region)) {

--- a/app/Models/Beatmapset.php
+++ b/app/Models/Beatmapset.php
@@ -392,7 +392,9 @@ class Beatmapset extends Model implements AfterCommit
     public function fetchBeatmapsetArchive()
     {
         $oszFile = tmpfile();
-        $url = BeatmapMirror::getRandom()->generateURL($this, true);
+        $mirrorsToUse = config('osu.beatmap_processor.mirrors_to_use');
+        $url = BeatmapMirror::getRandomFromList($mirrorsToUse)->generateURL($this, true);
+
         if ($url === false) {
             return false;
         }


### PR DESCRIPTION
Seems like this behaviour was broken when adding the ability to download Beatmaps (when the `BeatmapMirror` logic was unified).

---
