### PR TITLE
Make deleted discussion visibly less opaque.

### DIFF
--- a/resources/assets/less/bem/beatmap-discussion.less
+++ b/resources/assets/less/bem/beatmap-discussion.less
@@ -22,7 +22,7 @@
   display: flex;
 
   &--deleted {
-    opacity: 0.75;
+    opacity: 0.5;
   }
 
   &__actions {


### PR DESCRIPTION
Because 0.75 opacity is like nothing

partially addresses #3607

---
