### PR TITLE
Add rel='nofollow' to forum and moderation post permalink... links.

### DIFF
--- a/resources/assets/coffee/react/beatmap-discussions/post.coffee
+++ b/resources/assets/coffee/react/beatmap-discussions/post.coffee
@@ -236,6 +236,7 @@ class BeatmapDiscussions.Post extends React.PureComponent
             a
               href: BeatmapDiscussionHelper.url discussion: @props.discussion
               onClick: @permalink
+              rel: 'nofollow'
               className: "#{bn}__action #{bn}__action--button"
 
               if @state.permalinkTimer?

--- a/resources/views/forum/topics/_post.blade.php
+++ b/resources/views/forum/topics/_post.blade.php
@@ -42,7 +42,7 @@
 
         <div class="forum-post__body">
             <div class="forum-post__content forum-post__content--header">
-                <a class="js-post-url link link--gray" href="{{ $post->exists ? route('forum.posts.show', $post->post_id) : '#' }}">
+                <a class="js-post-url link link--gray" rel="nofollow" href="{{ $post->exists ? route('forum.posts.show', $post->post_id) : '#' }}">
                     {!! trans("forum.post.posted_at", ["when" => timeago($post->post_time)]) !!}
                 </a>
             </div>


### PR DESCRIPTION
Discourages Googlebot from spidering individual posts unnecessarily -- the threads/discussions they belong to are being indexed already.

---