### PR TITLE
Turn off form autocomplete for the search page

### DIFF
--- a/resources/views/home/search.blade.php
+++ b/resources/views/home/search.blade.php
@@ -18,7 +18,7 @@
 @extends('master')
 
 @section('content')
-    <form action="{{ route('search') }}" data-loading-overlay="0" class="js-search">
+    <form action="{{ route('search') }}" data-loading-overlay="0" class="js-search" autocomplete="off">
         <input type="hidden" name="mode" value="{{ request('mode') }}">
 
         <div class="osu-page">


### PR DESCRIPTION
closes #3633

Beatmap listing wasn't affected since the `<input>` there wasn't in a `<form>`

---
