### PR TITLE
Check for first deleted post if there's no visible post

### DIFF
--- a/app/Libraries/OsuAuthorize.php
+++ b/app/Libraries/OsuAuthorize.php
@@ -695,7 +695,9 @@ class OsuAuthorize
 
     public function checkForumTopicEdit($user, $topic)
     {
-        return $this->checkForumPostEdit($user, $topic->posts()->first());
+        $firstPost = $topic->posts()->first() ?? $topic->posts()->withTrashed()->first();
+
+        return $this->checkForumPostEdit($user, $firstPost);
     }
 
     public function checkForumTopicReply($user, $topic)


### PR DESCRIPTION
Fixes #3358. Or more like fixes a different bug caused by recent merge.

Though looking again, we shouldn't even allow deleting first post.