### PR TITLE
Fix internal url check

### DIFF
--- a/resources/assets/coffee/_classes/url.coffee
+++ b/resources/assets/coffee/_classes/url.coffee
@@ -51,4 +51,4 @@ class @Url
 
 
   @isInternal: (location) ->
-    RegExp("^/(?:#{internal})(?:$|/)").test location.getPath()
+    RegExp("^/(?:#{internal})(?:$|/|#)").test location.getPath()


### PR DESCRIPTION
Apparently "#" stays so the check fails when location is something like "/home#".