### PR TITLE
Change the Source Code link to redirect to the osu-web repository

### DIFF
--- a/config/osu.php
+++ b/config/osu.php
@@ -123,7 +123,7 @@ return [
         'osx' => 'https://osx.ppy.sh',
         'server_status' => 'https://twitter.com/osustatus',
         'smilies' => '/forum/images/smilies',
-        'source_code' => 'https://github.com/ppy',
+        'source_code' => 'https://github.com/ppy/osu-web',
         'support-the-game' => '/p/support#transactionarea',
         'youtube-tutorial-playlist' => 'PLmWVQsxi34bMYwAawZtzuptfMmszUa_tl',
 


### PR DESCRIPTION
I think it makes sense to me that it *should* link to the osu-web repository instead of the organization.

---
