### PR TITLE
Increase top margin for comment replies

### DIFF
--- a/resources/assets/less/bem/comment.less
+++ b/resources/assets/less/bem/comment.less
@@ -165,7 +165,7 @@
   }
 
   &__replies {
-    margin-top: 10px;
+    margin-top: 20px;
 
     &--hidden {
       display: none;


### PR DESCRIPTION
20px makes it consistent with the spacing between the rest of the comments. not sure why this was set differently, it looks pretty strange

---