### PR TITLE
Update hashers for Laravel 5.6+

### DIFF
--- a/app/Hashing/OsuHasher.php
+++ b/app/Hashing/OsuHasher.php
@@ -32,6 +32,18 @@ class OsuHasher implements Hasher
     protected $rounds = 10;
 
     /**
+     * Get information about the given hashed value.
+     *
+     * @param string $hashedValue
+     *
+     * @return array
+     */
+    public function info($hashedValue)
+    {
+        return password_get_info(str_replace('$2a$', '$2y$', $hashedValue));
+    }
+
+    /**
      * Hash the given value.
      *
      * @param string $value


### PR DESCRIPTION
Laravel 5.6 onwards has an additional method on the Hasher interface
...which is just `password_get_info($hashedValue)` on the default implementations

...which is just there to complete the PHP password hashing api?

Basically we are going need this to update laravel beyond 5.5

---
