### PR TITLE
Add missing php extension to docker

### DIFF
--- a/docker/php/Dockerfile
+++ b/docker/php/Dockerfile
@@ -22,6 +22,7 @@ RUN apk update && \
     php7-tokenizer \
     php7-xml \
     php7-xmlwriter \
-    php7-zip
+    php7-zip \
+    php7-fileinfo
 
 RUN touch /usr/bin/yarn && chmod 555 /usr/bin/yarn


### PR DESCRIPTION
Composer didn't want to install some packages because of `fileinfo` missing.
