### PR TITLE
Change user session management to use sets instead of scan

### DIFF
--- a/app/Http/Controllers/AccountController.php
+++ b/app/Http/Controllers/AccountController.php
@@ -107,7 +107,7 @@ class AccountController extends Controller
             ->currentUserSessions();
 
         $currentSessionId = Request::session()
-            ->getIdWithoutPrefix();
+            ->getIdWithoutKeyPrefix();
 
         return view('accounts.edit', compact('blocks', 'sessions', 'currentSessionId'));
     }

--- a/app/Libraries/Session/Store.php
+++ b/app/Libraries/Session/Store.php
@@ -101,10 +101,7 @@ class Store extends \Illuminate\Session\Store
      */
     public function isGuestSession()
     {
-        $sessionId = $this->getId();
-        $prefix = substr($sessionId, 0, strlen($sessionId) - static::SESSION_ID_LENGTH - 1);
-
-        return $prefix === $this->keyPrefix(null);
+        return starts_with($this->getId(), static::keyPrefix(null).':');
     }
 
     public function currentUserSessions()

--- a/app/Libraries/Session/Store.php
+++ b/app/Libraries/Session/Store.php
@@ -76,7 +76,7 @@ class Store extends \Illuminate\Session\Store
             $fullSessionId = $this->keyPrefix($userId).":{$sessionId}";
             $this->handler->destroy($fullSessionId);
 
-            Redis::srem($this->sessionListKey($userId), config('cache.prefix').$fullSessionId);
+            Redis::srem($this->sessionListKey($userId), config('cache.prefix').':'.$fullSessionId);
 
             return true;
         }
@@ -216,7 +216,7 @@ class Store extends \Illuminate\Session\Store
 
         if ($destroy) {
             if (!$this->isGuestSession()) {
-                Redis::srem($this->sessionListKey($userId), $this->getId());
+                Redis::srem($this->sessionListKey($userId), config('cache.prefix').':'.$fullSessionId);
             }
             $this->handler->destroy($this->getId());
         }
@@ -238,7 +238,7 @@ class Store extends \Illuminate\Session\Store
         if ($data = $this->handler->read($this->getId())) {
             $data = @unserialize($this->prepareForUnserialize($data));
 
-            if ($data !== false && ! is_null($data) && is_array($data)) {
+            if ($data !== false && !is_null($data) && is_array($data)) {
                 return $data;
             }
         }
@@ -250,8 +250,6 @@ class Store extends \Illuminate\Session\Store
 
     /**
      * Save the session data to storage.
-     *
-     * @return bool
      */
     public function save()
     {

--- a/app/Libraries/Session/Store.php
+++ b/app/Libraries/Session/Store.php
@@ -227,6 +227,28 @@ class Store extends \Illuminate\Session\Store
     }
 
     /**
+     * Read the session data from the handler.
+     *
+     * @return array
+     */
+    protected function readFromHandler()
+    {
+        // Overridden to force session ids to be regenerated when trying to load a session that doesn't exist anymore
+
+        if ($data = $this->handler->read($this->getId())) {
+            $data = @unserialize($this->prepareForUnserialize($data));
+
+            if ($data !== false && ! is_null($data) && is_array($data)) {
+                return $data;
+            }
+        }
+
+        $this->regenerate(true);
+
+        return [];
+    }
+
+    /**
      * Save the session data to storage.
      *
      * @return bool

--- a/app/Libraries/Session/Store.php
+++ b/app/Libraries/Session/Store.php
@@ -30,24 +30,81 @@ class Store extends \Illuminate\Session\Store
 {
     const SESSION_ID_LENGTH = 40;
 
-    public function keyPrefix(int $userId = null)
+    /**
+     * Get the redis key prefix for the given user (excluding cache prefix).
+     *
+     * @return string
+     */
+    protected function keyPrefix(int $userId = null)
     {
         $userId = $userId ?? 'guest';
 
-        return "sessions:{$userId}:";
+        return "sessions:{$userId}";
     }
 
+    /**
+     * Get the redis key containing the session list for the given user.
+     *
+     * @return string
+     */
+    protected function sessionListKey(int $userId = null)
+    {
+        return config('cache.prefix').':'.$this->keyPrefix($userId);
+    }
+
+    /**
+     * Get the redis key prefix of the current session (excluding cache prefix).
+     *
+     * @return string
+     */
+    protected function getCurrentKeyPrefix()
+    {
+        $sessionId = $this->getId();
+
+        return substr($sessionId, 0, strlen($sessionId) - static::SESSION_ID_LENGTH - 1);
+    }
+
+    /**
+     * Destroys a session owned by the current user that is identified by the given id.
+     *
+     * @return bool
+     */
     public function destroyUserSession($sessionId)
     {
         if (Auth::check()) {
             $userId = Auth::user()->user_id;
-            $this->handler->destroy($this->keyPrefix($userId).$sessionId);
+            $fullSessionId = $this->keyPrefix($userId).":{$sessionId}";
+            $this->handler->destroy($fullSessionId);
+
+            Redis::srem($this->sessionListKey($userId), config('cache.prefix').$fullSessionId);
+
+            return true;
         }
+
+        return false;
     }
 
+    /**
+     * Return whether the given id matches the current session's id.
+     *
+     * @return bool
+     */
     public function isCurrentSession($sessionId)
     {
-        return $this->getIdWithoutPrefix() === $this->stripPrefix($sessionId);
+        return $this->getIdWithoutKeyPrefix() === $this->stripKeyPrefix($sessionId);
+    }
+
+    /**
+     * Returns whether the current session is a guest session based on the key prefix of the session id.
+     *
+     * @return bool
+     */
+    public function isGuestSession()
+    {
+        $sessionId = $this->getId();
+        $prefix = substr($sessionId, 0, strlen($sessionId) - static::SESSION_ID_LENGTH - 1);
+
+        return $prefix === $this->keyPrefix(null);
     }
 
     public function currentUserSessions()
@@ -62,29 +119,35 @@ class Store extends \Illuminate\Session\Store
 
         $userId = Auth::user()->user_id;
 
-        // flush the current session data to redis early, otherwise the scan below will get stale metadata for the current session
+        // flush the current session data to redis early, otherwise we will get stale metadata for the current session
         $this->save();
 
-        $sessionIds = [];
-        $cursor = 0;
         // TODO: When(if?) the session driver config is decoupled from the cache driver config, update the prefix below:
-        $keyPattern = config('cache.prefix').':'.$this->keyPrefix($userId).'*';
-        do {
-            list($cursor, $keys) = Redis::scan($cursor, 'match', $keyPattern);
-            $sessionIds = array_merge($sessionIds, $keys);
-        } while ($cursor);
+        $sessionIds = Redis::smembers($this->sessionListKey($userId));
+        if (empty($sessionIds)) {
+            return [];
+        }
+
         $sessions = array_combine($sessionIds, Redis::mget($sessionIds));
 
         $sessionMeta = [];
         $agent = new Agent();
         foreach ($sessions as $id => $session) {
-            // Sessions are stored in redis double-serialized for some reason...
+            if ($session === null) {
+                // cleanup expired sessions
+                Redis::srem($this->sessionListKey($userId), $id);
+                continue;
+            }
+            // Sessions are stored double-serialized in redis (session serialization + cache backend serialization)
             $session = unserialize(unserialize($session));
+
+            if (!isset($session['meta'])) {
+                continue;
+            }
 
             $meta = $session['meta'];
             $agent->setUserAgent($meta['agent']);
-            // strip keyPrefix
-            $id = $this->stripPrefix($id);
+            $id = $this->stripKeyPrefix($id);
 
             $sessionMeta[$id] = $meta;
             $sessionMeta[$id]['mobile'] = $agent->isMobile() || $agent->isTablet();
@@ -122,15 +185,20 @@ class Store extends \Illuminate\Session\Store
     {
         // Overriden to allow namespacing the session id (used as the redis key)
 
-        return $this->keyPrefix($userId).Str::random(static::SESSION_ID_LENGTH);
+        return $this->keyPrefix($userId).':'.Str::random(static::SESSION_ID_LENGTH);
     }
 
-    public function getIdWithoutPrefix()
+    public function getIdWithoutKeyPrefix()
     {
-        return $this->stripPrefix($this->getId());
+        return $this->stripKeyPrefix($this->getId());
     }
 
-    public function stripPrefix($sessionId)
+    /**
+     * Returns the session id without the key prefix.
+     *
+     * @return string
+     */
+    protected function stripKeyPrefix($sessionId)
     {
         return substr($sessionId, -static::SESSION_ID_LENGTH);
     }
@@ -145,12 +213,31 @@ class Store extends \Illuminate\Session\Store
     public function migrate($destroy = false, int $userId = null)
     {
         // Overriden to allow passing through $userId to namespace session ids
+
         if ($destroy) {
+            if (!$this->isGuestSession()) {
+                Redis::srem($this->sessionListKey($userId), $this->getId());
+            }
             $this->handler->destroy($this->getId());
         }
         $this->setExists(false);
         $this->setId($this->generateSessionId($userId));
 
         return true;
+    }
+
+    /**
+     * Save the session data to storage.
+     *
+     * @return bool
+     */
+    public function save()
+    {
+        // Overriden to track user sessions in Redis
+        parent::save();
+
+        if (!$this->isGuestSession()) {
+            Redis::sadd(config('cache.prefix').':'.$this->getCurrentKeyPrefix(), config('cache.prefix').':'.$this->getId());
+        }
     }
 }


### PR DESCRIPTION
Yeah so Redis' SCAN command isn't so scalable.

This replaces the need to perform the SCAN by maintaining an additional SET (per user) alongside the normal session keys that contains a list of all their sessions.

---
