### PR TITLE
Don't fail validating comment with missing commentable

### DIFF
--- a/app/Models/Comment.php
+++ b/app/Models/Comment.php
@@ -102,7 +102,11 @@ class Comment extends Model
             $this->validationErrors()->add('parent_id', 'invalid');
         }
 
-        if (!$this->allowEmptyCommentable && !$this->commentable()->exists()) {
+        if (!$this->allowEmptyCommentable && (
+            $this->commentable_type === null ||
+            $this->commentable_id === null ||
+            !$this->commentable()->exists()
+        )) {
             $this->validationErrors()->add('commentable', 'required');
         }
 


### PR DESCRIPTION
Laravel isn't even trying

```
Illuminate/Database/QueryException with message 'SQLSTATE[42S22]: 
Column not found: 1054 Unknown column 'comments.' in 'where clause' 
(SQL: select exists(select * from `comments` where `comments`.`` is null) as `exists`)'
```