### PR TITLE
Search classes refactoring

### DIFF
--- a/app/Http/Controllers/BeatmapsetsController.php
+++ b/app/Http/Controllers/BeatmapsetsController.php
@@ -156,7 +156,7 @@ class BeatmapsetsController extends Controller
                 'search-cache:',
                 config('osu.beatmapset.es_cache_duration'),
                 function () use ($params) {
-                    $search = (new BeatmapsetSearch($params))->source('_id');
+                    $search = (new BeatmapsetSearch($params))->source(false);
 
                     return $search->response()->ids();
                 }

--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -160,8 +160,7 @@ class UsersController extends Controller
         }
 
         $search = (new PostSearch(new PostSearchRequestParams(request(), $user)))
-            ->size(50)
-            ->page(LengthAwarePaginator::resolveCurrentPage());
+            ->size(50);
 
         return view('users.posts', compact('search', 'user'));
     }

--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -31,7 +31,6 @@ use App\Models\User;
 use App\Models\UserNotFound;
 use App\Models\UserReport;
 use Auth;
-use Illuminate\Pagination\LengthAwarePaginator;
 use PDOException;
 use Request;
 

--- a/app/Libraries/Elasticsearch/HasChildQuery.php
+++ b/app/Libraries/Elasticsearch/HasChildQuery.php
@@ -20,15 +20,18 @@
 
 namespace App\Libraries\Elasticsearch;
 
-class HasChildQuery implements Queryable
-{
-    use HasSearch;
+use App\Libraries\Search\EmptySearchParams;
 
+
+class HasChildQuery extends HasSearch implements Queryable
+{
     protected $name;
     protected $scoreMode;
 
     public function __construct(string $type, string $name)
     {
+        parent::__construct(new EmptySearchParams);
+
         $this->name = $name;
         $this->type = $type;
     }
@@ -52,11 +55,11 @@ class HasChildQuery implements Queryable
         // inner_hits in join queries.
         $inner = [
             'name' => $this->name,
-            'from' => $this->from,
+            'from' => $this->params->from,
             'size' => $this->getQuerySize(),
             'sort' => array_map(function ($sort) {
                 return $sort->toArray();
-            }, $this->sorts),
+            }, $this->params->sorts),
         ];
 
         if (isset($this->highlight)) {
@@ -64,7 +67,7 @@ class HasChildQuery implements Queryable
         }
 
         if (isset($this->source)) {
-            $inner['_source'] = $this->source;
+            $inner['_source'] = $this->params->source;
         }
 
         $body = [

--- a/app/Libraries/Elasticsearch/HasChildQuery.php
+++ b/app/Libraries/Elasticsearch/HasChildQuery.php
@@ -66,8 +66,8 @@ class HasChildQuery extends HasSearch implements Queryable
             $inner['highlight'] = $this->highlight->toArray();
         }
 
-        if (isset($this->params->source)) {
-            $inner['_source'] = $this->params->source;
+        if (isset($this->source)) {
+            $inner['_source'] = $this->source;
         }
 
         $body = [

--- a/app/Libraries/Elasticsearch/HasChildQuery.php
+++ b/app/Libraries/Elasticsearch/HasChildQuery.php
@@ -66,7 +66,7 @@ class HasChildQuery extends HasSearch implements Queryable
             $inner['highlight'] = $this->highlight->toArray();
         }
 
-        if (isset($this->source)) {
+        if (isset($this->params->source)) {
             $inner['_source'] = $this->params->source;
         }
 

--- a/app/Libraries/Elasticsearch/HasChildQuery.php
+++ b/app/Libraries/Elasticsearch/HasChildQuery.php
@@ -52,7 +52,7 @@ class HasChildQuery implements Queryable
         // inner_hits in join queries.
         $inner = [
             'name' => $this->name,
-            'from' => $this->getFrom(),
+            'from' => $this->from,
             'size' => $this->getQuerySize(),
             'sort' => array_map(function ($sort) {
                 return $sort->toArray();

--- a/app/Libraries/Elasticsearch/HasChildQuery.php
+++ b/app/Libraries/Elasticsearch/HasChildQuery.php
@@ -22,7 +22,6 @@ namespace App\Libraries\Elasticsearch;
 
 use App\Libraries\Search\EmptySearchParams;
 
-
 class HasChildQuery extends HasSearch implements Queryable
 {
     protected $name;

--- a/app/Libraries/Elasticsearch/HasSearch.php
+++ b/app/Libraries/Elasticsearch/HasSearch.php
@@ -25,6 +25,7 @@ abstract class HasSearch
     protected $highlight;
     protected $params;
     protected $query;
+    protected $source;
     protected $type;
 
     public function __construct(SearchParams $params)
@@ -84,7 +85,7 @@ abstract class HasSearch
      */
     public function source($fields)
     {
-        $this->params->source = $fields;
+        $this->source = $fields;
 
         return $this;
     }

--- a/app/Libraries/Elasticsearch/HasSearch.php
+++ b/app/Libraries/Elasticsearch/HasSearch.php
@@ -47,14 +47,6 @@ abstract class HasSearch
     /**
      * @return $this
      */
-    public function limit(int $limit)
-    {
-        return $this->size($limit);
-    }
-
-    /**
-     * @return $this
-     */
     public function size(int $size)
     {
         $this->params->size = $size;

--- a/app/Libraries/Elasticsearch/HasSearch.php
+++ b/app/Libraries/Elasticsearch/HasSearch.php
@@ -59,16 +59,6 @@ trait HasSearch
     }
 
     /**
-     * @return $this
-     */
-    public function page(?int $page)
-    {
-        $this->page = $page;
-
-        return $this;
-    }
-
-    /**
      * @param Highlight $highlight the fields and settings for highlighting. Set to null to remove.
      *
      * @return $this
@@ -145,7 +135,7 @@ trait HasSearch
      */
     protected function getFrom() : int
     {
-        return $this->from ?? $this->getSize() * ($this->getPage() - 1);
+        return $this->from ?? 0;
     }
 
     /**
@@ -179,10 +169,5 @@ trait HasSearch
         if (!$sort->isBlank()) {
             $this->sorts[] = $sort;
         }
-    }
-
-    private function getPage() : int
-    {
-        return max(1, $this->page ?? 1);
     }
 }

--- a/app/Libraries/Elasticsearch/HasSearch.php
+++ b/app/Libraries/Elasticsearch/HasSearch.php
@@ -22,7 +22,7 @@ namespace App\Libraries\Elasticsearch;
 
 trait HasSearch
 {
-    protected $from;
+    protected $from = 0;
     protected $highlight;
     protected $query;
     protected $size;
@@ -33,7 +33,7 @@ trait HasSearch
     /**
      * @return $this
      */
-    public function from(?int $from)
+    public function from(int $from)
     {
         $this->from = $from;
 
@@ -129,23 +129,13 @@ trait HasSearch
     }
 
     /**
-     *  Gets the actual offset to use in queries.
-     *
-     * @return int actual offset to use.
-     */
-    protected function getFrom() : int
-    {
-        return $this->from ?? 0;
-    }
-
-    /**
      *  Gets the actual size to use in queries.
      *
      * @return int actual size to use.
      */
     protected function getQuerySize() : int
     {
-        return min($this->maxResults() - $this->getFrom(), $this->getSize());
+        return min($this->maxResults() - $this->from, $this->getSize());
     }
 
     /**

--- a/app/Libraries/Elasticsearch/HasSearch.php
+++ b/app/Libraries/Elasticsearch/HasSearch.php
@@ -20,7 +20,7 @@
 
 namespace App\Libraries\Elasticsearch;
 
-class HasSearch
+abstract class HasSearch
 {
     protected $highlight;
     protected $params;

--- a/app/Libraries/Elasticsearch/HasSearch.php
+++ b/app/Libraries/Elasticsearch/HasSearch.php
@@ -25,7 +25,7 @@ trait HasSearch
     protected $from = 0;
     protected $highlight;
     protected $query;
-    protected $size;
+    protected $size = 10;
     protected $sorts = [];
     protected $source;
     protected $type;
@@ -51,7 +51,7 @@ trait HasSearch
     /**
      * @return $this
      */
-    public function size(?int $size)
+    public function size(int $size)
     {
         $this->size = $size;
 
@@ -123,11 +123,6 @@ trait HasSearch
         return $this;
     }
 
-    protected function getDefaultSize() : int
-    {
-        return 10;
-    }
-
     /**
      *  Gets the actual size to use in queries.
      *
@@ -135,17 +130,7 @@ trait HasSearch
      */
     protected function getQuerySize() : int
     {
-        return min($this->maxResults() - $this->from, $this->getSize());
-    }
-
-    /**
-     *  Gets the size or default size if none was give..
-     *
-     * @return int size.
-     */
-    protected function getSize() : int
-    {
-        return $this->size ?? $this->getDefaultSize();
+        return min($this->maxResults() - $this->from, $this->size);
     }
 
     protected function maxResults() : int

--- a/app/Libraries/Elasticsearch/HasSearch.php
+++ b/app/Libraries/Elasticsearch/HasSearch.php
@@ -27,8 +27,6 @@ abstract class HasSearch
     protected $query;
     protected $type;
 
-
-
     public function __construct(SearchParams $params)
     {
         $this->params = $params;

--- a/app/Libraries/Elasticsearch/HasSearch.php
+++ b/app/Libraries/Elasticsearch/HasSearch.php
@@ -20,22 +20,26 @@
 
 namespace App\Libraries\Elasticsearch;
 
-trait HasSearch
+class HasSearch
 {
-    protected $from = 0;
     protected $highlight;
+    protected $params;
     protected $query;
-    protected $size = 10;
-    protected $sorts = [];
-    protected $source;
     protected $type;
+
+
+
+    public function __construct(SearchParams $params)
+    {
+        $this->params = $params;
+    }
 
     /**
      * @return $this
      */
     public function from(int $from)
     {
-        $this->from = $from;
+        $this->params->from = $from;
 
         return $this;
     }
@@ -43,7 +47,7 @@ trait HasSearch
     /**
      * @return $this
      */
-    public function limit(?int $limit)
+    public function limit(int $limit)
     {
         return $this->size($limit);
     }
@@ -53,7 +57,7 @@ trait HasSearch
      */
     public function size(int $size)
     {
-        $this->size = $size;
+        $this->params->size = $size;
 
         return $this;
     }
@@ -90,7 +94,7 @@ trait HasSearch
      */
     public function source($fields)
     {
-        $this->source = $fields;
+        $this->params->source = $fields;
 
         return $this;
     }
@@ -130,7 +134,7 @@ trait HasSearch
      */
     protected function getQuerySize() : int
     {
-        return min($this->maxResults() - $this->from, $this->size);
+        return min($this->maxResults() - $this->params->from, $this->params->size);
     }
 
     protected function maxResults() : int
@@ -142,7 +146,7 @@ trait HasSearch
     private function addSort(Sort $sort)
     {
         if (!$sort->isBlank()) {
-            $this->sorts[] = $sort;
+            $this->params->sorts[] = $sort;
         }
     }
 }

--- a/app/Libraries/Elasticsearch/Search.php
+++ b/app/Libraries/Elasticsearch/Search.php
@@ -164,8 +164,8 @@ abstract class Search extends HasSearch implements Queryable
             $body['highlight'] = $this->highlight->toArray();
         }
 
-        if (isset($this->params->source)) {
-            $body['_source'] = $this->params->source;
+        if (isset($this->source)) {
+            $body['_source'] = $this->source;
         }
 
         if (isset($this->aggregations)) {

--- a/app/Libraries/Elasticsearch/Search.php
+++ b/app/Libraries/Elasticsearch/Search.php
@@ -47,8 +47,6 @@ abstract class Search extends HasSearch implements Queryable
     private $error;
     private $response;
 
-    const ASSIGN_FIELDS = ['from', 'size', 'sort', 'source'];
-
     public function __construct(string $index, SearchParams $params)
     {
         parent::__construct($params);

--- a/app/Libraries/Elasticsearch/Search.php
+++ b/app/Libraries/Elasticsearch/Search.php
@@ -64,7 +64,7 @@ abstract class Search implements Queryable
         }
 
         $page = max(1, $this->params->page ?? 1);
-        $this->from = $this->getSize() * ($page - 1);
+        $this->from = $this->size * ($page - 1);
     }
 
     // for paginator
@@ -122,11 +122,11 @@ abstract class Search implements Queryable
         // this does mean it's possible to do something stupid
         // like having $this->from start from the middle of a page,
         // but you've got other problems if the paginator is used like that.
-        $page = floor($this->from / $this->getSize()) + 1;
+        $page = floor($this->from / $this->size) + 1;
 
         return new SearchPaginator(
             $this,
-            $this->getSize(),
+            $this->size,
             $page,
             $options
         );
@@ -204,11 +204,6 @@ abstract class Search implements Queryable
     public function total()
     {
         return min($this->response()->total(), $this->maxResults());
-    }
-
-    protected function getDefaultSize() : int
-    {
-        return 50;
     }
 
     private function fetch()

--- a/app/Libraries/Elasticsearch/Search.php
+++ b/app/Libraries/Elasticsearch/Search.php
@@ -140,6 +140,16 @@ abstract class Search implements Queryable
     }
 
     /**
+     * @return $this
+     */
+    public function page(?int $page)
+    {
+        $this->page = $page;
+
+        return $this;
+    }
+
+    /**
      * @return SearchResponse
      */
     public function response() : SearchResponse
@@ -208,6 +218,11 @@ abstract class Search implements Queryable
         return 50;
     }
 
+    protected function getFrom() : int
+    {
+        return $this->from ?? $this->getSize() * ($this->getPage() - 1);
+    }
+
     private function fetch()
     {
         if ($this->params->shouldReturnEmptyResponse() || $this->isSearchWindowExceeded()) {
@@ -248,6 +263,11 @@ abstract class Search implements Queryable
             'type' => $this->loggingTag ?? get_class_basename(get_called_class()),
             'index' => $this->index,
         ];
+    }
+
+    private function getPage() : int
+    {
+        return max(1, $this->page ?? 1);
     }
 
     private function isSearchWindowExceeded()

--- a/app/Libraries/Elasticsearch/Search.php
+++ b/app/Libraries/Elasticsearch/Search.php
@@ -50,7 +50,7 @@ abstract class Search implements Queryable
     private $error;
     private $response;
 
-    const ASSIGN_FIELDS = ['size', 'sort', 'source'];
+    const ASSIGN_FIELDS = ['from', 'size', 'sort', 'source'];
 
     public function __construct(string $index, SearchParams $params)
     {
@@ -62,9 +62,6 @@ abstract class Search implements Queryable
                 $this->$field($params->$field);
             }
         }
-
-        $page = max(1, $this->params->page ?? 1);
-        $this->from = $this->size * ($page - 1);
     }
 
     // for paginator

--- a/app/Libraries/Elasticsearch/Search.php
+++ b/app/Libraries/Elasticsearch/Search.php
@@ -50,25 +50,17 @@ abstract class Search implements Queryable
     private $error;
     private $response;
 
+    const ASSIGN_FIELDS = ['page', 'size', 'sort', 'source'];
+
     public function __construct(string $index, SearchParams $params)
     {
         $this->index = $index;
         $this->params = $params;
 
-        if ($this->params->page !== null) {
-            $this->page($this->params->page);
-        }
-
-        if ($this->params->size !== null) {
-            $this->size($this->params->size);
-        }
-
-        if ($this->params->sort !== null) {
-            $this->sort($this->params->sort);
-        }
-
-        if ($this->params->source !== null) {
-            $this->source($this->params->source);
+        foreach (static::ASSIGN_FIELDS as $field) {
+            if ($params->$field !== null) {
+                $this->$field($params->$field);
+            }
         }
     }
 

--- a/app/Libraries/Elasticsearch/Search.php
+++ b/app/Libraries/Elasticsearch/Search.php
@@ -164,7 +164,7 @@ abstract class Search extends HasSearch implements Queryable
             $body['highlight'] = $this->highlight->toArray();
         }
 
-        if (isset($this->source)) {
+        if (isset($this->params->source)) {
             $body['_source'] = $this->params->source;
         }
 

--- a/app/Libraries/Elasticsearch/SearchParams.php
+++ b/app/Libraries/Elasticsearch/SearchParams.php
@@ -71,7 +71,6 @@ abstract class SearchParams
         return false;
     }
 
-
     /**
      * Helper to convert a page request parameter to a from query parameter.
      * The desired page size should be set first, otherwise the default size will be used.
@@ -82,6 +81,7 @@ abstract class SearchParams
     public function pageAsFrom($page) : int
     {
         $page = max(1, $page ?? 1);
+
         return $this->size * ($page - 1);
     }
 }

--- a/app/Libraries/Elasticsearch/SearchParams.php
+++ b/app/Libraries/Elasticsearch/SearchParams.php
@@ -27,8 +27,8 @@ abstract class SearchParams
     /** @var int|null */
     public $page = null;
 
-    /** @var int|null */
-    public $size = null;
+    /** @var int */
+    public $size = 50;
 
     /** @var array|Sort|null */
     public $sort = null;

--- a/app/Libraries/Elasticsearch/SearchParams.php
+++ b/app/Libraries/Elasticsearch/SearchParams.php
@@ -33,25 +33,8 @@ abstract class SearchParams
     /** @var array */
     public $sorts = [];
 
-    /**
-     * This is just for applyParams used by MultiSearch
-     * @var array|string|null
-     * */
-    public $source = null;
-
     public function __construct()
     {
-    }
-
-    /**
-     * This function only exists for MultiSearch to apply additional params.
-     * It should probably be replaced in favour of having different SearchParams subclasses.
-     */
-    public function applyParams(array $params)
-    {
-        foreach ($params as $key => $value) {
-            $this->$key = $value;
-        }
     }
 
     /**

--- a/app/Libraries/Elasticsearch/SearchParams.php
+++ b/app/Libraries/Elasticsearch/SearchParams.php
@@ -30,8 +30,8 @@ abstract class SearchParams
     /** @var int */
     public $size = 50;
 
-    /** @var array|Sort|null */
-    public $sort = null;
+    /** @var array */
+    public $sorts = [];
 
     /** @var array|string|null */
     public $source = null;

--- a/app/Libraries/Elasticsearch/SearchParams.php
+++ b/app/Libraries/Elasticsearch/SearchParams.php
@@ -33,7 +33,10 @@ abstract class SearchParams
     /** @var array */
     public $sorts = [];
 
-    /** @var array|string|null */
+    /**
+     * This is just for applyParams used by MultiSearch
+     * @var array|string|null
+     * */
     public $source = null;
 
     public function __construct()

--- a/app/Libraries/Elasticsearch/SearchParams.php
+++ b/app/Libraries/Elasticsearch/SearchParams.php
@@ -24,8 +24,8 @@ use Cache;
 
 abstract class SearchParams
 {
-    /** @var int|null */
-    public $page = null;
+    /** @var int */
+    public $from = 0;
 
     /** @var int */
     public $size = 50;
@@ -35,6 +35,10 @@ abstract class SearchParams
 
     /** @var array|string|null */
     public $source = null;
+
+    public function __construct()
+    {
+    }
 
     /**
      * This function only exists for MultiSearch to apply additional params.
@@ -79,5 +83,19 @@ abstract class SearchParams
     public function shouldReturnEmptyResponse() : bool
     {
         return false;
+    }
+
+
+    /**
+     * Helper to convert a page request parameter to a from query parameter.
+     * The desired page size should be set first, otherwise the default size will be used.
+     *
+     * @param $page
+     * @return integer
+     */
+    public function pageAsFrom($page) : int
+    {
+        $page = max(1, $page ?? 1);
+        return $this->size * ($page - 1);
     }
 }

--- a/app/Libraries/Elasticsearch/SearchParams.php
+++ b/app/Libraries/Elasticsearch/SearchParams.php
@@ -76,7 +76,7 @@ abstract class SearchParams
      * The desired page size should be set first, otherwise the default size will be used.
      *
      * @param $page
-     * @return integer
+     * @return int
      */
     public function pageAsFrom($page) : int
     {

--- a/app/Libraries/Search/BeatmapsetSearch.php
+++ b/app/Libraries/Search/BeatmapsetSearch.php
@@ -187,26 +187,6 @@ class BeatmapsetSearch extends RecordSearch
         $mainQuery->filter($query);
     }
 
-    private function getDefaultSort() : array
-    {
-        if (present($this->params->queryString)) {
-            return [new Sort('_score', 'desc')];
-        }
-
-        if ($this->params->status === 3) {
-            return [
-                new Sort('queued_at', 'desc'),
-                new Sort('approved_date', 'desc'), // fallback
-            ];
-        }
-
-        if (in_array($this->params->status, [4, 5, 6], true)) {
-            return [new Sort('last_update', 'desc')];
-        }
-
-        return [new Sort('approved_date', 'desc')];
-    }
-
     private function getPlayedBeatmapIds(?array $rank = null)
     {
         $unionQuery = null;

--- a/app/Libraries/Search/BeatmapsetSearch.php
+++ b/app/Libraries/Search/BeatmapsetSearch.php
@@ -46,11 +46,6 @@ class BeatmapsetSearch extends RecordSearch
         }
     }
 
-    public function getDefaultSize() : int
-    {
-        return config('osu.beatmaps.max');
-    }
-
     /**
      * {@inheritdoc}
      */

--- a/app/Libraries/Search/BeatmapsetSearch.php
+++ b/app/Libraries/Search/BeatmapsetSearch.php
@@ -40,10 +40,6 @@ class BeatmapsetSearch extends RecordSearch
             $params ?? new BeatmapsetSearchParams,
             Beatmapset::class
         );
-
-        if (empty($this->sorts)) {
-            $this->sorts = $this->getDefaultSort();
-        }
     }
 
     /**

--- a/app/Libraries/Search/BeatmapsetSearch.php
+++ b/app/Libraries/Search/BeatmapsetSearch.php
@@ -23,7 +23,6 @@ namespace App\Libraries\Search;
 use App\Libraries\Elasticsearch\BoolQuery;
 use App\Libraries\Elasticsearch\QueryHelper;
 use App\Libraries\Elasticsearch\RecordSearch;
-use App\Libraries\Elasticsearch\Sort;
 use App\Models\Beatmap;
 use App\Models\Beatmapset;
 use App\Models\Score;

--- a/app/Libraries/Search/BeatmapsetSearchParams.php
+++ b/app/Libraries/Search/BeatmapsetSearchParams.php
@@ -63,6 +63,14 @@ class BeatmapsetSearchParams extends SearchParams
     /** @var User|null */
     public $user = null;
 
+    public function __construct()
+    {
+        parent::__construct();
+
+        $this->size = config('osu.beatmaps.max');
+    }
+
+
     /**
      * {@inheritdoc}
      */

--- a/app/Libraries/Search/BeatmapsetSearchParams.php
+++ b/app/Libraries/Search/BeatmapsetSearchParams.php
@@ -70,7 +70,6 @@ class BeatmapsetSearchParams extends SearchParams
         $this->size = config('osu.beatmaps.max');
     }
 
-
     /**
      * {@inheritdoc}
      */

--- a/app/Libraries/Search/BeatmapsetSearchRequestParams.php
+++ b/app/Libraries/Search/BeatmapsetSearchRequestParams.php
@@ -135,16 +135,14 @@ class BeatmapsetSearchRequestParams extends BeatmapsetSearchParams
         if (empty($array[0])) {
             $this->sorts = $this->getDefaultSort();
         } else {
-            $sort = new Sort($array[0], $order);
-            $this->sorts = $this->normalizeSort(static::remapSortField($sort));
+            $this->sorts = $this->normalizeSort(new Sort(static::remapSortField($array[0]), $order));
         }
 
         // generic tie-breaker.
         $this->sorts[] = new Sort('_id', $order);
     }
 
-
-    private static function remapSortField(Sort $sort)
+    private static function remapSortField(?string $name)
     {
         static $fields = [
             'artist' => 'artist.raw',
@@ -159,6 +157,6 @@ class BeatmapsetSearchRequestParams extends BeatmapsetSearchParams
             'updated' => 'last_update',
         ];
 
-        return new Sort($fields[$sort->field] ?? null, $sort->order, $sort->mode);
+        return $fields[$name] ?? null;
     }
 }

--- a/app/Libraries/Search/BeatmapsetSearchRequestParams.php
+++ b/app/Libraries/Search/BeatmapsetSearchRequestParams.php
@@ -63,6 +63,8 @@ class BeatmapsetSearchRequestParams extends BeatmapsetSearchParams
         $array = explode('_', $request['sort']);
         $sort = new Sort($array[0] ?? static::DEFAULT_SORT_TYPE, $array[1] ?? static::DEFAULT_SORT_ORDER);
         $this->sorts = $this->normalizeSort(static::remapSortField($sort));
+        // generic tie-breaker.
+        $this->sorts[] = new Sort('_id', $sort->order);
 
         // Supporter-only options.
         $this->rank = array_intersect(
@@ -79,7 +81,7 @@ class BeatmapsetSearchRequestParams extends BeatmapsetSearchParams
     /**
      * Generate sort parameters for the elasticsearch query.
      */
-    private function normalizeSort(Sort $sort)
+    private function normalizeSort(Sort $sort) : array
     {
         // additional options
         static $orderOptions = [

--- a/app/Libraries/Search/BeatmapsetSearchRequestParams.php
+++ b/app/Libraries/Search/BeatmapsetSearchRequestParams.php
@@ -27,9 +27,6 @@ use Illuminate\Http\Request;
 
 class BeatmapsetSearchRequestParams extends BeatmapsetSearchParams
 {
-    const DEFAULT_SORT_TYPE = 'ranked';
-    const DEFAULT_SORT_ORDER = 'desc';
-
     public function __construct(Request $request, ?User $user = null)
     {
         parent::__construct();
@@ -60,12 +57,13 @@ class BeatmapsetSearchRequestParams extends BeatmapsetSearchParams
             $this->showRecommended = in_array('recommended', $generals, true);
         }
 
+        // TODO: fix this; array[0] always has a value, etc.
         $array = explode('_', $request['sort']);
         if (empty($array[0])) {
             $this->sorts = $this->getDefaultSort();
             $this->sorts[] = new Sort('_id', 'desc');
         } else {
-            $sort = new Sort($array[0] ?? static::DEFAULT_SORT_TYPE, $array[1] ?? static::DEFAULT_SORT_ORDER);
+            $sort = new Sort($array[0], $array[1] ?? null);
             $this->sorts = $this->normalizeSort(static::remapSortField($sort));
             // generic tie-breaker.
             $this->sorts[] = new Sort('_id', $sort->order);

--- a/app/Libraries/Search/BeatmapsetSearchRequestParams.php
+++ b/app/Libraries/Search/BeatmapsetSearchRequestParams.php
@@ -27,6 +27,9 @@ use Illuminate\Http\Request;
 
 class BeatmapsetSearchRequestParams extends BeatmapsetSearchParams
 {
+    const DEFAULT_SORT_TYPE = 'ranked';
+    const DEFAULT_SORT_ORDER = 'desc';
+
     public function __construct(Request $request, ?User $user = null)
     {
         parent::__construct();
@@ -57,10 +60,9 @@ class BeatmapsetSearchRequestParams extends BeatmapsetSearchParams
             $this->showRecommended = in_array('recommended', $generals, true);
         }
 
-        $sort = explode('_', $request['sort']);
-        $this->sorts = $this->normalizeSort(
-            static::remapSortField(new Sort($sort[0] ?? null, $sort[1] ?? null))
-        );
+        $array = explode('_', $request['sort']);
+        $sort = new Sort($array[0] ?? static::DEFAULT_SORT_TYPE, $array[1] ?? static::DEFAULT_SORT_ORDER);
+        $this->sorts = $this->normalizeSort(static::remapSortField($sort));
 
         // Supporter-only options.
         $this->rank = array_intersect(

--- a/app/Libraries/Search/BeatmapsetSearchRequestParams.php
+++ b/app/Libraries/Search/BeatmapsetSearchRequestParams.php
@@ -126,16 +126,17 @@ class BeatmapsetSearchRequestParams extends BeatmapsetSearchParams
     private function parseSortOrder(?string $value)
     {
         $array = explode('_', $value);
+        $field = static::remapSortField($array[0]);
         $order = $array[1] ?? null;
 
         if (!in_array($order, ['asc', 'desc'], true)) {
             $order = 'desc';
         }
 
-        if (empty($array[0])) {
+        if (empty($field)) {
             $this->sorts = $this->getDefaultSort();
         } else {
-            $this->sorts = $this->normalizeSort(new Sort(static::remapSortField($array[0]), $order));
+            $this->sorts = $this->normalizeSort(new Sort($field, $order));
         }
 
         // generic tie-breaker.

--- a/app/Libraries/Search/BeatmapsetSearchRequestParams.php
+++ b/app/Libraries/Search/BeatmapsetSearchRequestParams.php
@@ -57,17 +57,7 @@ class BeatmapsetSearchRequestParams extends BeatmapsetSearchParams
             $this->showRecommended = in_array('recommended', $generals, true);
         }
 
-        // TODO: fix this; array[0] always has a value, etc.
-        $array = explode('_', $request['sort']);
-        if (empty($array[0])) {
-            $this->sorts = $this->getDefaultSort();
-            $this->sorts[] = new Sort('_id', 'desc');
-        } else {
-            $sort = new Sort($array[0], $array[1] ?? null);
-            $this->sorts = $this->normalizeSort(static::remapSortField($sort));
-            // generic tie-breaker.
-            $this->sorts[] = new Sort('_id', $sort->order);
-        }
+        $this->parseSortOrder($request['sort']);
 
         // Supporter-only options.
         $this->rank = array_intersect(
@@ -132,6 +122,27 @@ class BeatmapsetSearchRequestParams extends BeatmapsetSearchParams
 
         return $newSort;
     }
+
+    private function parseSortOrder(?string $value)
+    {
+        $array = explode('_', $value);
+        $order = $array[1] ?? null;
+
+        if (!in_array($order, ['asc', 'desc'], true)) {
+            $order = 'desc';
+        }
+
+        if (empty($array[0])) {
+            $this->sorts = $this->getDefaultSort();
+        } else {
+            $sort = new Sort($array[0], $order);
+            $this->sorts = $this->normalizeSort(static::remapSortField($sort));
+        }
+
+        // generic tie-breaker.
+        $this->sorts[] = new Sort('_id', $order);
+    }
+
 
     private static function remapSortField(Sort $sort)
     {

--- a/app/Libraries/Search/BeatmapsetSearchRequestParams.php
+++ b/app/Libraries/Search/BeatmapsetSearchRequestParams.php
@@ -58,7 +58,7 @@ class BeatmapsetSearchRequestParams extends BeatmapsetSearchParams
         }
 
         $sort = explode('_', $request['sort']);
-        $this->sort = $this->normalizeSort(
+        $this->sorts = $this->normalizeSort(
             [static::remapSortField(new Sort($sort[0] ?? null, $sort[1] ?? null))]
         );
 

--- a/app/Libraries/Search/BeatmapsetSearchRequestParams.php
+++ b/app/Libraries/Search/BeatmapsetSearchRequestParams.php
@@ -29,11 +29,13 @@ class BeatmapsetSearchRequestParams extends BeatmapsetSearchParams
 {
     public function __construct(Request $request, ?User $user = null)
     {
+        parent::__construct();
+
         static $validExtras = ['video', 'storyboard'];
         static $validRanks = ['A', 'B', 'C', 'D', 'S', 'SH', 'X', 'XH'];
 
         $this->user = $user;
-        $this->page = get_int($request['page']) ?? 1;
+        $this->from = $this->pageAsFrom(get_int($request['page']));
 
         if ($this->user !== null) {
             $this->queryString = es_query_escape_with_caveats($request['q'] ?? $request['query']);

--- a/app/Libraries/Search/BeatmapsetSearchRequestParams.php
+++ b/app/Libraries/Search/BeatmapsetSearchRequestParams.php
@@ -71,24 +71,24 @@ class BeatmapsetSearchRequestParams extends BeatmapsetSearchParams
         }
     }
 
-    private function getDefaultSort() : array
+    private function getDefaultSort(string $order) : array
     {
         if (present($this->queryString)) {
-            return [new Sort('_score', 'desc')];
+            return [new Sort('_score', $order)];
         }
 
         if ($this->status === 3) {
             return [
-                new Sort('queued_at', 'desc'),
-                new Sort('approved_date', 'desc'), // fallback
+                new Sort('queued_at', $order),
+                new Sort('approved_date', $order), // fallback
             ];
         }
 
         if (in_array($this->status, [4, 5, 6], true)) {
-            return [new Sort('last_update', 'desc')];
+            return [new Sort('last_update', $order)];
         }
 
-        return [new Sort('approved_date', 'desc')];
+        return [new Sort('approved_date', $order)];
     }
 
     /**
@@ -134,7 +134,7 @@ class BeatmapsetSearchRequestParams extends BeatmapsetSearchParams
         }
 
         if (empty($field)) {
-            $this->sorts = $this->getDefaultSort();
+            $this->sorts = $this->getDefaultSort($order);
         } else {
             $this->sorts = $this->normalizeSort(new Sort($field, $order));
         }

--- a/app/Libraries/Search/ForumSearch.php
+++ b/app/Libraries/Search/ForumSearch.php
@@ -150,9 +150,4 @@ class ForumSearch extends Search
 
         return User::whereIn('user_id', $ids);
     }
-
-    protected function getDefaultSize() : int
-    {
-        return 20;
-    }
 }

--- a/app/Libraries/Search/ForumSearchParams.php
+++ b/app/Libraries/Search/ForumSearchParams.php
@@ -37,6 +37,9 @@ class ForumSearchParams extends SearchParams
     /** @var string|null */
     public $queryString = null;
 
+    /** {@inheritdoc} */
+    public $size = 20;
+
     /** @var int|null */
     public $topicId = null;
 

--- a/app/Libraries/Search/ForumSearchRequestParams.php
+++ b/app/Libraries/Search/ForumSearchRequestParams.php
@@ -26,8 +26,10 @@ class ForumSearchRequestParams extends ForumSearchParams
 {
     public function __construct(Request $request)
     {
+        parent::__construct();
+
         $this->queryString = presence(trim($request['query']));
-        $this->page = get_int($request['page']) ?? 1;
+        $this->from = $this->pageAsFrom(get_int($request['page']));
         $this->includeSubforums = get_bool($request['forum_children']) ?? false;
         $this->username = presence(trim($request['username']));
         $this->forumId = get_int($request['forum_id']);

--- a/app/Libraries/Search/ForumSearchRequestParams.php
+++ b/app/Libraries/Search/ForumSearchRequestParams.php
@@ -27,7 +27,7 @@ class ForumSearchRequestParams extends ForumSearchParams
     public function __construct(Request $request)
     {
         $this->queryString = presence(trim($request['query']));
-        $this->page = get_int($request['page']);
+        $this->page = get_int($request['page']) ?? 1;
         $this->includeSubforums = get_bool($request['forum_children']) ?? false;
         $this->username = presence(trim($request['username']));
         $this->forumId = get_int($request['forum_id']);

--- a/app/Libraries/Search/MultiSearch.php
+++ b/app/Libraries/Search/MultiSearch.php
@@ -35,7 +35,7 @@ class MultiSearch
             'type' => BeatmapsetSearch::class,
             'paramsType' => BeatmapsetSearchRequestParams::class,
             'size' => 8,
-            'options' => ['source' => 'id'],
+            'options' => ['source' => ''],
         ],
         'wiki_page' => [
             'type' => WikiSearch::class,

--- a/app/Libraries/Search/MultiSearch.php
+++ b/app/Libraries/Search/MultiSearch.php
@@ -35,7 +35,6 @@ class MultiSearch
             'type' => BeatmapsetSearch::class,
             'paramsType' => BeatmapsetSearchRequestParams::class,
             'size' => 8,
-            'options' => ['source' => ''],
         ],
         'wiki_page' => [
             'type' => WikiSearch::class,
@@ -85,8 +84,10 @@ class MultiSearch
                 $paramsClass = $settings['paramsType'];
 
                 $params = new $paramsClass($this->request, $this->options['user']);
-                $params->applyParams($settings['options'] ?? []);
                 $search = new $class($params);
+                if ($search instanceof BeatmapsetSearch) {
+                    $search->source(false);
+                }
 
                 if ($this->getMode() === 'all') {
                     $search->from(0)->size($settings['size']);

--- a/app/Libraries/Search/MultiSearch.php
+++ b/app/Libraries/Search/MultiSearch.php
@@ -89,7 +89,7 @@ class MultiSearch
                 $search = new $class($params);
 
                 if ($this->getMode() === 'all') {
-                    $search->page(1)->size($settings['size']);
+                    $search->from(0)->size($settings['size']);
                     if ($this->hasQuery()) {
                         $search->response(); // FIXME: run query before counts for tab; need better way to do this.
                     }

--- a/app/Libraries/Search/PostSearchRequestParams.php
+++ b/app/Libraries/Search/PostSearchRequestParams.php
@@ -28,7 +28,7 @@ class PostSearchRequestParams extends PostSearchParams
     public function __construct(Request $request, User $user)
     {
         $this->queryString = presence(trim($request['query']));
-        $this->page = get_int($request['page']);
+        $this->page = get_int($request['page']) ?? 1;
         $this->userId = $user->getKey();
         $this->forumId = get_int($request['forum_id']);
         $this->includeSubforums = get_bool($request['forum_children']);

--- a/app/Libraries/Search/PostSearchRequestParams.php
+++ b/app/Libraries/Search/PostSearchRequestParams.php
@@ -27,7 +27,7 @@ class PostSearchRequestParams extends PostSearchParams
 {
     public function __construct(Request $request, User $user)
     {
-        $this->__construct();
+        parent::__construct();
 
         $this->queryString = presence(trim($request['query']));
         $this->from = $this->pageAsFrom(get_int($request['page']));

--- a/app/Libraries/Search/PostSearchRequestParams.php
+++ b/app/Libraries/Search/PostSearchRequestParams.php
@@ -27,8 +27,10 @@ class PostSearchRequestParams extends PostSearchParams
 {
     public function __construct(Request $request, User $user)
     {
+        $this->__construct();
+
         $this->queryString = presence(trim($request['query']));
-        $this->page = get_int($request['page']) ?? 1;
+        $this->from = $this->pageAsFrom(get_int($request['page']));
         $this->userId = $user->getKey();
         $this->forumId = get_int($request['forum_id']);
         $this->includeSubforums = get_bool($request['forum_children']);

--- a/app/Libraries/Search/UserSearch.php
+++ b/app/Libraries/Search/UserSearch.php
@@ -83,11 +83,6 @@ class UserSearch extends RecordSearch
         return $query;
     }
 
-    protected function getDefaultSize() : int
-    {
-        return 20;
-    }
-
     protected function maxResults() : int
     {
         return config('osu.search.max.user');

--- a/app/Libraries/Search/UserSearchParams.php
+++ b/app/Libraries/Search/UserSearchParams.php
@@ -29,6 +29,9 @@ class UserSearchParams extends SearchParams
     public $queryString = null;
     public $recentOnly = false;
 
+    /** {@inheritdoc} */
+    public $size = 20;
+
     /**
      * {@inheritdoc}
      */

--- a/app/Libraries/Search/UserSearchRequestParams.php
+++ b/app/Libraries/Search/UserSearchRequestParams.php
@@ -26,8 +26,10 @@ class UserSearchRequestParams extends UserSearchParams
 {
     public function __construct(Request $request)
     {
+        parent::__construct();
+
         $this->queryString = presence(trim($request['query']));
-        $this->page = get_int($request['page']);
+        $this->from = $this->pageAsFrom(get_int($request['page']));
         $this->recentOnly = get_bool($request['recent_only']);
     }
 }

--- a/app/Libraries/Search/WikiSearch.php
+++ b/app/Libraries/Search/WikiSearch.php
@@ -104,9 +104,4 @@ class WikiSearch extends RecordSearch
             ->must($langQuery)
             ->must($matchQuery);
     }
-
-    protected function getDefaultSize(): int
-    {
-        return 50;
-    }
 }

--- a/app/Libraries/Search/WikiSearchRequestParams.php
+++ b/app/Libraries/Search/WikiSearchRequestParams.php
@@ -26,8 +26,10 @@ class WikiSearchRequestParams extends WikiSearchParams
 {
     public function __construct(Request $request)
     {
+        parent::__construct();
+
         $this->queryString = trim($request['query']);
         $this->locale = $request['locale'];
-        $this->page = get_int($request['page']) ?? 1;
+        $this->from = $this->pageAsFrom(get_int($request['page']));
     }
 }

--- a/app/Libraries/Search/WikiSearchRequestParams.php
+++ b/app/Libraries/Search/WikiSearchRequestParams.php
@@ -28,6 +28,6 @@ class WikiSearchRequestParams extends WikiSearchParams
     {
         $this->queryString = trim($request['query']);
         $this->locale = $request['locale'];
-        $this->page = get_int($request['page']);
+        $this->page = get_int($request['page']) ?? 1;
     }
 }


### PR DESCRIPTION
- parse parameters and set defaults earlier.
- changes `HasSearch` from trait to class.
- limit use of `page` to request params.
- include `_id` as part of beatmap search sort order, so that there's a deterministic order if the sort values would otherwise have ben the same.
- excluding `_source` from results should be using `false` instead of fields that don't exist in `_source` (`_id` is always included in the elasticsearch response).

This is a dependency of some incoming changes but this is PR'ed first since it's not dependent on the other changes, so we can check for breakage on this part separately.

---
