### PR TITLE
Change contest image size limits to 8MB

### DIFF
--- a/app/Http/Controllers/ContestEntriesController.php
+++ b/app/Http/Controllers/ContestEntriesController.php
@@ -61,7 +61,7 @@ class ContestEntriesController extends Controller
                 $allowedExtensions[] = 'jpg';
                 $allowedExtensions[] = 'jpeg';
                 $allowedExtensions[] = 'png';
-                $maxFilesize = 4000000;
+                $maxFilesize = 8000000;
                 break;
             case 'beatmap':
                 $allowedExtensions[] = 'osu';

--- a/resources/assets/coffee/react/contest/entry/uploader.coffee
+++ b/resources/assets/coffee/react/contest/entry/uploader.coffee
@@ -33,7 +33,7 @@ class Contest.Entry.Uploader extends React.Component
     switch @props.contest.type
       when 'art'
         allowedExtensions = ['.jpg', '.jpeg', '.png']
-        maxSize = 4000000
+        maxSize = 8000000
 
       when 'beatmap'
         allowedExtensions = ['.osu', '.osz']


### PR DESCRIPTION
Closes #3816

---

The contest upload page currently only allows images up to 4MB in size. This can be insufficient for highly detailed images at the resolution requested by the contest. This PR updates the limit to 8MB, which should be sufficient for the requested size.