### PR TITLE
Convert int cursors to string for javascript

### DIFF
--- a/app/Libraries/Elasticsearch/Search.php
+++ b/app/Libraries/Elasticsearch/Search.php
@@ -130,7 +130,13 @@ abstract class Search extends HasSearch implements Queryable
                 return $sort->field;
             }, $this->params->sorts);
 
-            return array_combine($fields, $last['sort']);
+            $casted = array_map(function ($value) {
+                // stringify all ints since javascript doesn't like big ints.
+                // fortunately the minimum value is PHP_INT_MIN instead of the equivalent double.
+                return is_int($value) ? (string) $value : $value;
+            }, $last['sort']);
+
+            return array_combine($fields, $casted);
         }
     }
 


### PR DESCRIPTION
Fixes possible missing results in beatmap listing on the tail end of results when ordering by ranking date and including maps that aren't ranked.

javascript thinks `-9223372036854775808` is `-9223372036854776000` 🥇 

---
