### PR TITLE
Fix the chat updates endpoint defaulting to a limit of 1 instead of 50.

### DIFF
--- a/app/Http/Controllers/Chat/ChatController.php
+++ b/app/Http/Controllers/Chat/ChatController.php
@@ -46,7 +46,7 @@ class ChatController extends Controller
         }
 
         $since = Request::input('since');
-        $limit = clamp(get_int(Request::input('limit')) || 50, 1, 50);
+        $limit = clamp(get_int(Request::input('limit')) ?? 50, 1, 50);
 
         $messages = Message::forUser(Auth::user())
             ->with('sender')


### PR DESCRIPTION
This should fix messages randomly not being received while polling for updates.

Until now, only the single newest message was being returned (instead of all new messages since the given message_id). Those lost messages would then never make it to the client, as the client would only poll for messages newer then that single returned message... yeah. 🤦‍♂️ 

---