### PR TITLE
Fix triangle background in header peeking through

### DIFF
--- a/resources/assets/less/bem/nav2-header.less
+++ b/resources/assets/less/bem/nav2-header.less
@@ -46,6 +46,9 @@
 
   &__legacy-gradient-overlay {
     .full-size();
+    // workaround for the background not being covered properly
+    // due to browser rounding off sizes at different zoom levels.
+    height: calc(100% ~'+' 1px);
 
     .@{header-pinned} & {
       background-position-y: 100%;

--- a/resources/assets/less/bem/nav2-header.less
+++ b/resources/assets/less/bem/nav2-header.less
@@ -46,11 +46,9 @@
 
   &__legacy-gradient-overlay {
     .full-size();
-    // workaround for the background not being covered properly
-    // due to browser rounding off sizes at different zoom levels.
-    height: calc(100% ~'+' 1px);
 
     .@{header-pinned} & {
+      background-repeat-y: no-repeat; // prevents triangles from peeking through at some zoom levels.
       background-position-y: 100%;
     }
 


### PR DESCRIPTION
closes #3845

The triangle background in header peeks through at some scaling levels making it look like the sticky bits below it are not attached.

---
