### PR TITLE
fix(gitattributes): Files should be LF by default now

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,2 @@
 * text=auto
-*.sh eol=lf
+* eol=lf


### PR DESCRIPTION
Tells Git to force files to be checked-out and normalize all files in index as LF by default.

- Closes #3851 

---

There are instances where files in the repository when checked out end up with CRLF. `gitattributes` has been modified to always check out and push as LF by default.