### PR TITLE
Fix comments in beatmapsets/events

### DIFF
--- a/app/Models/BeatmapsetEvent.php
+++ b/app/Models/BeatmapsetEvent.php
@@ -54,6 +54,7 @@ class BeatmapsetEvent extends Model
             $discussionPostId = $object->getKey();
             $discussionId = $object->beatmap_discussion_id;
             $beatmapsetId = $object->beatmapDiscussion->beatmapset_id;
+            $message = $object->message;
         } elseif ($object instanceof BeatmapDiscussion) {
             $discussionId = $object->getKey();
             $beatmapsetId = $object->beatmapset_id;
@@ -68,6 +69,7 @@ class BeatmapsetEvent extends Model
             'comment' => array_merge([
                 'beatmap_discussion_id' => $discussionId ?? null,
                 'beatmap_discussion_post_id' => $discussionPostId ?? null,
+                'message' => $message ?? null
             ], $extraData),
         ]);
     }

--- a/app/Models/BeatmapsetEvent.php
+++ b/app/Models/BeatmapsetEvent.php
@@ -69,7 +69,7 @@ class BeatmapsetEvent extends Model
             'comment' => array_merge([
                 'beatmap_discussion_id' => $discussionId ?? null,
                 'beatmap_discussion_post_id' => $discussionPostId ?? null,
-                'message' => $message ?? null
+                'message' => $message ?? null,
             ], $extraData),
         ]);
     }

--- a/resources/views/beatmapset_events/_item.blade.php
+++ b/resources/views/beatmapset_events/_item.blade.php
@@ -18,6 +18,7 @@
 @php
     $discussionId = isset($event->comment['beatmap_discussion_id']) ? $event->comment['beatmap_discussion_id'] : null;
     $discussionLink = route('beatmapsets.discussion', $event->beatmapset);
+    $message = isset($event->comment['message']) ? $event->comment['message'] : null;
     if ($discussionId) {
         $discussionLink .= '#/'.$discussionId;
     }
@@ -55,7 +56,7 @@
                 {!! trans('beatmapset_events.event.'.$event->typeForTranslation(), [
                     'user' => link_to_user($event->user),
                     'discussion' => $discussionId ? "<a href='$discussionLink'>#$discussionId</a>" : '',
-                    'text' => is_string($event->comment) ? $event->comment : '[no preview]',
+                    'text' => is_string($message) ? $message : '[no preview]',
                 ]) !!}
             </div>
             <div>{!! timeago($event->created_at) !!}</div>


### PR DESCRIPTION
Attempt to fix it by adding a new field to the array passed, will fix the ones created from now on.

- Closes #3686

---

Disqualifications currently just say [no preview] on the /event page, from now on will display the actual message.