### PR TITLE
Add API scopes

### DIFF
--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -176,7 +176,7 @@ class Handler extends ExceptionHandler
             return 403;
         } elseif ($e instanceof AuthenticationException) {
             return 401;
-        } elseif ($e instanceof AuthorizationException) {
+        } elseif ($e instanceof AuthorizationException || $e instanceof LaravelAuthorizationException) {
             return 403;
         } else {
             return 500;

--- a/app/Http/Controllers/API/BeatmapsetsController.php
+++ b/app/Http/Controllers/API/BeatmapsetsController.php
@@ -27,7 +27,8 @@ use Request;
 
 class BeatmapsetsController extends Controller
 {
-    public function __construct() {
+    public function __construct()
+    {
         $this->middleware('scopes:read', ['only' => ['favourites']]);
 
         return parent::__construct();

--- a/app/Http/Controllers/API/BeatmapsetsController.php
+++ b/app/Http/Controllers/API/BeatmapsetsController.php
@@ -27,6 +27,12 @@ use Request;
 
 class BeatmapsetsController extends Controller
 {
+    public function __construct() {
+        $this->middleware('scopes:read', ['only' => ['favourites']]);
+
+        return parent::__construct();
+    }
+
     public function favourites()
     {
         $favourites = Auth::user()->favouriteBeatmapsets();

--- a/app/Http/Controllers/BeatmapsetsController.php
+++ b/app/Http/Controllers/BeatmapsetsController.php
@@ -43,7 +43,8 @@ class BeatmapsetsController extends Controller
 {
     protected $section = 'beatmapsets';
 
-    public function __construct() {
+    public function __construct()
+    {
         $this->middleware('scopes:internal', ['only' => ['download']]);
 
         return parent::__construct();

--- a/app/Http/Controllers/BeatmapsetsController.php
+++ b/app/Http/Controllers/BeatmapsetsController.php
@@ -43,6 +43,12 @@ class BeatmapsetsController extends Controller
 {
     protected $section = 'beatmapsets';
 
+    public function __construct() {
+        $this->middleware('scopes:internal', ['only' => ['download']]);
+
+        return parent::__construct();
+    }
+
     public function destroy($id)
     {
         $beatmapset = Beatmapset::findOrFail($id);

--- a/app/Http/Controllers/Chat/Channels/MessagesController.php
+++ b/app/Http/Controllers/Chat/Channels/MessagesController.php
@@ -29,6 +29,13 @@ use Request;
 
 class MessagesController extends BaseController
 {
+    public function __construct() {
+        $this->middleware('scopes:read', ['only' => ['index']]);
+        $this->middleware('scopes:write', ['only' => ['store']]);
+
+        return parent::__construct();
+    }
+
     public function index($channelId)
     {
         $userId = Auth::user()->user_id;

--- a/app/Http/Controllers/Chat/Channels/MessagesController.php
+++ b/app/Http/Controllers/Chat/Channels/MessagesController.php
@@ -29,7 +29,8 @@ use Request;
 
 class MessagesController extends BaseController
 {
-    public function __construct() {
+    public function __construct()
+    {
         $this->middleware('scopes:read', ['only' => ['index']]);
         $this->middleware('scopes:write', ['only' => ['store']]);
 

--- a/app/Http/Controllers/Chat/ChannelsController.php
+++ b/app/Http/Controllers/Chat/ChannelsController.php
@@ -27,7 +27,8 @@ use DB;
 
 class ChannelsController extends Controller
 {
-    public function __construct() {
+    public function __construct()
+    {
         $this->middleware('scopes:write', ['only' => ['join', 'part', 'markAsRead']]);
 
         return parent::__construct();

--- a/app/Http/Controllers/Chat/ChannelsController.php
+++ b/app/Http/Controllers/Chat/ChannelsController.php
@@ -27,6 +27,12 @@ use DB;
 
 class ChannelsController extends Controller
 {
+    public function __construct() {
+        $this->middleware('scopes:write', ['only' => ['join', 'part', 'markAsRead']]);
+
+        return parent::__construct();
+    }
+
     public function index()
     {
         return json_collection(

--- a/app/Http/Controllers/Chat/ChatController.php
+++ b/app/Http/Controllers/Chat/ChatController.php
@@ -36,6 +36,9 @@ class ChatController extends Controller
     {
         $this->middleware('auth');
 
+        $this->middleware('scopes:read', ['only' => ['presence', 'updates']]);
+        $this->middleware('scopes:write', ['only' => ['newConversation']]);
+
         return parent::__construct();
     }
 

--- a/app/Http/Controllers/FriendsController.php
+++ b/app/Http/Controllers/FriendsController.php
@@ -35,6 +35,8 @@ class FriendsController extends Controller
     {
         $this->middleware('auth');
 
+        $this->middleware('scopes:read', ['only' => ['index']]);
+
         $this->middleware('verify-user', [
             'only' => [
                 'store',

--- a/app/Http/Controllers/HomeController.php
+++ b/app/Http/Controllers/HomeController.php
@@ -46,6 +46,8 @@ class HomeController extends Controller
             ],
         ]);
 
+        $this->middleware('scopes:internal', ['only' => ['downloadQuotaCheck']]);
+
         return parent::__construct();
     }
 

--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -46,6 +46,8 @@ class UsersController extends Controller
             'checkUsernameExists',
         ]]);
 
+        $this->middleware('scopes:identify', ['only' => ['me']]);
+
         $this->middleware('throttle:10,60', ['only' => ['store']]);
 
         $this->middleware(function ($request, $next) {

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -64,6 +64,7 @@ class Kernel extends HttpKernel
         'auth.basic' => \Illuminate\Auth\Middleware\AuthenticateWithBasicAuth::class,
         'check-user-restricted' => Middleware\CheckUserRestricted::class,
         'guest' => Middleware\RedirectIfAuthenticated::class,
+        'scopes' => Middleware\CheckScopesForAPI::class,
         'throttle' => \Illuminate\Routing\Middleware\ThrottleRequests::class,
         'verify-user' => Middleware\VerifyUser::class,
     ];

--- a/app/Http/Middleware/CheckScopesForAPI.php
+++ b/app/Http/Middleware/CheckScopesForAPI.php
@@ -18,17 +18,28 @@
  *    along with osu!web.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-return [
-    'error' => [
-        'chat' => [
-            'limit_exceeded' => 'You are sending messages too quickly, please wait a bit before trying again.',
-            'too_long' => 'The message you are trying to send is too long.',
-        ],
-    ],
+namespace App\Http\Middleware;
 
-    'scopes' => [
-        'identify' => 'Identify your osu! account',
-        'read' => 'View your private profile information',
-        'write' => 'Perform actions on your behalf',
-    ],
-];
+use Laravel\Passport\Http\Middleware\CheckScopes;
+
+class CheckScopesForAPI
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param \Illuminate\Http\Request $request
+     * @param \Closure                 $next
+     * @param  mixed                ...$scopes
+     * @return \Illuminate\Http\Response
+     * @throws \Illuminate\Auth\AuthenticationException
+     * @throws \Laravel\Passport\Exceptions\MissingScopeException
+     */
+    public function handle($request, $next, ...$scopes)
+    {
+        if (is_api_request()) {
+            return app(CheckScopes::class)->handle($request, $next, ...$scopes);
+        }
+
+        return $next($request);
+    }
+}

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -28,5 +28,13 @@ class AuthServiceProvider extends ServiceProvider
         }
 
         Passport::routes();
+
+        Passport::tokensCan([
+            'identify' => trans('api.scopes.identify'),
+            'read' => trans('api.scopes.read'),
+            // TODO: This can be enabled in the future, according to
+            // https://github.com/ppy/osu-web/pull/3863#issuecomment-436904257
+            // 'write' => trans('api.scopes.write'),
+        ]);
     }
 }

--- a/routes/web.php
+++ b/routes/web.php
@@ -287,9 +287,10 @@ Route::group(['as' => 'api.', 'prefix' => 'api', 'namespace' => 'API', 'middlewa
             Route::apiResource('channels', '\App\Http\Controllers\Chat\ChannelsController', ['only' => ['index']]);
         });
 
-        Route::resource('rooms', 'RoomsController', ['only' => ['show']]);
+        Route::apiResource('rooms', 'RoomsController', ['only' => ['show']]);
 
         Route::group(['prefix' => 'beatmapsets'], function () {
+            // TODO: Should be moved under /me, and probably call to UsersController instead?
             Route::get('favourites', 'BeatmapsetsController@favourites');     //  GET /api/v2/beatmapsets/favourites
         });
 
@@ -299,7 +300,7 @@ Route::group(['as' => 'api.', 'prefix' => 'api', 'namespace' => 'API', 'middlewa
         //   GET /api/v2/beatmaps/lookup
         Route::get('beatmaps/lookup', 'BeatmapsController@lookup');
         //   GET /api/v2/beatmaps/:beatmap_id
-        Route::resource('beatmaps', 'BeatmapsController', ['only' => ['show']]);
+        Route::apiResource('beatmaps', 'BeatmapsController', ['only' => ['show']]);
 
         // Beatmapsets
         //   GET /api/v2/beatmapsets/search/:filters
@@ -309,11 +310,11 @@ Route::group(['as' => 'api.', 'prefix' => 'api', 'namespace' => 'API', 'middlewa
         //   GET /api/v2/beatmapsets/:beatmapset/download
         Route::get('beatmapsets/{beatmapset}/download', '\App\Http\Controllers\BeatmapsetsController@download');
         //   GET /api/v2/beatmapsets/:beatmapset_id
-        Route::resource('beatmapsets', '\App\Http\Controllers\BeatmapsetsController', ['only' => ['show']]);
+        Route::apiResource('beatmapsets', '\App\Http\Controllers\BeatmapsetsController', ['only' => ['show']]);
 
         // Friends
         //  GET /api/v2/friends
-        Route::resource('friends', '\App\Http\Controllers\FriendsController', ['only' => ['index']]);
+        Route::apiResource('friends', '\App\Http\Controllers\FriendsController', ['only' => ['index']]);
 
         //  GET /api/v2/me
         Route::get('me', '\App\Http\Controllers\UsersController@me');
@@ -333,6 +334,7 @@ Route::group(['as' => 'api.', 'prefix' => 'api', 'namespace' => 'API', 'middlewa
         //  GET /api/v2/users/:user_id/:mode [osu, taiko, fruits, mania]
         Route::get('users/{user}/{mode?}', '\App\Http\Controllers\UsersController@show');
     });
+
     // legacy api routes
     Route::group(['prefix' => 'v1'], function () {
         Route::get('get_match', 'LegacyController@getMatch');

--- a/tests/Controllers/Chat/Channels/MessagesControllerTest.php
+++ b/tests/Controllers/Chat/Channels/MessagesControllerTest.php
@@ -25,6 +25,7 @@ use App\Models\Chat\UserChannel;
 use App\Models\User;
 use App\Models\UserRelation;
 use Faker;
+use Laravel\Passport\Passport;
 use TestCase;
 
 class MessagesControllerTest extends TestCase
@@ -62,21 +63,21 @@ class MessagesControllerTest extends TestCase
 
     public function testChannelShowPublicWhenUnjoined() // fail
     {
-        $this->actingAs($this->user, 'api')
-            ->json('GET', route('api.chat.channels.messages.index', ['channel_id' => $this->publicChannel->channel_id]))
+        Passport::actingAs($this->user, ['read']);
+        $this->json('GET', route('api.chat.channels.messages.index', ['channel_id' => $this->publicChannel->channel_id]))
             ->assertStatus(404);
     }
 
     public function testChannelShowPublicWhenJoined() // success
     {
-        $this->actingAs($this->user, 'api')
-            ->json('PUT', route('api.chat.channels.join', [
+        Passport::actingAs($this->user, ['write']);
+        $this->json('PUT', route('api.chat.channels.join', [
                 'channel_id' => $this->publicChannel->channel_id,
                 'user_id' => $this->user->user_id,
             ]));
 
-        $this->actingAs($this->user, 'api')
-            ->json('GET', route('api.chat.channels.messages.index', ['channel_id' => $this->publicChannel->channel_id]))
+        Passport::actingAs($this->user, ['read']);
+        $this->json('GET', route('api.chat.channels.messages.index', ['channel_id' => $this->publicChannel->channel_id]))
             ->assertStatus(200);
         // TODO: Add check for messages being present?
     }
@@ -92,8 +93,8 @@ class MessagesControllerTest extends TestCase
 
     public function testChannelShowPrivateWhenNotJoined() // fail
     {
-        $this->actingAs($this->user, 'api')
-            ->json('GET', route('api.chat.channels.messages.index', ['channel_id' => $this->privateChannel->channel_id]))
+        Passport::actingAs($this->user, ['read']);
+        $this->json('GET', route('api.chat.channels.messages.index', ['channel_id' => $this->privateChannel->channel_id]))
             ->assertStatus(404);
     }
 
@@ -104,8 +105,8 @@ class MessagesControllerTest extends TestCase
             'channel_id' => $this->privateChannel->channel_id,
         ]);
 
-        $this->actingAs($this->user, 'api')
-            ->json('GET', route('api.chat.channels.messages.index', ['channel_id' => $this->privateChannel->channel_id]))
+        Passport::actingAs($this->user, ['read']);
+        $this->json('GET', route('api.chat.channels.messages.index', ['channel_id' => $this->privateChannel->channel_id]))
             ->assertStatus(200);
     }
 
@@ -120,8 +121,8 @@ class MessagesControllerTest extends TestCase
 
     public function testChannelShowPMWhenNotJoined() // fail
     {
-        $this->actingAs($this->user, 'api')
-            ->json('GET', route('api.chat.channels.messages.index', ['channel_id' => $this->pmChannel->channel_id]))
+        Passport::actingAs($this->user, ['read']);
+        $this->json('GET', route('api.chat.channels.messages.index', ['channel_id' => $this->pmChannel->channel_id]))
             ->assertStatus(404);
     }
 
@@ -138,8 +139,8 @@ class MessagesControllerTest extends TestCase
             'channel_id' => $pmChannel->channel_id,
         ]);
 
-        $this->actingAs($this->user, 'api')
-            ->json('GET', route('api.chat.channels.messages.index', ['channel_id' => $pmChannel->channel_id]))
+        Passport::actingAs($this->user, ['read']);
+        $this->json('GET', route('api.chat.channels.messages.index', ['channel_id' => $pmChannel->channel_id]))
             ->assertStatus(404);
     }
 
@@ -151,8 +152,8 @@ class MessagesControllerTest extends TestCase
             'channel_id' => $pmChannel->channel_id,
         ]);
 
-        $this->actingAs($this->user, 'api')
-            ->json('GET', route('api.chat.channels.messages.index', ['channel_id' => $pmChannel->channel_id]))
+        Passport::actingAs($this->user, ['read']);
+        $this->json('GET', route('api.chat.channels.messages.index', ['channel_id' => $pmChannel->channel_id]))
             ->assertStatus(200);
         // TODO: Add check for messages being present?
     }
@@ -171,8 +172,8 @@ class MessagesControllerTest extends TestCase
 
     public function testChannelSendWhenUnjoined() // fail
     {
-        $this->actingAs($this->user, 'api')
-            ->json(
+        Passport::actingAs($this->user, ['write']);
+        $this->json(
                 'POST',
                 route('api.chat.channels.messages.store', ['channel_id' => $this->publicChannel->channel_id]),
                 ['message' => self::$faker->sentence()]
@@ -184,14 +185,14 @@ class MessagesControllerTest extends TestCase
     {
         $message = self::$faker->sentence();
 
-        $this->actingAs($this->user, 'api')
-            ->json('PUT', route('api.chat.channels.join', [
+        Passport::actingAs($this->user, ['write']);
+
+        $this->json('PUT', route('api.chat.channels.join', [
                 'channel_id' => $this->publicChannel->channel_id,
                 'user_id' => $this->user->user_id,
             ]));
 
-        $this->actingAs($this->user, 'api')
-            ->json(
+        $this->json(
                 'POST',
                 route('api.chat.channels.messages.store', ['channel_id' => $this->publicChannel->channel_id]),
                 ['message' => $message]
@@ -204,8 +205,8 @@ class MessagesControllerTest extends TestCase
     {
         $moderatedChannel = factory(Chat\Channel::class)->states('public')->create(['moderated' => true]);
 
-        $this->actingAs($this->user, 'api')
-            ->json(
+        Passport::actingAs($this->user, ['write']);
+        $this->json(
                 'POST',
                 route('api.chat.channels.messages.store', ['channel_id' => $moderatedChannel->channel_id]),
                 ['message' => self::$faker->sentence()]
@@ -229,8 +230,8 @@ class MessagesControllerTest extends TestCase
             'zebra_id' => $this->anotherUser->user_id,
         ]);
 
-        $this->actingAs($this->user, 'api')
-            ->json(
+        Passport::actingAs($this->user, ['write']);
+        $this->json(
                 'POST',
                 route('api.chat.channels.messages.store', ['channel_id' => $pmChannel->channel_id]),
                 ['message' => self::$faker->sentence()]
@@ -254,8 +255,8 @@ class MessagesControllerTest extends TestCase
             'zebra_id' => $this->user->user_id,
         ]);
 
-        $this->actingAs($this->user, 'api')
-            ->json(
+        Passport::actingAs($this->user, ['write']);
+        $this->json(
                 'POST',
                 route('api.chat.channels.messages.store', ['channel_id' => $pmChannel->channel_id]),
                 ['message' => self::$faker->sentence()]
@@ -276,8 +277,8 @@ class MessagesControllerTest extends TestCase
             'channel_id' => $pmChannel->channel_id,
         ]);
 
-        $this->actingAs($this->restrictedUser, 'api')
-            ->json(
+        Passport::actingAs($this->restrictedUser, ['write']);
+        $this->json(
                 'POST',
                 route('api.chat.channels.messages.store', ['channel_id' => $pmChannel->channel_id]),
                 ['message' => self::$faker->sentence()]
@@ -287,14 +288,14 @@ class MessagesControllerTest extends TestCase
 
     public function testChannelSendWhenRestrictedToPublic() // fail
     {
-        $this->actingAs($this->restrictedUser, 'api')
-            ->json('PUT', route('api.chat.channels.join', [
+        Passport::actingAs($this->restrictedUser, ['write']);
+
+        $this->json('PUT', route('api.chat.channels.join', [
                 'channel_id' => $this->publicChannel->channel_id,
                 'user_id' => $this->restrictedUser->user_id,
             ]));
 
-        $this->actingAs($this->restrictedUser, 'api')
-            ->json(
+        $this->json(
                 'POST',
                 route('api.chat.channels.messages.store', ['channel_id' => $this->publicChannel->channel_id]),
                 ['message' => self::$faker->sentence()]
@@ -315,8 +316,8 @@ class MessagesControllerTest extends TestCase
             'channel_id' => $pmChannel->channel_id,
         ]);
 
-        $this->actingAs($this->user, 'api')
-            ->json(
+        Passport::actingAs($this->user, ['write']);
+        $this->json(
                 'POST',
                 route('api.chat.channels.messages.store', ['channel_id' => $pmChannel->channel_id]),
                 ['message' => self::$faker->sentence()]
@@ -337,8 +338,8 @@ class MessagesControllerTest extends TestCase
             'channel_id' => $pmChannel->channel_id,
         ]);
 
-        $this->actingAs($this->silencedUser, 'api')
-            ->json(
+        Passport::actingAs($this->silencedUser, ['write']);
+        $this->json(
                 'POST',
                 route('api.chat.channels.messages.store', ['channel_id' => $pmChannel->channel_id]),
                 ['message' => self::$faker->sentence()]
@@ -348,14 +349,14 @@ class MessagesControllerTest extends TestCase
 
     public function testChannelSendWhenSilencedToPublic() // fail
     {
-        $this->actingAs($this->silencedUser, 'api')
-            ->json('PUT', route('api.chat.channels.join', [
+        Passport::actingAs($this->silencedUser, ['write']);
+
+        $this->json('PUT', route('api.chat.channels.join', [
                 'channel_id' => $this->publicChannel->channel_id,
                 'user_id' => $this->silencedUser->user_id,
             ]));
 
-        $this->actingAs($this->silencedUser, 'api')
-            ->json(
+        $this->json(
                 'POST',
                 route('api.chat.channels.messages.store', ['channel_id' => $this->publicChannel->channel_id]),
                 ['message' => self::$faker->sentence()]

--- a/tests/Controllers/Chat/Channels/MessagesControllerTest.php
+++ b/tests/Controllers/Chat/Channels/MessagesControllerTest.php
@@ -61,6 +61,13 @@ class MessagesControllerTest extends TestCase
             ->assertStatus(401);
     }
 
+    public function testChannelShowPublicWithoutScopes() // fail
+    {
+        Passport::actingAs($this->user, []);
+        $this->json('GET', route('api.chat.channels.messages.index', ['channel_id' => $this->publicChannel->channel_id]))
+            ->assertStatus(403);
+    }
+
     public function testChannelShowPublicWhenUnjoined() // fail
     {
         Passport::actingAs($this->user, ['read']);
@@ -91,6 +98,13 @@ class MessagesControllerTest extends TestCase
             ->assertStatus(401);
     }
 
+    public function testChannelShowPrivateWithoutScopes() // fail
+    {
+        Passport::actingAs($this->user, []);
+        $this->json('GET', route('api.chat.channels.messages.index', ['channel_id' => $this->privateChannel->channel_id]))
+            ->assertStatus(403);
+    }
+
     public function testChannelShowPrivateWhenNotJoined() // fail
     {
         Passport::actingAs($this->user, ['read']);
@@ -117,6 +131,13 @@ class MessagesControllerTest extends TestCase
     {
         $this->json('GET', route('api.chat.channels.messages.index', ['channel_id' => $this->pmChannel->channel_id]))
             ->assertStatus(401);
+    }
+
+    public function testChannelShowPMWithoutScopes() // fail
+    {
+        Passport::actingAs($this->user, []);
+        $this->json('GET', route('api.chat.channels.messages.index', ['channel_id' => $this->pmChannel->channel_id]))
+            ->assertStatus(403);
     }
 
     public function testChannelShowPMWhenNotJoined() // fail
@@ -168,6 +189,16 @@ class MessagesControllerTest extends TestCase
             route('api.chat.channels.messages.store', ['channel_id' => $this->publicChannel->channel_id]),
             ['message' => self::$faker->sentence()]
         )->assertStatus(401);
+    }
+
+    public function testChannelSendWithoutScopes() // fail
+    {
+        Passport::actingAs($this->user, []);
+        $this->json(
+            'POST',
+            route('api.chat.channels.messages.store', ['channel_id' => $this->publicChannel->channel_id]),
+            ['message' => self::$faker->sentence()]
+        )->assertStatus(403);
     }
 
     public function testChannelSendWhenUnjoined() // fail

--- a/tests/Controllers/Chat/ChannelsControllerTest.php
+++ b/tests/Controllers/Chat/ChannelsControllerTest.php
@@ -75,6 +75,16 @@ class ChannelsControllerTest extends TestCase
             ->assertStatus(401);
     }
 
+    public function testChannelJoinPublicWithoutScopes() // fail
+    {
+        Passport::actingAs($this->user, []);
+        $this->json('PUT', route('api.chat.channels.join', [
+                'channel_id' => $this->publicChannel->channel_id,
+                'user_id' => $this->user->user_id,
+            ]))
+            ->assertStatus(403);
+    }
+
     public function testChannelJoinPublicWhenDifferentUser() // fail
     {
         Passport::actingAs($this->user, ['write']);
@@ -168,6 +178,19 @@ class ChannelsControllerTest extends TestCase
             ])
         )
         ->assertStatus(401);
+    }
+
+    public function testChannelMarkAsReadWithoutScopes() // fail
+    {
+        Passport::actingAs($this->user, []);
+        $this->json(
+            'PUT',
+            route('api.chat.channels.mark-as-read', [
+                'channel_id' => $this->publicChannel->channel_id,
+                'message_id' => $this->publicMessage->message_id,
+            ])
+        )
+        ->assertStatus(403);
     }
 
     public function testChannelMarkAsReadWhenUnjoined() // fail
@@ -267,6 +290,16 @@ class ChannelsControllerTest extends TestCase
                 'user_id' => $this->user->user_id,
             ]))
             ->assertStatus(401);
+    }
+
+    public function testChannelLeaveWithoutScopes() // fail
+    {
+        Passport::actingAs($this->user, []);
+        $this->json('DELETE', route('api.chat.channels.part', [
+                'channel_id' => $this->publicChannel->channel_id,
+                'user_id' => $this->user->user_id,
+            ]))
+            ->assertStatus(403);
     }
 
     public function testChannelLeaveWhenNotPublic() // fail

--- a/tests/Controllers/Chat/ChannelsControllerTest.php
+++ b/tests/Controllers/Chat/ChannelsControllerTest.php
@@ -22,6 +22,7 @@ namespace Tests\Chat;
 use App\Models\Chat;
 use App\Models\User;
 use Faker;
+use Laravel\Passport\Passport;
 use TestCase;
 
 class ChannelsControllerTest extends TestCase
@@ -54,8 +55,8 @@ class ChannelsControllerTest extends TestCase
 
     public function testChannelIndex()
     {
-        $this->actingAs($this->user, 'api')
-            ->json('GET', route('api.chat.channels.index'))
+        Passport::actingAs($this->user, []);
+        $this->json('GET', route('api.chat.channels.index'))
             ->assertStatus(200)
             ->assertJsonFragment(['channel_id' => $this->publicChannel->channel_id])
             ->assertJsonMissing(['channel_id' => $this->privateChannel->channel_id])
@@ -76,8 +77,8 @@ class ChannelsControllerTest extends TestCase
 
     public function testChannelJoinPublicWhenDifferentUser() // fail
     {
-        $this->actingAs($this->user, 'api')
-            ->json('PUT', route('api.chat.channels.join', [
+        Passport::actingAs($this->user, ['write']);
+        $this->json('PUT', route('api.chat.channels.join', [
                 'channel_id' => $this->publicChannel->channel_id,
                 'user_id' => $this->anotherUser->user_id,
             ]))
@@ -86,8 +87,8 @@ class ChannelsControllerTest extends TestCase
 
     public function testChannelJoinNonPublic() // fail
     {
-        $this->actingAs($this->user, 'api')
-            ->json('PUT', route('api.chat.channels.join', [
+        Passport::actingAs($this->user, ['write']);
+        $this->json('PUT', route('api.chat.channels.join', [
                 'channel_id' => $this->privateChannel->channel_id,
                 'user_id' => $this->user->user_id,
             ]))
@@ -97,22 +98,22 @@ class ChannelsControllerTest extends TestCase
     public function testChannelJoinPublic() // succeed
     {
         // ensure not in channel
-        $this->actingAs($this->user, 'api')
-            ->json('GET', route('api.chat.presence'))
+        Passport::actingAs($this->user, ['read']);
+        $this->json('GET', route('api.chat.presence'))
             ->assertStatus(200)
             ->assertJsonMissing(['channel_id' => $this->publicChannel->channel_id]);
 
         // join channel
-        $this->actingAs($this->user, 'api')
-            ->json('PUT', route('api.chat.channels.join', [
+        Passport::actingAs($this->user, ['write']);
+        $this->json('PUT', route('api.chat.channels.join', [
                 'channel_id' => $this->publicChannel->channel_id,
                 'user_id' => $this->user->user_id,
             ]))
             ->assertStatus(204);
 
         // ensure now in channel
-        $this->actingAs($this->user, 'api')
-            ->json('GET', route('api.chat.presence'))
+        Passport::actingAs($this->user, ['read']);
+        $this->json('GET', route('api.chat.presence'))
             ->assertStatus(200)
             ->assertJsonFragment(['channel_id' => $this->publicChannel->channel_id]);
     }
@@ -120,36 +121,36 @@ class ChannelsControllerTest extends TestCase
     public function testChannelJoinPublicWhenAlreadyJoined() // succeed
     {
         // ensure not in channel
-        $this->actingAs($this->user, 'api')
-            ->json('GET', route('api.chat.presence'))
+        Passport::actingAs($this->user, ['read']);
+        $this->json('GET', route('api.chat.presence'))
             ->assertStatus(200)
             ->assertJsonMissing(['channel_id' => $this->publicChannel->channel_id]);
 
         // join channel
-        $this->actingAs($this->user, 'api')
-            ->json('PUT', route('api.chat.channels.join', [
+        Passport::actingAs($this->user, ['write']);
+        $this->json('PUT', route('api.chat.channels.join', [
                 'channel_id' => $this->publicChannel->channel_id,
                 'user_id' => $this->user->user_id,
             ]))
             ->assertStatus(204);
 
         // ensure now in channel
-        $this->actingAs($this->user, 'api')
-            ->json('GET', route('api.chat.presence'))
+        Passport::actingAs($this->user, ['read']);
+        $this->json('GET', route('api.chat.presence'))
             ->assertStatus(200)
             ->assertJsonFragment(['channel_id' => $this->publicChannel->channel_id]);
 
         // attempt to join channel again
-        $this->actingAs($this->user, 'api')
-            ->json('PUT', route('api.chat.channels.join', [
+        Passport::actingAs($this->user, ['write']);
+        $this->json('PUT', route('api.chat.channels.join', [
                 'channel_id' => $this->publicChannel->channel_id,
                 'user_id' => $this->user->user_id,
             ]))
             ->assertStatus(204);
 
         // ensure still in channel
-        $this->actingAs($this->user, 'api')
-            ->json('GET', route('api.chat.presence'))
+        Passport::actingAs($this->user, ['read']);
+        $this->json('GET', route('api.chat.presence'))
             ->assertStatus(200)
             ->assertJsonFragment(['channel_id' => $this->publicChannel->channel_id]);
     }
@@ -171,8 +172,8 @@ class ChannelsControllerTest extends TestCase
 
     public function testChannelMarkAsReadWhenUnjoined() // fail
     {
-        $this->actingAs($this->user, 'api')
-            ->json(
+        Passport::actingAs($this->user, ['write']);
+        $this->json(
                 'PUT',
                 route('api.chat.channels.mark-as-read', [
                     'channel_id' => $this->publicChannel->channel_id,
@@ -184,14 +185,13 @@ class ChannelsControllerTest extends TestCase
 
     public function testChannelMarkAsReadWhenJoined() // success
     {
-        $this->actingAs($this->user, 'api')
-            ->json('PUT', route('api.chat.channels.join', [
+        Passport::actingAs($this->user, ['write']);
+        $this->json('PUT', route('api.chat.channels.join', [
                 'channel_id' => $this->publicChannel->channel_id,
                 'user_id' => $this->user->user_id,
             ]));
 
-        $this->actingAs($this->user, 'api')
-            ->json(
+        $this->json(
                 'PUT',
                 route('api.chat.channels.mark-as-read', [
                     'channel_id' => $this->publicChannel->channel_id,
@@ -200,8 +200,8 @@ class ChannelsControllerTest extends TestCase
             )
             ->assertStatus(204);
 
-        $this->actingAs($this->user, 'api')
-            ->json('GET', route('api.chat.presence'))
+        Passport::actingAs($this->user, ['read']);
+        $this->json('GET', route('api.chat.presence'))
             ->assertStatus(200)
             ->assertJsonFragment([
                 'channel_id' => $this->publicChannel->channel_id,
@@ -213,15 +213,14 @@ class ChannelsControllerTest extends TestCase
     {
         $newerPublicMessage = factory(Chat\Message::class)->create(['channel_id' => $this->publicChannel->channel_id]);
 
-        $this->actingAs($this->user, 'api')
-            ->json('PUT', route('api.chat.channels.join', [
+        Passport::actingAs($this->user, ['write']);
+        $this->json('PUT', route('api.chat.channels.join', [
                 'channel_id' => $this->publicChannel->channel_id,
                 'user_id' => $this->user->user_id,
             ]));
 
         // mark as read to $newerPublicMessage->message_id
-        $this->actingAs($this->user, 'api')
-            ->json(
+        $this->json(
                 'PUT',
                 route('api.chat.channels.mark-as-read', [
                     'channel_id' => $this->publicChannel->channel_id,
@@ -230,8 +229,8 @@ class ChannelsControllerTest extends TestCase
             )
             ->assertStatus(204);
 
-        $this->actingAs($this->user, 'api')
-            ->json('GET', route('api.chat.presence'))
+        Passport::actingAs($this->user, ['read']);
+        $this->json('GET', route('api.chat.presence'))
             ->assertStatus(200)
             ->assertJsonFragment([
                 'channel_id' => $this->publicChannel->channel_id,
@@ -239,8 +238,8 @@ class ChannelsControllerTest extends TestCase
             ]);
 
         // attempt to mark as read to the older $this->publicMessage->message_id
-        $this->actingAs($this->user, 'api')
-            ->json(
+        Passport::actingAs($this->user, ['write']);
+        $this->json(
                 'PUT',
                 route('api.chat.channels.mark-as-read', [
                     'channel_id' => $this->publicChannel->channel_id,
@@ -249,8 +248,8 @@ class ChannelsControllerTest extends TestCase
             )
             ->assertStatus(204);
 
-        $this->actingAs($this->user, 'api')
-            ->json('GET', route('api.chat.presence'))
+        Passport::actingAs($this->user, ['read']);
+        $this->json('GET', route('api.chat.presence'))
             ->assertStatus(200)
             ->assertJsonFragment([
                 'channel_id' => $this->publicChannel->channel_id,
@@ -272,8 +271,8 @@ class ChannelsControllerTest extends TestCase
 
     public function testChannelLeaveWhenNotPublic() // fail
     {
-        $this->actingAs($this->user, 'api')
-            ->json('DELETE', route('api.chat.channels.part', [
+        Passport::actingAs($this->user, ['write']);
+        $this->json('DELETE', route('api.chat.channels.part', [
                 'channel_id' => $this->privateChannel->channel_id,
                 'user_id' => $this->user->user_id,
             ]))
@@ -282,20 +281,20 @@ class ChannelsControllerTest extends TestCase
 
     public function testChannelLeaveWhenNotJoined() // success ?
     {
-        $this->actingAs($this->user, 'api')
-            ->json('GET', route('api.chat.presence'))
+        Passport::actingAs($this->user, ['read']);
+        $this->json('GET', route('api.chat.presence'))
             ->assertStatus(200)
             ->assertJsonMissing(['channel_id' => $this->publicChannel->channel_id]);
 
-        $this->actingAs($this->user, 'api')
-            ->json('DELETE', route('api.chat.channels.part', [
+        Passport::actingAs($this->user, ['write']);
+        $this->json('DELETE', route('api.chat.channels.part', [
                 'channel_id' => $this->publicChannel->channel_id,
                 'user_id' => $this->user->user_id,
             ]))
             ->assertStatus(204);
 
-        $this->actingAs($this->user, 'api')
-            ->json('GET', route('api.chat.presence'))
+        Passport::actingAs($this->user, ['read']);
+        $this->json('GET', route('api.chat.presence'))
             ->assertStatus(200)
             ->assertJsonMissing(['channel_id' => $this->publicChannel->channel_id]);
     }
@@ -303,36 +302,36 @@ class ChannelsControllerTest extends TestCase
     public function testChannelLeaveWhenJoined() // success
     {
         // ensure not in channel
-        $this->actingAs($this->user, 'api')
-            ->json('GET', route('api.chat.presence'))
+        Passport::actingAs($this->user, ['read']);
+        $this->json('GET', route('api.chat.presence'))
             ->assertStatus(200)
             ->assertJsonMissing(['channel_id' => $this->publicChannel->channel_id]);
 
         // join channel
-        $this->actingAs($this->user, 'api')
-            ->json('PUT', route('api.chat.channels.join', [
+        Passport::actingAs($this->user, ['write']);
+        $this->json('PUT', route('api.chat.channels.join', [
                 'channel_id' => $this->publicChannel->channel_id,
                 'user_id' => $this->user->user_id,
             ]))
             ->assertStatus(204);
 
         // ensure now in channel
-        $this->actingAs($this->user, 'api')
-            ->json('GET', route('api.chat.presence'))
+        Passport::actingAs($this->user, ['read']);
+        $this->json('GET', route('api.chat.presence'))
             ->assertStatus(200)
             ->assertJsonFragment(['channel_id' => $this->publicChannel->channel_id]);
 
         // leave channel
-        $this->actingAs($this->user, 'api')
-            ->json('DELETE', route('api.chat.channels.part', [
+        Passport::actingAs($this->user, ['write']);
+        $this->json('DELETE', route('api.chat.channels.part', [
                 'channel_id' => $this->publicChannel->channel_id,
                 'user_id' => $this->user->user_id,
             ]))
             ->assertStatus(204);
 
         // ensure no longer in channel
-        $this->actingAs($this->user, 'api')
-            ->json('GET', route('api.chat.presence'))
+        Passport::actingAs($this->user, ['read']);
+        $this->json('GET', route('api.chat.presence'))
             ->assertStatus(200)
             ->assertJsonMissing(['channel_id' => $this->publicChannel->channel_id]);
     }

--- a/tests/Controllers/Chat/ChatControllerTest.php
+++ b/tests/Controllers/Chat/ChatControllerTest.php
@@ -71,6 +71,19 @@ class ChatControllerTest extends TestCase
         )->assertStatus(401);
     }
 
+    public function testCreatePMWithoutScopes() // fail
+    {
+        Passport::actingAs($this->user, []);
+        $this->json(
+            'POST',
+            route('api.chat.new'),
+            [
+                'target_id' => $this->anotherUser->user_id,
+                'message' => self::$faker->sentence(),
+            ]
+        )->assertStatus(403);
+    }
+
     public function testCreatePMWhenBlocked() // fail
     {
         factory(UserRelation::class)->states('block')->create([
@@ -231,6 +244,13 @@ class ChatControllerTest extends TestCase
             ->assertStatus(401);
     }
 
+    public function testChatPresenceWithoutScopes() // fail
+    {
+        Passport::actingAs($this->user, []);
+        $this->json('GET', route('api.chat.presence'))
+            ->assertStatus(403);
+    }
+
     public function testChatPresence() // success
     {
         $publicChannel = factory(Chat\Channel::class)->states('public')->create();
@@ -335,6 +355,13 @@ class ChatControllerTest extends TestCase
     {
         $this->json('GET', route('api.chat.updates'))
             ->assertStatus(401);
+    }
+
+    public function testChatUpdatesWithoutScopes() // fail
+    {
+        Passport::actingAs($this->user, []);
+        $this->json('GET', route('api.chat.updates'))
+            ->assertStatus(403);
     }
 
     public function testChatUpdatesWithNoNewMessages() // success


### PR DESCRIPTION
closes #3857 

~~adds five scopes: `beatmapset.download`, `chat.read`, `chat.write`, `user.identify` and `user.read`~~
https://github.com/ppy/osu-web/pull/3863#issuecomment-436904257

---