### PR TITLE
Replace timeago with moment

### DIFF
--- a/config/app.php
+++ b/config/app.php
@@ -79,7 +79,7 @@ return [
     'locale' => 'en',
 
     /*
-     * Make sure to check locale name in timeago, momentjs, and carbon.
+     * Make sure to check locale name in momentjs, and carbon.
      * Carbon is in Http\Middleware\SetLocale (no helper... yet?).
      * momentjs and timeago are in helper (locale_for_*).
      * Check respective packages for supported list of languages.

--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
     "react-virtual-list": "^2.2.4",
     "require-dir": "^0.3.2",
     "retina.js": "^1.1.0",
-    "timeago": "^1.5.0",
     "turbolinks": "^5.1.1",
     "url-polyfill": "^1.0.10",
     "webpack-sentry-plugin": "^1.9.2"

--- a/resources/assets/coffee/_classes/timeago.coffee
+++ b/resources/assets/coffee/_classes/timeago.coffee
@@ -25,21 +25,18 @@ class @Timeago
           addedNode.querySelectorAll && addedNode.querySelectorAll('.timeago').forEach (node) =>
             @moment node
 
-
     $(document).on 'turbolinks:load', =>
       document.querySelectorAll('.timeago').forEach (node) =>
         @moment node
 
       @observer.observe document.body, childList: true, subtree: true
 
-      setInterval () =>
-        document.querySelectorAll('.timeago').forEach (node) =>
-          @moment node
-      , 60000
-
+    @constructor.timer ?= setInterval () =>
+      document.querySelectorAll('.timeago').forEach (node) =>
+        @moment node
+    , 60000
 
   moment: (elem) ->
     datetime = elem.getAttribute('datetime')
     from_now = moment(datetime).fromNow()
-
     elem.textContent = from_now

--- a/resources/assets/coffee/_classes/timeago.coffee
+++ b/resources/assets/coffee/_classes/timeago.coffee
@@ -36,6 +36,7 @@ class @Timeago
         @moment node
     , 60000
 
+
   moment: (elem) ->
     datetime = elem.getAttribute('datetime')
     from_now = moment(datetime).fromNow()

--- a/resources/assets/coffee/_classes/timeago.coffee
+++ b/resources/assets/coffee/_classes/timeago.coffee
@@ -18,15 +18,23 @@
 
 class @Timeago
   constructor: ->
-    @observer = new MutationObserver (mutations) ->
-      # Third-party scripts may init conflicting versions of jquery
-      return unless $.fn.timeago
-
-      mutations.forEach (mutation) ->
-        $nodes = $(mutation.addedNodes)
-        $nodes.find('.timeago').add($nodes.filter('.timeago')).timeago()
+    @observer = new MutationObserver (mutations) =>
+      mutations.forEach (mutation) =>
+        mutation.addedNodes.forEach (addedNode) =>
+          # not all node types have querySelectorAll
+          addedNode.querySelectorAll && addedNode.querySelectorAll('.timeago').forEach (node) =>
+            @moment node
 
 
     $(document).on 'turbolinks:load', =>
-      $('.timeago').timeago()
+      document.querySelectorAll('.timeago').forEach (node) =>
+        @moment node
+
       @observer.observe document.body, childList: true, subtree: true
+
+
+  moment: (elem) ->
+    datetime = elem.getAttribute('datetime')
+    from_now = moment(datetime).fromNow()
+
+    elem.textContent = from_now

--- a/resources/assets/coffee/_classes/timeago.coffee
+++ b/resources/assets/coffee/_classes/timeago.coffee
@@ -32,6 +32,11 @@ class @Timeago
 
       @observer.observe document.body, childList: true, subtree: true
 
+      setInterval () =>
+        document.querySelectorAll('.timeago').forEach (node) =>
+          @moment node
+      , 60000
+
 
   moment: (elem) ->
     datetime = elem.getAttribute('datetime')

--- a/resources/assets/coffee/_classes/timeago.coffee
+++ b/resources/assets/coffee/_classes/timeago.coffee
@@ -40,3 +40,4 @@ class @Timeago
     datetime = elem.getAttribute('datetime')
     from_now = moment(datetime).fromNow()
     elem.textContent = from_now
+    elem.title = datetime

--- a/resources/assets/coffee/main.coffee
+++ b/resources/assets/coffee/main.coffee
@@ -21,6 +21,7 @@
 Turbolinks.setProgressBarDelay(0)
 
 Lang.setLocale(currentLocale)
+moment.relativeTimeRounding(Math.floor)
 
 # loading animation overlay
 # fired from turbolinks

--- a/resources/assets/coffee/main.coffee
+++ b/resources/assets/coffee/main.coffee
@@ -21,7 +21,6 @@
 Turbolinks.setProgressBarDelay(0)
 
 Lang.setLocale(currentLocale)
-jQuery.timeago.settings.allowFuture = true
 
 # loading animation overlay
 # fired from turbolinks

--- a/resources/views/layout/metadata.blade.php
+++ b/resources/views/layout/metadata.blade.php
@@ -87,7 +87,6 @@
 @endif
 <script src="{{ mix("js/app-deps.js") }}" data-turbolinks-track="reload"></script>
 <script src="{{ mix("js/app.js") }}" data-turbolinks-track="reload"></script>
-<script src="/vendor/js/timeago-locales/jquery.timeago.{{ locale_for_timeago(Lang::getLocale()) }}.js" data-turbolinks-track="reload"></script>
 <script src="//s.ppy.sh/js/site-switcher.js?{{config('osu.site-switcher-js-hash')}}" async></script>
 
 @if (($momentLocale = locale_for_moment(Lang::getLocale())) !== null)

--- a/webpack.mix.js
+++ b/webpack.mix.js
@@ -61,7 +61,6 @@ const vendor = [
   path.join(node_root, 'jquery-ui/ui/widgets/slider.js'),
   path.join(node_root, 'jquery-ui/ui/widgets/sortable.js'),
   path.join(node_root, 'jquery-ui/ui/keycode.js'),
-  path.join(node_root, 'timeago/jquery.timeago.js'),
   path.join(node_root, 'blueimp-file-upload/js/jquery.fileupload.js'),
   path.join(node_root, 'bootstrap/dist/js/bootstrap.js'),
   path.join(node_root, 'lodash/lodash.js'),
@@ -194,7 +193,6 @@ mix
 ], 'js/react/contest-voting.js')
 .copy('node_modules/@fortawesome/fontawesome-free-webfonts/webfonts', 'public/vendor/fonts/font-awesome')
 .copy('node_modules/photoswipe/dist/default-skin', 'public/vendor/_photoswipe-default-skin')
-.copy('node_modules/timeago/locales', 'public/vendor/js/timeago-locales')
 .copy('node_modules/moment/locale', 'public/vendor/js/moment-locales')
 .less('resources/assets/less/app.less', 'public/css')
 .scripts([

--- a/yarn.lock
+++ b/yarn.lock
@@ -3550,7 +3550,7 @@ jquery.scrollto@^2.1.2:
   dependencies:
     jquery ">=1.8"
 
-jquery@>=1.2.3, jquery@>=1.6.0, jquery@>=1.8, jquery@>=1.8.0:
+jquery@>=1.6.0, jquery@>=1.8, jquery@>=1.8.0:
   version "3.2.1"
   resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.2.1.tgz#5c4d9de652af6cd0a770154a631bba12b015c787"
 
@@ -6146,12 +6146,6 @@ time-stamp@^1.0.0:
 time-stamp@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/time-stamp/-/time-stamp-2.0.0.tgz#95c6a44530e15ba8d6f4a3ecb8c3a3fac46da357"
-
-timeago@^1.5.0:
-  version "1.6.1"
-  resolved "https://registry.yarnpkg.com/timeago/-/timeago-1.6.1.tgz#fa9aa932e6cfae1f0c9b62f49d8a6071fdf69c5b"
-  dependencies:
-    jquery ">=1.2.3"
 
 timed-out@^3.0.0:
   version "3.1.3"


### PR DESCRIPTION
Removes `timeago` library and uses `moment` for relative time display.
We're already using `moment` for the tooltips so `timeago` itself offers very little of use.
<em>updates automatically</em>

Also set relative times to round down; closes #3762

~~whoops, need more fixes first :D~~

---
