### PR TITLE
Fix not being able to see forum posts with a poll

### DIFF
--- a/app/Libraries/OsuAuthorize.php
+++ b/app/Libraries/OsuAuthorize.php
@@ -941,7 +941,7 @@ class OsuAuthorize
 
         $forumTopicStorePermission = $this->doCheckUser($user, 'ForumTopicStore', $topic->forum);
         if (!$forumTopicStorePermission->can()) {
-            return $postStorePermission->rawMessage();
+            return $forumTopicStorePermission->rawMessage();
         }
 
         if ($topic->posts()->withTrashed()->first()->poster_id === $user->user_id) {


### PR DESCRIPTION
wrong variable name :fire:

Basically for about an hour only the poll creator and moderators could see the post until the editable period expires

closes #3893

---
