### PR TITLE
Use priv_check for joining/leaving channel

### DIFF
--- a/app/Http/Controllers/Chat/ChannelsController.php
+++ b/app/Http/Controllers/Chat/ChannelsController.php
@@ -37,8 +37,9 @@ class ChannelsController extends Controller
 
     public function join($channel_id, $user_id)
     {
-        // FIXME: Update this to proper permission check when public-only restriction is lifted
-        $channel = Channel::public()->where('channel_id', $channel_id)->firstOrFail();
+        $channel = Channel::where('channel_id', $channel_id)->firstOrFail();
+
+        priv_check('ChatChannelJoin', $channel)->ensureCan();
 
         if (Auth::user()->user_id !== get_int($user_id)) {
             abort(403);

--- a/app/Http/Controllers/Chat/ChannelsController.php
+++ b/app/Http/Controllers/Chat/ChannelsController.php
@@ -54,8 +54,10 @@ class ChannelsController extends Controller
 
     public function part($channel_id, $user_id)
     {
-        // FIXME: Update this to proper permission check when public-only restriction is lifted
-        $channel = Channel::public()->where('channel_id', $channel_id)->firstOrFail();
+        $channel = Channel::where('channel_id', $channel_id)->firstOrFail();
+
+        // FIXME: doesn't seem right authorizing leaving channel
+        priv_check('ChatChannelJoin', $channel)->ensureCan();
 
         if (Auth::user()->user_id !== get_int($user_id)) {
             abort(403);

--- a/app/Libraries/OsuAuthorize.php
+++ b/app/Libraries/OsuAuthorize.php
@@ -540,36 +540,43 @@ class OsuAuthorize
         $this->ensureLoggedIn($user);
         $this->ensureCleanRecord($user, $prefix);
 
-        switch ($channel->type) {
-            case Channel::TYPES['public']:
-                return 'ok';
+        if ($channel->type === Channel::TYPES['public']) {
+            return 'ok';
+        }
 
-            case Channel::TYPES['private']:
-                $commonGroupIds = array_intersect(
-                    $user->groupIds(),
-                    $channel->allowed_groups
-                );
-
-                if (count($commonGroupIds) > 0) {
+        // FIXME: needs further check before allowing other types.
+        if (false) {
+            switch ($channel->type) {
+                case Channel::TYPES['public']:
                     return 'ok';
-                }
-                break;
 
-            case Channel::TYPES['spectator']:
-            case Channel::TYPES['multiplayer']:
-            case Channel::TYPES['temporary']: // this and the comparisons below are needed until bancho is updated to use the new channel types
-                if (starts_with($channel->name, '#spect_')) {
-                    return 'ok';
-                }
+                case Channel::TYPES['private']:
+                    $commonGroupIds = array_intersect(
+                        $user->groupIds(),
+                        $channel->allowed_groups
+                    );
 
-                if (starts_with($channel->name, '#mp_')) {
-                    $matchId = intval(str_replace('#mp_', '', $channel->name));
-
-                    if (in_array($user->user_id, MultiplayerMatch::findOrFail($matchId)->currentPlayers(), true)) {
+                    if (count($commonGroupIds) > 0) {
                         return 'ok';
                     }
-                }
-                break;
+                    break;
+
+                case Channel::TYPES['spectator']:
+                case Channel::TYPES['multiplayer']:
+                case Channel::TYPES['temporary']: // this and the comparisons below are needed until bancho is updated to use the new channel types
+                    if (starts_with($channel->name, '#spect_')) {
+                        return 'ok';
+                    }
+
+                    if (starts_with($channel->name, '#mp_')) {
+                        $matchId = intval(str_replace('#mp_', '', $channel->name));
+
+                        if (in_array($user->user_id, MultiplayerMatch::findOrFail($matchId)->currentPlayers(), true)) {
+                            return 'ok';
+                        }
+                    }
+                    break;
+            }
         }
 
         return $prefix.'no_access';

--- a/app/Models/Chat/Channel.php
+++ b/app/Models/Chat/Channel.php
@@ -152,11 +152,6 @@ class Channel extends Model
 
     public function addUser(User $user)
     {
-        // TODO: Remove this when join restriction is lifted
-        if ($this->type !== self::TYPES['public']) {
-            return;
-        }
-
         $userChannel = new UserChannel();
         $userChannel->user()->associate($user);
         $userChannel->channel()->associate($this);

--- a/tests/Controllers/Chat/ChannelsControllerTest.php
+++ b/tests/Controllers/Chat/ChannelsControllerTest.php
@@ -91,7 +91,7 @@ class ChannelsControllerTest extends TestCase
                 'channel_id' => $this->privateChannel->channel_id,
                 'user_id' => $this->user->user_id,
             ]))
-            ->assertStatus(404);
+            ->assertStatus(403);
     }
 
     public function testChannelJoinPublic() // succeed

--- a/tests/Controllers/Chat/ChannelsControllerTest.php
+++ b/tests/Controllers/Chat/ChannelsControllerTest.php
@@ -277,7 +277,7 @@ class ChannelsControllerTest extends TestCase
                 'channel_id' => $this->privateChannel->channel_id,
                 'user_id' => $this->user->user_id,
             ]))
-            ->assertStatus(404);
+            ->assertStatus(403);
     }
 
     public function testChannelLeaveWhenNotJoined() // success ?


### PR DESCRIPTION
- use (and update) `ChatChannelJoin` auth check
  - allow admin to join any channels
  - only allow channel type public for others for now
  - return code on joining non-public channel is changed (from 404 to 403) but should be fine because `channelId` doesn't give out much information?
  - not sure why it's never used ?_?
- remove type check in `addUser`/`removeUser`
  - only one place is using it (and already checked) so it should be safe
  - it looks like `ChatController#newConversation` can be updated to use `addUser`