### PR TITLE
Apply OAuth permission scoping to API

### DIFF
--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -28,6 +28,7 @@ use Illuminate\Auth\AuthenticationException;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Foundation\Exceptions\Handler as ExceptionHandler;
 use Illuminate\Session\TokenMismatchException;
+use Laravel\Passport\Exceptions\MissingScopeException;
 use Sentry;
 use Symfony\Component\HttpKernel\Exception\NotFoundHttpException;
 
@@ -176,7 +177,7 @@ class Handler extends ExceptionHandler
             return 403;
         } elseif ($e instanceof AuthenticationException) {
             return 401;
-        } elseif ($e instanceof AuthorizationException) {
+        } elseif ($e instanceof AuthorizationException || $e instanceof MissingScopeException) {
             return 403;
         } else {
             return 500;

--- a/app/Http/Controllers/AuthorizationController.php
+++ b/app/Http/Controllers/AuthorizationController.php
@@ -1,0 +1,48 @@
+<?php
+
+/**
+ *    Copyright 2015-2017 ppy Pty. Ltd.
+ *
+ *    This file is part of osu!web. osu!web is distributed with the hope of
+ *    attracting more community contributions to the core ecosystem of osu!.
+ *
+ *    osu!web is free software: you can redistribute it and/or modify
+ *    it under the terms of the Affero GNU General Public License version 3
+ *    as published by the Free Software Foundation.
+ *
+ *    osu!web is distributed WITHOUT ANY WARRANTY; without even the implied
+ *    warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *    See the GNU Affero General Public License for more details.
+ *
+ *    You should have received a copy of the GNU Affero General Public License
+ *    along with osu!web.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace App\Http\Controllers;
+
+use Laravel\Passport\Passport;
+use Laravel\Passport\Bridge\Scope;
+use Laravel\Passport\Http\Controllers\AuthorizationController as PassportAuthorizationController;
+
+class AuthorizationController extends PassportAuthorizationController
+{
+    /**
+     * Transform the authorization requests's scopes into Scope instances.
+     *
+     * @param  \League\OAuth2\Server\RequestTypes\AuthorizationRequest  $authRequest
+     * @return array
+     */
+    protected function parseScopes($authRequest)
+    {
+        $scopes = $authRequest->getScopes();
+        if (empty($scopes)) {
+            $scopes = [new Scope('identify')];
+        }
+
+        return Passport::scopesFor(
+            collect($scopes)->map(function ($scope) {
+                return $scope->getIdentifier();
+            })->all()
+        );
+    }
+}

--- a/app/Http/Controllers/AuthorizationController.php
+++ b/app/Http/Controllers/AuthorizationController.php
@@ -34,15 +34,14 @@ class AuthorizationController extends PassportAuthorizationController
      */
     protected function parseScopes($authRequest)
     {
-        $scopes = $authRequest->getScopes();
-        if (empty($scopes)) {
-            $scopes = [new Scope('identify')];
+        $scopes = collect($authRequest->getScopes())->map(function ($scope) {
+            return $scope->getIdentifier();
+        });
+
+        if (!$scopes->containsStrict('identify')) {
+            $scopes->push('identify');
         }
 
-        return Passport::scopesFor(
-            collect($scopes)->map(function ($scope) {
-                return $scope->getIdentifier();
-            })->all()
-        );
+        return Passport::scopesFor($scopes->all());
     }
 }

--- a/app/Http/Controllers/Passport/AuthorizationController.php
+++ b/app/Http/Controllers/Passport/AuthorizationController.php
@@ -18,16 +18,21 @@
  *    along with osu!web.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-namespace App\Http\Controllers;
+namespace App\Http\Controllers\Passport;
 
 use Laravel\Passport\Passport;
 use Laravel\Passport\Bridge\Scope;
 use Laravel\Passport\Http\Controllers\AuthorizationController as PassportAuthorizationController;
 
+/**
+ * Extension of Laravel\Passport\Http\Controllers\AuthorizationController
+ * to add support for scope normalization when requesting token scopes.
+ */
 class AuthorizationController extends PassportAuthorizationController
 {
     /**
      * Transform the authorization requests's scopes into Scope instances.
+     * This overrides the default implementation to normalize scope requests.
      *
      * @param  \League\OAuth2\Server\RequestTypes\AuthorizationRequest  $authRequest
      * @return array

--- a/app/Http/Controllers/Passport/AuthorizationController.php
+++ b/app/Http/Controllers/Passport/AuthorizationController.php
@@ -21,10 +21,9 @@
 namespace App\Http\Controllers\Passport;
 
 use Illuminate\Http\Request;
-use Laravel\Passport\ClientRepository;
 use Laravel\Passport\Bridge\Scope;
+use Laravel\Passport\ClientRepository;
 use Laravel\Passport\Http\Controllers\AuthorizationController as PassportAuthorizationController;
-use Laravel\Passport\Passport;
 use Laravel\Passport\TokenRepository;
 use Psr\Http\Message\ServerRequestInterface;
 
@@ -62,7 +61,22 @@ class AuthorizationController extends PassportAuthorizationController
     private function normalizeRequestScopes(ServerRequestInterface $request) : ServerRequestInterface
     {
         $params = $request->getQueryParams();
-        $scopes = explode(' ', $params['scope'] ?? null);
+        $scopes = $this->normalizeScopes(
+            explode(' ', $params['scope'] ?? null)
+        );
+        $params['scope'] = implode(' ', $scopes);
+
+        return $request->withQueryParams($params);
+    }
+
+    /**
+     * Normalizes and sorts scopes.
+     *
+     * @param array $scopes
+     * @return array
+     */
+    private function normalizeScopes(array $scopes) : array
+    {
         if (!in_array('identify', $scopes, true)) {
             $scopes[] = 'identify';
         }
@@ -70,6 +84,6 @@ class AuthorizationController extends PassportAuthorizationController
         sort($scopes);
         $params['scope'] = implode(' ', $scopes);
 
-        return $request->withQueryParams($params);
+        return $scopes;
     }
 }

--- a/app/Http/Controllers/Passport/AuthorizationController.php
+++ b/app/Http/Controllers/Passport/AuthorizationController.php
@@ -82,7 +82,6 @@ class AuthorizationController extends PassportAuthorizationController
         }
 
         sort($scopes);
-        $params['scope'] = implode(' ', $scopes);
 
         return $scopes;
     }

--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -49,7 +49,7 @@ class UsersController extends Controller
         $this->middleware('throttle:10,60', ['only' => ['store']]);
 
         if (is_api_request()) {
-            $this->middleware('require-scopes:identify', ['only' => 'me']);
+            $this->middleware('require-scopes:identify', ['only' => ['me']]);
         }
 
         $this->middleware(function ($request, $next) {
@@ -274,7 +274,7 @@ class UsersController extends Controller
             'user_achievements',
         ];
 
-        if (priv_check('UserSilenceShowExtendedInfo')->can()) {
+        if (priv_check('UserSilenceShowExtendedInfo')->can() && !is_api_request()) {
             $userIncludes[] = 'account_history.actor';
         }
 

--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -48,6 +48,10 @@ class UsersController extends Controller
 
         $this->middleware('throttle:10,60', ['only' => ['store']]);
 
+        if (is_api_request()) {
+            $this->middleware('require-scopes:identify', ['only' => 'me']);
+        }
+
         $this->middleware(function ($request, $next) {
             $this->parsePaginationParams();
 

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -66,6 +66,7 @@ class Kernel extends HttpKernel
         'check-user-restricted' => Middleware\CheckUserRestricted::class,
         'guest' => Middleware\RedirectIfAuthenticated::class,
         'throttle' => \Illuminate\Routing\Middleware\ThrottleRequests::class,
+        'require-scopes' => Middleware\RequireScopes::class,
         'verify-user' => Middleware\VerifyUser::class,
     ];
 }

--- a/app/Http/Middleware/RequireScopes.php
+++ b/app/Http/Middleware/RequireScopes.php
@@ -49,9 +49,14 @@ class RequireScopes
             throw new MissingScopeException();
         }
 
-        if (!empty($scopes)) {
+        if (empty($scopes)) {
+            // use a non-existent scope; only '*' should pass.
+            if (!$token->can('invalid')) {
+                throw new MissingScopeException();
+            }
+        } else {
             foreach ($scopes as $scope) {
-                if ($token->cant($scope)) {
+                if (!$token->can($scope)) {
                     throw new MissingScopeException();
                 }
             }

--- a/app/Http/Middleware/RequireScopes.php
+++ b/app/Http/Middleware/RequireScopes.php
@@ -34,12 +34,23 @@ class RequireScopes
      *
      * @return mixed
      */
-    public function handle(Request $request, Closure $next)
+    public function handle(Request $request, Closure $next, ...$scopes)
     {
         $token = $request->user()->token();
+        if ($token === null) {
+            throw new AuthorizationException();
+        }
 
         if (empty($token->scopes)) {
             throw new AuthorizationException();
+        }
+
+        if (!empty($scopes)) {
+            foreach ($scopes as $scope) {
+                if ($token->cant($scope)) {
+                    throw new AuthorizationException();
+                }
+            }
         }
 
         return $next($request);

--- a/app/Http/Middleware/RequireScopes.php
+++ b/app/Http/Middleware/RequireScopes.php
@@ -37,7 +37,7 @@ class RequireScopes
      */
     public function handle(Request $request, Closure $next, ...$scopes)
     {
-        $token = $request->user()->token();
+        $token = optional($request->user())->token();
         if ($token === null) {
             throw new AuthorizationException();
         }

--- a/app/Http/Middleware/RequireScopes.php
+++ b/app/Http/Middleware/RequireScopes.php
@@ -23,6 +23,7 @@ namespace App\Http\Middleware;
 use App\Exceptions\AuthorizationException;
 use Closure;
 use Illuminate\Http\Request;
+use Laravel\Passport\Exceptions\MissingScopeException;
 
 class RequireScopes
 {
@@ -41,14 +42,17 @@ class RequireScopes
             throw new AuthorizationException();
         }
 
-        if (empty($token->scopes)) {
-            throw new AuthorizationException();
+        // assignment is so Mockery doesn't troll us.
+        $tokenScopes = $token->scopes;
+
+        if (empty($tokenScopes)) {
+            throw new MissingScopeException();
         }
 
         if (!empty($scopes)) {
             foreach ($scopes as $scope) {
                 if ($token->cant($scope)) {
-                    throw new AuthorizationException();
+                    throw new MissingScopeException();
                 }
             }
         }

--- a/app/Http/Middleware/RequireScopes.php
+++ b/app/Http/Middleware/RequireScopes.php
@@ -27,11 +27,15 @@ use Laravel\Passport\Exceptions\MissingScopeException;
 
 class RequireScopes
 {
+    /** @var bool|null */
+    private $requestHasScopedMiddleware;
+
     /**
      * Handle an incoming request.
      *
-     * @param \Illuminate\Http\Request $request
-     * @param \Closure                 $next
+     * @param Request $request
+     * @param Closure $next
+     * @param string[] ...$scopes
      *
      * @return mixed
      */
@@ -62,7 +66,23 @@ class RequireScopes
         return $next($request);
     }
 
-    private function requestHasScopedMiddleware(Request $request)
+    /**
+     * Returns if the request contains this middleware with scope parameter checks.
+     *
+     * @param Request $request
+     *
+     * @return bool
+     */
+    private function requestHasScopedMiddleware(Request $request) : bool
+    {
+        if ($this->requestHasScopedMiddleware === null) {
+            $this->requestHasScopedMiddleware = $this->containsScoped($request);
+        }
+
+        return $this->requestHasScopedMiddleware;
+    }
+
+    private function containsScoped(Request $request)
     {
         foreach ($request->route()->gatherMiddleware() as $middleware) {
             if (starts_with($middleware, 'require-scopes:')) {

--- a/app/Http/Middleware/RequireScopes.php
+++ b/app/Http/Middleware/RequireScopes.php
@@ -1,0 +1,47 @@
+<?php
+
+/**
+ *    Copyright 2015-2018 ppy Pty. Ltd.
+ *
+ *    This file is part of osu!web. osu!web is distributed with the hope of
+ *    attracting more community contributions to the core ecosystem of osu!.
+ *
+ *    osu!web is free software: you can redistribute it and/or modify
+ *    it under the terms of the Affero GNU General Public License version 3
+ *    as published by the Free Software Foundation.
+ *
+ *    osu!web is distributed WITHOUT ANY WARRANTY; without even the implied
+ *    warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *    See the GNU Affero General Public License for more details.
+ *
+ *    You should have received a copy of the GNU Affero General Public License
+ *    along with osu!web.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace App\Http\Middleware;
+
+use App\Exceptions\AuthorizationException;
+use Closure;
+use Illuminate\Http\Request;
+
+class RequireScopes
+{
+    /**
+     * Handle an incoming request.
+     *
+     * @param \Illuminate\Http\Request $request
+     * @param \Closure                 $next
+     *
+     * @return mixed
+     */
+    public function handle(Request $request, Closure $next)
+    {
+        $token = $request->user()->token();
+
+        if (empty($token->scopes)) {
+            throw new AuthorizationException();
+        }
+
+        return $next($request);
+    }
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -20,6 +20,7 @@
 
 namespace App\Providers;
 
+use App\Http\Middleware\RequireScopes;
 use App\Http\Middleware\StartSession;
 use App\Libraries\OsuAuthorize;
 use App\Models\Comment;
@@ -72,6 +73,10 @@ class AppServiceProvider extends ServiceProvider
 
         $this->app->singleton('OsuAuthorize', function () {
             return new OsuAuthorize();
+        });
+
+        $this->app->singleton(RequireScopes::class, function () {
+            return new RequireScopes;
         });
 
         // The middleware breaks without this. Not sure why.

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -5,6 +5,7 @@ namespace App\Providers;
 use Carbon\Carbon;
 use Illuminate\Foundation\Support\Providers\AuthServiceProvider as ServiceProvider;
 use Laravel\Passport\Passport;
+use Route;
 
 class AuthServiceProvider extends ServiceProvider
 {
@@ -28,6 +29,10 @@ class AuthServiceProvider extends ServiceProvider
         }
 
         Passport::routes();
+
+        // RouteServiceProvider current runs before our provider, so Passport's default routes will override
+        // those set in routes/web.php.
+        Route::get('oauth/authorize', 'App\Http\Controllers\AuthorizationController@authorize');
 
         Passport::tokensCan([
             'identify' => trans('api.scopes.identify'),

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -33,7 +33,7 @@ class AuthServiceProvider extends ServiceProvider
 
         // RouteServiceProvider current runs before our provider, so Passport's default routes will override
         // those set in routes/web.php.
-        Route::get('oauth/authorize', AuthorizationController::class.'@authorize');
+        Route::get('oauth/authorize', AuthorizationController::class.'@authorize')->middleware(['web', 'auth']);
 
         Passport::tokensCan([
             'identify' => trans('api.scopes.identify'),

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -28,5 +28,9 @@ class AuthServiceProvider extends ServiceProvider
         }
 
         Passport::routes();
+
+        Passport::tokensCan([
+            'identify' => trans('api.scopes.identify'),
+        ]);
     }
 }

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -2,6 +2,7 @@
 
 namespace App\Providers;
 
+use App\Http\Controllers\Passport\AuthorizationController;
 use Carbon\Carbon;
 use Illuminate\Foundation\Support\Providers\AuthServiceProvider as ServiceProvider;
 use Laravel\Passport\Passport;
@@ -32,7 +33,7 @@ class AuthServiceProvider extends ServiceProvider
 
         // RouteServiceProvider current runs before our provider, so Passport's default routes will override
         // those set in routes/web.php.
-        Route::get('oauth/authorize', 'App\Http\Controllers\AuthorizationController@authorize');
+        Route::get('oauth/authorize', AuthorizationController::class.'@authorize');
 
         Passport::tokensCan([
             'identify' => trans('api.scopes.identify'),

--- a/app/Transformers/UserTransformer.php
+++ b/app/Transformers/UserTransformer.php
@@ -102,7 +102,7 @@ class UserTransformer extends Fractal\TransformerAbstract
     {
         $histories = $user->accountHistories()->recent();
 
-        if (!priv_check('UserSilenceShowExtendedInfo')->can()) {
+        if (!priv_check('UserSilenceShowExtendedInfo')->can() || is_api_request()) {
             $histories->default();
         } else {
             $histories->with('actor');

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -495,7 +495,7 @@ function i18n_view($view)
 
 function is_api_request()
 {
-    return Request::is('api/*');
+    return request()->is('api/*');
 }
 
 function is_sql_unique_exception($ex)

--- a/resources/lang/en/api.php
+++ b/resources/lang/en/api.php
@@ -25,4 +25,8 @@ return [
             'too_long' => 'The message you are trying to send is too long.',
         ],
     ],
+
+    'scopes' => [
+        'identify' => 'Identify your osu! account',
+    ],
 ];

--- a/resources/lang/en/api.php
+++ b/resources/lang/en/api.php
@@ -27,6 +27,6 @@ return [
     ],
 
     'scopes' => [
-        'identify' => 'Identify your osu! account',
+        'identify' => 'Identify you and read your public profile.',
     ],
 ];

--- a/routes/web.php
+++ b/routes/web.php
@@ -294,78 +294,78 @@ Route::middleware(['auth:api', 'require-scopes'])
     ->prefix('api')
     ->namespace('API')
     ->group(function () {
-    Route::group(['prefix' => 'v2'], function () {
-        Route::group(['as' => 'chat.', 'prefix' => 'chat', 'namespace' => 'Chat'], function () {
-            Route::post('new', '\App\Http\Controllers\Chat\ChatController@newConversation')->name('new');
-            Route::get('updates', '\App\Http\Controllers\Chat\ChatController@updates')->name('updates');
-            Route::get('presence', '\App\Http\Controllers\Chat\ChatController@presence')->name('presence');
-            Route::group(['as' => 'channels.', 'prefix' => 'channels'], function () {
-                Route::apiResource('{channel_id}/messages', '\App\Http\Controllers\Chat\Channels\MessagesController', ['only' => ['index', 'store']]);
-                Route::put('{channel_id}/users/{user_id}', '\App\Http\Controllers\Chat\ChannelsController@join')->name('join');
-                Route::delete('{channel_id}/users/{user_id}', '\App\Http\Controllers\Chat\ChannelsController@part')->name('part');
-                Route::put('{channel_id}/mark-as-read/{message_id}', '\App\Http\Controllers\Chat\ChannelsController@markAsRead')->name('mark-as-read');
+        Route::group(['prefix' => 'v2'], function () {
+            Route::group(['as' => 'chat.', 'prefix' => 'chat', 'namespace' => 'Chat'], function () {
+                Route::post('new', '\App\Http\Controllers\Chat\ChatController@newConversation')->name('new');
+                Route::get('updates', '\App\Http\Controllers\Chat\ChatController@updates')->name('updates');
+                Route::get('presence', '\App\Http\Controllers\Chat\ChatController@presence')->name('presence');
+                Route::group(['as' => 'channels.', 'prefix' => 'channels'], function () {
+                    Route::apiResource('{channel_id}/messages', '\App\Http\Controllers\Chat\Channels\MessagesController', ['only' => ['index', 'store']]);
+                    Route::put('{channel_id}/users/{user_id}', '\App\Http\Controllers\Chat\ChannelsController@join')->name('join');
+                    Route::delete('{channel_id}/users/{user_id}', '\App\Http\Controllers\Chat\ChannelsController@part')->name('part');
+                    Route::put('{channel_id}/mark-as-read/{message_id}', '\App\Http\Controllers\Chat\ChannelsController@markAsRead')->name('mark-as-read');
+                });
+                Route::apiResource('channels', '\App\Http\Controllers\Chat\ChannelsController', ['only' => ['index']]);
             });
-            Route::apiResource('channels', '\App\Http\Controllers\Chat\ChannelsController', ['only' => ['index']]);
+
+            Route::resource('rooms', 'RoomsController', ['only' => ['show']]);
+
+            Route::group(['prefix' => 'beatmapsets'], function () {
+                Route::get('favourites', 'BeatmapsetsController@favourites');     //  GET /api/v2/beatmapsets/favourites
+            });
+
+            // Beatmaps
+            //   GET /api/v2/beatmaps/:beatmap_id/scores
+            Route::get('beatmaps/{id}/scores', '\App\Http\Controllers\BeatmapsController@scores');
+            //   GET /api/v2/beatmaps/lookup
+            Route::get('beatmaps/lookup', 'BeatmapsController@lookup');
+            //   GET /api/v2/beatmaps/:beatmap_id
+            Route::resource('beatmaps', 'BeatmapsController', ['only' => ['show']]);
+
+            // Beatmapsets
+            //   GET /api/v2/beatmapsets/search/:filters
+            Route::get('beatmapsets/search/{filters?}', '\App\Http\Controllers\BeatmapsetsController@search');
+            //   GET /api/v2/beatmapsets/lookup
+            Route::get('beatmapsets/lookup', 'BeatmapsetsController@lookup');
+            //   GET /api/v2/beatmapsets/:beatmapset/download
+            Route::get('beatmapsets/{beatmapset}/download', '\App\Http\Controllers\BeatmapsetsController@download');
+            //   GET /api/v2/beatmapsets/:beatmapset_id
+            Route::resource('beatmapsets', '\App\Http\Controllers\BeatmapsetsController', ['only' => ['show']]);
+
+            // Friends
+            //  GET /api/v2/friends
+            Route::resource('friends', '\App\Http\Controllers\FriendsController', ['only' => ['index']]);
+
+            //  GET /api/v2/me
+            Route::get('me', '\App\Http\Controllers\UsersController@me');
+            //  GET /api/v2/me/download-quota-check
+            Route::get('me/download-quota-check', '\App\Http\Controllers\HomeController@downloadQuotaCheck');
+            //  GET /api/v2/rankings/:mode/:type
+            Route::get('rankings/{mode}/{type}', '\App\Http\Controllers\RankingController@index');
+
+            //  GET /api/v2/users/:user_id/kudosu
+            Route::get('users/{user}/kudosu', '\App\Http\Controllers\UsersController@kudosu');
+            //  GET /api/v2/users/:user_id/scores/:type [best, firsts, recent]
+            Route::get('users/{user}/scores/{type}', '\App\Http\Controllers\UsersController@scores');
+            //  GET /api/v2/users/:user_id/beatmapsets/:type [most_played, favourite, ranked_and_approved, unranked, graveyard]
+            Route::get('users/{user}/beatmapsets/{type}', '\App\Http\Controllers\UsersController@beatmapsets');
+            // GET /api/v2/users/:user_id/recent_activity
+            Route::get('users/{user}/recent_activity', '\App\Http\Controllers\UsersController@recentActivity');
+            //  GET /api/v2/users/:user_id/:mode [osu, taiko, fruits, mania]
+            Route::get('users/{user}/{mode?}', '\App\Http\Controllers\UsersController@show');
         });
-
-        Route::resource('rooms', 'RoomsController', ['only' => ['show']]);
-
-        Route::group(['prefix' => 'beatmapsets'], function () {
-            Route::get('favourites', 'BeatmapsetsController@favourites');     //  GET /api/v2/beatmapsets/favourites
+        // legacy api routes
+        Route::group(['prefix' => 'v1'], function () {
+            Route::get('get_match', 'LegacyController@getMatch');
+            Route::get('get_packs', 'LegacyController@getPacks');
+            Route::get('get_user', 'LegacyController@getUser');
+            Route::get('get_user_best', 'LegacyController@getUserBest');
+            Route::get('get_user_recent', 'LegacyController@getUserRecent');
+            Route::get('get_replay', 'LegacyController@getReplay');
+            Route::get('get_scores', 'LegacyController@getScores');
+            Route::get('get_beatmaps', 'LegacyController@getBeatmaps');
         });
-
-        // Beatmaps
-        //   GET /api/v2/beatmaps/:beatmap_id/scores
-        Route::get('beatmaps/{id}/scores', '\App\Http\Controllers\BeatmapsController@scores');
-        //   GET /api/v2/beatmaps/lookup
-        Route::get('beatmaps/lookup', 'BeatmapsController@lookup');
-        //   GET /api/v2/beatmaps/:beatmap_id
-        Route::resource('beatmaps', 'BeatmapsController', ['only' => ['show']]);
-
-        // Beatmapsets
-        //   GET /api/v2/beatmapsets/search/:filters
-        Route::get('beatmapsets/search/{filters?}', '\App\Http\Controllers\BeatmapsetsController@search');
-        //   GET /api/v2/beatmapsets/lookup
-        Route::get('beatmapsets/lookup', 'BeatmapsetsController@lookup');
-        //   GET /api/v2/beatmapsets/:beatmapset/download
-        Route::get('beatmapsets/{beatmapset}/download', '\App\Http\Controllers\BeatmapsetsController@download');
-        //   GET /api/v2/beatmapsets/:beatmapset_id
-        Route::resource('beatmapsets', '\App\Http\Controllers\BeatmapsetsController', ['only' => ['show']]);
-
-        // Friends
-        //  GET /api/v2/friends
-        Route::resource('friends', '\App\Http\Controllers\FriendsController', ['only' => ['index']]);
-
-        //  GET /api/v2/me
-        Route::get('me', '\App\Http\Controllers\UsersController@me');
-        //  GET /api/v2/me/download-quota-check
-        Route::get('me/download-quota-check', '\App\Http\Controllers\HomeController@downloadQuotaCheck');
-        //  GET /api/v2/rankings/:mode/:type
-        Route::get('rankings/{mode}/{type}', '\App\Http\Controllers\RankingController@index');
-
-        //  GET /api/v2/users/:user_id/kudosu
-        Route::get('users/{user}/kudosu', '\App\Http\Controllers\UsersController@kudosu');
-        //  GET /api/v2/users/:user_id/scores/:type [best, firsts, recent]
-        Route::get('users/{user}/scores/{type}', '\App\Http\Controllers\UsersController@scores');
-        //  GET /api/v2/users/:user_id/beatmapsets/:type [most_played, favourite, ranked_and_approved, unranked, graveyard]
-        Route::get('users/{user}/beatmapsets/{type}', '\App\Http\Controllers\UsersController@beatmapsets');
-        // GET /api/v2/users/:user_id/recent_activity
-        Route::get('users/{user}/recent_activity', '\App\Http\Controllers\UsersController@recentActivity');
-        //  GET /api/v2/users/:user_id/:mode [osu, taiko, fruits, mania]
-        Route::get('users/{user}/{mode?}', '\App\Http\Controllers\UsersController@show');
     });
-    // legacy api routes
-    Route::group(['prefix' => 'v1'], function () {
-        Route::get('get_match', 'LegacyController@getMatch');
-        Route::get('get_packs', 'LegacyController@getPacks');
-        Route::get('get_user', 'LegacyController@getUser');
-        Route::get('get_user_best', 'LegacyController@getUserBest');
-        Route::get('get_user_recent', 'LegacyController@getUserRecent');
-        Route::get('get_replay', 'LegacyController@getReplay');
-        Route::get('get_scores', 'LegacyController@getScores');
-        Route::get('get_beatmaps', 'LegacyController@getBeatmaps');
-    });
-});
 
 // Callbacks for legacy systems to interact with
 Route::group(['prefix' => '_lio', 'middleware' => 'lio'], function () {

--- a/routes/web.php
+++ b/routes/web.php
@@ -289,7 +289,11 @@ Route::group(['as' => 'payments.', 'prefix' => 'payments', 'namespace' => 'Payme
 });
 
 // API
-Route::group(['as' => 'api.', 'prefix' => 'api', 'namespace' => 'API', 'middleware' => 'auth:api'], function () {
+Route::middleware(['auth:api', 'require-scopes'])
+    ->as('api.')
+    ->prefix('api')
+    ->namespace('API')
+    ->group(function () {
     Route::group(['prefix' => 'v2'], function () {
         Route::group(['as' => 'chat.', 'prefix' => 'chat', 'namespace' => 'Chat'], function () {
             Route::post('new', '\App\Http\Controllers\Chat\ChatController@newConversation')->name('new');

--- a/routes/web.php
+++ b/routes/web.php
@@ -289,83 +289,79 @@ Route::group(['as' => 'payments.', 'prefix' => 'payments', 'namespace' => 'Payme
 });
 
 // API
-Route::middleware(['auth:api', 'require-scopes'])
-    ->as('api.')
-    ->prefix('api')
-    ->namespace('API')
-    ->group(function () {
-        Route::group(['prefix' => 'v2'], function () {
-            Route::group(['as' => 'chat.', 'prefix' => 'chat', 'namespace' => 'Chat'], function () {
-                Route::post('new', '\App\Http\Controllers\Chat\ChatController@newConversation')->name('new');
-                Route::get('updates', '\App\Http\Controllers\Chat\ChatController@updates')->name('updates');
-                Route::get('presence', '\App\Http\Controllers\Chat\ChatController@presence')->name('presence');
-                Route::group(['as' => 'channels.', 'prefix' => 'channels'], function () {
-                    Route::apiResource('{channel_id}/messages', '\App\Http\Controllers\Chat\Channels\MessagesController', ['only' => ['index', 'store']]);
-                    Route::put('{channel_id}/users/{user_id}', '\App\Http\Controllers\Chat\ChannelsController@join')->name('join');
-                    Route::delete('{channel_id}/users/{user_id}', '\App\Http\Controllers\Chat\ChannelsController@part')->name('part');
-                    Route::put('{channel_id}/mark-as-read/{message_id}', '\App\Http\Controllers\Chat\ChannelsController@markAsRead')->name('mark-as-read');
-                });
-                Route::apiResource('channels', '\App\Http\Controllers\Chat\ChannelsController', ['only' => ['index']]);
+Route::group(['as' => 'api.', 'prefix' => 'api', 'namespace' => 'API', 'middleware' => ['auth:api', 'require-scopes']], function () {
+    Route::group(['prefix' => 'v2'], function () {
+        Route::group(['as' => 'chat.', 'prefix' => 'chat', 'namespace' => 'Chat'], function () {
+            Route::post('new', '\App\Http\Controllers\Chat\ChatController@newConversation')->name('new');
+            Route::get('updates', '\App\Http\Controllers\Chat\ChatController@updates')->name('updates');
+            Route::get('presence', '\App\Http\Controllers\Chat\ChatController@presence')->name('presence');
+            Route::group(['as' => 'channels.', 'prefix' => 'channels'], function () {
+                Route::apiResource('{channel_id}/messages', '\App\Http\Controllers\Chat\Channels\MessagesController', ['only' => ['index', 'store']]);
+                Route::put('{channel_id}/users/{user_id}', '\App\Http\Controllers\Chat\ChannelsController@join')->name('join');
+                Route::delete('{channel_id}/users/{user_id}', '\App\Http\Controllers\Chat\ChannelsController@part')->name('part');
+                Route::put('{channel_id}/mark-as-read/{message_id}', '\App\Http\Controllers\Chat\ChannelsController@markAsRead')->name('mark-as-read');
             });
-
-            Route::resource('rooms', 'RoomsController', ['only' => ['show']]);
-
-            Route::group(['prefix' => 'beatmapsets'], function () {
-                Route::get('favourites', 'BeatmapsetsController@favourites');     //  GET /api/v2/beatmapsets/favourites
-            });
-
-            // Beatmaps
-            //   GET /api/v2/beatmaps/:beatmap_id/scores
-            Route::get('beatmaps/{id}/scores', '\App\Http\Controllers\BeatmapsController@scores');
-            //   GET /api/v2/beatmaps/lookup
-            Route::get('beatmaps/lookup', 'BeatmapsController@lookup');
-            //   GET /api/v2/beatmaps/:beatmap_id
-            Route::resource('beatmaps', 'BeatmapsController', ['only' => ['show']]);
-
-            // Beatmapsets
-            //   GET /api/v2/beatmapsets/search/:filters
-            Route::get('beatmapsets/search/{filters?}', '\App\Http\Controllers\BeatmapsetsController@search');
-            //   GET /api/v2/beatmapsets/lookup
-            Route::get('beatmapsets/lookup', 'BeatmapsetsController@lookup');
-            //   GET /api/v2/beatmapsets/:beatmapset/download
-            Route::get('beatmapsets/{beatmapset}/download', '\App\Http\Controllers\BeatmapsetsController@download');
-            //   GET /api/v2/beatmapsets/:beatmapset_id
-            Route::resource('beatmapsets', '\App\Http\Controllers\BeatmapsetsController', ['only' => ['show']]);
-
-            // Friends
-            //  GET /api/v2/friends
-            Route::resource('friends', '\App\Http\Controllers\FriendsController', ['only' => ['index']]);
-
-            //  GET /api/v2/me
-            Route::get('me', '\App\Http\Controllers\UsersController@me');
-            //  GET /api/v2/me/download-quota-check
-            Route::get('me/download-quota-check', '\App\Http\Controllers\HomeController@downloadQuotaCheck');
-            //  GET /api/v2/rankings/:mode/:type
-            Route::get('rankings/{mode}/{type}', '\App\Http\Controllers\RankingController@index');
-
-            //  GET /api/v2/users/:user_id/kudosu
-            Route::get('users/{user}/kudosu', '\App\Http\Controllers\UsersController@kudosu');
-            //  GET /api/v2/users/:user_id/scores/:type [best, firsts, recent]
-            Route::get('users/{user}/scores/{type}', '\App\Http\Controllers\UsersController@scores');
-            //  GET /api/v2/users/:user_id/beatmapsets/:type [most_played, favourite, ranked_and_approved, unranked, graveyard]
-            Route::get('users/{user}/beatmapsets/{type}', '\App\Http\Controllers\UsersController@beatmapsets');
-            // GET /api/v2/users/:user_id/recent_activity
-            Route::get('users/{user}/recent_activity', '\App\Http\Controllers\UsersController@recentActivity');
-            //  GET /api/v2/users/:user_id/:mode [osu, taiko, fruits, mania]
-            Route::get('users/{user}/{mode?}', '\App\Http\Controllers\UsersController@show');
+            Route::apiResource('channels', '\App\Http\Controllers\Chat\ChannelsController', ['only' => ['index']]);
         });
-        // legacy api routes
-        Route::group(['prefix' => 'v1'], function () {
-            Route::get('get_match', 'LegacyController@getMatch');
-            Route::get('get_packs', 'LegacyController@getPacks');
-            Route::get('get_user', 'LegacyController@getUser');
-            Route::get('get_user_best', 'LegacyController@getUserBest');
-            Route::get('get_user_recent', 'LegacyController@getUserRecent');
-            Route::get('get_replay', 'LegacyController@getReplay');
-            Route::get('get_scores', 'LegacyController@getScores');
-            Route::get('get_beatmaps', 'LegacyController@getBeatmaps');
+
+        Route::resource('rooms', 'RoomsController', ['only' => ['show']]);
+
+        Route::group(['prefix' => 'beatmapsets'], function () {
+            Route::get('favourites', 'BeatmapsetsController@favourites');     //  GET /api/v2/beatmapsets/favourites
         });
+
+        // Beatmaps
+        //   GET /api/v2/beatmaps/:beatmap_id/scores
+        Route::get('beatmaps/{id}/scores', '\App\Http\Controllers\BeatmapsController@scores');
+        //   GET /api/v2/beatmaps/lookup
+        Route::get('beatmaps/lookup', 'BeatmapsController@lookup');
+        //   GET /api/v2/beatmaps/:beatmap_id
+        Route::resource('beatmaps', 'BeatmapsController', ['only' => ['show']]);
+
+        // Beatmapsets
+        //   GET /api/v2/beatmapsets/search/:filters
+        Route::get('beatmapsets/search/{filters?}', '\App\Http\Controllers\BeatmapsetsController@search');
+        //   GET /api/v2/beatmapsets/lookup
+        Route::get('beatmapsets/lookup', 'BeatmapsetsController@lookup');
+        //   GET /api/v2/beatmapsets/:beatmapset/download
+        Route::get('beatmapsets/{beatmapset}/download', '\App\Http\Controllers\BeatmapsetsController@download');
+        //   GET /api/v2/beatmapsets/:beatmapset_id
+        Route::resource('beatmapsets', '\App\Http\Controllers\BeatmapsetsController', ['only' => ['show']]);
+
+        // Friends
+        //  GET /api/v2/friends
+        Route::resource('friends', '\App\Http\Controllers\FriendsController', ['only' => ['index']]);
+
+        //  GET /api/v2/me
+        Route::get('me', '\App\Http\Controllers\UsersController@me');
+        //  GET /api/v2/me/download-quota-check
+        Route::get('me/download-quota-check', '\App\Http\Controllers\HomeController@downloadQuotaCheck');
+        //  GET /api/v2/rankings/:mode/:type
+        Route::get('rankings/{mode}/{type}', '\App\Http\Controllers\RankingController@index');
+
+        //  GET /api/v2/users/:user_id/kudosu
+        Route::get('users/{user}/kudosu', '\App\Http\Controllers\UsersController@kudosu');
+        //  GET /api/v2/users/:user_id/scores/:type [best, firsts, recent]
+        Route::get('users/{user}/scores/{type}', '\App\Http\Controllers\UsersController@scores');
+        //  GET /api/v2/users/:user_id/beatmapsets/:type [most_played, favourite, ranked_and_approved, unranked, graveyard]
+        Route::get('users/{user}/beatmapsets/{type}', '\App\Http\Controllers\UsersController@beatmapsets');
+        // GET /api/v2/users/:user_id/recent_activity
+        Route::get('users/{user}/recent_activity', '\App\Http\Controllers\UsersController@recentActivity');
+        //  GET /api/v2/users/:user_id/:mode [osu, taiko, fruits, mania]
+        Route::get('users/{user}/{mode?}', '\App\Http\Controllers\UsersController@show');
     });
+    // legacy api routes
+    Route::group(['prefix' => 'v1'], function () {
+        Route::get('get_match', 'LegacyController@getMatch');
+        Route::get('get_packs', 'LegacyController@getPacks');
+        Route::get('get_user', 'LegacyController@getUser');
+        Route::get('get_user_best', 'LegacyController@getUserBest');
+        Route::get('get_user_recent', 'LegacyController@getUserRecent');
+        Route::get('get_replay', 'LegacyController@getReplay');
+        Route::get('get_scores', 'LegacyController@getScores');
+        Route::get('get_beatmaps', 'LegacyController@getBeatmaps');
+    });
+});
 
 // Callbacks for legacy systems to interact with
 Route::group(['prefix' => '_lio', 'middleware' => 'lio'], function () {

--- a/tests/Controllers/Chat/Channels/MessagesControllerTest.php
+++ b/tests/Controllers/Chat/Channels/MessagesControllerTest.php
@@ -185,14 +185,12 @@ class MessagesControllerTest extends TestCase
         $message = self::$faker->sentence();
 
         $this->actAsScopedUser($this->user, ['*']);
-        $this->user->token()->shouldReceive('getAttribute')->with('scopes')->andReturn(['*']);
         $this->json('PUT', route('api.chat.channels.join', [
                 'channel_id' => $this->publicChannel->channel_id,
                 'user_id' => $this->user->user_id,
             ]));
 
         $this->actAsScopedUser($this->user, ['*']);
-        $this->user->token()->shouldReceive('getAttribute')->with('scopes')->andReturn(['*']);
 
         $this->json(
                 'POST',

--- a/tests/Controllers/Chat/Channels/MessagesControllerTest.php
+++ b/tests/Controllers/Chat/Channels/MessagesControllerTest.php
@@ -62,21 +62,21 @@ class MessagesControllerTest extends TestCase
 
     public function testChannelShowPublicWhenUnjoined() // fail
     {
-        $this->actingAs($this->user, 'api')
-            ->json('GET', route('api.chat.channels.messages.index', ['channel_id' => $this->publicChannel->channel_id]))
+        $this->actAsScopedUser($this->user, ['*']);
+        $this->json('GET', route('api.chat.channels.messages.index', ['channel_id' => $this->publicChannel->channel_id]))
             ->assertStatus(404);
     }
 
     public function testChannelShowPublicWhenJoined() // success
     {
-        $this->actingAs($this->user, 'api')
-            ->json('PUT', route('api.chat.channels.join', [
+        $this->actAsScopedUser($this->user, ['*']);
+        $this->json('PUT', route('api.chat.channels.join', [
                 'channel_id' => $this->publicChannel->channel_id,
                 'user_id' => $this->user->user_id,
             ]));
 
-        $this->actingAs($this->user, 'api')
-            ->json('GET', route('api.chat.channels.messages.index', ['channel_id' => $this->publicChannel->channel_id]))
+        $this->actAsScopedUser($this->user, ['*']);
+        $this->json('GET', route('api.chat.channels.messages.index', ['channel_id' => $this->publicChannel->channel_id]))
             ->assertStatus(200);
         // TODO: Add check for messages being present?
     }
@@ -92,8 +92,8 @@ class MessagesControllerTest extends TestCase
 
     public function testChannelShowPrivateWhenNotJoined() // fail
     {
-        $this->actingAs($this->user, 'api')
-            ->json('GET', route('api.chat.channels.messages.index', ['channel_id' => $this->privateChannel->channel_id]))
+        $this->actAsScopedUser($this->user, ['*']);
+        $this->json('GET', route('api.chat.channels.messages.index', ['channel_id' => $this->privateChannel->channel_id]))
             ->assertStatus(404);
     }
 
@@ -104,8 +104,8 @@ class MessagesControllerTest extends TestCase
             'channel_id' => $this->privateChannel->channel_id,
         ]);
 
-        $this->actingAs($this->user, 'api')
-            ->json('GET', route('api.chat.channels.messages.index', ['channel_id' => $this->privateChannel->channel_id]))
+        $this->actAsScopedUser($this->user, ['*']);
+        $this->json('GET', route('api.chat.channels.messages.index', ['channel_id' => $this->privateChannel->channel_id]))
             ->assertStatus(200);
     }
 
@@ -120,8 +120,8 @@ class MessagesControllerTest extends TestCase
 
     public function testChannelShowPMWhenNotJoined() // fail
     {
-        $this->actingAs($this->user, 'api')
-            ->json('GET', route('api.chat.channels.messages.index', ['channel_id' => $this->pmChannel->channel_id]))
+        $this->actAsScopedUser($this->user, ['*']);
+        $this->json('GET', route('api.chat.channels.messages.index', ['channel_id' => $this->pmChannel->channel_id]))
             ->assertStatus(404);
     }
 
@@ -138,8 +138,8 @@ class MessagesControllerTest extends TestCase
             'channel_id' => $pmChannel->channel_id,
         ]);
 
-        $this->actingAs($this->user, 'api')
-            ->json('GET', route('api.chat.channels.messages.index', ['channel_id' => $pmChannel->channel_id]))
+        $this->actAsScopedUser($this->user, ['*']);
+        $this->json('GET', route('api.chat.channels.messages.index', ['channel_id' => $pmChannel->channel_id]))
             ->assertStatus(404);
     }
 
@@ -151,8 +151,8 @@ class MessagesControllerTest extends TestCase
             'channel_id' => $pmChannel->channel_id,
         ]);
 
-        $this->actingAs($this->user, 'api')
-            ->json('GET', route('api.chat.channels.messages.index', ['channel_id' => $pmChannel->channel_id]))
+        $this->actAsScopedUser($this->user, ['*']);
+        $this->json('GET', route('api.chat.channels.messages.index', ['channel_id' => $pmChannel->channel_id]))
             ->assertStatus(200);
         // TODO: Add check for messages being present?
     }
@@ -171,8 +171,8 @@ class MessagesControllerTest extends TestCase
 
     public function testChannelSendWhenUnjoined() // fail
     {
-        $this->actingAs($this->user, 'api')
-            ->json(
+        $this->actAsScopedUser($this->user, ['*']);
+        $this->json(
                 'POST',
                 route('api.chat.channels.messages.store', ['channel_id' => $this->publicChannel->channel_id]),
                 ['message' => self::$faker->sentence()]
@@ -184,14 +184,17 @@ class MessagesControllerTest extends TestCase
     {
         $message = self::$faker->sentence();
 
-        $this->actingAs($this->user, 'api')
-            ->json('PUT', route('api.chat.channels.join', [
+        $this->actAsScopedUser($this->user, ['*']);
+        $this->user->token()->shouldReceive('getAttribute')->with('scopes')->andReturn(['*']);
+        $this->json('PUT', route('api.chat.channels.join', [
                 'channel_id' => $this->publicChannel->channel_id,
                 'user_id' => $this->user->user_id,
             ]));
 
-        $this->actingAs($this->user, 'api')
-            ->json(
+        $this->actAsScopedUser($this->user, ['*']);
+        $this->user->token()->shouldReceive('getAttribute')->with('scopes')->andReturn(['*']);
+
+        $this->json(
                 'POST',
                 route('api.chat.channels.messages.store', ['channel_id' => $this->publicChannel->channel_id]),
                 ['message' => $message]
@@ -204,8 +207,8 @@ class MessagesControllerTest extends TestCase
     {
         $moderatedChannel = factory(Chat\Channel::class)->states('public')->create(['moderated' => true]);
 
-        $this->actingAs($this->user, 'api')
-            ->json(
+        $this->actAsScopedUser($this->user, ['*']);
+        $this->json(
                 'POST',
                 route('api.chat.channels.messages.store', ['channel_id' => $moderatedChannel->channel_id]),
                 ['message' => self::$faker->sentence()]
@@ -229,8 +232,8 @@ class MessagesControllerTest extends TestCase
             'zebra_id' => $this->anotherUser->user_id,
         ]);
 
-        $this->actingAs($this->user, 'api')
-            ->json(
+        $this->actAsScopedUser($this->user, ['*']);
+        $this->json(
                 'POST',
                 route('api.chat.channels.messages.store', ['channel_id' => $pmChannel->channel_id]),
                 ['message' => self::$faker->sentence()]
@@ -254,8 +257,8 @@ class MessagesControllerTest extends TestCase
             'zebra_id' => $this->user->user_id,
         ]);
 
-        $this->actingAs($this->user, 'api')
-            ->json(
+        $this->actAsScopedUser($this->user, ['*']);
+        $this->json(
                 'POST',
                 route('api.chat.channels.messages.store', ['channel_id' => $pmChannel->channel_id]),
                 ['message' => self::$faker->sentence()]
@@ -276,8 +279,8 @@ class MessagesControllerTest extends TestCase
             'channel_id' => $pmChannel->channel_id,
         ]);
 
-        $this->actingAs($this->restrictedUser, 'api')
-            ->json(
+        $this->actAsScopedUser($this->restrictedUser, ['*']);
+        $this->json(
                 'POST',
                 route('api.chat.channels.messages.store', ['channel_id' => $pmChannel->channel_id]),
                 ['message' => self::$faker->sentence()]
@@ -287,14 +290,14 @@ class MessagesControllerTest extends TestCase
 
     public function testChannelSendWhenRestrictedToPublic() // fail
     {
-        $this->actingAs($this->restrictedUser, 'api')
-            ->json('PUT', route('api.chat.channels.join', [
+        $this->actAsScopedUser($this->restrictedUser, ['*']);
+        $this->json('PUT', route('api.chat.channels.join', [
                 'channel_id' => $this->publicChannel->channel_id,
                 'user_id' => $this->restrictedUser->user_id,
             ]));
 
-        $this->actingAs($this->restrictedUser, 'api')
-            ->json(
+        $this->actAsScopedUser($this->restrictedUser, ['*']);
+        $this->json(
                 'POST',
                 route('api.chat.channels.messages.store', ['channel_id' => $this->publicChannel->channel_id]),
                 ['message' => self::$faker->sentence()]
@@ -315,8 +318,8 @@ class MessagesControllerTest extends TestCase
             'channel_id' => $pmChannel->channel_id,
         ]);
 
-        $this->actingAs($this->user, 'api')
-            ->json(
+        $this->actAsScopedUser($this->user, ['*']);
+        $this->json(
                 'POST',
                 route('api.chat.channels.messages.store', ['channel_id' => $pmChannel->channel_id]),
                 ['message' => self::$faker->sentence()]
@@ -337,8 +340,8 @@ class MessagesControllerTest extends TestCase
             'channel_id' => $pmChannel->channel_id,
         ]);
 
-        $this->actingAs($this->silencedUser, 'api')
-            ->json(
+        $this->actAsScopedUser($this->silencedUser, ['*']);
+        $this->json(
                 'POST',
                 route('api.chat.channels.messages.store', ['channel_id' => $pmChannel->channel_id]),
                 ['message' => self::$faker->sentence()]
@@ -348,14 +351,14 @@ class MessagesControllerTest extends TestCase
 
     public function testChannelSendWhenSilencedToPublic() // fail
     {
-        $this->actingAs($this->silencedUser, 'api')
-            ->json('PUT', route('api.chat.channels.join', [
+        $this->actAsScopedUser($this->silencedUser, ['*']);
+        $this->json('PUT', route('api.chat.channels.join', [
                 'channel_id' => $this->publicChannel->channel_id,
                 'user_id' => $this->silencedUser->user_id,
             ]));
 
-        $this->actingAs($this->silencedUser, 'api')
-            ->json(
+        $this->actAsScopedUser($this->silencedUser, ['*']);
+        $this->json(
                 'POST',
                 route('api.chat.channels.messages.store', ['channel_id' => $this->publicChannel->channel_id]),
                 ['message' => self::$faker->sentence()]

--- a/tests/Controllers/Chat/ChannelsControllerTest.php
+++ b/tests/Controllers/Chat/ChannelsControllerTest.php
@@ -54,8 +54,8 @@ class ChannelsControllerTest extends TestCase
 
     public function testChannelIndex()
     {
-        $this->actingAs($this->user, 'api')
-            ->json('GET', route('api.chat.channels.index'))
+        $this->actAsScopedUser($this->user, ['*']);
+        $this->json('GET', route('api.chat.channels.index'))
             ->assertStatus(200)
             ->assertJsonFragment(['channel_id' => $this->publicChannel->channel_id])
             ->assertJsonMissing(['channel_id' => $this->privateChannel->channel_id])
@@ -76,8 +76,8 @@ class ChannelsControllerTest extends TestCase
 
     public function testChannelJoinPublicWhenDifferentUser() // fail
     {
-        $this->actingAs($this->user, 'api')
-            ->json('PUT', route('api.chat.channels.join', [
+        $this->actAsScopedUser($this->user, ['*']);
+        $this->json('PUT', route('api.chat.channels.join', [
                 'channel_id' => $this->publicChannel->channel_id,
                 'user_id' => $this->anotherUser->user_id,
             ]))
@@ -86,8 +86,8 @@ class ChannelsControllerTest extends TestCase
 
     public function testChannelJoinNonPublic() // fail
     {
-        $this->actingAs($this->user, 'api')
-            ->json('PUT', route('api.chat.channels.join', [
+        $this->actAsScopedUser($this->user, ['*']);
+        $this->json('PUT', route('api.chat.channels.join', [
                 'channel_id' => $this->privateChannel->channel_id,
                 'user_id' => $this->user->user_id,
             ]))
@@ -97,22 +97,22 @@ class ChannelsControllerTest extends TestCase
     public function testChannelJoinPublic() // succeed
     {
         // ensure not in channel
-        $this->actingAs($this->user, 'api')
-            ->json('GET', route('api.chat.presence'))
+        $this->actAsScopedUser($this->user, ['*']);
+        $this->json('GET', route('api.chat.presence'))
             ->assertStatus(200)
             ->assertJsonMissing(['channel_id' => $this->publicChannel->channel_id]);
 
         // join channel
-        $this->actingAs($this->user, 'api')
-            ->json('PUT', route('api.chat.channels.join', [
+        $this->actAsScopedUser($this->user, ['*']);
+        $this->json('PUT', route('api.chat.channels.join', [
                 'channel_id' => $this->publicChannel->channel_id,
                 'user_id' => $this->user->user_id,
             ]))
             ->assertStatus(204);
 
         // ensure now in channel
-        $this->actingAs($this->user, 'api')
-            ->json('GET', route('api.chat.presence'))
+        $this->actAsScopedUser($this->user, ['*']);
+        $this->json('GET', route('api.chat.presence'))
             ->assertStatus(200)
             ->assertJsonFragment(['channel_id' => $this->publicChannel->channel_id]);
     }
@@ -120,36 +120,36 @@ class ChannelsControllerTest extends TestCase
     public function testChannelJoinPublicWhenAlreadyJoined() // succeed
     {
         // ensure not in channel
-        $this->actingAs($this->user, 'api')
-            ->json('GET', route('api.chat.presence'))
+        $this->actAsScopedUser($this->user, ['*']);
+        $this->json('GET', route('api.chat.presence'))
             ->assertStatus(200)
             ->assertJsonMissing(['channel_id' => $this->publicChannel->channel_id]);
 
         // join channel
-        $this->actingAs($this->user, 'api')
-            ->json('PUT', route('api.chat.channels.join', [
+        $this->actAsScopedUser($this->user, ['*']);
+        $this->json('PUT', route('api.chat.channels.join', [
                 'channel_id' => $this->publicChannel->channel_id,
                 'user_id' => $this->user->user_id,
             ]))
             ->assertStatus(204);
 
         // ensure now in channel
-        $this->actingAs($this->user, 'api')
-            ->json('GET', route('api.chat.presence'))
+        $this->actAsScopedUser($this->user, ['*']);
+        $this->json('GET', route('api.chat.presence'))
             ->assertStatus(200)
             ->assertJsonFragment(['channel_id' => $this->publicChannel->channel_id]);
 
         // attempt to join channel again
-        $this->actingAs($this->user, 'api')
-            ->json('PUT', route('api.chat.channels.join', [
+        $this->actAsScopedUser($this->user, ['*']);
+        $this->json('PUT', route('api.chat.channels.join', [
                 'channel_id' => $this->publicChannel->channel_id,
                 'user_id' => $this->user->user_id,
             ]))
             ->assertStatus(204);
 
         // ensure still in channel
-        $this->actingAs($this->user, 'api')
-            ->json('GET', route('api.chat.presence'))
+        $this->actAsScopedUser($this->user, ['*']);
+        $this->json('GET', route('api.chat.presence'))
             ->assertStatus(200)
             ->assertJsonFragment(['channel_id' => $this->publicChannel->channel_id]);
     }
@@ -171,8 +171,8 @@ class ChannelsControllerTest extends TestCase
 
     public function testChannelMarkAsReadWhenUnjoined() // fail
     {
-        $this->actingAs($this->user, 'api')
-            ->json(
+        $this->actAsScopedUser($this->user, ['*']);
+        $this->json(
                 'PUT',
                 route('api.chat.channels.mark-as-read', [
                     'channel_id' => $this->publicChannel->channel_id,
@@ -184,14 +184,14 @@ class ChannelsControllerTest extends TestCase
 
     public function testChannelMarkAsReadWhenJoined() // success
     {
-        $this->actingAs($this->user, 'api')
-            ->json('PUT', route('api.chat.channels.join', [
+        $this->actAsScopedUser($this->user, ['*']);
+        $this->json('PUT', route('api.chat.channels.join', [
                 'channel_id' => $this->publicChannel->channel_id,
                 'user_id' => $this->user->user_id,
             ]));
 
-        $this->actingAs($this->user, 'api')
-            ->json(
+        $this->actAsScopedUser($this->user, ['*']);
+        $this->json(
                 'PUT',
                 route('api.chat.channels.mark-as-read', [
                     'channel_id' => $this->publicChannel->channel_id,
@@ -200,8 +200,8 @@ class ChannelsControllerTest extends TestCase
             )
             ->assertStatus(204);
 
-        $this->actingAs($this->user, 'api')
-            ->json('GET', route('api.chat.presence'))
+        $this->actAsScopedUser($this->user, ['*']);
+        $this->json('GET', route('api.chat.presence'))
             ->assertStatus(200)
             ->assertJsonFragment([
                 'channel_id' => $this->publicChannel->channel_id,
@@ -213,15 +213,15 @@ class ChannelsControllerTest extends TestCase
     {
         $newerPublicMessage = factory(Chat\Message::class)->create(['channel_id' => $this->publicChannel->channel_id]);
 
-        $this->actingAs($this->user, 'api')
-            ->json('PUT', route('api.chat.channels.join', [
+        $this->actAsScopedUser($this->user, ['*']);
+        $this->json('PUT', route('api.chat.channels.join', [
                 'channel_id' => $this->publicChannel->channel_id,
                 'user_id' => $this->user->user_id,
             ]));
 
         // mark as read to $newerPublicMessage->message_id
-        $this->actingAs($this->user, 'api')
-            ->json(
+        $this->actAsScopedUser($this->user, ['*']);
+        $this->json(
                 'PUT',
                 route('api.chat.channels.mark-as-read', [
                     'channel_id' => $this->publicChannel->channel_id,
@@ -230,8 +230,8 @@ class ChannelsControllerTest extends TestCase
             )
             ->assertStatus(204);
 
-        $this->actingAs($this->user, 'api')
-            ->json('GET', route('api.chat.presence'))
+        $this->actAsScopedUser($this->user, ['*']);
+        $this->json('GET', route('api.chat.presence'))
             ->assertStatus(200)
             ->assertJsonFragment([
                 'channel_id' => $this->publicChannel->channel_id,
@@ -239,8 +239,8 @@ class ChannelsControllerTest extends TestCase
             ]);
 
         // attempt to mark as read to the older $this->publicMessage->message_id
-        $this->actingAs($this->user, 'api')
-            ->json(
+        $this->actAsScopedUser($this->user, ['*']);
+        $this->json(
                 'PUT',
                 route('api.chat.channels.mark-as-read', [
                     'channel_id' => $this->publicChannel->channel_id,
@@ -249,8 +249,8 @@ class ChannelsControllerTest extends TestCase
             )
             ->assertStatus(204);
 
-        $this->actingAs($this->user, 'api')
-            ->json('GET', route('api.chat.presence'))
+        $this->actAsScopedUser($this->user, ['*']);
+        $this->json('GET', route('api.chat.presence'))
             ->assertStatus(200)
             ->assertJsonFragment([
                 'channel_id' => $this->publicChannel->channel_id,
@@ -272,8 +272,8 @@ class ChannelsControllerTest extends TestCase
 
     public function testChannelLeaveWhenNotPublic() // fail
     {
-        $this->actingAs($this->user, 'api')
-            ->json('DELETE', route('api.chat.channels.part', [
+        $this->actAsScopedUser($this->user, ['*']);
+        $this->json('DELETE', route('api.chat.channels.part', [
                 'channel_id' => $this->privateChannel->channel_id,
                 'user_id' => $this->user->user_id,
             ]))
@@ -282,20 +282,20 @@ class ChannelsControllerTest extends TestCase
 
     public function testChannelLeaveWhenNotJoined() // success ?
     {
-        $this->actingAs($this->user, 'api')
-            ->json('GET', route('api.chat.presence'))
+        $this->actAsScopedUser($this->user, ['*']);
+        $this->json('GET', route('api.chat.presence'))
             ->assertStatus(200)
             ->assertJsonMissing(['channel_id' => $this->publicChannel->channel_id]);
 
-        $this->actingAs($this->user, 'api')
-            ->json('DELETE', route('api.chat.channels.part', [
+        $this->actAsScopedUser($this->user, ['*']);
+        $this->json('DELETE', route('api.chat.channels.part', [
                 'channel_id' => $this->publicChannel->channel_id,
                 'user_id' => $this->user->user_id,
             ]))
             ->assertStatus(204);
 
-        $this->actingAs($this->user, 'api')
-            ->json('GET', route('api.chat.presence'))
+        $this->actAsScopedUser($this->user, ['*']);
+        $this->json('GET', route('api.chat.presence'))
             ->assertStatus(200)
             ->assertJsonMissing(['channel_id' => $this->publicChannel->channel_id]);
     }
@@ -303,36 +303,36 @@ class ChannelsControllerTest extends TestCase
     public function testChannelLeaveWhenJoined() // success
     {
         // ensure not in channel
-        $this->actingAs($this->user, 'api')
-            ->json('GET', route('api.chat.presence'))
+        $this->actAsScopedUser($this->user, ['*']);
+        $this->json('GET', route('api.chat.presence'))
             ->assertStatus(200)
             ->assertJsonMissing(['channel_id' => $this->publicChannel->channel_id]);
 
         // join channel
-        $this->actingAs($this->user, 'api')
-            ->json('PUT', route('api.chat.channels.join', [
+        $this->actAsScopedUser($this->user, ['*']);
+        $this->json('PUT', route('api.chat.channels.join', [
                 'channel_id' => $this->publicChannel->channel_id,
                 'user_id' => $this->user->user_id,
             ]))
             ->assertStatus(204);
 
         // ensure now in channel
-        $this->actingAs($this->user, 'api')
-            ->json('GET', route('api.chat.presence'))
+        $this->actAsScopedUser($this->user, ['*']);
+        $this->json('GET', route('api.chat.presence'))
             ->assertStatus(200)
             ->assertJsonFragment(['channel_id' => $this->publicChannel->channel_id]);
 
         // leave channel
-        $this->actingAs($this->user, 'api')
-            ->json('DELETE', route('api.chat.channels.part', [
+        $this->actAsScopedUser($this->user, ['*']);
+        $this->json('DELETE', route('api.chat.channels.part', [
                 'channel_id' => $this->publicChannel->channel_id,
                 'user_id' => $this->user->user_id,
             ]))
             ->assertStatus(204);
 
         // ensure no longer in channel
-        $this->actingAs($this->user, 'api')
-            ->json('GET', route('api.chat.presence'))
+        $this->actAsScopedUser($this->user, ['*']);
+        $this->json('GET', route('api.chat.presence'))
             ->assertStatus(200)
             ->assertJsonMissing(['channel_id' => $this->publicChannel->channel_id]);
     }

--- a/tests/Controllers/Chat/ChatControllerTest.php
+++ b/tests/Controllers/Chat/ChatControllerTest.php
@@ -77,8 +77,8 @@ class ChatControllerTest extends TestCase
             'zebra_id' => $this->user->user_id,
         ]);
 
-        $this->actingAs($this->user, 'api')
-            ->json(
+        $this->actAsScopedUser($this->user, ['*']);
+        $this->json(
                 'POST',
                 route('api.chat.new'),
                 [
@@ -92,8 +92,8 @@ class ChatControllerTest extends TestCase
     {
         $restrictedUser = factory(User::class)->states('restricted')->create();
 
-        $this->actingAs($restrictedUser, 'api')
-            ->json(
+        $this->actAsScopedUser($restrictedUser, ['*']);
+        $this->json(
                 'POST',
                 route('api.chat.new'),
                 [
@@ -111,8 +111,8 @@ class ChatControllerTest extends TestCase
             factory(App\Models\UserAccountHistory::class)->states('silence')->make()
         );
 
-        $this->actingAs($silencedUser, 'api')
-            ->json(
+        $this->actAsScopedUser($silencedUser, ['*']);
+        $this->json(
                 'POST',
                 route('api.chat.new'),
                 [
@@ -126,8 +126,8 @@ class ChatControllerTest extends TestCase
     {
         $restrictedUser = factory(User::class)->states('restricted')->create();
 
-        $this->actingAs($this->user, 'api')
-            ->json(
+        $this->actAsScopedUser($this->user, ['*']);
+        $this->json(
                 'POST',
                 route('api.chat.new'),
                 [
@@ -139,8 +139,8 @@ class ChatControllerTest extends TestCase
 
     public function testCreatePMWithSelf() // fail
     {
-        $this->actingAs($this->user, 'api')
-            ->json(
+        $this->actAsScopedUser($this->user, ['*']);
+        $this->json(
                 'POST',
                 route('api.chat.new'),
                 [
@@ -154,8 +154,8 @@ class ChatControllerTest extends TestCase
     {
         $privateUser = factory(User::class)->create(['pm_friends_only' => true]);
 
-        $this->actingAs($this->user, 'api')
-            ->json(
+        $this->actAsScopedUser($this->user, ['*']);
+        $this->json(
                 'POST',
                 route('api.chat.new'),
                 [
@@ -173,8 +173,8 @@ class ChatControllerTest extends TestCase
             'zebra_id' => $this->user->user_id,
         ]);
 
-        $this->actingAs($this->user, 'api')
-            ->json(
+        $this->actAsScopedUser($this->user, ['*']);
+        $this->json(
                 'POST',
                 route('api.chat.new'),
                 [
@@ -186,8 +186,8 @@ class ChatControllerTest extends TestCase
 
     public function testCreatePM() // success
     {
-        $this->actingAs($this->user, 'api')
-            ->json(
+        $this->actAsScopedUser($this->user, ['*']);
+        $this->json(
                 'POST',
                 route('api.chat.new'),
                 [
@@ -199,8 +199,8 @@ class ChatControllerTest extends TestCase
 
     public function testCreatePMWhenAlreadyExists() // success
     {
-        $this->actingAs($this->user, 'api')
-            ->json(
+        $this->actAsScopedUser($this->user, ['*']);
+        $this->json(
                 'POST',
                 route('api.chat.new'),
                 [
@@ -210,8 +210,8 @@ class ChatControllerTest extends TestCase
             )->assertStatus(200);
 
         // should return existing conversation and not error
-        $this->actingAs($this->user, 'api')
-            ->json(
+        $this->actAsScopedUser($this->user, ['*']);
+        $this->json(
                 'POST',
                 route('api.chat.new'),
                 [
@@ -235,15 +235,15 @@ class ChatControllerTest extends TestCase
         $publicChannel = factory(Chat\Channel::class)->states('public')->create();
 
         // join the channel
-        $this->actingAs($this->user, 'api')
-            ->json('PUT', route('api.chat.channels.join', [
+        $this->actAsScopedUser($this->user, ['*']);
+        $this->json('PUT', route('api.chat.channels.join', [
                 'channel_id' => $publicChannel->channel_id,
                 'user_id' => $this->user->user_id,
             ]))
             ->assertStatus(204);
 
-        $this->actingAs($this->user, 'api')
-            ->json('GET', route('api.chat.presence'))
+        $this->actAsScopedUser($this->user, ['*']);
+        $this->json('GET', route('api.chat.presence'))
             ->assertStatus(200)
             ->assertJsonFragment(['channel_id' => $publicChannel->channel_id]);
     }
@@ -251,8 +251,8 @@ class ChatControllerTest extends TestCase
     public function testChatPresenceHidingBlocked() // success
     {
         // start conversation with $this->anotherUser
-        $this->actingAs($this->user, 'api')
-            ->json(
+        $this->actAsScopedUser($this->user, ['*']);
+        $this->json(
                 'POST',
                 route('api.chat.new'),
                 [
@@ -268,8 +268,8 @@ class ChatControllerTest extends TestCase
         ]);
 
         // ensure conversation with $this->anotherUser isn't visible
-        $this->actingAs($this->user, 'api')
-            ->json('GET', route('api.chat.presence'))
+        $this->actAsScopedUser($this->user, ['*']);
+        $this->json('GET', route('api.chat.presence'))
             ->assertStatus(200)
             ->assertJsonMissing(['users' => [
                 $this->user->user_id,
@@ -280,8 +280,8 @@ class ChatControllerTest extends TestCase
         $block->delete();
 
         // ensure conversation with $this->anotherUser is visible again
-        $this->actingAs($this->user, 'api')
-            ->json('GET', route('api.chat.presence'))
+        $this->actAsScopedUser($this->user, ['*']);
+        $this->json('GET', route('api.chat.presence'))
             ->assertStatus(200)
             ->assertJsonFragment(['users' => [
                 $this->user->user_id,
@@ -292,8 +292,8 @@ class ChatControllerTest extends TestCase
     public function testChatPresenceHidingRestricted() // success
     {
         // start conversation with $this->anotherUser
-        $this->actingAs($this->user, 'api')
-            ->json(
+        $this->actAsScopedUser($this->user, ['*']);
+        $this->json(
                 'POST',
                 route('api.chat.new'),
                 [
@@ -306,8 +306,8 @@ class ChatControllerTest extends TestCase
         $this->anotherUser->update(['user_warnings' => 1]);
 
         // ensure conversation with $this->anotherUser isn't visible
-        $this->actingAs($this->user, 'api')
-            ->json('GET', route('api.chat.presence'))
+        $this->actAsScopedUser($this->user, ['*']);
+        $this->json('GET', route('api.chat.presence'))
             ->assertStatus(200)
             ->assertJsonMissing(['users' => [
                 $this->user->user_id,
@@ -318,8 +318,8 @@ class ChatControllerTest extends TestCase
         $this->anotherUser->update(['user_warnings' => 0]);
 
         // ensure conversation with $this->anotherUser is visible again
-        $this->actingAs($this->user, 'api')
-            ->json('GET', route('api.chat.presence'))
+        $this->actAsScopedUser($this->user, ['*']);
+        $this->json('GET', route('api.chat.presence'))
             ->assertStatus(200)
             ->assertJsonFragment(['users' => [
                 $this->user->user_id,
@@ -342,15 +342,15 @@ class ChatControllerTest extends TestCase
         $publicMessage = factory(Chat\Message::class)->create(['channel_id' => $publicChannel->channel_id]);
 
         // join the channel
-        $this->actingAs($this->user, 'api')
-            ->json('PUT', route('api.chat.channels.join', [
+        $this->actAsScopedUser($this->user, ['*']);
+        $this->json('PUT', route('api.chat.channels.join', [
                 'channel_id' => $publicChannel->channel_id,
                 'user_id' => $this->user->user_id,
             ]))
             ->assertStatus(204);
 
-        $this->actingAs($this->user, 'api')
-            ->json('GET', route('api.chat.updates'), ['since' => $publicMessage->message_id])
+        $this->actAsScopedUser($this->user, ['*']);
+        $this->json('GET', route('api.chat.updates'), ['since' => $publicMessage->message_id])
             ->assertStatus(204);
     }
 
@@ -360,15 +360,15 @@ class ChatControllerTest extends TestCase
         $publicMessage = factory(Chat\Message::class)->create(['channel_id' => $publicChannel->channel_id]);
 
         // join channel
-        $this->actingAs($this->user, 'api')
-            ->json('PUT', route('api.chat.channels.join', [
+        $this->actAsScopedUser($this->user, ['*']);
+        $this->json('PUT', route('api.chat.channels.join', [
                 'channel_id' => $publicChannel->channel_id,
                 'user_id' => $this->user->user_id,
             ]))
             ->assertStatus(204);
 
-        $this->actingAs($this->user, 'api')
-            ->json('GET', route('api.chat.updates'), ['since' => 0])
+        $this->actAsScopedUser($this->user, ['*']);
+        $this->json('GET', route('api.chat.updates'), ['since' => 0])
             ->assertStatus(200)
             ->assertJsonFragment(['content' => $publicMessage->content]);
     }

--- a/tests/Controllers/Passport/AuthorizationControllerTest.php
+++ b/tests/Controllers/Passport/AuthorizationControllerTest.php
@@ -1,0 +1,99 @@
+<?php
+
+/**
+ *    Copyright 2015-2017 ppy Pty. Ltd.
+ *
+ *    This file is part of osu!web. osu!web is distributed with the hope of
+ *    attracting more community contributions to the core ecosystem of osu!.
+ *
+ *    osu!web is free software: you can redistribute it and/or modify
+ *    it under the terms of the Affero GNU General Public License version 3
+ *    as published by the Free Software Foundation.
+ *
+ *    osu!web is distributed WITHOUT ANY WARRANTY; without even the implied
+ *    warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *    See the GNU Affero General Public License for more details.
+ *
+ *    You should have received a copy of the GNU Affero General Public License
+ *    along with osu!web.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace Tests\Passport;
+
+use App\Http\Controllers\Passport\AuthorizationController;
+use Laravel\Passport\Http\Controllers\AuthorizationController as PassportAuthorizationController;
+use Laravel\Passport\Bridge\Scope;
+use Mockery;
+use ReflectionClass;
+use TestCase;
+
+class AuthorizationControllerTest extends TestCase
+{
+    protected $request;
+    protected $controller;
+
+    private static function scopeIdentifiers(array $scopes) {
+        return collect($scopes)->map(function ($scope) {
+            return $scope->id;
+        })->all();
+    }
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->request = Mockery::mock('\League\OAuth2\Server\RequestTypes\AuthorizationRequest');
+
+        $this->controller = new AuthorizationController(
+            Mockery::mock('\League\OAuth2\Server\AuthorizationServer'),
+            Mockery::mock('\Illuminate\Contracts\Routing\ResponseFactory')
+        );
+    }
+
+    public function tearDown()
+    {
+        parent::tearDown();
+
+        Mockery::close();
+    }
+
+    public function testBaseClassDoesNotNormalize()
+    {
+        $this->request->shouldReceive('getScopes')->andReturn([]);
+        $this->controller = new PassportAuthorizationController(
+            Mockery::mock('\League\OAuth2\Server\AuthorizationServer'),
+            Mockery::mock('\Illuminate\Contracts\Routing\ResponseFactory')
+        );
+
+        $actual = $this->invokeMethod($this->controller, 'parseScopes', [$this->request]);
+
+        $this->assertSame(static::scopeIdentifiers($actual), []);
+    }
+
+    public function testIdentifyScopeAdded()
+    {
+        $this->request->shouldReceive('getScopes')->andReturn([]);
+
+        $actual = $this->invokeMethod($this->controller, 'parseScopes', [$this->request]);
+
+        $this->assertSame(static::scopeIdentifiers($actual), ['identify']);
+    }
+
+    public function testOnlyIdentifyScopeRequested()
+    {
+        $this->request->shouldReceive('getScopes')->andReturn([new Scope('identify')]);
+
+        $actual = $this->invokeMethod($this->controller, 'parseScopes', [$this->request]);
+
+        $this->assertSame(static::scopeIdentifiers($actual), ['identify']);
+    }
+
+    public function testOnlyIdentifyScopeIncludedInRequest()
+    {
+        $this->request->shouldReceive('getScopes')->andReturn([new Scope('identify'), new Scope('read')]);
+
+        $actual = $this->invokeMethod($this->controller, 'parseScopes', [$this->request]);
+
+        $this->assertSame(static::scopeIdentifiers($actual), ['identify', 'read']);
+    }
+}

--- a/tests/RequireScopesTest.php
+++ b/tests/RequireScopesTest.php
@@ -41,7 +41,6 @@ class RequireScopesTest extends TestCase
     public function testSingleton()
     {
         $this->assertSame(app(RequireScopes::class), app(RequireScopes::class));
-        $this->assertNotSame(app(RequireScopes::class), new RequireScopes);
     }
 
     public function testNullUser()

--- a/tests/RequireScopesTest.php
+++ b/tests/RequireScopesTest.php
@@ -33,7 +33,7 @@ class RequireScopesTest extends TestCase
     {
         parent::setUp();
 
-        $this->request = Request::create('/', 'GET', [], [], [], ['HTTP_ACCEPT' => 'application/json']);
+        $this->request = Request::create('/', 'GET');
         $this->next = static function () {
             // just an empty closure.
         };

--- a/tests/RequireScopesTest.php
+++ b/tests/RequireScopesTest.php
@@ -20,6 +20,7 @@
 use App\Exceptions\AuthorizationException;
 use App\Http\Middleware\RequireScopes;
 use App\Models\User;
+use Illuminate\Routing\Route;
 use Laravel\Passport\Exceptions\MissingScopeException;
 
 class RequireScopesTest extends TestCase
@@ -46,6 +47,7 @@ class RequireScopesTest extends TestCase
     public function testNullUser()
     {
         $this->setUser(null);
+        $this->setRequest();
 
         $this->expectException(AuthorizationException::class);
         app(RequireScopes::class)->handle($this->request, $this->next);
@@ -56,6 +58,7 @@ class RequireScopesTest extends TestCase
         $userScopes = [];
 
         $this->setUser($userScopes);
+        $this->setRequest();
 
         $this->expectException(MissingScopeException::class);
         app(RequireScopes::class)->handle($this->request, $this->next);
@@ -66,6 +69,7 @@ class RequireScopesTest extends TestCase
         $userScopes = ['*'];
 
         $this->setUser($userScopes);
+        $this->setRequest();
 
         app(RequireScopes::class)->handle($this->request, $this->next);
         $this->assertTrue(true);
@@ -77,6 +81,7 @@ class RequireScopesTest extends TestCase
         $requireScopes = ['identify'];
 
         $this->setUser($userScopes);
+        $this->setRequest($requireScopes);
 
         app(RequireScopes::class)->handle($this->request, $this->next, ...$requireScopes);
         $this->assertTrue(true);
@@ -88,6 +93,7 @@ class RequireScopesTest extends TestCase
         $requireScopes = ['identify'];
 
         $this->setUser($userScopes);
+        $this->setRequest($requireScopes);
 
         $this->expectException(MissingScopeException::class);
         app(RequireScopes::class)->handle($this->request, $this->next, ...$requireScopes);
@@ -99,6 +105,7 @@ class RequireScopesTest extends TestCase
         $requireScopes = ['identify'];
 
         $this->setUser($userScopes);
+        $this->setRequest($requireScopes);
 
         app(RequireScopes::class)->handle($this->request, $this->next, ...$requireScopes);
         $this->assertTrue(true);
@@ -110,6 +117,7 @@ class RequireScopesTest extends TestCase
         $requireScopes = ['identify'];
 
         $this->setUser($userScopes);
+        $this->setRequest($requireScopes);
 
         $this->expectException(MissingScopeException::class);
         app(RequireScopes::class)->handle($this->request, $this->next, ...$requireScopes);
@@ -121,6 +129,7 @@ class RequireScopesTest extends TestCase
         $requireScopes = ['identify'];
 
         $this->setUser($userScopes);
+        $this->setRequest($requireScopes);
 
         $this->expectException(MissingScopeException::class);
         app(RequireScopes::class)->handle($this->request, $this->next, ...$requireScopes);
@@ -132,6 +141,7 @@ class RequireScopesTest extends TestCase
         $requireScopes = ['identify'];
 
         $this->setUser($userScopes);
+        $this->setRequest($requireScopes);
 
         app(RequireScopes::class)->handle($this->request, $this->next, ...$requireScopes);
         $this->assertTrue(true);
@@ -142,6 +152,7 @@ class RequireScopesTest extends TestCase
         $userScopes = ['identify'];
 
         $this->setUser($userScopes);
+        $this->setRequest();
 
         $this->expectException(MissingScopeException::class);
         app(RequireScopes::class)->handle($this->request, $this->next);
@@ -153,6 +164,7 @@ class RequireScopesTest extends TestCase
         $requireScopes = ['identify'];
 
         $this->setUser($userScopes);
+        $this->setRequest($requireScopes);
 
         app(RequireScopes::class)->handle($this->request, function () use ($requireScopes) {
             app(RequireScopes::class)->handle($this->request, $this->next, ...$requireScopes);
@@ -167,10 +179,26 @@ class RequireScopesTest extends TestCase
         $requireScopes = ['identify'];
 
         $this->setUser($userScopes);
+        $this->setRequest($requireScopes);
 
         $this->expectException(MissingScopeException::class);
         app(RequireScopes::class)->handle($this->request, function () use ($requireScopes) {
             app(RequireScopes::class)->handle($this->request, $this->next, ...$requireScopes);
+        });
+    }
+
+    protected function setRequest(?array $scopes = null)
+    {
+        // set a fake route resolver
+        $this->request->setRouteResolver(function () use ($scopes) {
+            $route = new Route(['GET'], '/', null);
+            $route->middleware('require-scopes');
+
+            if ($scopes !== null) {
+                $route->middleware('require-scopes:'.implode(',', $scopes));
+            }
+
+            return $route;
         });
     }
 

--- a/tests/RequireScopesTest.php
+++ b/tests/RequireScopesTest.php
@@ -39,12 +39,18 @@ class RequireScopesTest extends TestCase
         };
     }
 
+    public function testSingleton()
+    {
+        $this->assertSame(app(RequireScopes::class), app(RequireScopes::class));
+        $this->assertNotSame(app(RequireScopes::class), new RequireScopes);
+    }
+
     public function testNullUser()
     {
         $this->setUser(null);
 
         $this->expectException(AuthorizationException::class);
-        (new RequireScopes)->handle($this->request, $this->next);
+        app(RequireScopes::class)->handle($this->request, $this->next);
     }
 
     public function testNoScopes()
@@ -54,7 +60,7 @@ class RequireScopesTest extends TestCase
         $this->setUser($userScopes);
 
         $this->expectException(MissingScopeException::class);
-        (new RequireScopes)->handle($this->request, $this->next);
+        app(RequireScopes::class)->handle($this->request, $this->next);
     }
 
     public function testAllScopes()
@@ -63,7 +69,7 @@ class RequireScopesTest extends TestCase
 
         $this->setUser($userScopes);
 
-        (new RequireScopes)->handle($this->request, $this->next);
+        app(RequireScopes::class)->handle($this->request, $this->next);
         $this->assertTrue(true);
     }
 
@@ -74,7 +80,7 @@ class RequireScopesTest extends TestCase
 
         $this->setUser($userScopes);
 
-        (new RequireScopes)->handle($this->request, $this->next, ...$requireScopes);
+        app(RequireScopes::class)->handle($this->request, $this->next, ...$requireScopes);
         $this->assertTrue(true);
     }
 
@@ -86,7 +92,7 @@ class RequireScopesTest extends TestCase
         $this->setUser($userScopes);
 
         $this->expectException(MissingScopeException::class);
-        (new RequireScopes)->handle($this->request, $this->next, ...$requireScopes);
+        app(RequireScopes::class)->handle($this->request, $this->next, ...$requireScopes);
     }
 
     public function testRequiresSpecificScopeAndAllScopeGiven()
@@ -96,7 +102,7 @@ class RequireScopesTest extends TestCase
 
         $this->setUser($userScopes);
 
-        (new RequireScopes)->handle($this->request, $this->next, ...$requireScopes);
+        app(RequireScopes::class)->handle($this->request, $this->next, ...$requireScopes);
         $this->assertTrue(true);
     }
 
@@ -108,7 +114,7 @@ class RequireScopesTest extends TestCase
         $this->setUser($userScopes);
 
         $this->expectException(MissingScopeException::class);
-        (new RequireScopes)->handle($this->request, $this->next, ...$requireScopes);
+        app(RequireScopes::class)->handle($this->request, $this->next, ...$requireScopes);
     }
 
     public function testBlankRequireShouldDenyRegularScopes()
@@ -118,7 +124,7 @@ class RequireScopesTest extends TestCase
         $this->setUser($userScopes);
 
         $this->expectException(MissingScopeException::class);
-        (new RequireScopes)->handle($this->request, $this->next);
+        app(RequireScopes::class)->handle($this->request, $this->next);
     }
 
     public function testRequireScopesLayered()
@@ -128,8 +134,8 @@ class RequireScopesTest extends TestCase
 
         $this->setUser($userScopes);
 
-        (new RequireScopes)->handle($this->request, function () use ($requireScopes) {
-            (new RequireScopes)->handle($this->request, $this->next, ...$requireScopes);
+        app(RequireScopes::class)->handle($this->request, function () use ($requireScopes) {
+            app(RequireScopes::class)->handle($this->request, $this->next, ...$requireScopes);
         });
 
         $this->assertTrue(true);
@@ -143,8 +149,8 @@ class RequireScopesTest extends TestCase
         $this->setUser($userScopes);
 
         $this->expectException(MissingScopeException::class);
-        (new RequireScopes)->handle($this->request, function () use ($requireScopes) {
-            (new RequireScopes)->handle($this->request, $this->next, ...$requireScopes);
+        app(RequireScopes::class)->handle($this->request, function () use ($requireScopes) {
+            app(RequireScopes::class)->handle($this->request, $this->next, ...$requireScopes);
         });
     }
 

--- a/tests/RequireScopesTest.php
+++ b/tests/RequireScopesTest.php
@@ -17,12 +17,10 @@
  *    You should have received a copy of the GNU Affero General Public License
  *    along with osu!web.  If not, see <http://www.gnu.org/licenses/>.
  */
-
 use App\Exceptions\AuthorizationException;
 use App\Http\Middleware\RequireScopes;
 use App\Models\User;
 use Laravel\Passport\Exceptions\MissingScopeException;
-use Laravel\Passport\Token;
 
 class RequireScopesTest extends TestCase
 {

--- a/tests/RequireScopesTest.php
+++ b/tests/RequireScopesTest.php
@@ -115,6 +115,28 @@ class RequireScopesTest extends TestCase
         app(RequireScopes::class)->handle($this->request, $this->next, ...$requireScopes);
     }
 
+    public function testRequiresSpecificScopeAndMultipleNonMatchingScopesGiven()
+    {
+        $userScopes = ['somethingelse', 'alsonotright', 'nope'];
+        $requireScopes = ['identify'];
+
+        $this->setUser($userScopes);
+
+        $this->expectException(MissingScopeException::class);
+        app(RequireScopes::class)->handle($this->request, $this->next, ...$requireScopes);
+    }
+
+    public function testRequiresSpecificScopeAndMultipleScopesGiven()
+    {
+        $userScopes = ['somethingelse', 'identify', 'nope'];
+        $requireScopes = ['identify'];
+
+        $this->setUser($userScopes);
+
+        app(RequireScopes::class)->handle($this->request, $this->next, ...$requireScopes);
+        $this->assertTrue(true);
+    }
+
     public function testBlankRequireShouldDenyRegularScopes()
     {
         $userScopes = ['identify'];

--- a/tests/RequireScopesTest.php
+++ b/tests/RequireScopesTest.php
@@ -1,0 +1,79 @@
+<?php
+
+/**
+ *    Copyright 2015-2018 ppy Pty. Ltd.
+ *
+ *    This file is part of osu!web. osu!web is distributed with the hope of
+ *    attracting more community contributions to the core ecosystem of osu!.
+ *
+ *    osu!web is free software: you can redistribute it and/or modify
+ *    it under the terms of the Affero GNU General Public License version 3
+ *    as published by the Free Software Foundation.
+ *
+ *    osu!web is distributed WITHOUT ANY WARRANTY; without even the implied
+ *    warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *    See the GNU Affero General Public License for more details.
+ *
+ *    You should have received a copy of the GNU Affero General Public License
+ *    along with osu!web.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+use App\Exceptions\AuthorizationException;
+use App\Http\Middleware\RequireScopes;
+use App\Models\User;
+use Laravel\Passport\Exceptions\MissingScopeException;
+
+class RequireScopesTest extends TestCase
+{
+    protected $next;
+    protected $request;
+
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->request = Request::create('/', 'GET', [], [], [], ['HTTP_ACCEPT' => 'application/json']);
+        $this->next = static function () {
+            // just an empty closure.
+        };
+    }
+
+    public function testNullUser()
+    {
+        $this->setUser(null);
+        $middleware = new RequireScopes;
+
+        $this->expectException(AuthorizationException::class);
+        $middleware->handle($this->request, $this->next);
+    }
+
+    public function testNoScopes()
+    {
+        $this->setUser(factory(User::class)->create(), []);
+
+        $middleware = new RequireScopes;
+
+        $this->expectException(MissingScopeException::class);
+        $middleware->handle($this->request, $this->next);
+    }
+
+    public function testAllScopes()
+    {
+        $this->setUser(factory(User::class)->create(), ['*']);
+
+        $middleware = new RequireScopes;
+        $middleware->handle($this->request, $this->next);
+        $this->assertTrue(true);
+    }
+
+    protected function setUser(?User $user, array $scopes = null)
+    {
+        $this->request->setUserResolver(function () use ($user) {
+            return $user;
+        });
+
+        if ($scopes !== null) {
+            $this->actAsScopedUser($user, $scopes);
+        }
+    }
+}

--- a/tests/RequireScopesTest.php
+++ b/tests/RequireScopesTest.php
@@ -84,6 +84,24 @@ class RequireScopesTest extends TestCase
         $middleware->handle($this->request, $this->next, ...['identify']);
     }
 
+    public function testRequiresSpecificScopeAndAllScopeGiven()
+    {
+        $this->setUser(factory(User::class)->create(), ['*']);
+        $middleware = new RequireScopes;
+
+        $middleware->handle($this->request, $this->next, ...['identify']);
+        $this->assertTrue(true);
+    }
+
+    public function testRequiresSpecificScopeAndNoScopeGiven()
+    {
+        $this->setUser(factory(User::class)->create(), []);
+        $middleware = new RequireScopes;
+
+        $this->expectException(MissingScopeException::class);
+        $middleware->handle($this->request, $this->next, ...['identify']);
+    }
+
     protected function setUser(?User $user, ?array $scopes = null)
     {
         $this->request->setUserResolver(function () use ($user) {

--- a/tests/RequireScopesTest.php
+++ b/tests/RequireScopesTest.php
@@ -109,14 +109,7 @@ class RequireScopesTest extends TestCase
         });
 
         if ($user !== null) {
-            $token = Token::unguarded(function () use ($scopes, $user) {
-                return new Token([
-                    'scopes' => $scopes,
-                    'user_id' => $user->user_id,
-                ]);
-            });
-
-            $user->withAccessToken($token);
+            $this->actAsScopedUser($user, $scopes);
         }
     }
 }

--- a/tests/RouteScopesTest.php
+++ b/tests/RouteScopesTest.php
@@ -1,0 +1,60 @@
+<?php
+
+/**
+ *    Copyright 2015-2018 ppy Pty. Ltd.
+ *
+ *    This file is part of osu!web. osu!web is distributed with the hope of
+ *    attracting more community contributions to the core ecosystem of osu!.
+ *
+ *    osu!web is free software: you can redistribute it and/or modify
+ *    it under the terms of the Affero GNU General Public License version 3
+ *    as published by the Free Software Foundation.
+ *
+ *    osu!web is distributed WITHOUT ANY WARRANTY; without even the implied
+ *    warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *    See the GNU Affero General Public License for more details.
+ *
+ *    You should have received a copy of the GNU Affero General Public License
+ *    along with osu!web.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+class RouteScopesTest extends TestCase
+{
+    public function testApiRoutesRequireScope()
+    {
+        $expected = [
+            'api/v2/me' => ['identify'],
+        ];
+
+        $loaded = [];
+
+        foreach (Route::getRoutes() as $route) {
+            if (!starts_with($route->uri, 'api/')) {
+                continue;
+            }
+
+            // uri will still have the placeholders, but it's fine.
+            $request = Request::create($route->uri, 'GET', [], [], [], ['HTTP_ACCEPT' => 'application/json']);
+            $this->app->instance('request', $request); // set current request so is_api_request can work.
+
+            $middlewares = $route->gatherMiddleware();
+
+            foreach ($middlewares as $middleware) {
+                if (!is_string($middleware)) {
+                    continue;
+                }
+
+                if (starts_with($middleware, 'require-scopes:')) {
+                    $scopes = explode(',', substr($middleware, strlen('require-scopes:')));
+                    sort($scopes);
+                    $loaded[$route->uri] = $scopes;
+                }
+            }
+
+            // FIXME: separate this assertion.
+            $this->assertTrue(in_array('require-scopes', $middlewares));
+        }
+
+        $this->assertSame($expected, $loaded);
+    }
+}

--- a/tests/RouteScopesTest.php
+++ b/tests/RouteScopesTest.php
@@ -33,8 +33,8 @@ class RouteScopesTest extends TestCase
                 continue;
             }
 
-            // uri will still have the placeholders, but it's fine.
-            $request = Request::create($route->uri, 'GET', [], [], [], ['HTTP_ACCEPT' => 'application/json']);
+            // uri will still have the placeholders and wrong verbs, but we don't need them.
+            $request = Request::create($route->uri, 'GET');
             $this->app->instance('request', $request); // set current request so is_api_request can work.
 
             $middlewares = $route->gatherMiddleware();

--- a/tests/RouteScopesTest.php
+++ b/tests/RouteScopesTest.php
@@ -17,7 +17,6 @@
  *    You should have received a copy of the GNU Affero General Public License
  *    along with osu!web.  If not, see <http://www.gnu.org/licenses/>.
  */
-
 class RouteScopesTest extends TestCase
 {
     public function testApiRoutesRequireScope()
@@ -44,6 +43,7 @@ class RouteScopesTest extends TestCase
                     continue;
                 }
 
+                // FIXME: need something that isn't string checking.
                 if (starts_with($middleware, 'require-scopes:')) {
                     $scopes = explode(',', substr($middleware, strlen('require-scopes:')));
                     sort($scopes);
@@ -52,7 +52,7 @@ class RouteScopesTest extends TestCase
             }
 
             // FIXME: separate this assertion.
-            $this->assertTrue(in_array('require-scopes', $middlewares));
+            $this->assertTrue(in_array('require-scopes', $middlewares, true));
         }
 
         $this->assertSame($expected, $loaded);

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -17,7 +17,6 @@
  *    You should have received a copy of the GNU Affero General Public License
  *    along with osu!web.  If not, see <http://www.gnu.org/licenses/>.
  */
-
 use Illuminate\Foundation\Testing\DatabaseTransactions;
 use Laravel\Passport\Token;
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -17,7 +17,9 @@
  *    You should have received a copy of the GNU Affero General Public License
  *    along with osu!web.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Laravel\Passport\Passport;
 
 class TestCase extends Illuminate\Foundation\Testing\TestCase
 {
@@ -63,6 +65,13 @@ class TestCase extends Illuminate\Foundation\Testing\TestCase
                 $connection->disconnect();
             }
         });
+    }
+
+    protected function actAsScopedUser($user, array $scopes = ['*'])
+    {
+        Passport::actingAs($user, $scopes);
+        // Token will be a Mockery object, so the accessor needs to be mocked as well.
+        $user->token()->shouldReceive('getAttribute')->with('scopes')->andReturn($scopes);
     }
 
     protected function invokeMethod($obj, string $name, array $params = [])


### PR DESCRIPTION
- Makes the API endpoints require OAuth tokens to have the correct scopes.
- ~~Implicit scope normalization isn't included in this change, so for the time being, scopes will have to be explicitly requested.~~

The current checking of permissions and the ability to filter output based on permissions is kind of crap, so we're probably going to have to do something about that too.

Initially, the only scope available for third-party authorization is `identify` for `/me`; other endpoints and scopes will be made available as they're checked.

Expected behaviour should be:
- `require-scopes` with parameters should require tokens to have all the scopes listed
- `require-scopes` without parameters should deny access by default except for tokens with `*` scope, or more explicit scopes are required
- only `password` grant clients can request `*` scope

lazer needs to be update to include `"scope": "*"` in its token requests

---
