### PR TITLE
Don't fail when passing certain string for route parameter

### DIFF
--- a/app/Models/Wiki/Page.php
+++ b/app/Models/Wiki/Page.php
@@ -226,7 +226,7 @@ class Page
 
                     if (present($body)) {
                         $page = OsuMarkdownProcessor::process($body, [
-                            'path' => route('wiki.show', $this->path),
+                            'path' => wiki_url($this->path),
                         ]);
                     }
                 }

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -555,7 +555,9 @@ function link_to_user($user_id, $user_name = null, $user_color = null)
     $style = user_color_style($user_color, 'color');
 
     if ($user_id) {
-        $user_url = e(route('users.show', $user_id));
+        // FIXME: remove `rawurlencode` workaround when fixed upstream.
+        // Reference: https://github.com/laravel/framework/issues/26715
+        $user_url = e(route('users.show', rawurlencode($user_id)));
 
         return "<a class='user-name js-usercard' data-user-id='{$user_id}' href='{$user_url}' style='{$style}'>{$user_name}</a>";
     } else {
@@ -594,7 +596,9 @@ function post_url($topicId, $postId, $jumpHash = true, $tail = false)
 
 function wiki_url($page = 'Welcome', $locale = null)
 {
-    $params = compact('page');
+    // FIXME: remove `rawurlencode` workaround when fixed upstream.
+    // Reference: https://github.com/laravel/framework/issues/26715
+    $params = ['page' => rawurlencode($page)];
 
     if (present($locale) && $locale !== App::getLocale()) {
         $params['locale'] = $locale;

--- a/resources/views/wiki/show.blade.php
+++ b/resources/views/wiki/show.blade.php
@@ -66,7 +66,7 @@
                                 type="button"
                                 class="btn-circle"
                                 data-remote="true"
-                                data-url="{{ route('wiki.show', [$page->path]) }}"
+                                data-url="{{ wiki_url($page->path) }}"
                                 data-method="PUT"
                                 title="{{ trans('wiki.show.edit.refresh') }}"
                                 data-tooltip-position="left center"


### PR DESCRIPTION
I might've missed more places requiring this workaround. Will fix them as encountered.

Works around laravel/framework#26715.