### PR TITLE
Fix anchor offsets on news pages

### DIFF
--- a/resources/assets/less/bem/osu-md.less
+++ b/resources/assets/less/bem/osu-md.less
@@ -66,6 +66,10 @@
       margin-top: 0;
     }
 
+    & > a {
+      .fragment-target-fn();
+    }
+
     &--2 {
       font-size: @font-size--header-wiki-2;
       margin: 50px -20px 10px;

--- a/resources/assets/less/bem/osu-md.less
+++ b/resources/assets/less/bem/osu-md.less
@@ -66,7 +66,7 @@
       margin-top: 0;
     }
 
-    & > a {
+    > a {
       .fragment-target-fn();
     }
 


### PR DESCRIPTION
closes #3928 

We should probably look at supporting markdown extensions for custom header ids (which seems to have made no progress in commonmark) instead, like:

```
# Header {#anchor-here}
```

---
