### PR TITLE
Immediately regenerate csrf token on login

### DIFF
--- a/app/Http/Controllers/Controller.php
+++ b/app/Http/Controllers/Controller.php
@@ -63,6 +63,7 @@ abstract class Controller extends BaseController
     protected function login($user, $remember = false)
     {
         Request::session()->flush();
+        Request::session()->regenerateToken();
         Auth::login($user, $remember);
         Request::session()->migrate(true, Auth::user()->user_id);
     }

--- a/resources/assets/coffee/_classes/user-login.coffee
+++ b/resources/assets/coffee/_classes/user-login.coffee
@@ -30,6 +30,7 @@ class @UserLogin
 
     $(document).on 'click', '.js-user-link', @showOnClick
     $(document).on 'click', '.js-login-required--click', @showToContinue
+    $(document).on 'ajax:before', '.js-login-required--click', -> currentUser.id?
 
     $(document).on 'ajax:error', @showOnError
     $(document).on 'turbolinks:load', @showOnLoad


### PR DESCRIPTION
Removed when adding user session listing. Also allow `js-login-required--click` to intercept UJS.