### PR TITLE
Fix RequireScopes middleware containsScoped check

### DIFF
--- a/app/Http/Middleware/RequireScopes.php
+++ b/app/Http/Middleware/RequireScopes.php
@@ -85,7 +85,7 @@ class RequireScopes
     private function containsScoped(Request $request)
     {
         foreach ($request->route()->gatherMiddleware() as $middleware) {
-            if (starts_with($middleware, 'require-scopes:')) {
+            if (is_string($middleware) && starts_with($middleware, 'require-scopes:')) {
                 return true;
             }
         }


### PR DESCRIPTION
Because the middleware list can contain functions

---
