### PR TITLE
Remove exists dependent subquery when validating previous users of a username

### DIFF
--- a/app/Libraries/UsernameValidation.php
+++ b/app/Libraries/UsernameValidation.php
@@ -124,8 +124,8 @@ class UsernameValidation
 
     public static function usersOfUsername(string $username) : Collection
     {
-        $user_ids = UsernameChangeHistory::where('username_last', $username)->pluck('user_id');
-        $users = User::whereIn('user_id', $user_ids)->get();
+        $user_ids = UsernameChangeHistory::on('mysql-readonly')->where('username_last', $username)->pluck('user_id');
+        $users = User::on('mysql-readonly')->whereIn('user_id', $user_ids)->get();
         $existing = User::findByUsernameForInactive($username);
         if ($existing !== null) {
             $users->push($existing);

--- a/app/Libraries/UsernameValidation.php
+++ b/app/Libraries/UsernameValidation.php
@@ -22,6 +22,7 @@ namespace App\Libraries;
 
 use App\Models\Beatmap;
 use App\Models\User;
+use App\Models\UsernameChangeHistory;
 use Carbon\Carbon;
 use DB;
 use Illuminate\Support\Collection;
@@ -123,10 +124,8 @@ class UsernameValidation
 
     public static function usersOfUsername(string $username) : Collection
     {
-        $users = User::whereHas('usernameChangeHistory', function ($query) use ($username) {
-            $query->where('username_last', $username);
-        })->get();
-
+        $user_ids = UsernameChangeHistory::where('username_last', $username)->pluck('user_id');
+        $users = User::whereIn('user_id', $user_ids)->get();
         $existing = User::findByUsernameForInactive($username);
         if ($existing !== null) {
             $users->push($existing);

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -220,6 +220,7 @@ class User extends Model implements AuthenticatableContract
         return $existing;
     }
 
+    // TODO: be able to change which connection this runs on?
     public static function findByUsernameForInactive($username) : ?self
     {
         return static::whereIn(


### PR DESCRIPTION
Bad query when there are no matches.
Also move query to readonly database.

---

