### PR TITLE
Update url when navigating to anchors

### DIFF
--- a/resources/assets/coffee/turbolinks-overrides.coffee
+++ b/resources/assets/coffee/turbolinks-overrides.coffee
@@ -26,7 +26,8 @@ $(document).on 'click', 'a[href^="#"]', (e) ->
   return if !target?
 
   e.preventDefault()
-  history.pushState null, document.title, href if location.href != href
+  # still behaves weird in cases where push/popping state wouldn't normally result in a scroll.
+  Turbolinks.controller.advanceHistory href if location.href != href
   target.scrollIntoView()
 
 

--- a/resources/assets/coffee/turbolinks-overrides.coffee
+++ b/resources/assets/coffee/turbolinks-overrides.coffee
@@ -26,6 +26,7 @@ $(document).on 'click', 'a[href^="#"]', (e) ->
   return if !target?
 
   e.preventDefault()
+  history.pushState null, document.title, href if location.href != href
   target.scrollIntoView()
 
 


### PR DESCRIPTION
Closes #3948

Doesn't have effect on pages where scrolling to anchor is done by some other means, e.g. modding discussions

---

