### PR TITLE
Set csrf token when logging in from legacy cookie

### DIFF
--- a/app/Http/Middleware/AutologinFromLegacyCookie.php
+++ b/app/Http/Middleware/AutologinFromLegacyCookie.php
@@ -41,6 +41,7 @@ class AutologinFromLegacyCookie
 
             if ($session !== null) {
                 $request->session()->flush();
+                $request->session()->regenerateToken();
                 $this->auth->loginUsingId($session->session_user_id, $session->session_autologin);
                 $request->session()->migrate(true, $session->session_user_id);
             }


### PR DESCRIPTION
Otherwise user might not be able to verify if the first thing a user goes to on the new site triggers verification. 

---
