### PR TITLE
Add message support for legacy changelog entries

### DIFF
--- a/app/Models/ChangelogEntry.php
+++ b/app/Models/ChangelogEntry.php
@@ -34,10 +34,11 @@ class ChangelogEntry extends Model
     public static function convertLegacy($changelog)
     {
         $message = $changelog->message;
-        $title = static::splitMessage($message)[0];
+        $splitMessage = static::splitMessage($message);
+        $title = $splitMessage[0];
 
         if ($title === null) {
-            $title = $message;
+            $title = $splitMessage[1];
             $message = null;
         }
 

--- a/app/Models/ChangelogEntry.php
+++ b/app/Models/ChangelogEntry.php
@@ -33,8 +33,17 @@ class ChangelogEntry extends Model
 
     public static function convertLegacy($changelog)
     {
+        $message = $changelog->message;
+        $title = static::splitMessage($message)[0];
+
+        if ($title === null) {
+            $title = $message;
+            $message = null;
+        }
+
         return new static([
-            'title' => $changelog->message,
+            'title' => $title,
+            'message' => $message,
             'url' => $changelog->url,
             'category' => $changelog->category,
             'type' => $changelog->prefix,
@@ -88,6 +97,27 @@ class ChangelogEntry extends Model
             ]),
             'repository' => null,
         ]);
+    }
+
+    public static function splitMessage($message)
+    {
+        if (!present($message)) {
+            return [null, null];
+        }
+
+        static $separator = "\n\n---\n";
+        // prepended with \n\n just in case the message starts with ---\n (blank first part).
+        $message = "\n\n".trim(str_replace("\r\n", "\n", $message));
+        $splitPos = strpos($message, $separator);
+
+        if ($splitPos === false) {
+            $splitPos = strlen($message);
+        }
+
+        return [
+            presence(trim(substr($message, 0, $splitPos))),
+            presence(trim(substr($message, $splitPos + strlen($separator)))),
+        ];
     }
 
     public function builds()
@@ -148,29 +178,10 @@ class ChangelogEntry extends Model
 
     public function messageHTML()
     {
-        if (!present($this->message)) {
-            return;
+        list($private, $public) = static::splitMessage($this->message);
+
+        if ($public !== null) {
+            return Markdown::convertToHtml($public);
         }
-
-        static $separator = "\n\n---\n";
-        static $openingSeparator = "---\n";
-
-        $origMessage = trim(str_replace("\r\n", "\n", $this->message));
-
-        if (starts_with($origMessage, $openingSeparator)) {
-            $publicMessageStart = strlen($openingSeparator);
-        } else {
-            $publicMessageStart = strpos($origMessage, $separator);
-
-            if ($publicMessageStart === false) {
-                return;
-            } else {
-                $publicMessageStart += strlen($separator);
-            }
-        }
-
-        $message = trim(substr($origMessage, $publicMessageStart));
-
-        return present($message) ? Markdown::convertToHtml($message) : null;
     }
 }

--- a/tests/Models/ChangelogEntryTest.php
+++ b/tests/Models/ChangelogEntryTest.php
@@ -17,8 +17,8 @@
  *    You should have received a copy of the GNU Affero General Public License
  *    along with osu!web.  If not, see <http://www.gnu.org/licenses/>.
  */
-use App\Models\ChangelogEntry;
 use App\Models\Changelog;
+use App\Models\ChangelogEntry;
 
 class ChangelogEntryTest extends TestCase
 {

--- a/tests/Models/ChangelogEntryTest.php
+++ b/tests/Models/ChangelogEntryTest.php
@@ -69,4 +69,13 @@ class ChangelogEntryTest extends TestCase
         $this->assertSame($title, $converted->title);
         $this->assertSame("<p>{$message}</p>\n", $converted->messageHTML());
     }
+
+    public function testConvertLegacyChangelogWithMessage()
+    {
+        $message = 'Some message';
+        $legacy = new Changelog(['message' => "---\n{$message}"]);
+        $converted = ChangelogEntry::convertLegacy($legacy);
+        $this->assertSame($message, $converted->title);
+        $this->assertNull($converted->messageHTML());
+    }
 }

--- a/tests/Models/ChangelogEntryTest.php
+++ b/tests/Models/ChangelogEntryTest.php
@@ -18,6 +18,7 @@
  *    along with osu!web.  If not, see <http://www.gnu.org/licenses/>.
  */
 use App\Models\ChangelogEntry;
+use App\Models\Changelog;
 
 class ChangelogEntryTest extends TestCase
 {
@@ -48,5 +49,24 @@ class ChangelogEntryTest extends TestCase
 
         $entry->message = "Hidden\n\n---\nVisible";
         $this->assertSame("<p>Visible</p>\n", $entry->messageHTML());
+    }
+
+    public function testConvertLegacyChangelogWithTitle()
+    {
+        $title = 'Some title';
+        $legacy = new Changelog(['message' => $title]);
+        $converted = ChangelogEntry::convertLegacy($legacy);
+        $this->assertSame($title, $converted->title);
+        $this->assertNull($converted->messageHTML());
+    }
+
+    public function testConvertLegacyChangelogWithTitleAndMessage()
+    {
+        $title = 'Some title';
+        $message = 'Some message';
+        $legacy = new Changelog(['message' => "{$title}\n\n---\n{$message}"]);
+        $converted = ChangelogEntry::convertLegacy($legacy);
+        $this->assertSame($title, $converted->title);
+        $this->assertSame("<p>{$message}</p>\n", $converted->messageHTML());
     }
 }


### PR DESCRIPTION
Split by `\n\n---\n` just like new one except the first part is used for title instead of hidden.