### PR TITLE
Fix beatmapset cover thumbnailer image presence check

### DIFF
--- a/app/Models/BeatmapsetArchive.php
+++ b/app/Models/BeatmapsetArchive.php
@@ -68,7 +68,7 @@ class BeatmapsetArchive
             return false;
         }
 
-        return $this->zip->locateName($filename, \ZipArchive::FL_NOCASE | \ZipArchive::FL_NODIR) !== false;
+        return $this->zip->locateName($filename, \ZipArchive::FL_NOCASE) !== false;
     }
 
     // Parses given list (of .osu files) and finds background images referenced.


### PR DESCRIPTION
Was incorrectly ignoring path when checking for the presence of background images.

---
