### PR TITLE
Allow burger menu to be scrolled on mobile

### DIFF
--- a/resources/assets/coffee/main.coffee
+++ b/resources/assets/coffee/main.coffee
@@ -88,6 +88,7 @@ $(document).on 'turbolinks:load', ->
 @forumTopicPostJump ?= new ForumTopicPostJump(@forum)
 @forumTopicReply ?= new ForumTopicReply(@forum, @stickyFooter)
 @twitchPlayer ?= new TwitchPlayer(@turbolinksReload)
+_exported.WindowVHPatcher.init(window)
 
 
 $(document).on 'change', '.js-url-selector', (e) ->

--- a/resources/assets/less/bem/navbar-mobile.less
+++ b/resources/assets/less/bem/navbar-mobile.less
@@ -72,6 +72,9 @@
     padding: 0 10px;
     background-color: #444;
     width: 100%;
+    max-height: calc((var(--vh, 1vh) * 100) - @navbar-height);
+    overflow-y: scroll;
+    -webkit-overflow-scrolling: touch;
     z-index: @z-index--nav2;
 
     &:focus,

--- a/resources/assets/lib/import-shims.coffee
+++ b/resources/assets/lib/import-shims.coffee
@@ -31,6 +31,7 @@ import Promise from 'promise-polyfill'
 import TextareaAutosize from 'react-autosize-textarea'
 import VirtualList from 'react-virtual-list'
 import GalleryContest from 'gallery-contest'
+import WindowVHPatcher from 'window-vh-patcher';
 
 # polyfill non-Edge IE
 window.Promise ?= Promise
@@ -45,6 +46,7 @@ window._exported = {
   SelectOptions
   SpotlightSelectOptions
   GalleryContest
+  WindowVHPatcher
 }
 
 # refer to variables.less

--- a/resources/assets/lib/osu-core.ts
+++ b/resources/assets/lib/osu-core.ts
@@ -22,7 +22,6 @@ import RootDataStore from 'stores/root-data-store';
 import UserLoginObserver from 'user-login-observer';
 import Dispatcher from './dispatcher';
 import WindowFocusObserver from './window-focus-observer';
-import WindowVHPatcher from './window-vh-patcher';
 
 // will this replace main.coffee eventually?
 export default class OsuCore {
@@ -33,7 +32,6 @@ export default class OsuCore {
   chatOrchestrator: ChatOrchestrator;
   userLoginObserver: UserLoginObserver;
   windowFocusObserver: WindowFocusObserver;
-  windowVHPatcher: WindowVHPatcher;
 
   constructor(window: Window) {
     this.window = window;
@@ -44,7 +42,6 @@ export default class OsuCore {
     this.chatOrchestrator = new ChatOrchestrator(this.dispatcher, this.dataStore);
     this.userLoginObserver = new UserLoginObserver(this.window, this.dispatcher);
     this.windowFocusObserver = new WindowFocusObserver(this.window, this.dispatcher);
-    this.windowVHPatcher = WindowVHPatcher.init(this.window);
 
     if (currentUser !== null) {
       this.dataStore.userStore.getOrCreate(currentUser.id, currentUser);

--- a/resources/assets/lib/osu-core.ts
+++ b/resources/assets/lib/osu-core.ts
@@ -37,13 +37,14 @@ export default class OsuCore {
 
   constructor(window: Window) {
     this.window = window;
+    // should probably figure how to conditionally or lazy initialize these so they don't all init when not needed.
     this.dispatcher = new Dispatcher();
     this.dataStore = new RootDataStore(this.dispatcher);
     this.chatWorker = new ChatWorker(this.dispatcher, this.dataStore);
     this.chatOrchestrator = new ChatOrchestrator(this.dispatcher, this.dataStore);
     this.userLoginObserver = new UserLoginObserver(this.window, this.dispatcher);
     this.windowFocusObserver = new WindowFocusObserver(this.window, this.dispatcher);
-    this.windowVHPatcher = new WindowVHPatcher(this.window);
+    this.windowVHPatcher = WindowVHPatcher.init(this.window);
 
     if (currentUser !== null) {
       this.dataStore.userStore.getOrCreate(currentUser.id, currentUser);

--- a/resources/assets/lib/window-vh-patcher.ts
+++ b/resources/assets/lib/window-vh-patcher.ts
@@ -22,15 +22,26 @@
  * height: calc(var(--vh, 1vh) ~'*' 100);
  */
 export default class WindowVHPatcher {
+  private static instance: WindowVHPatcher;
   private window: Window;
 
-  constructor(window: Window) {
+  private constructor(window: Window) {
     this.window = window;
     $(this.window).on('throttled-resize.windowVHPatch', this.handleResize);
     this.handleResize();
   }
 
-  handleResize = () => {
+  static init(window: Window) {
+    if (this.instance != null) {
+      return this.instance;
+    }
+
+    this.instance = new WindowVHPatcher(window);
+
+    return this.instance;
+  }
+
+  private handleResize() {
     const vh = this.window.innerHeight * 0.01;
     if (this.window.document.documentElement !== null) {
       this.window.document.documentElement.style.setProperty('--vh', `${vh}px`);


### PR DESCRIPTION
closes #3852

Still has problems on mobile Safari where the body element behind the menu will scroll instead of the menu in some cases, but there doesn't seem to be a reliable solution for this as long as the body is scrollable (and Safari insists the body is scrollable as long as the content extends past the visible window).

---
