### PR TITLE
Fix chrome/webkit line-clamp styling

### DIFF
--- a/resources/assets/less/bem/forum-topic-title.less
+++ b/resources/assets/less/bem/forum-topic-title.less
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2015-2017 ppy Pty. Ltd.
+ *    Copyright 2015-2019 ppy Pty. Ltd.
  *
  *    This file is part of osu!web. osu!web is distributed with the hope of
  *    attracting more community contributions to the core ecosystem of osu!.
@@ -81,10 +81,6 @@
     min-width: 0;
     max-width: calc(100% - @_button-edit-width);
 
-    /* magic line-clamping on webkit browsers (safari, chrome, etc) */
-    /* (other browsers won't show ellipses) */
-    display: -webkit-box;
-    -webkit-line-clamp: 3;
-    -webkit-box-orient: vertical;
+    .webkit-line-clamp(3);
   }
 }

--- a/resources/assets/less/functions.less
+++ b/resources/assets/less/functions.less
@@ -1,5 +1,5 @@
 /**
- *    Copyright 2015-2017 ppy Pty. Ltd.
+ *    Copyright 2015-2019 ppy Pty. Ltd.
  *
  *    This file is part of osu!web. osu!web is distributed with the hope of
  *    attracting more community contributions to the core ecosystem of osu!.
@@ -270,4 +270,15 @@
 .default-font() {
   font-family: @font-default;
   font-family: var(--font-default-override, var(--font-default));
+}
+
+.webkit-line-clamp(@lines) {
+  // Magic line-clamping on webkit browsers (safari, chrome, etc).
+  // Other browsers won't show ellipses.
+  display: -webkit-box;
+  -webkit-line-clamp: @lines;
+  // It's required to tell autoprefixer to ignore the following line.
+  // Reference: https://github.com/postcss/autoprefixer/issues/1141
+  /* autoprefixer: ignore next */
+  -webkit-box-orient: vertical;
 }


### PR DESCRIPTION
Thanks, autoprefixer :100: 

Or the lack of finalized actual standard for this (I think?).