### PR TITLE
Return null instead of object with null fields if country is null.

### DIFF
--- a/app/Transformers/CountryStatisticsTransformer.php
+++ b/app/Transformers/CountryStatisticsTransformer.php
@@ -40,6 +40,8 @@ class CountryStatisticsTransformer extends Fractal\TransformerAbstract
 
     public function includeCountry(CountryStatistics $stat)
     {
-        return $this->item($stat->country, new CountryTransformer);
+        return $stat->country === null
+            ? $this->primitive(null)
+            : $this->item($stat->country, new CountryTransformer);
     }
 }

--- a/app/Transformers/UserCompactTransformer.php
+++ b/app/Transformers/UserCompactTransformer.php
@@ -51,7 +51,9 @@ class UserCompactTransformer extends Fractal\TransformerAbstract
 
     public function includeCountry(User $user)
     {
-        return $this->item($user->country, new CountryTransformer);
+        return $user->country === null
+            ? $this->primitive(null)
+            : $this->item($user->country, new CountryTransformer);
     }
 
     public function includeCover(User $user)

--- a/app/Transformers/UserTransformer.php
+++ b/app/Transformers/UserTransformer.php
@@ -53,14 +53,18 @@ class UserTransformer extends Fractal\TransformerAbstract
     {
         $profileCustomization = $user->profileCustomization();
 
+        $country = $user->country_acronym === null
+            ? null
+            : [
+                'code' => $user->country_acronym,
+                'name' => $user->countryName(),
+            ];
+
         return [
             'id' => $user->user_id,
             'username' => $user->username,
             'join_date' => json_time($user->user_regdate),
-            'country' => [
-                'code' => $user->country_acronym,
-                'name' => $user->countryName(),
-            ],
+            'country' => $country,
             'avatar_url' => $user->user_avatar,
             'is_supporter' => $user->osu_subscriber,
             'has_supported' => $user->hasSupported(),

--- a/resources/assets/coffee/react/_components/flag-country.coffee
+++ b/resources/assets/coffee/react/_components/flag-country.coffee
@@ -22,7 +22,7 @@ el = React.createElement
 bn = 'flag-country'
 
 @FlagCountry = ({country, modifiers}) ->
-  return null if !country.code?
+  return null if !country?.code?
 
   blockClass = osu.classWithModifiers(bn, modifiers)
 


### PR DESCRIPTION
closes #3875

would be better if `transform` itself could return null instead of array

---
