### PR TITLE
Fix wording on osu!supporter gift email

### DIFF
--- a/resources/lang/en/fulfillments.php
+++ b/resources/lang/en/fulfillments.php
@@ -24,7 +24,7 @@ return [
             'subject' => 'Thanks, osu! <3s you',
         ],
         'supporter_gift' => [
-            'subject' => 'You have an osu!supporter tag!',
+            'subject' => 'You have been gifted an osu!supporter tag!',
         ],
     ],
 ];

--- a/resources/views/emails/store/supporter_gift-en.blade.php
+++ b/resources/views/emails/store/supporter_gift-en.blade.php
@@ -17,11 +17,11 @@
 --}}
 Hey there {{ $giftee->username }},
 
-Someone has just gifted you an osu! supporter tag!
-Thanks to them, you now have access osu!direct and other supporter benefits for the next {{ $duration }}.
-You can find out more details on these features at {{ route('support-the-game') }}
-The person who gifted you this tag may choose to remain anonymous, so they have not been mentioned in this notification
-(But you likely already know who it is ;).
+Someone has just gifted you an osu!supporter tag!
+Thanks to them, you have access to osu!direct and other osu!supporter benefits for the next {{ $duration }}.
+You can find out more details on these features at {{ route('support-the-game') }}.
+The person who gifted you this tag may choose to remain anonymous, so they have not been mentioned in this notification.
+But you likely already know who it is ;).
 
 Regards,
 osu! Management


### PR DESCRIPTION
- title of email was vague
- removed `now`, since a user might still have osu!supporter
- proper styling of `osu!supporter`
- periods

---