### PR TITLE
Fix username lookups with ints instead of strings

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -417,7 +417,7 @@ class User extends Model implements AuthenticatableContract
 
         switch ($lookup_type) {
             case 'string':
-                $user = self::where('username', $username_or_id)->orWhere('username_clean', '=', $username_or_id);
+                $user = self::where('username', strval($username_or_id))->orWhere('username_clean', '=', strval($username_or_id));
                 break;
 
             case 'id':

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -417,7 +417,7 @@ class User extends Model implements AuthenticatableContract
 
         switch ($lookup_type) {
             case 'string':
-                $user = self::where('username', strval($username_or_id))->orWhere('username_clean', '=', strval($username_or_id));
+                $user = self::where('username', (string) $username_or_id)->orWhere('username_clean', '=', (string) $username_or_id);
                 break;
 
             case 'id':


### PR DESCRIPTION
In cases a user profile is hit using `user_id`, there is a potential that php/eloquent will be "smart" and not quote it as a string in the adjusted query, causing a complete index miss.

Fix has been applied server-side.