### PR TITLE
Fix forum post keyboard navigation

### DIFF
--- a/resources/assets/coffee/_classes/forum.coffee
+++ b/resources/assets/coffee/_classes/forum.coffee
@@ -125,14 +125,13 @@ class @Forum
     return if @_postsCounter.length == 0
 
     currentPost = null
-    anchorHeight = window.innerHeight * 0.5
 
     if osu.bottomPage()
       currentPost = @posts[@posts.length - 1]
     else
       for post in @posts
         postTop = post.getBoundingClientRect().top
-        if postTop <= anchorHeight
+        if Math.floor(window.stickyHeader.scrollOffset(postTop)) <= 0
           currentPost = post
         else
           break


### PR DESCRIPTION
Anchor position is now at the bottom of the header, so the post position was incorrect which breaks the keyboard navigation.

closes #4116

---
