### PR TITLE
Update tests to use assertSame instead of assertEquals

### DIFF
--- a/tests/Libraries/Fulfillments/SupporterTagFulfillmentTest.php
+++ b/tests/Libraries/Fulfillments/SupporterTagFulfillmentTest.php
@@ -59,8 +59,8 @@ class SupporterTagFulfillmentTest extends TestCase
 
         $donor->refresh();
         $this->assertTrue($donor->osu_subscriber);
-        $this->assertEquals($expectedExpiry, $donor->osu_subscriptionexpiry);
-        $this->assertEquals(2, $donor->osu_featurevotes);
+        $this->assertTrue($expectedExpiry->equalTo($donor->osu_subscriptionexpiry));
+        $this->assertSame(2, $donor->osu_featurevotes);
     }
 
     public function testDonateSupporterTagToOthers()
@@ -88,12 +88,12 @@ class SupporterTagFulfillmentTest extends TestCase
         $this->assertTrue($giftee->osu_subscriber);
 
         // donor's expiry should not change.
-        $this->assertEquals($expectedExpiry, $giftee->osu_subscriptionexpiry);
-        $this->assertEquals($today, $donor->osu_subscriptionexpiry);
+        $this->assertTrue($expectedExpiry->equalTo($giftee->osu_subscriptionexpiry));
+        $this->assertTrue($today->equalTo($donor->osu_subscriptionexpiry));
 
         // votes go to donor.
-        $this->assertEquals(2, $donor->osu_featurevotes);
-        $this->assertEquals(0, $giftee->osu_featurevotes);
+        $this->assertSame(2, $donor->osu_featurevotes);
+        $this->assertSame(0, $giftee->osu_featurevotes);
     }
 
     public function testMailDonateSupporterTagToOthers()
@@ -141,8 +141,8 @@ class SupporterTagFulfillmentTest extends TestCase
         $donor->refresh();
         // Should only apply one supporter tag.
         $this->assertTrue($donor->osu_subscriber);
-        $this->assertEquals($expectedExpiry, $donor->osu_subscriptionexpiry);
-        $this->assertEquals(2, $donor->osu_featurevotes);
+        $this->assertTrue($expectedExpiry->equalTo($donor->osu_subscriptionexpiry));
+        $this->assertSame(2, $donor->osu_featurevotes);
     }
 
     public function testAlreadyFulfilledOrder()
@@ -159,8 +159,8 @@ class SupporterTagFulfillmentTest extends TestCase
         $donor->refresh();
         // Should not apply any supporter tags
         $this->assertFalse($donor->osu_subscriber);
-        $this->assertEquals($expectedExpiry, $donor->osu_subscriptionexpiry);
-        $this->assertEquals(0, $donor->osu_featurevotes);
+        $this->assertTrue($expectedExpiry->equalTo($donor->osu_subscriptionexpiry));
+        $this->assertSame(0, $donor->osu_featurevotes);
     }
 
     public function testRevokeDonateSupporterTagToSelf()
@@ -188,8 +188,8 @@ class SupporterTagFulfillmentTest extends TestCase
 
         $donor->refresh();
 
-        $this->assertEquals($expectedExpiry, $donor->osu_subscriptionexpiry);
-        $this->assertEquals(0, $donor->osu_featurevotes);
+        $this->assertTrue($expectedExpiry->equalTo($donor->osu_subscriptionexpiry));
+        $this->assertSame(0, $donor->osu_featurevotes);
         $this->assertFalse($donor->osu_subscriber);
     }
 
@@ -215,8 +215,8 @@ class SupporterTagFulfillmentTest extends TestCase
         $donor->refresh();
 
         // there should be 1 month left.
-        $this->assertEquals($oldExpiry->subMonthsNoOverflow(1), $donor->osu_subscriptionexpiry);
-        $this->assertEquals(2, $donor->osu_featurevotes);
+        $this->assertTrue($oldExpiry->subMonthsNoOverflow(1)->equalTo($donor->osu_subscriptionexpiry));
+        $this->assertSame(2, $donor->osu_featurevotes);
         $this->assertTrue($donor->osu_subscriber);
     }
 
@@ -239,8 +239,8 @@ class SupporterTagFulfillmentTest extends TestCase
 
         $donor->refresh();
 
-        $this->assertEquals($today->copy()->addMonthsNoOverflow(2), $donor->osu_subscriptionexpiry);
-        $this->assertEquals(4, $donor->osu_featurevotes);
+        $this->assertTrue($today->copy()->addMonthsNoOverflow(2)->equalTo($donor->osu_subscriptionexpiry));
+        $this->assertSame(4, $donor->osu_featurevotes);
         $this->assertTrue($donor->osu_subscriber);
     }
 
@@ -262,8 +262,8 @@ class SupporterTagFulfillmentTest extends TestCase
 
         $donor->refresh();
         $this->assertTrue($donor->osu_subscriber);
-        $this->assertEquals($expectedExpiry, $donor->osu_subscriptionexpiry);
-        $this->assertEquals(2, $donor->osu_featurevotes);
+        $this->assertTrue($expectedExpiry->equalTo($donor->osu_subscriptionexpiry));
+        $this->assertSame(2, $donor->osu_featurevotes);
     }
 
     private function createDonationOrderItem($order, $giftee, $cancelled = false, $run = false)

--- a/tests/Libraries/UserRegistrationTest.php
+++ b/tests/Libraries/UserRegistrationTest.php
@@ -32,7 +32,7 @@ class UserRegistrationTest extends TestCase
         $thrown = $this->runSubject($reg);
 
         $this->assertFalse($thrown);
-        $this->assertEquals($origCount + 1, User::count());
+        $this->assertSame($origCount + 1, User::count());
     }
 
     public function testRequiresUsername()
@@ -51,7 +51,7 @@ class UserRegistrationTest extends TestCase
                 'username' => [trans('model_validation.required', ['attribute' => 'username'])],
             ]
         );
-        $this->assertEquals($origCount, User::count());
+        $this->assertSame($origCount, User::count());
     }
 
     public function testStoreRequiresEmail()
@@ -70,7 +70,7 @@ class UserRegistrationTest extends TestCase
                 'user_email' => [trans('model_validation.required', ['attribute' => 'user_email'])],
             ]
         );
-        $this->assertEquals($origCount, User::count());
+        $this->assertSame($origCount, User::count());
     }
 
     public function testStoreRequiresPassword()
@@ -89,7 +89,7 @@ class UserRegistrationTest extends TestCase
                 'password' => [trans('model_validation.required', ['attribute' => 'password'])],
             ]
         );
-        $this->assertEquals($origCount, User::count());
+        $this->assertSame($origCount, User::count());
     }
 
     // wrapper to catch the exception


### PR DESCRIPTION
One is more sane than the other. Also I keep forgetting which one is correct. Time comparison is updated to use carbon's `equalTo`.