### PR TITLE
Update difficulty color bracket thresholds

### DIFF
--- a/resources/assets/coffee/_classes/beatmap-helper.coffee
+++ b/resources/assets/coffee/_classes/beatmap-helper.coffee
@@ -39,15 +39,15 @@ class @BeatmapHelper
 
 
   @getDiffRating: (rating) ->
-    if rating < 1.5
+    if rating < 2
       'easy'
-    else if rating < 2.25
+    else if rating < 2.7
       'normal'
-    else if rating < 3.75
+    else if rating < 4
       'hard'
-    else if rating < 5.25
+    else if rating < 5.3
       'insane'
-    else if rating < 6.75
+    else if rating < 6.5
       'expert'
     else
       'expert-plus'


### PR DESCRIPTION
It's been a long time since the color brackets for difficulties were touched. Lots has changed in the star-rating system and community since then. This PR updates the thresholds to reflect that.

To numerically justify this change, I've analyzed every ranked osu!standard beatmap containing one of a number of different difficulty keywords in its version name and plotted them by time vs. difficulty, showing clear striation:

![plot](https://user-images.githubusercontent.com/1782081/52776537-ad738480-2ff6-11e9-95fc-9c8c6dee6779.png)

(Outliers include "[**Hard**est](https://osu.ppy.sh/beatmapsets/662526#osu/1402392)" and "[s**hard**ex's Extra](https://osu.ppy.sh/beatmapsets/819112#osu/1720423).") Note that the highest difficulty category is "Extra"—this is practically synonymous with "Expert" as the two terms occupy the same vertical space, but "Extra" is simply used more frequently than "Expert" (1863 maps vs. 576 maps). "Expert" has only begun to see common use in the last year and a half.

There are several other labels frequently used which are not shown on this chart, but for which statistics were collected, including:

* Beginner: 0.50★–2.00★ — Easy with a lower minimum
* Advanced: 2.30★–3.30★ — an intermediate between Normal and Hard
* Hyper: 3.30★–4.55★ — an intermediate between Hard and Insane
* Another: 4.25★–5.70★ — an intermediate between Insane and Expert
* Extreme: 5.50★–7.15★ — an additional category above Expert

**Note that this analysis was done on only osu!standard beatmaps—ideally, separate thresholds would be used for each other mode.**

Raw statistics ([excel file](https://github.com/ppy/osu-web/files/2864370/osu-difficulties.xlsx)):

```
╔═══════════╦══════╦══════╦══════╦══════╗
║           ║ X̄    ║ σ    ║ X̄−2σ ║ X̄+2σ ║
╠═══════════╬══════╬══════╬══════╬══════╣
║  Beginner ║ 1.57 ║ 0.31 ║ 0.95 ║ 2.19 ║
║ >Easy     ║ 1.64 ║ 0.23 ║ 1.18 ║ 2.11 ║
║ >Normal   ║ 2.11 ║ 0.28 ║ 1.55 ║ 2.67 ║
║  Advanced ║ 2.80 ║ 0.46 ║ 1.87 ║ 3.73 ║
║ >Hard     ║ 3.25 ║ 0.44 ║ 2.37 ║ 4.13 ║
║  Hyper    ║ 3.79 ║ 0.52 ║ 2.74 ║ 4.83 ║
║ >Insane   ║ 4.36 ║ 0.55 ║ 3.27 ║ 5.45 ║
║  Another  ║ 4.88 ║ 0.55 ║ 3.78 ║ 5.98 ║
║  Expert   ║ 5.31 ║ 0.69 ║ 3.93 ║ 6.68 ║
║ >Extra    ║ 5.64 ║ 0.46 ║ 4.72 ║ 6.56 ║
║  Extreme  ║ 5.64 ║ 0.86 ║ 3.91 ║ 7.37 ║
╚═══════════╩══════╩══════╩══════╩══════╝
```

---

Updates the star ratings each difficulty colour is associated with.