### PR TITLE
Allow sorting beatmap listing by favourite count

### DIFF
--- a/app/Libraries/Search/BeatmapsetSearchRequestParams.php
+++ b/app/Libraries/Search/BeatmapsetSearchRequestParams.php
@@ -153,6 +153,7 @@ class BeatmapsetSearchRequestParams extends BeatmapsetSearchParams
             'artist' => 'artist.raw',
             'creator' => 'creator.raw',
             'difficulty' => 'difficulties.difficultyrating',
+            'favourites' => 'favourite_count',
             'nominations' => 'nominations',
             'plays' => 'play_count',
             'ranked' => 'approved_date',

--- a/resources/assets/coffee/react/beatmaps/search-sort.coffee
+++ b/resources/assets/coffee/react/beatmaps/search-sort.coffee
@@ -48,6 +48,7 @@ class Beatmaps.SearchSort extends React.PureComponent
       ranked: false
       rating: true
       plays: true
+      favourites: true
       relevance: false
       nominations: false
 

--- a/resources/lang/en/beatmaps.php
+++ b/resources/lang/en/beatmaps.php
@@ -197,6 +197,7 @@ return [
                 'title' => 'Title',
                 'artist' => 'Artist',
                 'difficulty' => 'Difficulty',
+                'favourites' => 'Favourites',
                 'updated' => 'Updated',
                 'ranked' => 'Ranked',
                 'rating' => 'Rating',


### PR DESCRIPTION
closes #2536

Should just work?
Not sure `Favourites` is the best name, though.
