### PR TITLE
Fix disappearing wiki pages

### DIFF
--- a/app/Models/Wiki/Page.php
+++ b/app/Models/Wiki/Page.php
@@ -191,19 +191,20 @@ class Page
      */
     public function getContent(bool $force = false)
     {
-        if (!array_key_exists('content', $this->cache) || $force) {
+        $key = "content_{$this->locale}";
+        if (!array_key_exists($key, $this->cache) || $force) {
             try {
                 $this->log('fetch');
 
-                $this->cache['content'] = OsuWiki::fetchContent('wiki/'.$this->pagePath());
+                $this->cache[$key] = OsuWiki::fetchContent('wiki/'.$this->pagePath());
             } catch (GitHubNotFoundException $e) {
                 $this->log('not found');
 
-                $this->cache['content'] = null;
+                $this->cache[$key] = null;
             }
         }
 
-        return $this->cache['content'];
+        return $this->cache[$key];
     }
 
     public function getSource()


### PR DESCRIPTION
Accessing a wiki page in a language that doesn't have a localization of that page (besides the default language) for that language will cause the default `en` version to disappear if both versions are considered expired.