### PR TITLE
Fix relative image url

### DIFF
--- a/app/Libraries/Markdown/OsuMarkdown.php
+++ b/app/Libraries/Markdown/OsuMarkdown.php
@@ -31,7 +31,7 @@ use Webuni\CommonMark\TableExtension;
 
 class OsuMarkdown
 {
-    const VERSION = 11;
+    const VERSION = 12;
 
     const DEFAULT_CONFIG = [
         // CommonMark options

--- a/app/Libraries/Markdown/OsuMarkdownProcessor.php
+++ b/app/Libraries/Markdown/OsuMarkdownProcessor.php
@@ -155,6 +155,10 @@ class OsuMarkdownProcessor implements DocumentProcessorInterface, ConfigurationA
         $src = $this->node->getUrl();
 
         if (preg_match(',^(#|/|https?://|mailto:),', $src) !== 1) {
+            if (starts_with($src, './')) {
+                $src = substr($src, 2);
+            }
+
             $this->node->setUrl($this->config->getConfig('relative_url_root').'/'.$src);
         }
     }


### PR DESCRIPTION
camo uses old url library and it fails to normalize the url properly so it requests `/./` as is instead of normalizing it to `/`.

Ideally camo itself should be fixed to do the url normalization properly. It's rather annoying to test because the tools I tried normalize the url.