### PR TITLE
Fix user card tooltip lookup

### DIFF
--- a/resources/assets/coffee/_classes/user-card.coffee
+++ b/resources/assets/coffee/_classes/user-card.coffee
@@ -66,7 +66,7 @@ class @UserCard
     card = $('#js-usercard__loading-template').children().clone()[0]
     card.classList.replace 'js-react--user-card', 'js-react--user-card-tooltip'
     delete card.dataset.reactTurbolinksLoaded
-    card.dataset.userId = userId
+    card.dataset.lookup = userId
 
     options =
       events:

--- a/resources/assets/coffee/main.coffee
+++ b/resources/assets/coffee/main.coffee
@@ -133,7 +133,6 @@ reactTurbolinks.register 'user-card-store', _exported.UserCardStore, (el) ->
   user: JSON.parse(el.dataset.user)
 
 reactTurbolinks.register 'user-card-tooltip', _exported.UserCardTooltip, (el) ->
-  container: el
   lookup: el.dataset.lookup
 
 rootUrl = "#{document.location.protocol}//#{document.location.host}"

--- a/resources/assets/coffee/main.coffee
+++ b/resources/assets/coffee/main.coffee
@@ -134,7 +134,7 @@ reactTurbolinks.register 'user-card-store', _exported.UserCardStore, (el) ->
 
 reactTurbolinks.register 'user-card-tooltip', _exported.UserCardTooltip, (el) ->
   container: el
-  userId: el.dataset.userId
+  lookup: el.dataset.lookup
 
 rootUrl = "#{document.location.protocol}//#{document.location.host}"
 rootUrl += ":#{document.location.port}" if document.location.port

--- a/resources/assets/coffee/main.coffee
+++ b/resources/assets/coffee/main.coffee
@@ -134,7 +134,7 @@ reactTurbolinks.register 'user-card-store', _exported.UserCardStore, (el) ->
 
 reactTurbolinks.register 'user-card-tooltip', _exported.UserCardTooltip, (el) ->
   container: el
-  userId: parseInt(el.dataset.userId)
+  userId: el.dataset.userId
 
 rootUrl = "#{document.location.protocol}//#{document.location.host}"
 rootUrl += ":#{document.location.port}" if document.location.port

--- a/resources/assets/lib/user-card-tooltip.tsx
+++ b/resources/assets/lib/user-card-tooltip.tsx
@@ -20,7 +20,7 @@ import * as React from 'react';
 import { UserCard } from 'user-card';
 
 interface PropsInterface {
-  userId: number;
+  userId: string;
 }
 
 interface StateInterface {

--- a/resources/assets/lib/user-card-tooltip.tsx
+++ b/resources/assets/lib/user-card-tooltip.tsx
@@ -20,7 +20,7 @@ import * as React from 'react';
 import { UserCard } from 'user-card';
 
 interface PropsInterface {
-  userId: string;
+  lookup: string;
 }
 
 interface StateInterface {
@@ -40,7 +40,7 @@ export class UserCardTooltip extends React.PureComponent<PropsInterface, StateIn
   }
 
   getUser() {
-    const url = laroute.route('users.card', { user: this.props.userId });
+    const url = laroute.route('users.card', { user: this.props.lookup });
 
     return $.ajax({
       dataType: 'json',


### PR DESCRIPTION
Lookup parameter can be a username and shouldn't be parsed into `number`

closes #4275 