### PR TITLE
remove useless flag

### DIFF
--- a/app/Libraries/WikiRedirect.php
+++ b/app/Libraries/WikiRedirect.php
@@ -40,7 +40,7 @@ class WikiRedirect
                 60,
                 function () {
                     try {
-                        return Yaml::parse(strip_utf8_bom(OsuWiki::fetchContent('wiki/redirect.yaml')), true);
+                        return Yaml::parse(strip_utf8_bom(OsuWiki::fetchContent('wiki/redirect.yaml')));
                     } catch (GitHubNotFoundException $_e) {
                         return;
                     }


### PR DESCRIPTION
`$flag` should be an `int` and `(int) true` is `Yaml::DUMP_OBJECT` which does
nothing for `Yaml::parse`.

