### PR TITLE
Change username validation short-circuiting order

### DIFF
--- a/app/Libraries/ChangeUsername.php
+++ b/app/Libraries/ChangeUsername.php
@@ -67,11 +67,11 @@ class ChangeUsername
             return $this->validationErrors();
         }
 
-        if ($this->validationErrors()->merge(UsernameValidation::validateAvailability($this->username))->isAny()) {
+        if ($this->validationErrors()->merge(UsernameValidation::validateUsersOfUsername($this->username))->isAny()) {
             return $this->validationErrors();
         }
 
-        return $this->validationErrors()->merge(UsernameValidation::validateUsersOfUsername($this->username));
+        return $this->validationErrors()->merge(UsernameValidation::validateAvailability($this->username));
     }
 
     public function validationErrorsTranslationPrefix()

--- a/app/Libraries/UsernameValidation.php
+++ b/app/Libraries/UsernameValidation.php
@@ -20,7 +20,6 @@
 
 namespace App\Libraries;
 
-use App\Models\Beatmap;
 use App\Models\User;
 use App\Models\UsernameChangeHistory;
 use Carbon\Carbon;

--- a/app/Libraries/UsernameValidation.php
+++ b/app/Libraries/UsernameValidation.php
@@ -109,16 +109,6 @@ class UsernameValidation
             if ($user->beatmapsets()->rankedOrApproved()->exists()) {
                 return $errors->add('username', '.username_locked');
             }
-
-            // ranks
-            foreach (Beatmap::MODES as $mode => $_modeInt) {
-                $stats = $user->statistics($mode);
-                if ($stats !== null
-                    && $stats->rank_score_index > 0
-                    && $stats->rank_score_index <= config('osu.user.username_lock_rank_limit')) {
-                    return $errors->add('username', '.username_locked');
-                }
-            }
         }
 
         return $errors;

--- a/tests/Libraries/ChangeUsernameTest.php
+++ b/tests/Libraries/ChangeUsernameTest.php
@@ -119,9 +119,8 @@ class ChangeUsernameTest extends TestCase
         $this->assertTrue($historyExists);
     }
 
-    public function testPreviousUserIsRankedLocked()
+    public function testPreviousUserHasBadge()
     {
-        config()->set('osu.user.username_lock_rank_limit', 10);
         $newUsername = 'newusername';
 
         $user = $this->createUser();
@@ -138,17 +137,14 @@ class ChangeUsernameTest extends TestCase
             'type' => 'paid',
         ]);
 
-        $existing->statisticsOsu()->save(
-            factory(UserStatistics\Osu::class)->make(['rank' => 10, 'rank_score_index' => 10, 'playcount' => 0])
-        );
+        $existing->badges()->create(['image' => 'test', 'description' => 'test', 'awarded' => now()]);
 
         $this->expectException(ChangeUsernameException::class);
         $user->changeUsername($newUsername, 'paid');
     }
 
-    public function testPreviousUserIsNotRankedLocked()
+    public function testPreviousUserHasNoBadge()
     {
-        config()->set('osu.user.username_lock_rank_limit', 9);
         $newUsername = 'newusername';
 
         $user = $this->createUser();
@@ -165,48 +161,14 @@ class ChangeUsernameTest extends TestCase
             'type' => 'paid',
         ]);
 
-        $existing->statisticsOsu()->save(
-            factory(UserStatistics\Osu::class)->make(['rank' => 10, 'rank_score_index' => 10, 'playcount' => 0])
-        );
-
-        $history = $user->changeUsername($newUsername, 'paid');
+        $user->changeUsername($newUsername, 'paid');
         $user->refresh();
 
         $this->assertSame($newUsername, $user->username);
     }
 
-    public function testPreviousUserIsNotRanked()
+    public function testInactiveUserHasBadge()
     {
-        config()->set('osu.user.username_lock_rank_limit', 10);
-        $newUsername = 'newusername';
-
-        $user = $this->createUser();
-        $existing = $this->createUser([
-            'username' => 'existing_now',
-            'username_clean' => 'existing_now',
-            'osu_subscriptionexpiry' => null,
-        ]);
-
-        $existing->usernameChangeHistory()->create([
-            'username' => 'existing_now',
-            'username_last' => $newUsername,
-            'timestamp' => Carbon::now()->subYear(),
-            'type' => 'paid',
-        ]);
-
-        $existing->statisticsOsu()->save(
-            factory(UserStatistics\Osu::class)->make(['rank' => 0, 'rank_score_index' => 0, 'playcount' => 0])
-        );
-
-        $history = $user->changeUsername($newUsername, 'paid');
-        $user->refresh();
-
-        $this->assertSame($newUsername, $user->username);
-    }
-
-    public function testInactiveUserIsRankLocked()
-    {
-        config()->set('osu.user.username_lock_rank_limit', 10);
         $newUsername = 'newusername';
 
         $user = $this->createUser();
@@ -217,9 +179,7 @@ class ChangeUsernameTest extends TestCase
             'user_lastvisit' => Carbon::now()->subYear(),
         ]);
 
-        $existing->statisticsOsu()->save(
-            factory(UserStatistics\Osu::class)->make(['rank' => 10, 'rank_score_index' => 10, 'playcount' => 0])
-        );
+        $existing->badges()->create(['image' => 'test', 'description' => 'test', 'awarded' => now()]);
 
         $this->expectException(ChangeUsernameException::class);
         $user->changeUsername($newUsername, 'paid');

--- a/tests/Libraries/ChangeUsernameTest.php
+++ b/tests/Libraries/ChangeUsernameTest.php
@@ -20,7 +20,6 @@
 use App\Exceptions\ChangeUsernameException;
 use App\Libraries\ChangeUsername;
 use App\Models\User;
-use App\Models\UserStatistics;
 use Carbon\Carbon;
 
 // FIXME: need more tests


### PR DESCRIPTION
Does the reserved username validation before the time availability checks.

Fixes the misleading "username will be available in x days" when they're actually not.

Also removes the flaky rank check on inactive users since ranks stop getting updated when they're inactive