### PR TITLE
Improved accept language detection

### DIFF
--- a/app/Http/Controllers/HomeController.php
+++ b/app/Http/Controllers/HomeController.php
@@ -139,7 +139,7 @@ class HomeController extends Controller
 
     public function setLocale()
     {
-        $newLocale = get_valid_locale(Request::input('locale'));
+        $newLocale = get_valid_locale(Request::input('locale')) ?? config('app.fallback_locale');
         App::setLocale($newLocale);
 
         if (Auth::check()) {

--- a/app/Http/Middleware/SetLocale.php
+++ b/app/Http/Middleware/SetLocale.php
@@ -45,6 +45,8 @@ class SetLocale
             $locale = presence($request->cookie('locale'));
         }
 
+        $locale = get_valid_locale($locale);
+
         if ($locale === null) {
             $accept = $request->server('HTTP_ACCEPT_LANGUAGE');
             $parser = new Parser($accept);

--- a/app/Http/Middleware/SetLocale.php
+++ b/app/Http/Middleware/SetLocale.php
@@ -21,8 +21,9 @@
 namespace App\Http\Middleware;
 
 use App;
+use App\Libraries\AcceptHttpLanguage\Parser;
 use Auth;
-use Carbon;
+use Carbon\Carbon;
 use Closure;
 use Illuminate\Http\Request;
 
@@ -41,16 +42,18 @@ class SetLocale
         if (Auth::check()) {
             $locale = Auth::user()->user_lang;
         } else {
-            $locale =
-                presence($request->cookie('locale')) ??
-                locale_accept_from_http($request->server('HTTP_ACCEPT_LANGUAGE'));
+            $locale = presence($request->cookie('locale'));
         }
 
-        $locale = get_valid_locale($locale);
+        if ($locale === null) {
+            $accept = $request->server('HTTP_ACCEPT_LANGUAGE');
+            $parser = new Parser($accept);
+            $locale = $parser->languageRegionCompatibleFrom(config('app.available_locales')) ?? config('app.fallback_locale');
+        }
 
         App::setLocale($locale);
         // Carbon setLocale normalizes the locale
-        Carbon\Carbon::setLocale($locale);
+        Carbon::setLocale($locale);
 
         return $next($request);
     }

--- a/app/Libraries/AcceptHttpLanguage/Parser.php
+++ b/app/Libraries/AcceptHttpLanguage/Parser.php
@@ -102,8 +102,7 @@ class Parser
             $preferredLanguage = explode('-', $preferred, 2)[0];
 
             foreach ($availableLanguages as $available) {
-                $available = strtolower($available);
-                if ($preferred === $available || $preferredLanguage === explode('-', $available, 2)[0]) {
+                if ($preferred === strtolower($available) || $preferredLanguage === explode('-', $available, 2)[0]) {
                     return $available;
                 }
             }

--- a/app/Libraries/AcceptHttpLanguage/Parser.php
+++ b/app/Libraries/AcceptHttpLanguage/Parser.php
@@ -20,7 +20,7 @@
 
 /**
  * This is a port of HttpAcceptLanguage::Parser from the http_accept_language gem
- * https://github.com/iain/http_accept_language/blob/v2.1.1/lib/http_accept_language/parser.rb
+ * https://github.com/iain/http_accept_language/blob/v2.1.1/lib/http_accept_language/parser.rb.
  */
 
 namespace App\Libraries\AcceptHttpLanguage;
@@ -48,7 +48,6 @@ class Parser
      *
      * request.userPreferredLanguages
      * $ => [ 'nl-NL', 'nl-BE', 'nl', 'en-US', 'en' ]
-     *
      */
     public function userPreferredLanguages()
     {
@@ -75,8 +74,7 @@ class Parser
      *
      *   request.preferred_language_from I18n.available_locales
      *   $ => 'nl'
-     *
-    */
+     */
     public function preferredLanguageFrom(array $array)
     {
         return array_values(array_intersect($this->userPreferredLanguages(), $array))[0] ?? null;
@@ -89,7 +87,6 @@ class Parser
      * Example:
      *
      *   request.compatibleLanguageFrom I18n.available_locales
-     *
      */
     public function compatibleLanguageFrom(array $availableLanguages)
     {
@@ -113,7 +110,6 @@ class Parser
      *
      * Example:
      * [ja_JP-x1, en-US-x4, en_UK-x5, fr-FR-x3] => [ja-JP, en-US, en-UK, fr-FR]
-     *
      */
     public function sanitizeAvailableLocales(array $availableLanguages)
     {
@@ -133,7 +129,6 @@ class Parser
      * Example:
      *
      *   request.language_region_compatible($availableLanguages)
-     *
      */
     public function languageRegionCompatibleFrom($availableLanguages)
     {
@@ -171,7 +166,9 @@ class Parser
                 throw new InvalidArgumentException('Not correctly formatted');
             }
 
-            $locale = preg_replace_callback('/-[a-z0-9]+$/i', function ($match) { return strtoupper($match[0]); }, $locale); # Uppercase territory
+            $locale = preg_replace_callback('/-[a-z0-9]+$/i', function ($match) {
+                return strtoupper($match[0]);
+            }, $locale); // Uppercase territory
             if ($locale === '*') {
                 $locale = null; // Ignore wildcards
             }

--- a/app/Libraries/AcceptHttpLanguage/Parser.php
+++ b/app/Libraries/AcceptHttpLanguage/Parser.php
@@ -1,0 +1,166 @@
+<?php
+
+namespace App\Libraries\AcceptHttpLanguage;
+
+use InvalidArgumentException;
+
+// port of iain/http_accept_language HttpAcceptLanguage::Parser
+class Parser
+{
+    /** @var string */
+    public $header;
+
+    /** @var array */
+    private $userPreferredLanguages;
+
+    public function __construct(string $header)
+    {
+        $this->header = $header;
+    }
+
+    /**
+     * Returns a sorted array based on user preference in HTTP_ACCEPT_LANGUAGE.
+     * Browsers send this HTTP header, so don't think this is holy.
+     *
+     * Example:
+     *
+     * request.userPreferredLanguages
+     * $ => [ 'nl-NL', 'nl-BE', 'nl', 'en-US', 'en' ]
+     *
+     */
+    public function userPreferredLanguages()
+    {
+        if ($this->userPreferredLanguages === null) {
+            try {
+                $header = preg_replace('/\s+/', '', $this->header);
+                $header = explode(',', $header);
+                $mappings = array_map(function ($language) {
+                    $exploded = explode(';q=', $language);
+                    $locale = $exploded[0];
+                    $quality = (float) ($exploded[1] ?? 1.0);
+                    if (!preg_match('/^[a-z\-0-9]+|\*$/i', $locale)) {
+                        throw new InvalidArgumentException('Not correctly formatted');
+                    }
+
+                    $locale = preg_replace_callback('/-[a-z0-9]+$/i', function ($match) { return strtoupper($match[0]); }, $locale); # Uppercase territory
+                    if ($locale === '*') {
+                        $locale = null; // Ignore wildcards
+                    }
+
+                    return [$locale, $quality];
+                }, $header);
+
+                usort($mappings, function ($left, $right) {
+                    return $right[1] > $left[1];
+                });
+
+                $sorted = array_filter(array_map(function ($mapping) {
+                    return $mapping[0];
+                }, $mappings));
+
+                $this->userPreferredLanguages = $sorted;
+            } catch (InvalidArgumentException $_e) {
+                $this->userPreferredLanguages = [];
+            }
+        }
+
+        return $this->userPreferredLanguages;
+    }
+
+    public function setUserPreferredLanguages(array $languages)
+    {
+        $this->userPreferredLanguages = $languages;
+    }
+
+    /**
+     * Finds the locale specifically requested by the browser.
+     *
+     * Example:
+     *
+     *   request.preferred_language_from I18n.available_locales
+     *   $ => 'nl'
+     *
+    */
+    public function preferredLanguageFrom(array $array)
+    {
+        return array_values(array_intersect($this->userPreferredLanguages(), $array))[0] ?? null;
+    }
+
+    /**
+     * Returns the first of the userPreferredLanguages that is compatible
+     * with the available locales. Ignores region.
+     *
+     * Example:
+     *
+     *   request.compatibleLanguageFrom I18n.available_locales
+     *
+     */
+    public function compatibleLanguageFrom(array $availableLanguages)
+    {
+        $compatible = array_map(function ($preferred) use ($availableLanguages) { // en-US
+            $preferred = strtolower($preferred);
+            $preferredLanguage = explode('-', $preferred, 2)[0];
+
+            foreach ($availableLanguages as $available) {
+                $available = strtolower($available);
+                if ($preferred === $available || $preferredLanguage === explode('-', $available, 2)[0]) {
+                    return $available;
+                }
+            }
+        }, $this->userPreferredLanguages());
+
+        return array_values(array_filter($compatible))[0] ?? null; // .compact.first
+    }
+
+    /**
+     * Returns a supplied list of available locals without any extra application info
+     * that may be attached to the locale for storage in the application.
+     *
+     * Example:
+     * [ja_JP-x1, en-US-x4, en_UK-x5, fr-FR-x3] => [ja-JP, en-US, en-UK, fr-FR]
+     *
+     */
+    public function sanitizeAvailableLocales(array $availableLanguages)
+    {
+        return array_map(function ($avaialble) {
+            return implode('-', array_filter(preg_split('/[_-]/', $avaialble), function ($part) {
+                return !starts_with($part, 'x');
+            }));
+        }, $availableLanguages);
+    }
+
+    /**
+     * Returns the first of the user preferred languages that is
+     * also found in available languages.  Finds best fit by matching on
+     * primary language first and secondarily on region.  If no matching region is
+     * found, return the first language in the group matching that primary language.
+     *
+     * Example:
+     *
+     *   request.language_region_compatible($availableLanguages)
+     *
+     */
+    public function languageRegionCompatibleFrom($availableLanguages)
+    {
+        $availableLanguages = $this->sanitizeAvailableLocales($availableLanguages);
+        $array = array_map(function ($preferred) use ($availableLanguages) { // en-US
+            $preferred = strtolower($preferred);
+            $preferredLanguage = explode('-', $preferred, 2)[0] ?? null;
+
+            $langGroup = array_values(array_filter($availableLanguages, function ($available) use ($preferredLanguage) { // en
+                return $preferredLanguage === explode('-', strtolower($available), 2)[0] ?? null;
+            }));
+
+            foreach ($langGroup as $lang) {
+                if (strtolower($lang) === $preferred) {
+                    $result = $lang;
+                    break;
+                }
+            }
+
+            return $result ?? ($langGroup[0] ?? null);
+        }, $this->userPreferredLanguages());
+
+        return array_values(array_filter($array))[0] ?? null; // .compact.first
+    }
+}

--- a/app/Libraries/AcceptHttpLanguage/Parser.php
+++ b/app/Libraries/AcceptHttpLanguage/Parser.php
@@ -35,7 +35,7 @@ class Parser
     /** @var array */
     private $userPreferredLanguages;
 
-    public function __construct(string $header)
+    public function __construct(?string $header = null)
     {
         $this->header = $header;
     }

--- a/app/Libraries/AcceptHttpLanguage/Parser.php
+++ b/app/Libraries/AcceptHttpLanguage/Parser.php
@@ -113,8 +113,8 @@ class Parser
      */
     public function sanitizeAvailableLocales(array $availableLanguages)
     {
-        return array_map(function ($avaialble) {
-            return implode('-', array_filter(preg_split('/[_-]/', $avaialble), function ($part) {
+        return array_map(function ($available) {
+            return implode('-', array_filter(preg_split('/[_-]/', $available), function ($part) {
                 return !starts_with($part, 'x');
             }));
         }, $availableLanguages);

--- a/app/Libraries/AcceptHttpLanguage/Parser.php
+++ b/app/Libraries/AcceptHttpLanguage/Parser.php
@@ -1,10 +1,32 @@
 <?php
 
+/**
+ *    Copyright (c) ppy Pty Ltd <contact@ppy.sh>.
+ *
+ *    This file is part of osu!web. osu!web is distributed with the hope of
+ *    attracting more community contributions to the core ecosystem of osu!.
+ *
+ *    osu!web is free software: you can redistribute it and/or modify
+ *    it under the terms of the Affero GNU General Public License version 3
+ *    as published by the Free Software Foundation.
+ *
+ *    osu!web is distributed WITHOUT ANY WARRANTY; without even the implied
+ *    warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *    See the GNU Affero General Public License for more details.
+ *
+ *    You should have received a copy of the GNU Affero General Public License
+ *    along with osu!web.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * This is a port of HttpAcceptLanguage::Parser from the http_accept_language gem
+ * https://github.com/iain/http_accept_language/blob/v2.1.1/lib/http_accept_language/parser.rb
+ */
+
 namespace App\Libraries\AcceptHttpLanguage;
 
 use InvalidArgumentException;
 
-// port of iain/http_accept_language HttpAcceptLanguage::Parser
 class Parser
 {
     /** @var string */

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -205,14 +205,6 @@ function get_valid_locale($requestedLocale)
     if (in_array($requestedLocale, config('app.available_locales'), true)) {
         return $requestedLocale;
     }
-
-    return array_first(
-        config('app.available_locales'),
-        function ($value) use ($requestedLocale) {
-            return starts_with($requestedLocale, $value);
-        },
-        config('app.fallback_locale')
-    );
 }
 
 function html_entity_decode_better($string)

--- a/tests/Libraries/AcceptHttpLanguage/ParserTest.php
+++ b/tests/Libraries/AcceptHttpLanguage/ParserTest.php
@@ -20,7 +20,7 @@
 
 /**
  * This is a port of parser_spec from the http_accept_language gem
- * https://github.com/iain/http_accept_language/blob/v2.1.1/spec/parser_spec.rb
+ * https://github.com/iain/http_accept_language/blob/v2.1.1/spec/parser_spec.rb.
  */
 
 namespace Test\Libraries\AcceptHttpLanguage;
@@ -38,52 +38,62 @@ class ParserTest extends TestCase
         $this->parser = new Parser('en-us,en-gb;q=0.8,en;q=0.6,es-419');
     }
 
-    public function testShouldReturnEmptyArray() {
+    public function testShouldReturnEmptyArray()
+    {
         $this->parser->header = null;
         $this->assertSame([], $this->parser->userPreferredLanguages());
     }
 
-    public function testShouldProperlySplit() {
+    public function testShouldProperlySplit()
+    {
         $this->assertSame(['en-US', 'es-419', 'en-GB', 'en'], $this->parser->userPreferredLanguages());
     }
 
-    public function testShouldIgnoreJambledHeader() {
+    public function testShouldIgnoreJambledHeader()
+    {
         $this->parser->header = 'odkhjf89fioma098jq .,.,';
         $this->assertSame([], $this->parser->userPreferredLanguages());
     }
 
-    public function testShouldProperlyRespectWhitespace() {
+    public function testShouldProperlyRespectWhitespace()
+    {
         $this->parser->header = 'en-us, en-gb; q=0.8,en;q = 0.6,es-419';
         $this->assertSame(['en-US', 'es-419', 'en-GB', 'en'], $this->parser->userPreferredLanguages());
     }
 
-    public function testShouldFindFirstAvailableLanguage() {
+    public function testShouldFindFirstAvailableLanguage()
+    {
         $this->assertSame('en-GB', $this->parser->preferredLanguageFrom(['en', 'en-GB']));
     }
 
-    public function testShouldFindFirstCompatibleLanguage() {
+    public function testShouldFindFirstCompatibleLanguage()
+    {
         $this->assertSame('en-hk', $this->parser->compatibleLanguageFrom(['en-hk']));
         $this->assertSame('en', $this->parser->compatibleLanguageFrom(['en']));
     }
 
-    public function testShouldfindFirstCompatibleFromUserPreferred() {
+    public function testShouldfindFirstCompatibleFromUserPreferred()
+    {
         $this->parser->header = 'en-us,de-de';
         $this->assertSame('en', $this->parser->compatibleLanguageFrom(['de', 'en']));
     }
 
-    public function testShouldAcceptAndIgnoreWildcards() {
+    public function testShouldAcceptAndIgnoreWildcards()
+    {
         $this->parser->header = 'en-US,en,*';
         $this->assertSame('en-US', $this->parser->compatibleLanguageFrom(['en-US']));
     }
 
-    public function testShouldSanitizeAvailableLanguageNames() {
+    public function testShouldSanitizeAvailableLanguageNames()
+    {
         $this->assertSame(
             ['en-UK', 'en-US', 'ja-JP', 'pt-BR', 'es-419'],
             $this->parser->sanitizeAvailableLocales(['en_UK-x3', 'en-US-x1', 'ja_JP-x2', 'pt-BR-x5', 'es-419-x4'])
         );
     }
 
-    public function testShouldFindMostCompatibleLanguageFromUserPreferred() {
+    public function testShouldFindMostCompatibleLanguageFromUserPreferred()
+    {
         $this->parser->header = 'ja,en-gb,en-us,fr-fr';
         $this->assertSame('ja-JP', $this->parser->languageRegionCompatibleFrom(['en-UK', 'en-US', 'ja-JP']));
     }

--- a/tests/Libraries/AcceptHttpLanguage/ParserTest.php
+++ b/tests/Libraries/AcceptHttpLanguage/ParserTest.php
@@ -1,5 +1,28 @@
 <?php
 
+/**
+ *    Copyright (c) ppy Pty Ltd <contact@ppy.sh>.
+ *
+ *    This file is part of osu!web. osu!web is distributed with the hope of
+ *    attracting more community contributions to the core ecosystem of osu!.
+ *
+ *    osu!web is free software: you can redistribute it and/or modify
+ *    it under the terms of the Affero GNU General Public License version 3
+ *    as published by the Free Software Foundation.
+ *
+ *    osu!web is distributed WITHOUT ANY WARRANTY; without even the implied
+ *    warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *    See the GNU Affero General Public License for more details.
+ *
+ *    You should have received a copy of the GNU Affero General Public License
+ *    along with osu!web.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+/**
+ * This is a port of parser_spec from the http_accept_language gem
+ * https://github.com/iain/http_accept_language/blob/v2.1.1/spec/parser_spec.rb
+ */
+
 namespace Test\Libraries\AcceptHttpLanguage;
 
 use App\Libraries\AcceptHttpLanguage\Parser;

--- a/tests/Libraries/AcceptHttpLanguage/ParserTest.php
+++ b/tests/Libraries/AcceptHttpLanguage/ParserTest.php
@@ -1,0 +1,67 @@
+<?php
+
+namespace Test\Libraries\AcceptHttpLanguage;
+
+use App\Libraries\AcceptHttpLanguage\Parser;
+use TestCase;
+
+class ParserTest extends TestCase
+{
+    /** @var Parser */
+    private $parser;
+
+    public function setUp()
+    {
+        $this->parser = new Parser('en-us,en-gb;q=0.8,en;q=0.6,es-419');
+    }
+
+    public function testShouldReturnEmptyArray() {
+        $this->parser->header = null;
+        $this->assertSame([], $this->parser->userPreferredLanguages());
+    }
+
+    public function testShouldProperlySplit() {
+        $this->assertSame(['en-US', 'es-419', 'en-GB', 'en'], $this->parser->userPreferredLanguages());
+    }
+
+    public function testShouldIgnoreJambledHeader() {
+        $this->parser->header = 'odkhjf89fioma098jq .,.,';
+        $this->assertSame([], $this->parser->userPreferredLanguages());
+    }
+
+    public function testShouldProperlyRespectWhitespace() {
+        $this->parser->header = 'en-us, en-gb; q=0.8,en;q = 0.6,es-419';
+        $this->assertSame(['en-US', 'es-419', 'en-GB', 'en'], $this->parser->userPreferredLanguages());
+    }
+
+    public function testShouldFindFirstAvailableLanguage() {
+        $this->assertSame('en-GB', $this->parser->preferredLanguageFrom(['en', 'en-GB']));
+    }
+
+    public function testShouldFindFirstCompatibleLanguage() {
+        $this->assertSame('en-hk', $this->parser->compatibleLanguageFrom(['en-hk']));
+        $this->assertSame('en', $this->parser->compatibleLanguageFrom(['en']));
+    }
+
+    public function testShouldfindFirstCompatibleFromUserPreferred() {
+        $this->parser->header = 'en-us,de-de';
+        $this->assertSame('en', $this->parser->compatibleLanguageFrom(['de', 'en']));
+    }
+
+    public function testShouldAcceptAndIgnoreWildcards() {
+        $this->parser->header = 'en-US,en,*';
+        $this->assertSame('en-US', $this->parser->compatibleLanguageFrom(['en-US']));
+    }
+
+    public function testShouldSanitizeAvailableLanguageNames() {
+        $this->assertSame(
+            ['en-UK', 'en-US', 'ja-JP', 'pt-BR', 'es-419'],
+            $this->parser->sanitizeAvailableLocales(['en_UK-x3', 'en-US-x1', 'ja_JP-x2', 'pt-BR-x5', 'es-419-x4'])
+        );
+    }
+
+    public function testShouldFindMostCompatibleLanguageFromUserPreferred() {
+        $this->parser->header = 'ja,en-gb,en-us,fr-fr';
+        $this->assertSame('ja-JP', $this->parser->languageRegionCompatibleFrom(['en-UK', 'en-US', 'ja-JP']));
+    }
+}


### PR DESCRIPTION
Selects a default language from the preferred languages in the `Accept` according to priority, or a compatible one if an exact one can't be found.

Ported from parser part of https://github.com/iain/http_accept_language (so the syntax in the comments are all wrong 🥇)

closes #4194

---
