### PR TITLE
Add support for searching on Beatmapset title prefix

### DIFF
--- a/app/Libraries/Search/BeatmapsetSearch.php
+++ b/app/Libraries/Search/BeatmapsetSearch.php
@@ -54,9 +54,15 @@ class BeatmapsetSearch extends RecordSearch
 
         if (present($this->params->queryString)) {
             $terms = explode(' ', $this->params->queryString);
-            // results must contain at least one of the terms and boosted by containing all of them.
-            $query->must(QueryHelper::queryString($this->params->queryString, $partialMatchFields, 'or', 1 / count($terms)));
-            $query->should(QueryHelper::queryString($this->params->queryString, [], 'and'));
+
+            // the subscoping is not necessary but prevents unintentional accidents when combining other matchers
+            $query->must(
+                (new BoolQuery)
+                    // results must contain at least one of the terms and boosted by containing all of them.
+                    ->shouldMatch(1)
+                    ->should(QueryHelper::queryString($this->params->queryString, $partialMatchFields, 'or', 1 / count($terms)))
+                    ->should(QueryHelper::queryString($this->params->queryString, [], 'and'))
+            );
         }
 
         $this->addModeFilter($query);

--- a/app/Libraries/Search/BeatmapsetSearch.php
+++ b/app/Libraries/Search/BeatmapsetSearch.php
@@ -48,12 +48,14 @@ class BeatmapsetSearch extends RecordSearch
      */
     public function getQuery()
     {
+        static $partialMatchFields = ['artist', 'artist.*', 'artist_unicode', 'creator', 'description^0.5', 'title', 'title.raw', 'title.*', 'title_unicode', 'tags^0.5'];
+
         $query = (new BoolQuery());
 
         if (present($this->params->queryString)) {
             $terms = explode(' ', $this->params->queryString);
             // results must contain at least one of the terms and boosted by containing all of them.
-            $query->must(QueryHelper::queryString($this->params->queryString, [], 'or', 1 / count($terms)));
+            $query->must(QueryHelper::queryString($this->params->queryString, $partialMatchFields, 'or', 1 / count($terms)));
             $query->should(QueryHelper::queryString($this->params->queryString, [], 'and'));
         }
 

--- a/app/Libraries/Search/BeatmapsetSearch.php
+++ b/app/Libraries/Search/BeatmapsetSearch.php
@@ -48,7 +48,7 @@ class BeatmapsetSearch extends RecordSearch
      */
     public function getQuery()
     {
-        static $partialMatchFields = ['artist', 'artist.*', 'artist_unicode', 'creator', 'description^0.5', 'title', 'title.raw', 'title.*', 'title_unicode', 'tags^0.5'];
+        static $partialMatchFields = ['artist', 'artist.*', 'artist_unicode', 'creator', 'title', 'title.raw', 'title.*', 'title_unicode', 'tags^0.5'];
 
         $query = (new BoolQuery());
 

--- a/config/schemas/beatmaps.json
+++ b/config/schemas/beatmaps.json
@@ -160,6 +160,11 @@
         "title": {
           "type": "text",
           "fields": {
+            "_prefix": {
+              "type": "text",
+              "analyzer": "prefix",
+              "search_analyzer": "standard"
+            },
             "raw": {
               "type": "keyword"
             }
@@ -179,6 +184,30 @@
   },
   "settings": {
     "index": {
+      "analysis": {
+        "analyzer": {
+          "lowercase": {
+            "tokenizer": "lowercase"
+          },
+          "prefix": {
+            "filter": [
+              "lowercase"
+            ],
+            "tokenizer": "prefix"
+          }
+        },
+        "tokenizer": {
+          "prefix": {
+            "type": "edge_ngram",
+            "min_gram": "3",
+            "max_gram": "8",
+            "token_chars": [
+              "letter",
+              "digit"
+            ]
+          }
+        }
+      },
       "number_of_shards": "1",
       "number_of_replicas": "1"
     }


### PR DESCRIPTION
Support prefix search of terms from 3 to 8 characters; if it's not found with 8, it's probably not going to found with more.

Also limits the partial matching of multiple terms to the more relevant fields.