### PR TITLE
Add option to keep forum poll results hidden until the poll ends

### DIFF
--- a/app/Http/Controllers/Forum/TopicsController.php
+++ b/app/Http/Controllers/Forum/TopicsController.php
@@ -445,12 +445,12 @@ class TopicsController extends Controller
     private function getPollParams()
     {
         return get_params(request(), 'forum_topic_poll', [
+            'hide_results:bool',
             'length_days:int',
             'max_options:int',
             'options:string_split',
             'title',
             'vote_change:bool',
-            'hide_results:bool',
         ]);
     }
 

--- a/app/Http/Controllers/Forum/TopicsController.php
+++ b/app/Http/Controllers/Forum/TopicsController.php
@@ -450,6 +450,7 @@ class TopicsController extends Controller
             'options:string_split',
             'title',
             'vote_change:bool',
+            'hide_results:bool',
         ]);
     }
 

--- a/app/Libraries/OsuAuthorize.php
+++ b/app/Libraries/OsuAuthorize.php
@@ -956,11 +956,11 @@ class OsuAuthorize
 
     public function checkForumTopicPollShowResults($user, $topic)
     {
-        if ($this->doCheckUser($user, 'ForumModerate', $topic->forum)->can()) {
+        if (!$topic->poll_hide_results) {
             return 'ok';
         }
 
-        if ($user !== null && $topic->posts()->withTrashed()->first()->poster_id === $user->user_id) {
+        if ($this->doCheckUser($user, 'ForumModerate', $topic->forum)->can()) {
             return 'ok';
         }
 
@@ -968,7 +968,7 @@ class OsuAuthorize
             return 'ok';
         }
 
-        if (!$topic->poll_hide_results) {
+        if ($user !== null && $topic->posts()->withTrashed()->first()->poster_id === $user->user_id) {
             return 'ok';
         }
     }

--- a/app/Libraries/OsuAuthorize.php
+++ b/app/Libraries/OsuAuthorize.php
@@ -954,6 +954,25 @@ class OsuAuthorize
         }
     }
 
+    public function checkForumTopicPollShowResults($user, $topic)
+    {
+        if ($this->doCheckUser($user, 'ForumModerate', $topic->forum)->can()) {
+            return 'ok';
+        }
+
+        if ($user !== null && $topic->posts()->withTrashed()->first()->poster_id === $user->user_id) {
+            return 'ok';
+        }
+
+        if ($topic->pollEnd() === null || $topic->pollEnd()->isPast()) {
+            return 'ok';
+        }
+
+        if (!$topic->poll_hide_results) {
+            return 'ok';
+        }
+    }
+
     public function checkForumTopicVote($user, $topic)
     {
         $prefix = 'forum.topic.vote.';

--- a/app/Models/Forum/Topic.php
+++ b/app/Models/Forum/Topic.php
@@ -48,6 +48,7 @@ use Illuminate\Database\QueryException;
  * @property int $osu_starpriority
  * @property \Illuminate\Database\Eloquent\Collection $pollOptions PollOption
  * @property \Illuminate\Database\Eloquent\Collection $pollVotes PollVote
+ * @property bool $poll_hide_results
  * @property int $poll_last_vote
  * @property int $poll_length
  * @property mixed $poll_length_days
@@ -125,6 +126,7 @@ class Topic extends Model implements AfterCommit
     private $_issueTags;
 
     protected $casts = [
+        'poll_hide_results' => 'boolean',
         'poll_vote_change' => 'boolean',
         'topic_approved' => 'boolean',
     ];

--- a/app/Models/Forum/TopicPoll.php
+++ b/app/Models/Forum/TopicPoll.php
@@ -82,6 +82,10 @@ class TopicPoll
                 $this->validationErrors()->add('max_options', '.invalid_max_options');
             }
 
+            if (($this->params['hide_results'] ?? false) && ($this->params['length_days'] ?? 0) === 0) {
+                $this->validationErrors()->add('hide_results', '.hiding_results_forever');
+            }
+
             if ($this->topic !== null && $this->topic->exists && !$this->canEdit()) {
                 $this->validationErrors()->add(
                     'edit',

--- a/app/Models/Forum/TopicPoll.php
+++ b/app/Models/Forum/TopicPoll.php
@@ -107,6 +107,7 @@ class TopicPoll
                 'poll_length' => ($this->params['length_days'] ?? 0) * 3600 * 24,
                 'poll_max_options' => $this->params['max_options'],
                 'poll_vote_change' => $this->params['vote_change'] ?? false,
+                'poll_hide_results' => $this->params['hide_results'] ?? false,
             ]);
 
             $this

--- a/app/Models/Forum/TopicPoll.php
+++ b/app/Models/Forum/TopicPoll.php
@@ -45,7 +45,10 @@ class TopicPoll
     public function fill($params)
     {
         $this->params = array_merge([
+            'hide_results' => false,
+            'length_days' => 0,
             'max_options' => 1,
+            'vote_change' => false,
         ], $params);
         $this->validated = false;
 
@@ -82,7 +85,7 @@ class TopicPoll
                 $this->validationErrors()->add('max_options', '.invalid_max_options');
             }
 
-            if (($this->params['hide_results'] ?? false) && ($this->params['length_days'] ?? 0) === 0) {
+            if ($this->params['hide_results'] && $this->params['length_days'] === 0) {
                 $this->validationErrors()->add('hide_results', '.hiding_results_forever');
             }
 
@@ -108,10 +111,10 @@ class TopicPoll
             $this->topic->update([
                 'poll_title' => $this->params['title'],
                 'poll_start' => Carbon::now(),
-                'poll_length' => ($this->params['length_days'] ?? 0) * 3600 * 24,
+                'poll_length' => $this->params['length_days'] * 3600 * 24,
                 'poll_max_options' => $this->params['max_options'],
-                'poll_vote_change' => $this->params['vote_change'] ?? false,
-                'poll_hide_results' => $this->params['hide_results'] ?? false,
+                'poll_vote_change' => $this->params['vote_change'],
+                'poll_hide_results' => $this->params['hide_results'],
             ]);
 
             $this

--- a/database/migrations/2019_04_01_202237_add_poll_hide_results_to_topics.php
+++ b/database/migrations/2019_04_01_202237_add_poll_hide_results_to_topics.php
@@ -14,7 +14,7 @@ class AddPollHideResultsToTopics extends Migration
     public function up()
     {
         Schema::table('phpbb_topics', function (Blueprint $table) {
-            $table->boolean('poll_hide_results')->default(0);
+            $table->boolean('poll_hide_results')->after('poll_vote_change')->default(0);
         });
     }
 

--- a/database/migrations/2019_04_01_202237_add_poll_hide_results_to_topics.php
+++ b/database/migrations/2019_04_01_202237_add_poll_hide_results_to_topics.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddPollHideResultsToTopics extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('phpbb_topics', function (Blueprint $table) {
+            $table->boolean('poll_hide_results')->default(0);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('phpbb_topics', function (Blueprint $table) {
+            $table->dropColumn('poll_hide_results');
+        });
+    }
+}

--- a/resources/lang/en/forum.php
+++ b/resources/lang/en/forum.php
@@ -294,6 +294,7 @@ return [
                 'detail' => [
                     'end_time' => 'Polling will end at :time',
                     'ended' => 'Polling ended :time',
+                    'results_hidden' => 'Results will be shown after polling ends.',
                     'total' => 'Total votes: :count',
                 ],
             ],

--- a/resources/lang/en/forum.php
+++ b/resources/lang/en/forum.php
@@ -179,6 +179,8 @@ return [
             ],
 
             'poll' => [
+                'hide_results' => 'Hide the results of the poll.',
+                'hide_results_info' => 'They will be shown only after the poll concludes.',
                 'length' => 'Run poll for',
                 'length_days_suffix' => 'days',
                 'length_info' => 'Leave blank for a never ending poll',

--- a/resources/lang/en/model_validation.php
+++ b/resources/lang/en/model_validation.php
@@ -73,7 +73,8 @@ return [
 
         'topic_poll' => [
             'duplicate_options' => 'Duplicated option is not allowed.',
-            'grace_period_expired' => 'Can\'t edit a poll after more than :limit hours',
+            'grace_period_expired' => 'Can\'t edit a poll after more than :limit hours.',
+            'hiding_results_forever' => 'Can\'t hide results of a poll that never ends.',
             'invalid_max_options' => 'Option per user may not exceed the number of available options.',
             'minimum_one_selection' => 'A minimum of one option per user is required.',
             'minimum_two_options' => 'Need at least two options.',

--- a/resources/views/forum/topics/_create_poll.blade.php
+++ b/resources/views/forum/topics/_create_poll.blade.php
@@ -106,6 +106,28 @@
             <span class="simple-form__info">{{ trans('forum.topics.create.poll.vote_change_info') }}</span>
         </div>
     </label>
+
+    <label class="simple-form__row">
+        <div class="simple-form__label simple-form__label--full">
+            <div class="osu-checkbox">
+                <input
+                    class="osu-checkbox__input"
+                    name="forum_topic_poll[hide_results]"
+                    type="checkbox"
+                    @if (optional($topic)->poll_hide_results)
+                        checked
+                    @endif
+                />
+                <span class="osu-checkbox__box"></span>
+                <span class="osu-checkbox__tick">
+                    <i class="fas fa-check"></i>
+                </span>
+            </div>
+
+            {{ trans('forum.topics.create.poll.hide_results') }}
+            <span class="simple-form__info">{{ trans('forum.topics.create.poll.hide_results_info') }}</span>
+        </div>
+    </label>
 </div>
 
 @if (!$edit)

--- a/resources/views/forum/topics/_poll.blade.php
+++ b/resources/views/forum/topics/_poll.blade.php
@@ -16,6 +16,10 @@
     along with osu!web.  If not, see <http://www.gnu.org/licenses/>.
 --}}
 
+<?php
+    $canViewResults = priv_check('ForumTopicPollShowResults', $topic)->can();
+?>
+
 <div class="forum-poll js-forum-poll">
     {!! Form::open([
         'route' => ['forum.topics.vote', $topic->topic_id],

--- a/resources/views/forum/topics/_poll.blade.php
+++ b/resources/views/forum/topics/_poll.blade.php
@@ -60,6 +60,12 @@
                         {{ trans('forum.topics.show.poll.detail.ended', ['time' => $topic->pollEnd()]) }}
                     @endif
                 </div>
+
+                @if (!$canViewResults)
+                    <div class="forum-poll__detail forum-poll__detail--sub">
+                        {{ trans('forum.topics.show.poll.detail.results_hidden') }}
+                    </div>
+                @endif
             @endif
         </div>
 

--- a/resources/views/forum/topics/_poll_row.blade.php
+++ b/resources/views/forum/topics/_poll_row.blade.php
@@ -43,7 +43,10 @@
 
     <td class="forum-poll-row__column forum-poll-row__column--bar">
         <div class="bar bar--forum-poll {{ $pollOption['voted_by_user'] ? 'bar--forum-poll-voted' : '' }}">
-            <div class="bar__fill" style="width: {{ $percentage }}">
+            <div
+                class="bar__fill"
+                style="width: {{ $canViewResults ? $percentage : '100%' }}"
+            >
             </div>
             <div class="forum-poll-row__option-text">
                 {!! $pollOption['textHTML'] !!}
@@ -51,11 +54,13 @@
         </div>
     </td>
 
-    <td class="forum-poll-row__column forum-poll-row__column--percentage">
-        {{ $percentage }}
-    </td>
+    @if ($canViewResults)
+        <td class="forum-poll-row__column forum-poll-row__column--percentage">
+            {{ $percentage }}
+        </td>
 
-    <td class="forum-poll-row__column">
-        {{ $pollOption['total'] }}
-    </td>
+        <td class="forum-poll-row__column">
+            {{ $pollOption['total'] }}
+        </td>
+    @endif
 </tr>


### PR DESCRIPTION
suggested in #osu-loved to help prevent bandwagoning or fraud votes

probably a good idea for any poll where the outcome is important