### PR TITLE
Remove gap between content and edge of screen on mobile layout

### DIFF
--- a/resources/assets/less/bem/osu-page.less
+++ b/resources/assets/less/bem/osu-page.less
@@ -189,13 +189,6 @@
   }
 
   &--small {
-    .width(20px);
-    @media @desktop {
-      .width-desktop(20px);
-    }
-  }
-
-  &--small-desktop {
     @media @desktop {
       .width-desktop(20px);
     }

--- a/resources/views/forum/topics/_post.blade.php
+++ b/resources/views/forum/topics/_post.blade.php
@@ -26,7 +26,7 @@
     }
 ?>
 <div
-    class="js-forum-post {{ $post->trashed() ? 'js-forum-post--hidden' : '' }} osu-page {{ $options['large'] ? '' : 'osu-page--small-desktop' }}"
+    class="js-forum-post {{ $post->trashed() ? 'js-forum-post--hidden' : '' }} osu-page {{ $options['large'] ? '' : 'osu-page--small' }}"
     data-post-id="{{ $post->post_id }}"
     data-post-position="{{ $options["postPosition"] }}"
 >

--- a/resources/views/forum/topics/show.blade.php
+++ b/resources/views/forum/topics/show.blade.php
@@ -75,7 +75,7 @@
             'data-force-reload' => Auth::check() === false ? '1' : '0',
         ]) !!}
             @if (priv_check('ForumTopicReply', $topic)->can())
-                <div class="osu-page osu-page--small-desktop">
+                <div class="osu-page osu-page--small">
                     @if (!$topic->isActive())
                         <div class="warning-box">
                             <div class="warning-box__icon">

--- a/resources/views/home/search.blade.php
+++ b/resources/views/home/search.blade.php
@@ -50,7 +50,7 @@
             </div>
         </div>
 
-        <div class="osu-page osu-page--small-desktop">
+        <div class="osu-page osu-page--small">
             <div class="search">
                 @include('home._search_page_tabs', compact('allSearch'))
 

--- a/resources/views/home/user.blade.php
+++ b/resources/views/home/user.blade.php
@@ -26,7 +26,7 @@
         )])
     ])
 
-    <div class="osu-page osu-page--small-desktop">
+    <div class="osu-page osu-page--small">
         <div class="user-home">
             <div class="user-home__news">
                 <h2 class="user-home__news-title">{{ trans('home.user.news.title') }}</h2>

--- a/resources/views/users/posts.blade.php
+++ b/resources/views/users/posts.blade.php
@@ -39,7 +39,7 @@
             </div>
         </div>
 
-        <div class="osu-page osu-page--small-desktop">
+        <div class="osu-page osu-page--small">
             <div class="search">
                 @include('objects.search._forum_options', ['fields' => ['user' => null]])
 


### PR DESCRIPTION
The gap on both sides were taking too much space away from content on narrower screens, so we decided to remove it.