### PR TITLE
Support search keyword blacklist

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,6 +54,7 @@ install:
   # elasticsearch setup (part 2)
   # wait until es server is up
   - wget -q --waitretry=1 --retry-connrefused -T 10 -O - http://127.0.0.1:9200
+  - php artisan es:create-search-blacklist
   - php artisan es:index-documents --yes
 
 jobs:

--- a/app/Console/Commands/EsCreateSearchBlacklist.php
+++ b/app/Console/Commands/EsCreateSearchBlacklist.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace App\Console\Commands;
+
+use App\Libraries\Elasticsearch\Es;
+use Illuminate\Console\Command;
+
+class EsCreateSearchBlacklist extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'es:create-search-blacklist';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Creates the search blacklist index if it does not exist.';
+
+    /**
+     * Create a new command instance.
+     *
+     * @return void
+     */
+    public function __construct()
+    {
+        parent::__construct();
+    }
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function handle()
+    {
+        $alias = config('osu.elasticsearch.prefix').'blacklist';
+        $client = Es::getClient();
+
+        /** @var array $response The type-hint in the doc is wrong. */
+        $response = $client->indices()->get(['index' => $alias, 'client' => ['ignore' => 404]]);
+
+        $statusCode = $response['status'] ?? null;
+        if ($statusCode === null) {
+            $this->info("{$alias} already exists, skipping.");
+
+            return;
+        }
+
+        $index = $alias.'_'.time();
+        $this->info("{$alias} does exist, creating aliased index {$index}...");
+        $client->indices()->create([
+            'body' => [
+                'aliases' => [$alias => new \stdClass],
+                'settings' => ['number_of_shards' => 1],
+            ],
+            'index' => $index,
+        ]);
+    }
+}

--- a/app/Console/Commands/EsCreateSearchBlacklist.php
+++ b/app/Console/Commands/EsCreateSearchBlacklist.php
@@ -22,16 +22,6 @@ class EsCreateSearchBlacklist extends Command
     protected $description = 'Creates the search blacklist index if it does not exist.';
 
     /**
-     * Create a new command instance.
-     *
-     * @return void
-     */
-    public function __construct()
-    {
-        parent::__construct();
-    }
-
-    /**
      * Execute the console command.
      *
      * @return mixed

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -33,6 +33,7 @@ class Kernel extends ConsoleKernel
     protected $commands = [
         Commands\DisqusImport::class,
 
+        Commands\EsCreateSearchBlacklist::class,
         Commands\EsIndexDocuments::class,
         Commands\EsIndexWiki::class,
 

--- a/app/Libraries/Search/BeatmapsetSearch.php
+++ b/app/Libraries/Search/BeatmapsetSearch.php
@@ -93,7 +93,7 @@ class BeatmapsetSearch extends RecordSearch
                 'terms' => [
                     $field => [
                         'index' => config('osu.elasticsearch.prefix').'blacklist',
-                        'type' => '_doc',
+                        'type' => 'blacklist', // FIXME: change to _doc after upgrading from 6.1
                         'id' => 'beatmapsets',
                         // can be changed to per-field blacklist as different fields should probably have different restrictions.
                         'path' => 'keywords',


### PR DESCRIPTION
Adds search blacklist support via inline `terms` query.
Currently applies the blacklist to selected fields, but can be made to have different blacklisted keywords for different fields.


Managing the blacklist is currently manual and already set on production.