### PR TITLE
Link grouped forum topic events to first unread post

### DIFF
--- a/resources/assets/lib/notification-widget/item.tsx
+++ b/resources/assets/lib/notification-widget/item.tsx
@@ -265,7 +265,7 @@ export default class Item extends React.Component<Props, State> {
           break;
         case 'forum_topic':
           route = 'forum.topics.show';
-          params = { topic: item.objectId };
+          params = { topic: item.objectId, start: 'unread' };
           break;
       }
     }


### PR DESCRIPTION
Probably more useful than linking to initial post.