### PR TITLE
Fix multiplayer match not loading when a user has no country set

### DIFF
--- a/resources/assets/coffee/react/mp-history/score.coffee
+++ b/resources/assets/coffee/react/mp-history/score.coffee
@@ -49,7 +49,7 @@ export class Score extends React.Component
           a
             href: laroute.route 'rankings',
               mode: @props.mode
-              country: user.country.code
+              country: user.country?.code
               type: 'performance'
             el FlagCountry, country: user.country
 


### PR DESCRIPTION
fixes #4322

Will show `undefined` country in the link but since no flag is rendered, the link isn't visible.
Underlying issue is that having no country set was previously serialized as `country: { code: null, name: null }` but now it's just `country: null`