### PR TITLE
Preload beatmapset in the transformer

### DIFF
--- a/app/Transformers/BeatmapsetTransformer.php
+++ b/app/Transformers/BeatmapsetTransformer.php
@@ -218,7 +218,7 @@ class BeatmapsetTransformer extends Fractal\TransformerAbstract
     {
         $rel = $params->get('with_trashed') ? 'allBeatmaps' : 'beatmaps';
 
-        return $this->collection($beatmapset->$rel, new BeatmapTransformer);
+        return $this->collection($beatmapset->$rel()->with('beatmapset')->get(), new BeatmapTransformer);
     }
 
     public function includeConverts(Beatmapset $beatmapset)


### PR DESCRIPTION
Needed for authorization check when the beatmap is deleted.