### PR TITLE
Reduce error noise on Sentry from audio player

### DIFF
--- a/resources/assets/coffee/_classes/osu-audio.coffee
+++ b/resources/assets/coffee/_classes/osu-audio.coffee
@@ -43,7 +43,8 @@ class @OsuAudio
     promise = @player().play()
     # old api returns undefined
     promise?.catch (error) ->
-      throw error unless error.name == 'AbortError'
+      return if error.name == 'AbortError' || error.name == 'NotSupportedError' && !osu.present(@player.src)
+      throw error
 
 
   player: =>

--- a/resources/assets/coffee/_classes/osu-audio.coffee
+++ b/resources/assets/coffee/_classes/osu-audio.coffee
@@ -40,7 +40,10 @@ class @OsuAudio
 
     @urlSet url
     @publish 'initializing'
-    @player().play()
+    promise = @player().play()
+    # old api returns undefined
+    promise?.catch (error) ->
+      throw error unless error.name == 'AbortError'
 
 
   player: =>


### PR DESCRIPTION
aborted playback/loads don't need to be logged