### PR TITLE
Simple polyfill for composedPath

### DIFF
--- a/resources/assets/coffee/_classes/polyfills.coffee
+++ b/resources/assets/coffee/_classes/polyfills.coffee
@@ -21,6 +21,25 @@ class @Polyfills
     @customEvent()
     @localStorage()
     @mathTrunc()
+    @composedPath()
+
+
+  # Event.composedPath polyfill for Edge.
+  # Actual composedPath logic is a bit more complicated but this works for our usage
+  # until it gets implemented in Edge.
+  composedPath: ->
+    return if typeof Event.prototype.composedPath == 'function'
+
+    Event.prototype.composedPath = ->
+      target = @target
+      path = []
+      while target.parentNode?
+        path.push target
+        target = target.parentNode
+
+      path.push document, window
+
+      return path
 
 
   # For IE9+.


### PR DESCRIPTION
Polyfills `Event.prototype.composedPath()`; not completely accurate but does what we need it for, at least until it gets implemented in Edge.