### PR TITLE
Add beatmap discussion lock

### DIFF
--- a/app/Http/Controllers/BeatmapsetsController.php
+++ b/app/Http/Controllers/BeatmapsetsController.php
@@ -174,6 +174,26 @@ class BeatmapsetsController extends Controller
         }
     }
 
+    public function discussionUnlock($id)
+    {
+        priv_check('BeatmapsetDiscussionLock')->ensureCan();
+
+        $beatmapset = Beatmapset::where('discussion_enabled', true)->findOrFail($id);
+        $beatmapset->discussionUnlock(Auth::user(), request('reason'));
+
+        return $beatmapset->defaultDiscussionJson();
+    }
+
+    public function discussionLock($id)
+    {
+        priv_check('BeatmapsetDiscussionLock')->ensureCan();
+
+        $beatmapset = Beatmapset::where('discussion_enabled', true)->findOrFail($id);
+        $beatmapset->discussionLock(Auth::user(), request('reason'));
+
+        return $beatmapset->defaultDiscussionJson();
+    }
+
     public function download($id)
     {
         $beatmapset = Beatmapset::findOrFail($id);

--- a/app/Jobs/BroadcastNotification.php
+++ b/app/Jobs/BroadcastNotification.php
@@ -102,6 +102,26 @@ class BroadcastNotification implements ShouldQueue
         }
     }
 
+    private function onBeatmapsetDiscussionLock()
+    {
+        $this->receiverIds = static::beatmapsetReceiverIds($this->object);
+
+        $this->params['details'] = [
+            'title' => $this->object->title,
+            'cover_url' => $this->object->coverURL('card'),
+        ];
+    }
+
+    private function onBeatmapsetDiscussionUnlock()
+    {
+        $this->receiverIds = static::beatmapsetReceiverIds($this->object);
+
+        $this->params['details'] = [
+            'title' => $this->object->title,
+            'cover_url' => $this->object->coverURL('card'),
+        ];
+    }
+
     private function onBeatmapsetDiscussionPostNew()
     {
         $this->notifiable = $this->object->beatmapset;

--- a/app/Libraries/OsuAuthorize.php
+++ b/app/Libraries/OsuAuthorize.php
@@ -325,6 +325,14 @@ class OsuAuthorize
         $this->ensureLoggedIn($user);
         $this->ensureCleanRecord($user);
 
+        if ($user->isGMT() || $user->isQAT()) {
+            return 'ok';
+        }
+
+        if ($post->beatmapDiscussion->beatmapset->discussion_locked) {
+            return 'beatmap_discussion_post.store.beatmapset_locked';
+        }
+
         return 'ok';
     }
 
@@ -433,6 +441,15 @@ class OsuAuthorize
         }
 
         return 'ok';
+    }
+
+    public function checkBeatmapsetDiscussionLock($user)
+    {
+        $this->ensureLoggedIn($user);
+
+        if ($user->isGMT() || $user->isQAT()) {
+            return 'ok';
+        }
     }
 
     public function checkBeatmapsetEventViewUserId($user, $event)

--- a/app/Models/BeatmapsetEvent.php
+++ b/app/Models/BeatmapsetEvent.php
@@ -51,6 +51,9 @@ class BeatmapsetEvent extends Model
     const ISSUE_RESOLVE = 'issue_resolve';
     const ISSUE_REOPEN = 'issue_reopen';
 
+    const DISCUSSION_LOCK = 'discussion_lock';
+    const DISCUSSION_UNLOCK = 'discussion_unlock';
+
     const DISCUSSION_DELETE = 'discussion_delete';
     const DISCUSSION_RESTORE = 'discussion_restore';
 

--- a/app/Models/Notification.php
+++ b/app/Models/Notification.php
@@ -24,7 +24,9 @@ use App\Libraries\MorphMap;
 
 class Notification extends Model
 {
+    const BEATMAPSET_DISCUSSION_LOCK = 'beatmapset_discussion_lock';
     const BEATMAPSET_DISCUSSION_POST_NEW = 'beatmapset_discussion_post_new';
+    const BEATMAPSET_DISCUSSION_UNLOCK = 'beatmapset_discussion_unlock';
     const BEATMAPSET_DISQUALIFY = 'beatmapset_disqualify';
     const BEATMAPSET_LOVE = 'beatmapset_love';
     const BEATMAPSET_NOMINATE = 'beatmapset_nominate';

--- a/app/Transformers/BeatmapsetTransformer.php
+++ b/app/Transformers/BeatmapsetTransformer.php
@@ -81,6 +81,7 @@ class BeatmapsetTransformer extends Fractal\TransformerAbstract
             'status' => $beatmapset->status(),
             'has_scores' => $beatmapset->hasScores(),
             'discussion_enabled' => $beatmapset->discussion_enabled,
+            'discussion_locked' => $beatmapset->discussion_locked,
             'can_be_hyped' => $beatmapset->canBeHyped(),
             'hype' => [
                 'current' => $beatmapset->hype,

--- a/database/migrations/2019_04_17_103403_add_discussion_locked_to_beatmapsets.php
+++ b/database/migrations/2019_04_17_103403_add_discussion_locked_to_beatmapsets.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddDiscussionLockedToBeatmapsets extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('osu_beatmapsets', function (Blueprint $table) {
+            $table->boolean('discussion_locked')->after('discussion_enabled')->default(0);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('osu_beatmapsets', function (Blueprint $table) {
+            $table->dropColumn('discussion_locked');
+        });
+    }
+}

--- a/database/migrations/2019_04_23_051152_add_discussion_locked_to_beatmapset_events.php
+++ b/database/migrations/2019_04_23_051152_add_discussion_locked_to_beatmapset_events.php
@@ -1,0 +1,66 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+
+class AddDiscussionLockedToBeatmapsetEvents extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        DB::statement("ALTER TABLE beatmapset_events CHANGE type type ENUM(
+            'nominate',
+            'qualify',
+            'disqualify',
+            'approve',
+            'rank',
+            'kudosu_allow',
+            'kudosu_deny',
+            'kudosu_gain',
+            'kudosu_lost',
+            'issue_resolve',
+            'issue_reopen',
+            'discussion_delete',
+            'discussion_restore',
+            'discussion_post_delete',
+            'discussion_post_restore',
+            'kudosu_recalculate',
+            'nomination_reset',
+            'love',
+            'discussion_lock',
+            'discussion_unlock'
+        )");
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        DB::statement("ALTER TABLE beatmapset_events CHANGE type type ENUM(
+            'nominate',
+            'qualify',
+            'disqualify',
+            'approve',
+            'rank',
+            'kudosu_allow',
+            'kudosu_deny',
+            'kudosu_gain',
+            'kudosu_lost',
+            'issue_resolve',
+            'issue_reopen',
+            'discussion_delete',
+            'discussion_restore',
+            'discussion_post_delete',
+            'discussion_post_restore',
+            'kudosu_recalculate',
+            'nomination_reset',
+            'love'
+        )");
+    }
+}

--- a/resources/assets/coffee/react/beatmap-discussions/discussion.coffee
+++ b/resources/assets/coffee/react/beatmap-discussions/discussion.coffee
@@ -174,7 +174,8 @@ export class Discussion extends React.PureComponent
 
 
   canBeRepliedTo: =>
-    !@props.discussion.beatmap_id? || !@props.currentBeatmap.deleted_at?
+    (!@props.beatmapset.discussion_locked || BeatmapDiscussionHelper.canModeratePosts(@props.currentUser)) &&
+    (!@props.discussion.beatmap_id? || !@props.currentBeatmap.deleted_at?)
 
 
   post: (post, type) =>

--- a/resources/assets/coffee/react/beatmap-discussions/event.coffee
+++ b/resources/assets/coffee/react/beatmap-discussions/event.coffee
@@ -58,6 +58,9 @@ export class Event extends React.PureComponent
     else
       text = BeatmapDiscussionHelper.format @props.event.comment, newlines: false
 
+    if @props.event.type == 'discussion_lock'
+      text = BeatmapDiscussionHelper.format @props.event.comment.reason, newlines: false
+
     if @props.event.user_id?
       user = osu.link(laroute.route('users.show', user: @props.event.user_id), @props.users[@props.event.user_id].username)
 

--- a/resources/assets/coffee/react/beatmap-discussions/new-discussion.coffee
+++ b/resources/assets/coffee/react/beatmap-discussions/new-discussion.coffee
@@ -120,12 +120,7 @@ export class NewDiscussion extends React.PureComponent
                   onKeyDown: @handleKeyDown
                   onFocus: @onFocus
                   innerRef: @setInputBox
-                  placeholder:
-                    if @canPost()
-                      osu.trans "beatmaps.discussions.message_placeholder.#{@props.mode}", version: @props.currentBeatmap.version
-                    else
-                      # FIXME: reason should be passed from beatmap state
-                      osu.trans 'beatmaps.discussions.message_placeholder_deleted_beatmap'
+                  placeholder: @messagePlaceholder()
 
                 el MessageLengthCounter,
                   key: 'counter'
@@ -215,7 +210,8 @@ export class NewDiscussion extends React.PureComponent
 
 
   canPost: =>
-    !@props.currentBeatmap.deleted_at? || @props.mode == 'generalAll'
+    (!@props.beatmapset.discussion_locked || BeatmapDiscussionHelper.canModeratePosts(@props.currentUser)) &&
+    (!@props.currentBeatmap.deleted_at? || @props.mode == 'generalAll')
 
 
   cssTop: (sticky) =>
@@ -232,6 +228,16 @@ export class NewDiscussion extends React.PureComponent
 
   isTimeline: =>
     @props.mode == 'timeline'
+
+
+  messagePlaceholder: =>
+    if @canPost()
+      osu.trans "beatmaps.discussions.message_placeholder.#{@props.mode}", version: @props.currentBeatmap.version
+    else
+      if @props.beatmapset.discussion_locked
+        osu.trans 'beatmaps.discussions.message_placeholder_locked'
+      else
+        osu.trans 'beatmaps.discussions.message_placeholder_deleted_beatmap'
 
 
   nearbyDiscussions: =>

--- a/resources/assets/less/bem/beatmapset-event.less
+++ b/resources/assets/less/bem/beatmapset-event.less
@@ -41,9 +41,11 @@
 
     .type(approve, @blue);
     .type(discussion-delete, @yellow);
+    .type(discussion-lock, @red);
     .type(discussion-post-delete, @yellow);
     .type(discussion-post-restore, @blue);
     .type(discussion-restore, @blue);
+    .type(discussion-unlock, @green);
     .type(disqualify, @red);
     .type(issue-reopen, @yellow);
     .type(issue-resolve, @green);

--- a/resources/assets/lib/models/notification.ts
+++ b/resources/assets/lib/models/notification.ts
@@ -26,7 +26,9 @@ interface CategoryMap {
 }
 
 const CATEGORY_MAP: CategoryMap = {
+  beatmapset_discussion_lock: 'beatmapset_discussion',
   beatmapset_discussion_post_new: 'beatmapset_discussion',
+  beatmapset_discussion_unlock: 'beatmapset_discussion',
   beatmapset_disqualify: 'beatmapset_state',
   beatmapset_love: 'beatmapset_state',
   beatmapset_nominate: 'beatmapset_state',

--- a/resources/assets/lib/notification-widget/item.tsx
+++ b/resources/assets/lib/notification-widget/item.tsx
@@ -37,14 +37,16 @@ interface IconsMap {
 }
 
 const ITEM_CATEGORY_ICONS: IconsMap = {
-  beatmapset_discussion: ['fas fa-drafting-compass', 'fas fa-comment-medical'],
+  beatmapset_discussion: ['fas fa-drafting-compass', 'fas fa-comment'],
   beatmapset_state: ['fas fa-drafting-compass'],
   forum_topic_reply: ['fas fa-comment-medical'],
   legacy_pm: ['fas fa-envelope'],
 };
 
 const ITEM_NAME_ICONS: IconsMap = {
+  beatmapset_discussion_lock: ['fas fa-drafting-compass', 'fas fa-lock'],
   beatmapset_discussion_post_new: ['fas fa-drafting-compass', 'fas fa-comment-medical'],
+  beatmapset_discussion_unlock: ['fas fa-drafting-compass', 'fas fa-unlock'],
   beatmapset_disqualify: ['fas fa-drafting-compass', 'far fa-times-circle'],
   beatmapset_love: ['fas fa-drafting-compass', 'fas fa-heart'],
   beatmapset_nominate: ['fas fa-drafting-compass', 'fas fa-vote-yea'],
@@ -237,12 +239,20 @@ export default class Item extends React.Component<Props, State> {
 
     if (this.props.items.length === 1) {
       switch (item.name) {
+        case 'beatmapset_discussion_lock':
+          route = 'beatmapsets.discussion';
+          params = { beatmapset: item.objectId };
+          break;
         case 'beatmapset_discussion_post_new':
           return BeatmapDiscussionHelper.url({
             beatmapId: item.details.beatmapId,
             beatmapsetId: item.objectId,
             discussionId: item.details.discussionId,
           });
+        case 'beatmapset_discussion_unlock':
+          route = 'beatmapsets.discussion';
+          params = { beatmapset: item.objectId };
+          break;
         case 'beatmapset_disqualify':
           route = 'beatmapsets.discussion';
           params = { beatmapset: item.objectId };

--- a/resources/lang/en/authorization.php
+++ b/resources/lang/en/authorization.php
@@ -49,6 +49,9 @@ return [
             'system_generated' => 'Automatically generated post can not be edited.',
             'not_owner' => 'Only the poster can edit post.',
         ],
+        'store' => [
+            'beatmapset_locked' => 'This beatmap is locked for discussion.',
+        ],
     ],
 
     'chat' => [

--- a/resources/lang/en/beatmaps.php
+++ b/resources/lang/en/beatmaps.php
@@ -40,6 +40,7 @@ return [
         'edited' => 'Last edited by :editor :update_time.',
         'kudosu_denied' => 'Denied from obtaining kudosu.',
         'message_placeholder_deleted_beatmap' => 'This difficulty has been deleted so it may no longer be discussed.',
+        'message_placeholder_locked' => 'Discussion for this beatmap has been disabled.',
         'message_type_select' => 'Select Comment Type',
         'reply_notice' => 'Press enter to reply.',
         'reply_placeholder' => 'Type your response here',
@@ -57,6 +58,18 @@ return [
         'empty' => [
             'empty' => 'No discussions yet!',
             'hidden' => 'No discussion matches selected filter.',
+        ],
+
+        'lock' => [
+            'button' => [
+                'lock' => 'Lock discussion',
+                'unlock' => 'Unlock discussion',
+            ],
+
+            'prompt' => [
+                'lock' => 'Reason for locking',
+                'unlock' => 'Are you sure to unlock?',
+            ],
         ],
 
         'message_hint' => [

--- a/resources/lang/en/beatmapset_events.php
+++ b/resources/lang/en/beatmapset_events.php
@@ -22,9 +22,11 @@ return [
     'event' => [
         'approve' => 'Approved.',
         'discussion_delete' => 'Moderator deleted discussion :discussion.',
+        'discussion_lock' => 'Discussion for this beatmap has been disabled. (:text)',
         'discussion_post_delete' => 'Moderator deleted post from discussion :discussion.',
         'discussion_post_restore' => 'Moderator restored post from discussion :discussion.',
         'discussion_restore' => 'Moderator restored discussion :discussion.',
+        'discussion_unlock' => 'Discussion for this beatmap has been enabled.',
         'disqualify' => 'Disqualified by :user. Reason: :discussion (:text).',
         'disqualify_legacy' => 'Disqualified by :user. Reason: :text.',
         'issue_reopen' => 'Resolved issue :discussion reopened.',

--- a/resources/lang/en/notifications.php
+++ b/resources/lang/en/notifications.php
@@ -29,7 +29,9 @@ return [
 
             'beatmapset_discussion' => [
                 '_' => 'Beatmap discussion',
+                'beatmapset_discussion_lock' => 'Beatmap ":title" has been locked for discussion.',
                 'beatmapset_discussion_post_new' => ':username posted new message in ":title" beatmap discussion.',
+                'beatmapset_discussion_unlock' => 'Beatmap ":title" has been unlocked for discussion.',
             ],
 
             'beatmapset_state' => [

--- a/routes/web.php
+++ b/routes/web.php
@@ -78,6 +78,8 @@ Route::group(['prefix' => 'beatmapsets', 'as' => 'beatmapsets.'], function () {
 });
 Route::get('beatmapsets/search/{filters?}', 'BeatmapsetsController@search')->name('beatmapsets.search');
 Route::get('beatmapsets/{beatmapset}/discussion/{beatmap?}/{mode?}/{filter?}', 'BeatmapsetsController@discussion')->name('beatmapsets.discussion');
+Route::post('beatmapsets/{beatmapset}/discussion-lock', 'BeatmapsetsController@discussionLock')->name('beatmapsets.discussion-lock');
+Route::post('beatmapsets/{beatmapset}/discussion-unlock', 'BeatmapsetsController@discussionUnlock')->name('beatmapsets.discussion-unlock');
 Route::get('beatmapsets/{beatmapset}/download', 'BeatmapsetsController@download')->name('beatmapsets.download');
 Route::put('beatmapsets/{beatmapset}/love', 'BeatmapsetsController@love')->name('beatmapsets.love');
 Route::put('beatmapsets/{beatmapset}/nominate', 'BeatmapsetsController@nominate')->name('beatmapsets.nominate');


### PR DESCRIPTION
ಠ_ಠ

- only moderators can post on locked beatmap
- generates beatmap event
- generates notification
- requires reason for locking (not actual post, just inlined in the event)
- should name who locked it visible? (it's currently partially visible)