### PR TITLE
Fix user card tooltip closing too early

### DIFF
--- a/resources/assets/coffee/_classes/user-card.coffee
+++ b/resources/assets/coffee/_classes/user-card.coffee
@@ -60,7 +60,6 @@ class @UserCard
       show:
         delay: @triggerDelay
         ready: true
-        solo: true
         effect: -> $(this).fadeTo(110, 1)
       hide:
         fixed: true

--- a/resources/assets/coffee/_classes/user-card.coffee
+++ b/resources/assets/coffee/_classes/user-card.coffee
@@ -82,11 +82,11 @@ class @UserCard
     $('.qtip--user-card').qtip('hide') if e.keyCode == 27 && !@inCard
 
 
-  onMouseEnter: () =>
+  onMouseEnter: =>
     @inCard = true
 
 
-  onMouseLeave: () =>
+  onMouseLeave: =>
     @inCard = false
 
 

--- a/resources/assets/coffee/_classes/user-card.coffee
+++ b/resources/assets/coffee/_classes/user-card.coffee
@@ -22,6 +22,9 @@ class @UserCard
 
   constructor: ->
     $(document).on 'mouseover', '.js-usercard', @onMouseOver
+    $(document).on 'keydown', @onKeyDown
+    $(document).on 'mouseenter', '.js-react--user-card-tooltip', @onMouseEnter
+    $(document).on 'mouseleave', '.js-react--user-card-tooltip', @onMouseLeave
 
 
   createTooltip: (el) =>
@@ -67,6 +70,18 @@ class @UserCard
         effect: -> $(this).fadeTo(110, 0)
 
     $(el).qtip options
+
+
+  onKeyDown: (e) =>
+    $('.qtip--user-card').qtip('hide') if e.keyCode == 27 && !@inCard
+
+
+  onMouseEnter: () =>
+    @inCard = true
+
+
+  onMouseLeave: () =>
+    @inCard = false
 
 
   onMouseOver: (event) =>

--- a/resources/assets/coffee/_classes/user-card.coffee
+++ b/resources/assets/coffee/_classes/user-card.coffee
@@ -25,6 +25,7 @@ class @UserCard
     $(document).on 'keydown', @onKeyDown
     $(document).on 'mouseenter', '.js-react--user-card-tooltip', @onMouseEnter
     $(document).on 'mouseleave', '.js-react--user-card-tooltip', @onMouseLeave
+    $(document).on 'turbolinks:before-cache', @onBeforeCache
 
 
   createTooltip: (el) =>
@@ -70,6 +71,11 @@ class @UserCard
         effect: -> $(this).fadeTo(110, 0)
 
     $(el).qtip options
+
+
+  onBeforeCache: =>
+    @inCard = false
+    window.tooltipWithActiveMenu = null
 
 
   onKeyDown: (e) =>

--- a/resources/assets/coffee/_classes/user-card.coffee
+++ b/resources/assets/coffee/_classes/user-card.coffee
@@ -22,7 +22,7 @@ class @UserCard
 
   constructor: ->
     $(document).on 'mouseover', '.js-usercard', @onMouseOver
-    $(document).on 'keydown', @onKeyDown
+    $(document).on 'mousedown keydown', @handleForceHide
     $(document).on 'mouseenter', '.js-react--user-card-tooltip', @onMouseEnter
     $(document).on 'mouseleave', '.js-react--user-card-tooltip', @onMouseLeave
     $(document).on 'turbolinks:before-cache', @onBeforeCache
@@ -73,13 +73,13 @@ class @UserCard
     $(el).qtip options
 
 
+  handleForceHide: (e) =>
+    $('.qtip--user-card').qtip('hide') if (e.keyCode == 27 || e.button == 0) && !@inCard
+
+
   onBeforeCache: =>
     @inCard = false
     window.tooltipWithActiveMenu = null
-
-
-  onKeyDown: (e) =>
-    $('.qtip--user-card').qtip('hide') if e.keyCode == 27 && !@inCard
 
 
   onMouseEnter: =>


### PR DESCRIPTION
Turns out `solo` also changes the behaviour of whether events on the target element trigger keeping a qtip open or not.