### PR TITLE
Count NAT as full BNs when checking for full BN nominations

### DIFF
--- a/app/Models/Beatmapset.php
+++ b/app/Models/Beatmapset.php
@@ -903,7 +903,7 @@ class Beatmapset extends Model implements AfterCommit
             ->get()
             ->pluck('user')
             ->contains(function ($user) {
-                return $user->isFullBN();
+                return $user->isNAT() || $user->isFullBN();
             });
     }
 


### PR DESCRIPTION
fixes this issue when the first nominator is an NAT member and the second nominator is BN on probation
![](https://cdn.discordapp.com/attachments/316154420591067136/575533329860919337/unknown.png)

---