### PR TITLE
Additional beatmapset nomination tests

### DIFF
--- a/tests/Models/BeatmapsetTest.php
+++ b/tests/Models/BeatmapsetTest.php
@@ -82,10 +82,7 @@ class BeatmapsetTest extends TestCase
         $this->assertTrue($beatmapset->fresh()->isQualified());
     }
 
-    /**
-     * @doesNotPerformAssertions
-     */
-    public function testLimitedBNGNominatingBNGNominated()
+    public function testLimitedBNGQualifyingNominationBNGNominated()
     {
         $beatmapset = $this->createBeatmapset();
         $this->fillNominationsExceptLast($beatmapset, 'bng');
@@ -94,12 +91,11 @@ class BeatmapsetTest extends TestCase
         $nominator->userGroups()->create(['group_id' => UserGroup::GROUPS['bng_limited']]);
 
         priv_check_user($nominator, 'BeatmapsetNominate', $beatmapset)->ensureCan();
+        $beatmapset->nominate($nominator);
+        $this->assertTrue($beatmapset->isQualified());
     }
 
-    /**
-     * @doesNotPerformAssertions
-     */
-    public function testLimitedBNGNominatingNATNominated()
+    public function testLimitedBNGQualifyingNominationNATNominated()
     {
         $beatmapset = $this->createBeatmapset();
         $this->fillNominationsExceptLast($beatmapset, 'nat');
@@ -108,9 +104,11 @@ class BeatmapsetTest extends TestCase
         $nominator->userGroups()->create(['group_id' => UserGroup::GROUPS['bng_limited']]);
 
         priv_check_user($nominator, 'BeatmapsetNominate', $beatmapset)->ensureCan();
+        $beatmapset->nominate($nominator);
+        $this->assertTrue($beatmapset->isQualified());
     }
 
-    public function testLimitedBNGNominatingLimitedBNGNominated()
+    public function testLimitedBNGQualifyingNominationLimitedBNGNominated()
     {
         $beatmapset = $this->createBeatmapset();
         $this->fillNominationsExceptLast($beatmapset, 'bng_limited');
@@ -122,7 +120,7 @@ class BeatmapsetTest extends TestCase
         priv_check_user($nominator, 'BeatmapsetNominate', $beatmapset)->ensureCan();
     }
 
-    private function createBeatmapset($params = [])
+    private function createBeatmapset($params = []) : Beatmapset
     {
         $defaultParams = [
             'discussion_enabled' => true,

--- a/tests/Models/BeatmapsetTest.php
+++ b/tests/Models/BeatmapsetTest.php
@@ -88,10 +88,7 @@ class BeatmapsetTest extends TestCase
     public function testLimitedBNGNominatingBNGNominated()
     {
         $beatmapset = $this->createBeatmapset();
-
-        $user = factory(User::class)->create();
-        $user->userGroups()->create(['group_id' => UserGroup::GROUPS['bng']]);
-        $beatmapset->nominate($user);
+        $this->fillNominationsExceptLast($beatmapset, 'bng');
 
         $nominator = factory(User::class)->create();
         $nominator->userGroups()->create(['group_id' => UserGroup::GROUPS['bng_limited']]);
@@ -105,10 +102,7 @@ class BeatmapsetTest extends TestCase
     public function testLimitedBNGNominatingNATNominated()
     {
         $beatmapset = $this->createBeatmapset();
-
-        $user = factory(User::class)->create();
-        $user->userGroups()->create(['group_id' => UserGroup::GROUPS['nat']]);
-        $beatmapset->nominate($user);
+        $this->fillNominationsExceptLast($beatmapset, 'nat');
 
         $nominator = factory(User::class)->create();
         $nominator->userGroups()->create(['group_id' => UserGroup::GROUPS['bng_limited']]);
@@ -119,10 +113,7 @@ class BeatmapsetTest extends TestCase
     public function testLimitedBNGNominatingLimitedBNGNominated()
     {
         $beatmapset = $this->createBeatmapset();
-
-        $user = factory(User::class)->create();
-        $user->userGroups()->create(['group_id' => UserGroup::GROUPS['bng_limited']]);
-        $beatmapset->nominate($user);
+        $this->fillNominationsExceptLast($beatmapset, 'bng_limited');
 
         $nominator = factory(User::class)->create();
         $nominator->userGroups()->create(['group_id' => UserGroup::GROUPS['bng_limited']]);
@@ -150,5 +141,25 @@ class BeatmapsetTest extends TestCase
         factory(BeatmapMirror::class)->states('default')->create();
 
         return $beatmapset;
+    }
+
+    /**
+     * Fills a beatmpaset's nominations until one nomination left to qualify.
+     *
+     * @param Beatmapset $beatmapset Beatmapset to fill the nominations for.
+     * @param string $group A least one nomination will be by a user from this group.
+     *
+     * @return void
+     */
+    private function fillNominationsExceptLast(Beatmapset $beatmapset, string $group)
+    {
+        $user = factory(User::class)->create();
+        $user->userGroups()->create(['group_id' => UserGroup::GROUPS[$group]]);
+        $beatmapset->nominate($user);
+
+        $count = $beatmapset->requiredNominationCount() - $beatmapset->currentNominationCount() - 1;
+        for ($i = 0; $i < $count; $i++) {
+            $beatmapset->nominate(factory(User::class)->create());
+        }
     }
 }

--- a/tests/Models/BeatmapsetTest.php
+++ b/tests/Models/BeatmapsetTest.php
@@ -32,8 +32,6 @@ class BeatmapsetTest extends TestCase
     {
         $user = factory(User::class)->create();
         $beatmapset = $this->createBeatmapset();
-        $beatmap = $beatmapset->beatmaps()->save(factory(Beatmap::class)->make());
-        factory(BeatmapMirror::class)->states('default')->create();
 
         $notifications = Notification::count();
         $userNotifications = UserNotification::count();
@@ -52,8 +50,6 @@ class BeatmapsetTest extends TestCase
     {
         $user = factory(User::class)->create();
         $beatmapset = $this->createBeatmapset();
-        $beatmap = $beatmapset->beatmaps()->save(factory(Beatmap::class)->make());
-        factory(BeatmapMirror::class)->states('default')->create();
 
         $notifications = Notification::count();
         $userNotifications = UserNotification::count();
@@ -72,8 +68,6 @@ class BeatmapsetTest extends TestCase
     {
         $user = factory(User::class)->create();
         $beatmapset = $this->createBeatmapset();
-        $beatmap = $beatmapset->beatmaps()->save(factory(Beatmap::class)->make());
-        factory(BeatmapMirror::class)->states('default')->create();
 
         $notifications = Notification::count();
         $userNotifications = UserNotification::count();
@@ -94,8 +88,6 @@ class BeatmapsetTest extends TestCase
     public function testLimitedBNGNominatingBNGNominated()
     {
         $beatmapset = $this->createBeatmapset();
-        $beatmapset->beatmaps()->save(factory(Beatmap::class)->make());
-        factory(BeatmapMirror::class)->states('default')->create();
 
         $user = factory(User::class)->create();
         $user->userGroups()->create(['group_id' => UserGroup::GROUPS['bng']]);
@@ -113,8 +105,6 @@ class BeatmapsetTest extends TestCase
     public function testLimitedBNGNominatingNATNominated()
     {
         $beatmapset = $this->createBeatmapset();
-        $beatmapset->beatmaps()->save(factory(Beatmap::class)->make());
-        factory(BeatmapMirror::class)->states('default')->create();
 
         $user = factory(User::class)->create();
         $user->userGroups()->create(['group_id' => UserGroup::GROUPS['nat']]);
@@ -129,8 +119,6 @@ class BeatmapsetTest extends TestCase
     public function testLimitedBNGNominatingLimitedBNGNominated()
     {
         $beatmapset = $this->createBeatmapset();
-        $beatmapset->beatmaps()->save(factory(Beatmap::class)->make());
-        factory(BeatmapMirror::class)->states('default')->create();
 
         $user = factory(User::class)->create();
         $user->userGroups()->create(['group_id' => UserGroup::GROUPS['bng_limited']]);
@@ -157,6 +145,10 @@ class BeatmapsetTest extends TestCase
             $params['user_id'] = $user->getKey();
         }
 
-        return factory(Beatmapset::class)->create(array_merge($defaultParams, $params));
+        $beatmapset = factory(Beatmapset::class)->create(array_merge($defaultParams, $params));
+        $beatmapset->beatmaps()->save(factory(Beatmap::class)->make());
+        factory(BeatmapMirror::class)->states('default')->create();
+
+        return $beatmapset;
     }
 }


### PR DESCRIPTION
additional tests for #4416;

checks limited BNs can't make the qualifying nomination if someone from NAT or BNG has not nominated.