### PR TITLE
Re-add autoscrolling behaviour for chat

### DIFF
--- a/resources/assets/lib/chat/chat-orchestrator.ts
+++ b/resources/assets/lib/chat/chat-orchestrator.ts
@@ -63,6 +63,7 @@ export default class ChatOrchestrator implements DispatchListener {
 
     const channelStore = this.rootDataStore.channelStore;
     transaction(() => {
+      uiState.autoScroll = false;
       const channel = channelStore.getOrCreate(channelId);
 
       if (!channel.newChannel) {

--- a/resources/assets/lib/chat/chat-state-store.ts
+++ b/resources/assets/lib/chat/chat-state-store.ts
@@ -32,6 +32,7 @@ export default class ChatStateStore implements DispatchListener {
 
   @observable selected: number = -1;
   @observable lastReadId: number = -1;
+  @observable autoScroll: boolean = false;
 
   constructor(root: RootDataStore, parent: UIStateStore, dispatcher: Dispatcher) {
     this.root = root;
@@ -48,6 +49,7 @@ export default class ChatStateStore implements DispatchListener {
       }
     } else if (dispatchedAction instanceof ChatMessageSendAction) {
       this.lastReadId = this.root.channelStore.getOrCreate(dispatchedAction.message.channelId).lastMessageId;
+      this.autoScroll = true;
     } else if (dispatchedAction instanceof UserLogoutAction) {
       this.flushStore();
     }

--- a/resources/assets/lib/chat/conversation-view.tsx
+++ b/resources/assets/lib/chat/conversation-view.tsx
@@ -38,14 +38,15 @@ export default class ConversationView extends React.Component<any, any> {
   }
 
   componentDidUpdate = () => {
-    let chatView = this.chatViewRef.current;
-    if (!chatView)
+    const chatView = this.chatViewRef.current;
+    if (!chatView) {
       return;
+    }
 
     if (this.props.dataStore.uiState.chat.autoScroll) {
       $(chatView).scrollTop(chatView.scrollHeight);
     }
-  };
+  }
 
   noCanSendMessage(): React.ReactNode {
     const dataStore: RootDataStore = this.props.dataStore;
@@ -82,11 +83,11 @@ export default class ConversationView extends React.Component<any, any> {
   }
 
   onScroll = () => {
-    let chatView = this.chatViewRef.current;
+    const chatView = this.chatViewRef.current;
     if (chatView) {
       this.props.dataStore.uiState.chat.autoScroll = chatView.scrollTop + chatView.clientHeight >= chatView.scrollHeight;
     }
-  };
+  }
 
   render(): React.ReactNode {
     const dataStore: RootDataStore = this.props.dataStore;

--- a/resources/assets/lib/chat/conversation-view.tsx
+++ b/resources/assets/lib/chat/conversation-view.tsx
@@ -30,15 +30,22 @@ import MessageGroup from './message-group';
 @inject('dataStore')
 @observer
 export default class ConversationView extends React.Component<any, any> {
+  private chatViewRef = React.createRef<HTMLInputElement>();
+
   componentDidMount() {
     this.componentDidUpdate();
+    $(window).on('throttled-scroll', _.throttle(this.onScroll, 1000));
   }
 
-  componentDidUpdate() {
-    // if ($('.chat-conversation').length > 0) {
-    //   $('.chat-conversation').scrollTop($('.chat-conversation')[0].scrollHeight);
-    // }
-  }
+  componentDidUpdate = () => {
+    let chatView = this.chatViewRef.current;
+    if (!chatView)
+      return;
+
+    if (this.props.dataStore.uiState.chat.autoScroll) {
+      $(chatView).scrollTop(chatView.scrollHeight);
+    }
+  };
 
   noCanSendMessage(): React.ReactNode {
     const dataStore: RootDataStore = this.props.dataStore;
@@ -73,6 +80,13 @@ export default class ConversationView extends React.Component<any, any> {
       );
     }
   }
+
+  onScroll = () => {
+    let chatView = this.chatViewRef.current;
+    if (chatView) {
+      this.props.dataStore.uiState.chat.autoScroll = chatView.scrollTop + chatView.clientHeight >= chatView.scrollHeight;
+    }
+  };
 
   render(): React.ReactNode {
     const dataStore: RootDataStore = this.props.dataStore;
@@ -126,7 +140,7 @@ export default class ConversationView extends React.Component<any, any> {
     });
 
     return (
-      <div className='chat-conversation'>
+      <div className='chat-conversation' onScroll={this.onScroll} ref={this.chatViewRef}>
         <div className='chat-conversation__new-chat-avatar'>
           <UserAvatar user={{id: 0, avatar_url: channel.icon}} />
         </div>


### PR DESCRIPTION
Will only be enabled when you scroll to the bottom of a conversation or when you send a message.

There's some weirdness with scroll position occasionally not being reset when switching channels and this will also completely ignore the unread marker, but I'll fix those issues later... for now this should at least make having a conversation less annoying.