### PR TITLE
Add ability to close PMs

### DIFF
--- a/app/Http/Controllers/Chat/Channels/MessagesController.php
+++ b/app/Http/Controllers/Chat/Channels/MessagesController.php
@@ -38,7 +38,7 @@ class MessagesController extends BaseController
         $userChannel = UserChannel::where([
             'user_id' => $userId,
             'channel_id' => $channelId,
-            'hidden' => false
+            'hidden' => false,
         ])->firstOrFail();
 
         if ($userChannel->channel->isPM()) {

--- a/app/Http/Controllers/Chat/Channels/MessagesController.php
+++ b/app/Http/Controllers/Chat/Channels/MessagesController.php
@@ -35,7 +35,11 @@ class MessagesController extends BaseController
         $since = Request::input('since');
         $limit = clamp(Request::input('limit', 50), 1, 50);
 
-        $userChannel = UserChannel::where(['user_id' => $userId, 'channel_id' => $channelId])->firstOrFail();
+        $userChannel = UserChannel::where([
+            'user_id' => $userId,
+            'channel_id' => $channelId,
+            'hidden' => false
+        ])->firstOrFail();
 
         if ($userChannel->channel->isPM()) {
             // restricted users should be treated as if they do not exist

--- a/app/Http/Controllers/Chat/ChatController.php
+++ b/app/Http/Controllers/Chat/ChatController.php
@@ -111,11 +111,6 @@ class ChatController extends Controller
 
                 return $channel;
             });
-        } else {
-            UserChannel::firstOrCreate([
-                'user_id' => Auth::user()->user_id,
-                'channel_id' => $channel->channel_id,
-            ]);
         }
 
         try {

--- a/app/Http/Controllers/Chat/ChatController.php
+++ b/app/Http/Controllers/Chat/ChatController.php
@@ -44,11 +44,17 @@ class ChatController extends Controller
             abort(422);
         }
 
+        $presence = self::presence();
+
         $since = Request::input('since');
         $limit = clamp(get_int(Request::input('limit')) ?? 50, 1, 50);
 
+        // this is used to filter out messages from restricted users/etc
+        $channelIds = array_map(function($e) { return $e['channel_id']; }, $presence);
+
         $messages = Message::forUser(Auth::user())
             ->with('sender')
+            ->whereIn('channel_id', $channelIds)
             ->since($since)
             ->limit($limit);
 
@@ -63,7 +69,7 @@ class ChatController extends Controller
         }
 
         $response = [
-            'presence' => self::presence(),
+            'presence' => $presence,
             'messages' => json_collection(
                 $messages,
                 'Chat\Message',

--- a/app/Http/Controllers/Chat/ChatController.php
+++ b/app/Http/Controllers/Chat/ChatController.php
@@ -50,7 +50,9 @@ class ChatController extends Controller
         $limit = clamp(get_int(Request::input('limit')) ?? 50, 1, 50);
 
         // this is used to filter out messages from restricted users/etc
-        $channelIds = array_map(function($e) { return $e['channel_id']; }, $presence);
+        $channelIds = array_map(function ($e) {
+            return $e['channel_id'];
+        }, $presence);
 
         $messages = Message::forUser(Auth::user())
             ->with('sender')

--- a/app/Models/Chat/Channel.php
+++ b/app/Models/Chat/Channel.php
@@ -156,7 +156,7 @@ class Channel extends Model
 
         $userChannel = UserChannel::where([
             'channel_id' => $this->channel_id,
-            'user_id' => $sender->user_id
+            'user_id' => $sender->user_id,
         ])->first();
 
         if ($userChannel) {

--- a/app/Models/Chat/Message.php
+++ b/app/Models/Chat/Message.php
@@ -57,7 +57,7 @@ class Message extends Model
     {
         $channelIds = UserChannel::where([
             'user_id' => $user->user_id,
-            'hidden' => false
+            'hidden' => false,
         ])->pluck('channel_id');
 
         return $query->whereIn('channel_id', $channelIds)

--- a/app/Models/Chat/Message.php
+++ b/app/Models/Chat/Message.php
@@ -55,7 +55,12 @@ class Message extends Model
 
     public function scopeForUser($query, User $user)
     {
-        return $query->whereIn('channel_id', $user->channels->pluck('channel_id'))
+        $channelIds = UserChannel::where([
+            'user_id' => $user->user_id,
+            'hidden' => false
+        ])->pluck('channel_id');
+
+        return $query->whereIn('channel_id', $channelIds)
             ->orderBy('message_id', 'desc');
     }
 

--- a/app/Models/Chat/UserChannel.php
+++ b/app/Models/Chat/UserChannel.php
@@ -27,6 +27,7 @@ use Illuminate\Database\Eloquent\Builder;
 /**
  * @property Channel $channel
  * @property int $channel_id
+ * @property bool $hidden
  * @property int|null $last_read_id
  * @property User $user
  * @property User $userScoped
@@ -59,6 +60,7 @@ class UserChannel extends Model
 
         // retrieve all the channels the user is in and the metadata for each
         $userChannels = self::where('user_channels.user_id', $userId)
+            ->where('hidden', false)
             ->join('channels', 'channels.channel_id', '=', 'user_channels.channel_id')
             ->selectRaw('channels.*')
             ->selectRaw('user_channels.last_read_id')

--- a/database/migrations/2019_05_22_041713_add_hidden_to_user_channels.php
+++ b/database/migrations/2019_05_22_041713_add_hidden_to_user_channels.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\Schema;
+
+class AddHiddenToUserChannels extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        $builder = Schema::connection('mysql-chat');
+
+        $builder->table('user_channels', function ($table) {
+            $table->boolean('hidden')->default(0)->after('channel_id');
+            $table->index('hidden');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        $builder = Schema::connection('mysql-chat');
+
+        $builder->table('user_channels', function ($table) {
+            $table->dropColumn('hidden');
+        });
+    }
+}

--- a/resources/assets/less/bem/chat-conversation-list-item.less
+++ b/resources/assets/less/bem/chat-conversation-list-item.less
@@ -46,9 +46,13 @@
   }
 
   &__close-button {
-    .link-plain();
-    .link-white();
+    .reset-input();
+    padding: 5px;
     color: fade(white, 50%);
+
+    &:hover {
+      color: white;
+    }
 
     @media @desktop {
       opacity: 0;
@@ -68,8 +72,7 @@
   }
 
   &__tile {
-    .link-plain();
-    .link-white();
+    .reset-input();
     display: flex;
     align-items: center;
     flex: 1;
@@ -95,7 +98,7 @@
     }
 
     @media @desktop {
-      margin-left: -5px;
+      margin-left: -10px;
       margin-right: 10px;
       .@{top}:hover & {
         opacity: 0;
@@ -112,6 +115,7 @@
 
   &__name {
     flex: 1;
+    text-align: left;
 
     @media @mobile {
       display: none;

--- a/resources/assets/less/bem/chat-conversation-list-item.less
+++ b/resources/assets/less/bem/chat-conversation-list-item.less
@@ -75,6 +75,7 @@
     .reset-input();
     display: flex;
     align-items: center;
+    align-self: stretch;
     flex: 1;
   }
 

--- a/resources/assets/less/bem/chat-conversation-list-item.less
+++ b/resources/assets/less/bem/chat-conversation-list-item.less
@@ -25,21 +25,9 @@
   margin-left: 10px;
   padding-left: 10px;
 
-  .link-plain();
-  .link-white();
-
   @media @desktop {
     &:hover {
       background: linear-gradient(to right, @community-blue-darker 5%, lighten(@community-blue-dark, 2%) 33%, lighten(@community-blue-dark, 2%) 100%);
-    }
-  }
-
-  &--selected {
-    color: white;
-    background: linear-gradient(to right, @community-blue-darker 5%, @community-blue-dark 33%, @community-blue-dark 100%);
-    @media @mobile {
-      background: @community-blue-dark;
-      margin-right: 5px;
     }
   }
 
@@ -49,14 +37,49 @@
     flex-shrink: 0;
   }
 
+  &--selected {
+    color: white;
+    background: linear-gradient(to right, @community-blue-darker 5%, @community-blue-dark 33%, @community-blue-dark 100%);
+    @media @mobile {
+      background: @community-blue-dark;
+    }
+  }
+
+  &__close-button {
+    .link-plain();
+    .link-white();
+    color: fade(white, 50%);
+
+    @media @desktop {
+      opacity: 0;
+      margin-left: -10px;
+      .@{top}:hover & {
+        opacity: 1;
+      }
+    }
+
+    @media @mobile {
+      display: none;
+      .@{top}--selected & {
+        display: block;
+        margin-left: 5px;
+      }
+    }
+  }
+
+  &__tile {
+    .link-plain();
+    .link-white();
+    display: flex;
+    align-items: center;
+    flex: 1;
+  }
+
   &__unread-indicator {
     background: @green;
     width: 2px;
     height: 10px;
     border-radius: 1px;
-    margin-left: -10px;
-    margin-right: 8px;
-    transition: ease-in 50ms;
 
     opacity: 0;
     .@{top}--unread & {
@@ -68,6 +91,14 @@
         content: '';
         box-shadow: 0 0 5px lighten(@green, 10%);
         animation: glow-pulse 2s infinite;
+      }
+    }
+
+    @media @desktop {
+      margin-left: -5px;
+      margin-right: 10px;
+      .@{top}:hover & {
+        opacity: 0;
       }
     }
 
@@ -94,8 +125,8 @@
   &__chevron {
     margin-right: 10px;
     color: white;
-
     opacity: 0;
+
     .@{top}--selected & {
       opacity: 1;
     }

--- a/resources/assets/less/bem/chat-conversation-list-seperator.less
+++ b/resources/assets/less/bem/chat-conversation-list-seperator.less
@@ -30,7 +30,7 @@
   @media @mobile {
     width: 2px;
     height: 20px;
-    margin: 0px 10px;
+    margin: 0px 5px;
     align-self: center;
   }
 }

--- a/resources/assets/lib/actions/chat-actions.ts
+++ b/resources/assets/lib/actions/chat-actions.ts
@@ -18,6 +18,7 @@
 // tslint:disable:max-classes-per-file
 import Message from 'models/chat/message';
 import DispatcherAction from './dispatcher-action';
+import {PresenceJSON} from "../chat/chat-api-responses";
 
 export class ChatChannelSwitchAction implements DispatcherAction {
   constructor(public channelId: number) {
@@ -41,5 +42,10 @@ export class ChatMessageAddAction implements DispatcherAction {
 
 export class ChatMessageUpdateAction implements DispatcherAction {
   constructor(public message: Message) {
+  }
+}
+
+export class ChatPresenceUpdateAction implements DispatcherAction {
+  constructor(public presence: PresenceJSON) {
   }
 }

--- a/resources/assets/lib/actions/chat-actions.ts
+++ b/resources/assets/lib/actions/chat-actions.ts
@@ -24,6 +24,11 @@ export class ChatChannelSwitchAction implements DispatcherAction {
   }
 }
 
+export class ChatChannelPartAction implements DispatcherAction {
+  constructor(public channelId: number) {
+  }
+}
+
 export class ChatMessageSendAction implements DispatcherAction {
   constructor(public message: Message) {
   }

--- a/resources/assets/lib/actions/chat-actions.ts
+++ b/resources/assets/lib/actions/chat-actions.ts
@@ -17,8 +17,8 @@
  */
 // tslint:disable:max-classes-per-file
 import Message from 'models/chat/message';
+import {PresenceJSON} from '../chat/chat-api-responses';
 import DispatcherAction from './dispatcher-action';
-import {PresenceJSON} from "../chat/chat-api-responses";
 
 export class ChatChannelSwitchAction implements DispatcherAction {
   constructor(public channelId: number) {

--- a/resources/assets/lib/chat/chat-api.ts
+++ b/resources/assets/lib/chat/chat-api.ts
@@ -68,6 +68,21 @@ export default class ChatAPI {
     });
   }
 
+  partChannel(channelId: number, userId: number) {
+    return new Promise((resolve, reject) => {
+      $.ajax(laroute.route('chat.channels.part', {
+        channel: channelId,
+        user: userId,
+      }), {
+        method: 'DELETE',
+      }).done((response) => {
+        resolve(response);
+      }).fail((error) => {
+        reject(error);
+      });
+    });
+  }
+
   sendMessage(channelId: number, message: string): Promise<ApiResponses.SendMessageJSON> {
     return new Promise((resolve, reject) => {
       $.post(laroute.route('chat.channels.messages.store', {channel: channelId}), {

--- a/resources/assets/lib/chat/chat-orchestrator.ts
+++ b/resources/assets/lib/chat/chat-orchestrator.ts
@@ -19,7 +19,7 @@
 import {
   ChatChannelPartAction,
   ChatChannelSwitchAction,
-  ChatPresenceUpdateAction
+  ChatPresenceUpdateAction,
 } from 'actions/chat-actions';
 import DispatcherAction from 'actions/dispatcher-action';
 import { WindowBlurAction, WindowFocusAction } from 'actions/window-focus-actions';
@@ -52,7 +52,7 @@ export default class ChatOrchestrator implements DispatchListener {
     } else if (action instanceof ChatChannelPartAction) {
       this.partChannel(action.channelId);
     } else if (action instanceof ChatPresenceUpdateAction) {
-      if (this.rootDataStore.uiState.chat.selected == -1) {
+      if (this.rootDataStore.uiState.chat.selected === -1) {
         this.focusNextChannel();
       }
     } else if (action instanceof WindowFocusAction) {

--- a/resources/assets/lib/chat/chat-worker.ts
+++ b/resources/assets/lib/chat/chat-worker.ts
@@ -21,7 +21,7 @@ import {
   ChatMessageAddAction,
   ChatMessageSendAction,
   ChatMessageUpdateAction,
-  ChatPresenceUpdateAction
+  ChatPresenceUpdateAction,
 } from 'actions/chat-actions';
 import DispatcherAction from 'actions/dispatcher-action';
 import { WindowBlurAction, WindowFocusAction } from 'actions/window-focus-actions';

--- a/resources/assets/lib/chat/chat-worker.ts
+++ b/resources/assets/lib/chat/chat-worker.ts
@@ -16,7 +16,13 @@
  *    along with osu!web.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { ChatChannelSwitchAction, ChatMessageAddAction, ChatMessageSendAction, ChatMessageUpdateAction } from 'actions/chat-actions';
+import {
+  ChatChannelSwitchAction,
+  ChatMessageAddAction,
+  ChatMessageSendAction,
+  ChatMessageUpdateAction,
+  ChatPresenceUpdateAction
+} from 'actions/chat-actions';
 import DispatcherAction from 'actions/dispatcher-action';
 import { WindowBlurAction, WindowFocusAction } from 'actions/window-focus-actions';
 import DispatchListener from 'dispatch-listener';
@@ -130,7 +136,7 @@ export default class ChatWorker implements DispatchListener {
             this.dispatcher.dispatch(new ChatMessageAddAction(newMessage));
           });
 
-          this.rootDataStore.channelStore.updatePresence(updateJson.presence);
+          this.dispatcher.dispatch(new ChatPresenceUpdateAction(updateJson.presence));
         });
       })
       .catch((err) => {

--- a/resources/assets/lib/chat/conversation-list-item.tsx
+++ b/resources/assets/lib/chat/conversation-list-item.tsx
@@ -16,7 +16,7 @@
  *    along with osu!web.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { ChatChannelSwitchAction } from 'actions/chat-actions';
+import {ChatChannelPartAction, ChatChannelSwitchAction} from 'actions/chat-actions';
 import { inject, observer } from 'mobx-react';
 import * as React from 'react';
 import RootDataStore from 'stores/root-data-store';
@@ -33,33 +33,45 @@ export default class ConversationListItem extends React.Component<any, {}> {
     }
   }
 
+  part = (e: React.MouseEvent<HTMLElement>) => {
+    e.preventDefault();
+
+    this.props.dispatcher.dispatch(new ChatChannelPartAction(this.props.channelId));
+  }
+
   render(): React.ReactNode {
     const dataStore: RootDataStore = this.props.dataStore;
     const uiState = dataStore.uiState.chat;
     const conversation = dataStore.channelStore.get(this.props.channelId);
+    const baseClassName = 'chat-conversation-list-item';
 
     if (!conversation) {
       return;
     }
 
-    let className = 'chat-conversation-list-item';
+    let className = baseClassName;
     if (this.props.channelId === uiState.selected) {
-      className += ' chat-conversation-list-item--selected';
+      className += ` ${baseClassName}--selected`;
     }
 
     if (conversation.isUnread) {
-      className += ' chat-conversation-list-item--unread';
+      className += ` ${baseClassName}--unread`;
     }
 
     return (
-      <a href='#' className={className} onClick={this.switch}>
-        <div className='chat-conversation-list-item__unread-indicator' />
-        <img className='chat-conversation-list-item__avatar' src={conversation.icon} />
-        <div className='chat-conversation-list-item__name'>{conversation.name}</div>
-        <div className='chat-conversation-list-item__chevron'>
-          <i className='fas fa-chevron-right' />
-        </div>
-      </a>
+      <div className={className}>
+        <a href='#' className={`${baseClassName}__close-button`} onClick={this.part}>
+          <i className='fas fa-times' />
+        </a>
+        <div className={`${baseClassName}__unread-indicator`} />
+        <a href='#' className={`${baseClassName}__tile`} onClick={this.switch}>
+          <img className={`${baseClassName}__avatar`} src={conversation.icon} />
+          <div className={`${baseClassName}__name`}>{conversation.name}</div>
+          <div className={`${baseClassName}__chevron`}>
+            <i className='fas fa-chevron-right' />
+          </div>
+        </a>
+      </div>
     );
   }
 }

--- a/resources/assets/lib/chat/conversation-list-item.tsx
+++ b/resources/assets/lib/chat/conversation-list-item.tsx
@@ -26,16 +26,12 @@ import RootDataStore from 'stores/root-data-store';
 @observer
 export default class ConversationListItem extends React.Component<any, {}> {
   switch = (e: React.MouseEvent<HTMLElement>) => {
-    e.preventDefault();
-
     if (this.props.dataStore.uiState.chat.selected !== this.props.channelId) {
       this.props.dispatcher.dispatch(new ChatChannelSwitchAction(this.props.channelId));
     }
   }
 
   part = (e: React.MouseEvent<HTMLElement>) => {
-    e.preventDefault();
-
     this.props.dispatcher.dispatch(new ChatChannelPartAction(this.props.channelId));
   }
 
@@ -60,17 +56,17 @@ export default class ConversationListItem extends React.Component<any, {}> {
 
     return (
       <div className={className}>
-        <a href='#' className={`${baseClassName}__close-button`} onClick={this.part}>
+        <button className={`${baseClassName}__close-button`} onClick={this.part}>
           <i className='fas fa-times' />
-        </a>
+        </button>
         <div className={`${baseClassName}__unread-indicator`} />
-        <a href='#' className={`${baseClassName}__tile`} onClick={this.switch}>
+        <button className={`${baseClassName}__tile`} onClick={this.switch}>
           <img className={`${baseClassName}__avatar`} src={conversation.icon} />
           <div className={`${baseClassName}__name`}>{conversation.name}</div>
           <div className={`${baseClassName}__chevron`}>
             <i className='fas fa-chevron-right' />
           </div>
-        </a>
+        </button>
       </div>
     );
   }

--- a/resources/assets/lib/stores/channel-store.ts
+++ b/resources/assets/lib/stores/channel-store.ts
@@ -116,11 +116,7 @@ export default class ChannelStore implements DispatchListener {
 
   @computed
   get channelList(): Channel[] {
-    let channels: Channel[] = [];
-    channels = channels.concat(this.nonPmChannels);
-    channels = channels.concat(this.pmChannels);
-
-    return channels;
+    return [...this.nonPmChannels, ...this.pmChannels];
   }
 
   @action

--- a/resources/assets/lib/stores/channel-store.ts
+++ b/resources/assets/lib/stores/channel-store.ts
@@ -16,7 +16,12 @@
  *    along with osu!web.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-import { ChatMessageAddAction, ChatMessageSendAction, ChatMessageUpdateAction } from 'actions/chat-actions';
+import {
+  ChatMessageAddAction,
+  ChatMessageSendAction,
+  ChatMessageUpdateAction,
+  ChatPresenceUpdateAction
+} from 'actions/chat-actions';
 import DispatcherAction from 'actions/dispatcher-action';
 import { UserLogoutAction } from 'actions/user-login-actions';
 import { ChannelJSON } from 'chat/chat-api-responses';
@@ -48,6 +53,8 @@ export default class ChannelStore implements DispatchListener {
       const channel: Channel = this.getOrCreate(dispatchedAction.message.channelId);
       channel.updateMessage(dispatchedAction.message);
       channel.resortMessages();
+    } else if (dispatchedAction instanceof ChatPresenceUpdateAction) {
+      this.updatePresence(dispatchedAction.presence);
     } else if (dispatchedAction instanceof UserLogoutAction) {
       this.flushStore();
     }

--- a/resources/assets/lib/stores/channel-store.ts
+++ b/resources/assets/lib/stores/channel-store.ts
@@ -20,7 +20,7 @@ import {
   ChatMessageAddAction,
   ChatMessageSendAction,
   ChatMessageUpdateAction,
-  ChatPresenceUpdateAction
+  ChatPresenceUpdateAction,
 } from 'actions/chat-actions';
 import DispatcherAction from 'actions/dispatcher-action';
 import { UserLogoutAction } from 'actions/user-login-actions';

--- a/resources/assets/lib/stores/channel-store.ts
+++ b/resources/assets/lib/stores/channel-store.ts
@@ -107,6 +107,20 @@ export default class ChannelStore implements DispatchListener {
     });
   }
 
+  @computed
+  get channelList(): Channel[] {
+    let channels: Channel[] = [];
+    channels = channels.concat(this.nonPmChannels);
+    channels = channels.concat(this.pmChannels);
+
+    return channels;
+  }
+
+  @action
+  partChannel(channelId: number) {
+    this.channels.delete(channelId);
+  }
+
   get(channelId: number): Channel | undefined {
     return this.channels.get(channelId);
   }

--- a/tests/Controllers/Chat/ChannelsControllerTest.php
+++ b/tests/Controllers/Chat/ChannelsControllerTest.php
@@ -94,6 +94,16 @@ class ChannelsControllerTest extends TestCase
             ->assertStatus(403);
     }
 
+    public function testChannelJoinPM() // fail
+    {
+        $this->actAsScopedUser($this->user, ['*']);
+        $this->json('PUT', route('api.chat.channels.join', [
+                'channel' => $this->pmChannel->channel_id,
+                'user' => $this->user->user_id,
+            ]))
+            ->assertStatus(403);
+    }
+
     public function testChannelJoinPublic() // succeed
     {
         // ensure not in channel
@@ -270,7 +280,7 @@ class ChannelsControllerTest extends TestCase
             ->assertStatus(401);
     }
 
-    public function testChannelLeaveWhenNotPublic() // fail
+    public function testChannelLeaveWhenPrivate() // fail
     {
         $this->actAsScopedUser($this->user, ['*']);
         $this->json('DELETE', route('api.chat.channels.part', [

--- a/tests/Controllers/Chat/ChatControllerTest.php
+++ b/tests/Controllers/Chat/ChatControllerTest.php
@@ -341,7 +341,7 @@ class ChatControllerTest extends TestCase
             )->assertStatus(200);
 
         $presenceData = $response->decodeResponseJson();
-        $channelId = $presenceData["new_channel_id"];
+        $channelId = $presenceData['new_channel_id'];
 
         // leave PM with $this->anotherUser
         $this->actAsScopedUser($this->user, ['*']);
@@ -440,12 +440,12 @@ class ChatControllerTest extends TestCase
             )->assertStatus(200);
 
         $presenceData = $response->decodeResponseJson();
-        $channelId = $presenceData["new_channel_id"];
+        $channelId = $presenceData['new_channel_id'];
 
         // create reply
         $publicMessage = factory(Chat\Message::class)->create([
             'user_id' => $this->anotherUser->user_id,
-            'channel_id' => $channelId
+            'channel_id' => $channelId,
         ]);
 
         // ensure reply is visible

--- a/tests/Controllers/Chat/ChatControllerTest.php
+++ b/tests/Controllers/Chat/ChatControllerTest.php
@@ -58,6 +58,43 @@ class ChatControllerTest extends TestCase
     }
 
     //region POST /chat/new - Create New PM
+    public function testCreatePM() // success
+    {
+        $this->actAsScopedUser($this->user, ['*']);
+        $this->json(
+                'POST',
+                route('api.chat.new'),
+                [
+                    'target_id' => $this->anotherUser->user_id,
+                    'message' => self::$faker->sentence(),
+                ]
+            )->assertStatus(200);
+    }
+
+    public function testCreatePMWhenAlreadyExists() // success
+    {
+        $this->actAsScopedUser($this->user, ['*']);
+        $this->json(
+                'POST',
+                route('api.chat.new'),
+                [
+                    'target_id' => $this->anotherUser->user_id,
+                    'message' => self::$faker->sentence(),
+                ]
+            )->assertStatus(200);
+
+        // should return existing conversation and not error
+        $this->actAsScopedUser($this->user, ['*']);
+        $this->json(
+                'POST',
+                route('api.chat.new'),
+                [
+                    'target_id' => $this->anotherUser->user_id,
+                    'message' => self::$faker->sentence(),
+                ]
+            )->assertStatus(200);
+    }
+
     public function testCreatePMWhenGuest() // fail
     {
         $this->json(
@@ -184,43 +221,6 @@ class ChatControllerTest extends TestCase
             )->assertStatus(200);
     }
 
-    public function testCreatePM() // success
-    {
-        $this->actAsScopedUser($this->user, ['*']);
-        $this->json(
-                'POST',
-                route('api.chat.new'),
-                [
-                    'target_id' => $this->anotherUser->user_id,
-                    'message' => self::$faker->sentence(),
-                ]
-            )->assertStatus(200);
-    }
-
-    public function testCreatePMWhenAlreadyExists() // success
-    {
-        $this->actAsScopedUser($this->user, ['*']);
-        $this->json(
-                'POST',
-                route('api.chat.new'),
-                [
-                    'target_id' => $this->anotherUser->user_id,
-                    'message' => self::$faker->sentence(),
-                ]
-            )->assertStatus(200);
-
-        // should return existing conversation and not error
-        $this->actAsScopedUser($this->user, ['*']);
-        $this->json(
-                'POST',
-                route('api.chat.new'),
-                [
-                    'target_id' => $this->anotherUser->user_id,
-                    'message' => self::$faker->sentence(),
-                ]
-            )->assertStatus(200);
-    }
-
     //endregion
 
     //region GET /chat/presence - Get Presence
@@ -248,7 +248,7 @@ class ChatControllerTest extends TestCase
             ->assertJsonFragment(['channel_id' => $publicChannel->channel_id]);
     }
 
-    public function testChatPresenceHidingBlocked() // success
+    public function testChatPresenceHidesBlocked() // success
     {
         // start conversation with $this->anotherUser
         $this->actAsScopedUser($this->user, ['*']);
@@ -289,7 +289,7 @@ class ChatControllerTest extends TestCase
             ]]);
     }
 
-    public function testChatPresenceHidingRestricted() // success
+    public function testChatPresenceHidesRestricted() // success
     {
         // start conversation with $this->anotherUser
         $this->actAsScopedUser($this->user, ['*']);
@@ -316,6 +316,59 @@ class ChatControllerTest extends TestCase
 
         // unrestrict $this->anotherUser
         $this->anotherUser->update(['user_warnings' => 0]);
+
+        // ensure conversation with $this->anotherUser is visible again
+        $this->actAsScopedUser($this->user, ['*']);
+        $this->json('GET', route('api.chat.presence'))
+            ->assertStatus(200)
+            ->assertJsonFragment(['users' => [
+                $this->user->user_id,
+                $this->anotherUser->user_id,
+            ]]);
+    }
+
+    public function testChatPresenceHidesHidden() // success
+    {
+        // start conversation with $this->anotherUser
+        $this->actAsScopedUser($this->user, ['*']);
+        $response = $this->json(
+                'POST',
+                route('api.chat.new'),
+                [
+                    'target_id' => $this->anotherUser->user_id,
+                    'message' => self::$faker->sentence(),
+                ]
+            )->assertStatus(200);
+
+        $presenceData = $response->decodeResponseJson();
+        $channelId = $presenceData["new_channel_id"];
+
+        // leave PM with $this->anotherUser
+        $this->actAsScopedUser($this->user, ['*']);
+        $this->json('DELETE', route('api.chat.channels.part', [
+                'channel' => $channelId,
+                'user' => $this->user->user_id,
+            ]))
+            ->assertStatus(204);
+
+        // ensure conversation with $this->anotherUser isn't visible
+        $this->actAsScopedUser($this->user, ['*']);
+        $this->json('GET', route('api.chat.presence'))
+            ->assertStatus(200)
+            ->assertJsonMissing(['users' => [
+                $this->user->user_id,
+                $this->anotherUser->user_id,
+            ]]);
+
+        // reopen PM with $this->anotherUser
+        $this->json(
+                'POST',
+                route('api.chat.new'),
+                [
+                    'target_id' => $this->anotherUser->user_id,
+                    'message' => self::$faker->sentence(),
+                ]
+            )->assertStatus(200);
 
         // ensure conversation with $this->anotherUser is visible again
         $this->actAsScopedUser($this->user, ['*']);
@@ -371,6 +424,43 @@ class ChatControllerTest extends TestCase
         $this->json('GET', route('api.chat.updates'), ['since' => 0])
             ->assertStatus(200)
             ->assertJsonFragment(['content' => $publicMessage->content]);
+    }
+
+    public function testChatUpdatesHidesRestrictedUserMessages() // success
+    {
+        // create PM
+        $this->actAsScopedUser($this->user, ['*']);
+        $response = $this->json(
+                'POST',
+                route('api.chat.new'),
+                [
+                    'target_id' => $this->anotherUser->user_id,
+                    'message' => self::$faker->sentence(),
+                ]
+            )->assertStatus(200);
+
+        $presenceData = $response->decodeResponseJson();
+        $channelId = $presenceData["new_channel_id"];
+
+        // create reply
+        $publicMessage = factory(Chat\Message::class)->create([
+            'user_id' => $this->anotherUser->user_id,
+            'channel_id' => $channelId
+        ]);
+
+        // ensure reply is visible
+        $this->actAsScopedUser($this->user, ['*']);
+        $this->json('GET', route('api.chat.updates'), ['since' => 0])
+            ->assertStatus(200)
+            ->assertJsonFragment(['content' => $publicMessage->content]);
+
+        // restrict $this->anotherUser
+        $this->anotherUser->update(['user_warnings' => 1]);
+
+        // ensure reply is no longer visible
+        $this->actAsScopedUser($this->user, ['*']);
+        $this->json('GET', route('api.chat.updates'), ['since' => 0])
+            ->assertStatus(204);
     }
 
     //endregion


### PR DESCRIPTION
Leaving/closing a PM channel will hide it until a new message arrives in the channel.

Messaging the same user again will show the past chat history (if present and not culled), although right now the experience of re-opening a chat is a bit awkward and requires sending a message before the history is reloaded/shown (will fix later™).