### PR TITLE
Fix ranking command considering qualified beatmaps in recent count

### DIFF
--- a/app/Console/Commands/ModdingRankCommand.php
+++ b/app/Console/Commands/ModdingRankCommand.php
@@ -62,7 +62,7 @@ class ModdingRankCommand extends Command
     {
         $this->info('Ranking beatmapsets with at least mode: '.Beatmap::modeStr($modeInt));
 
-        $rankedTodayCount = Beatmapset::rankedOrApproved()
+        $rankedTodayCount = Beatmapset::ranked()
             ->withoutTrashed()
             ->withModesForRanking($modeInt)
             ->where('approved_date', '>=', now()->subDay())


### PR DESCRIPTION
Misleading scope name `rankedOrApproved` also includes qualified. Approved state does not need to be considered for this queue (last `approved = 2` beatmap was 2015-08).