### PR TITLE
Change the capitalization of permalinks in comments

### DIFF
--- a/resources/assets/less/bem/comment.less
+++ b/resources/assets/less/bem/comment.less
@@ -67,7 +67,11 @@
     &--active {
       color: @green;
     }
-
+    
+    #--permalink {
+      text-transform: lowercase;
+    }
+      
     .@{_top}--changelog & {
       .link-blue-light();
     }

--- a/resources/assets/less/bem/comment.less
+++ b/resources/assets/less/bem/comment.less
@@ -68,11 +68,6 @@
       color: @green;
     }
 
-    &--permalink::first-letter {
-      // the translation is lowercased
-      text-transform: uppercase;
-    }
-
     .@{_top}--changelog & {
       .link-blue-light();
     }

--- a/resources/assets/less/bem/comment.less
+++ b/resources/assets/less/bem/comment.less
@@ -59,6 +59,7 @@
   &__action {
     .reset-input();
     .link-default();
+    text-transform: lowercase;
 
     &:hover {
       text-decoration: underline;
@@ -66,10 +67,6 @@
 
     &--active {
       color: @green;
-    }
-
-    &--permalink {
-      text-transform: lowercase;
     }
 
     .@{_top}--changelog & {

--- a/resources/assets/less/bem/comment.less
+++ b/resources/assets/less/bem/comment.less
@@ -71,7 +71,7 @@
     #--permalink {
       text-transform: lowercase;
     }
-      
+
     .@{_top}--changelog & {
       .link-blue-light();
     }

--- a/resources/assets/less/bem/comment.less
+++ b/resources/assets/less/bem/comment.less
@@ -68,7 +68,7 @@
       color: @green;
     }
 
-    &--permalink {
+    &--permalink::first-letter {
       // the translation is lowercased
       text-transform: capitalize;
     }

--- a/resources/assets/less/bem/comment.less
+++ b/resources/assets/less/bem/comment.less
@@ -68,7 +68,7 @@
       color: @green;
     }
     
-    #--permalink {
+    &--permalink {
       text-transform: lowercase;
     }
 

--- a/resources/assets/less/bem/comment.less
+++ b/resources/assets/less/bem/comment.less
@@ -70,7 +70,7 @@
 
     &--permalink::first-letter {
       // the translation is lowercased
-      text-transform: capitalize;
+      text-transform: uppercase;
     }
 
     .@{_top}--changelog & {

--- a/resources/assets/less/bem/comment.less
+++ b/resources/assets/less/bem/comment.less
@@ -67,7 +67,7 @@
     &--active {
       color: @green;
     }
-    
+
     &--permalink {
       text-transform: lowercase;
     }


### PR DESCRIPTION
Changed the capitalization of permalinks in comments as it isn't fully correct in every language to capitalize the first letter of *every* word.

---