### PR TITLE
pin alpine version + reduce layers + image size

### DIFF
--- a/docker/php/Dockerfile
+++ b/docker/php/Dockerfile
@@ -1,7 +1,7 @@
-FROM alpine:latest
+FROM alpine:3.9
 
 RUN apk update && \
-    apk add \
+    apk add --no-cache \
     curl \
     php7 \
     php7-ctype \
@@ -24,6 +24,7 @@ RUN apk update && \
     php7-tokenizer \
     php7-xml \
     php7-xmlwriter \
-    php7-zip
-
-RUN touch /usr/bin/yarn && chmod 555 /usr/bin/yarn
+    php7-zip \
+    && rm -rf /var/cache/apk \
+    && touch /usr/bin/yarn \
+    && chmod 555 /usr/bin/yarn


### PR DESCRIPTION
PR:

* Ensures `alpine` is pinned to a specific version. Going off the [hadolint rule](https://github.com/hadolint/hadolint/wiki/DL3007), it's safer to pin it and update the `Dockerfile` with new releases of `alpine`
* Merge the `RUN`s, so that there's only one layer
* Add the `--no-cache` flag so the index isn't cached locally
* Run `rm -rf /var/cache/apk/*` at the end to further reduce the image size