### PR TITLE
Add chat actions

### DIFF
--- a/app/Exceptions/API/ChatMessageEmptyException.php
+++ b/app/Exceptions/API/ChatMessageEmptyException.php
@@ -18,20 +18,10 @@
  *    along with osu!web.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-return [
-    'error' => [
-        'chat' => [
-            'empty' => 'Cannot send blank message.',
-            'limit_exceeded' => 'You are sending messages too quickly, please wait a bit before trying again.',
-            'too_long' => 'The message you are trying to send is too long.',
-        ],
-    ],
+namespace App\Exceptions\API;
 
-    'scopes' => [
-        'identify' => 'Identify you and read your public profile.',
+use Exception;
 
-        'friends' => [
-            'read' => 'See who you are following.',
-        ],
-    ],
-];
+class ChatMessageEmptyException extends Exception
+{
+}

--- a/app/Http/Controllers/Chat/Channels/MessagesController.php
+++ b/app/Http/Controllers/Chat/Channels/MessagesController.php
@@ -150,6 +150,9 @@ class MessagesController extends BaseController
      *
      * @queryParam channel_id required The `channel_id` of the channel to send message to
      *
+     * @bodyParam message string required message to send
+     * @bodyParam is_action boolean required whether the message is an action
+     *
      * @response {
      *   "message_id": 9150005004,
      *   "sender_id": 2,

--- a/app/Http/Controllers/Chat/Channels/MessagesController.php
+++ b/app/Http/Controllers/Chat/Channels/MessagesController.php
@@ -186,18 +186,15 @@ class MessagesController extends BaseController
 
         priv_check('ChatChannelSend', $channel)->ensureCan();
 
-        $message = trim(Request::input('message'));
-
-        if (!present($message)) {
-            abort(422);
-        }
 
         try {
             $message = $channel->receiveMessage(
                 Auth::user(),
-                $message,
+                Request::input('message'),
                 get_bool(Request::input('is_action', false))
             );
+        } catch (API\ChatMessageEmptyException $e) {
+            abort(422, $e->getMessage());
         } catch (API\ChatMessageTooLongException $e) {
             abort(422, $e->getMessage());
         } catch (API\ExcessiveChatMessagesException $e) {

--- a/app/Http/Controllers/Chat/Channels/MessagesController.php
+++ b/app/Http/Controllers/Chat/Channels/MessagesController.php
@@ -186,7 +186,6 @@ class MessagesController extends BaseController
 
         priv_check('ChatChannelSend', $channel)->ensureCan();
 
-
         try {
             $message = $channel->receiveMessage(
                 Auth::user(),

--- a/app/Http/Controllers/Chat/Channels/MessagesController.php
+++ b/app/Http/Controllers/Chat/Channels/MessagesController.php
@@ -183,10 +183,16 @@ class MessagesController extends BaseController
 
         priv_check('ChatChannelSend', $channel)->ensureCan();
 
+        $message = trim(Request::input('message'));
+
+        if (!present($message)) {
+            abort(422);
+        }
+
         try {
             $message = $channel->receiveMessage(
                 Auth::user(),
-                Request::input('message'),
+                $message,
                 get_bool(Request::input('is_action', false))
             );
         } catch (API\ChatMessageTooLongException $e) {

--- a/app/Http/Controllers/Chat/ChatController.php
+++ b/app/Http/Controllers/Chat/ChatController.php
@@ -293,6 +293,8 @@ class ChatController extends Controller
                 Request::input('message'),
                 get_bool(Request::input('is_action', false))
             );
+        } catch (API\ChatMessageEmptyException $e) {
+            abort(422, $e->getMessage());
         } catch (API\ChatMessageTooLongException $e) {
             abort(422, $e->getMessage());
         } catch (API\ExcessiveChatMessagesException $e) {

--- a/app/Models/Chat/Channel.php
+++ b/app/Models/Chat/Channel.php
@@ -124,8 +124,14 @@ class Channel extends Model
 
     public function receiveMessage(User $sender, string $content, bool $isAction = false)
     {
+        $content = trim($content);
+
         if (mb_strlen($content, 'UTF-8') >= config('osu.chat.message_length_limit')) {
             throw new API\ChatMessageTooLongException(trans('api.error.chat.too_long'));
+        }
+
+        if (!present($content))  {
+            throw new API\ChatMessageEmptyException(trans('api.error.chat.empty'));
         }
 
         $sentMessages = Message::where('user_id', $sender->user_id)

--- a/app/Models/Chat/Channel.php
+++ b/app/Models/Chat/Channel.php
@@ -130,7 +130,7 @@ class Channel extends Model
             throw new API\ChatMessageTooLongException(trans('api.error.chat.too_long'));
         }
 
-        if (!present($content))  {
+        if (!present($content)) {
             throw new API\ChatMessageEmptyException(trans('api.error.chat.empty'));
         }
 

--- a/resources/assets/lib/chat/chat-api.ts
+++ b/resources/assets/lib/chat/chat-api.ts
@@ -55,9 +55,10 @@ export default class ChatAPI {
     });
   }
 
-  newConversation(userId: number, message: string): Promise<ApiResponses.NewConversationJSON> {
+  newConversation(userId: number, message: string, action?: boolean): Promise<ApiResponses.NewConversationJSON> {
     return new Promise((resolve, reject) => {
       $.post(laroute.route('chat.new'), {
+        is_action: action,
         message,
         target_id: userId,
       }).done((response) => {
@@ -83,9 +84,10 @@ export default class ChatAPI {
     });
   }
 
-  sendMessage(channelId: number, message: string): Promise<ApiResponses.SendMessageJSON> {
+  sendMessage(channelId: number, message: string, action?: boolean): Promise<ApiResponses.SendMessageJSON> {
     return new Promise((resolve, reject) => {
       $.post(laroute.route('chat.channels.messages.store', {channel: channelId}), {
+        is_action: action,
         message,
         target_id: channelId,
         target_type: 'channel',

--- a/resources/assets/lib/chat/chat-worker.ts
+++ b/resources/assets/lib/chat/chat-worker.ts
@@ -82,7 +82,7 @@ export default class ChatWorker implements DispatchListener {
         return;
       }
 
-      this.api.newConversation(userId, message.content)
+      this.api.newConversation(userId, message.content, message.isAction)
         .then((response) => {
           const newId = response.new_channel_id;
           transaction(() => {
@@ -96,7 +96,7 @@ export default class ChatWorker implements DispatchListener {
           this.dispatcher.dispatch(new ChatMessageUpdateAction(message));
         });
     } else {
-      this.api.sendMessage(channelId, message.content)
+      this.api.sendMessage(channelId, message.content, message.isAction)
         .then((updateJson) => {
           if (updateJson) {
             message.messageId = updateJson.message_id;

--- a/resources/assets/lib/chat/input-box.tsx
+++ b/resources/assets/lib/chat/input-box.tsx
@@ -49,7 +49,7 @@ export default class InputBox extends React.Component<any, any> implements Dispa
   }
 
   sendMessage(messageText?: string) {
-    if (!messageText || !osu.present(messageText)) {
+    if (!messageText || !osu.present(_.trim(messageText))) {
       return;
     }
 

--- a/resources/assets/lib/globals.d.ts
+++ b/resources/assets/lib/globals.d.ts
@@ -52,6 +52,7 @@ interface OsuCommon {
   parseJson: (id: string) => any;
   popup: (message: string, type: string) => void;
   presence: (str?: string | null) => string | null;
+  present: (str?: string | null) => boolean;
   promisify: (xhr: JQueryXHR) => Promise<any>;
   timeago: (time?: string) => string;
   trans: (...args: any[]) => string;


### PR DESCRIPTION
Additionally:
 - adds behaviour to the prevent sending of messages that appear to be slash-commands.
 - adds more leading/trailing space trims to prevent scenarios where blank messages could be sent.

resolves #4550