### PR TITLE
Add git to yarn container

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -53,7 +53,8 @@ services:
       OSU_SKIP_CACHE_PERMISSION_OVERRIDE: 1
     command: ['./docker/php/start.sh', 'db:3306']
   yarn:
-    image: node:8-alpine
+    build:
+      context: ./docker/yarn
     volumes:
       - .:/data/osuweb
     environment:

--- a/docker/yarn/Dockerfile
+++ b/docker/yarn/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:8-alpine
+FROM node:10-alpine
 
 RUN apk update && \
     apk add --no-cache git

--- a/docker/yarn/Dockerfile
+++ b/docker/yarn/Dockerfile
@@ -1,0 +1,4 @@
+FROM node:8-alpine
+
+RUN apk update && \
+    apk add --no-cache git


### PR DESCRIPTION
node alpine images don't come with git installed which then causes the package install to fail.