### PR TITLE
Additional blurry tournament banner fixes

### DIFF
--- a/resources/assets/coffee/react/profile-page/header.coffee
+++ b/resources/assets/coffee/react/profile-page/header.coffee
@@ -76,10 +76,11 @@ export class Header extends React.Component
           className: 'header-v3__bg'
           style:
             backgroundImage: osu.urlPresence(@state.coverUrl)
-        div
-          className: 'header-v3__spinner'
-          'data-visibility': if @state.isCoverUpdating then 'visible' else 'hidden'
-          el Spinner
+        if @props.withEdit
+          div
+            className: 'header-v3__spinner'
+            'data-visibility': if @state.isCoverUpdating then 'visible' else 'hidden'
+            el Spinner
         div className: 'header-v3__overlay'
         div className: 'osu-page osu-page--header-v3',
           @renderTournamentBanner()


### PR DESCRIPTION
helps #4516 with Safari.

#4520 doesn't fix it for Safari as it's compositing the banner with the invisible animation layer behind it.
To fix it in Safari, the layer behind the banner needs to be completely removed by using one of the options:
- `display: none`
- unsetting `will-change` and `animation`
- not rendering the loading spinner at all

all of which will break the spinner's fade in/out unless some delayed class changing hacks are used.
This fixes the blurry banner for everyone except the current user by not rendering the spinner if the header is not editable since it doesn't show anyway.