### PR TITLE
Restrict the viewing of history for private matches

### DIFF
--- a/app/Http/Controllers/MatchesController.php
+++ b/app/Http/Controllers/MatchesController.php
@@ -20,7 +20,6 @@
 
 namespace App\Http\Controllers;
 
-use App\Models\Country;
 use App\Models\Multiplayer\Match;
 use App\Models\User;
 use App\Transformers\Multiplayer\EventTransformer;
@@ -35,6 +34,8 @@ class MatchesController extends Controller
     public function show($id)
     {
         $match = Match::findOrFail($id);
+
+        priv_check('MatchView', $match)->ensureCan();
 
         $eventsJson = $this->eventsJson([
             'match' => $match,
@@ -52,8 +53,12 @@ class MatchesController extends Controller
 
     public function history($matchId)
     {
+        $match = Match::findOrFail($matchId);
+
+        priv_check('MatchView', $match)->ensureCan();
+
         return $this->eventsJson([
-            'match' => Match::findOrFail($matchId),
+            'match' => $match,
             'after' => request('after'),
             'before' => request('before'),
             'limit' => request('limit'),

--- a/app/Libraries/OsuAuthorize.php
+++ b/app/Libraries/OsuAuthorize.php
@@ -28,7 +28,6 @@ use App\Models\Forum\Authorize as ForumAuthorize;
 use App\Models\Forum\Topic;
 use App\Models\Forum\TopicCover;
 use App\Models\Multiplayer\Match as MultiplayerMatch;
-use App\Models\Multiplayer\Match;
 use App\Models\User;
 use App\Models\UserContestEntry;
 use Carbon\Carbon;

--- a/app/Libraries/OsuAuthorize.php
+++ b/app/Libraries/OsuAuthorize.php
@@ -1143,11 +1143,11 @@ class OsuAuthorize
 
         $this->ensureLoggedIn($user);
 
-        if (!$match->hadPlayer($user)) {
-            return 'unauthorized';
+        if ($user->canModerate() || $match->hadPlayer($user)) {
+            return 'ok';
         }
 
-        return 'ok';
+        return 'unauthorized';
     }
 
     public function checkUserSilenceShowExtendedInfo($user)

--- a/app/Libraries/OsuAuthorize.php
+++ b/app/Libraries/OsuAuthorize.php
@@ -28,6 +28,7 @@ use App\Models\Forum\Authorize as ForumAuthorize;
 use App\Models\Forum\Topic;
 use App\Models\Forum\TopicCover;
 use App\Models\Multiplayer\Match as MultiplayerMatch;
+use App\Models\Multiplayer\Match;
 use App\Models\User;
 use App\Models\UserContestEntry;
 use Carbon\Carbon;
@@ -1133,6 +1134,21 @@ class OsuAuthorize
         } else {
             return $prefix.'no_access';
         }
+    }
+
+    public function checkMatchView($user, $match)
+    {
+        if (!$match->private) {
+            return 'ok';
+        }
+
+        $this->ensureLoggedIn($user);
+
+        if (!$match->hadPlayer($user)) {
+            return 'unauthorized';
+        }
+
+        return 'ok';
     }
 
     public function checkUserSilenceShowExtendedInfo($user)

--- a/app/Models/Multiplayer/Match.php
+++ b/app/Models/Multiplayer/Match.php
@@ -20,6 +20,9 @@
 
 namespace App\Models\Multiplayer;
 
+use App\Models\User;
+use Cache;
+
 /**
  * @property \Carbon\Carbon|null $end_time
  * @property \Illuminate\Database\Eloquent\Collection $events Event
@@ -57,6 +60,13 @@ class Match extends Model
         if ($game !== null && $game->end_time === null) {
             return $game;
         }
+    }
+
+    public function hadPlayer(User $user)
+    {
+        return Cache::remember("multiplayer_participation_{$this->match_id}_{$user->user_id}", 60, function () use ($user) {
+            return $this->events()->where('user_id', $user->user_id)->where('text', 'JOIN')->exists();
+        });
     }
 
     public function currentPlayers()

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -787,6 +787,11 @@ class User extends Model implements AuthenticatableContract
         return $this->memoized[__FUNCTION__];
     }
 
+    public function canModerate()
+    {
+        return $this->isGMT() || $this->isNAT();
+    }
+
     /**
      * User group to be displayed in preference over other groups.
      *

--- a/database/factories/Multiplayer/EventFactory.php
+++ b/database/factories/Multiplayer/EventFactory.php
@@ -12,6 +12,20 @@ $factory->define(App\Models\Multiplayer\Event::class, function (Faker\Generator 
     ];
 });
 
+$factory->state(App\Models\Multiplayer\Event::class, 'create', function (Faker\Generator $faker) {
+    return [
+        'user_id' => null,
+        'text' => 'CREATE',
+    ];
+});
+
+$factory->state(App\Models\Multiplayer\Event::class, 'disband', function (Faker\Generator $faker) {
+    return [
+        'user_id' => null,
+        'text' => 'DISBAND',
+    ];
+});
+
 $factory->state(App\Models\Multiplayer\Event::class, 'join', function (Faker\Generator $faker) {
     return [
         'text' => 'JOIN',

--- a/database/factories/Multiplayer/MatchFactory.php
+++ b/database/factories/Multiplayer/MatchFactory.php
@@ -9,3 +9,9 @@ $factory->define(App\Models\Multiplayer\Match::class, function (Faker\Generator 
         'private' => 0,
     ];
 });
+
+$factory->state(App\Models\Multiplayer\Match::class, 'private', function (Faker\Generator $faker) {
+    return [
+        'private' => 1,
+    ];
+});

--- a/tests/Controllers/MatchesControllerTest.php
+++ b/tests/Controllers/MatchesControllerTest.php
@@ -76,11 +76,12 @@ class MatchesControllerTest extends TestCase
             ->assertStatus(200);
     }
 
-    public function testPrivateMatchLoggedOut() // Access Denied
+    public function testPrivateMatchLoggedOut() // Login Required
     {
         $this
             ->get($this->privateMatchRoute)
-            ->assertStatus(403);
+            ->assertSeeText('Please login to continue')
+            ->assertStatus(200);
     }
 
     public function testPrivateMatchLoggedInNotParticipated() // Access Denied

--- a/tests/Controllers/MatchesControllerTest.php
+++ b/tests/Controllers/MatchesControllerTest.php
@@ -23,6 +23,12 @@ use App\Models\User;
 
 class MatchesControllerTest extends TestCase
 {
+    private $privateMatch;
+    private $privateMatchRoute;
+    private $publicMatch;
+    private $publicMatchRoute;
+    private $user;
+
     public function setUp()
     {
         parent::setUp();
@@ -45,7 +51,6 @@ class MatchesControllerTest extends TestCase
     public function testPublicMatchLoggedOut() // OK
     {
         $this
-            ->actingAs($this->user)
             ->get($this->publicMatchRoute)
             ->assertStatus(200);
     }
@@ -60,6 +65,11 @@ class MatchesControllerTest extends TestCase
 
     public function testPublicMatchLoggedInParticipated() // OK
     {
+        factory(Event::class)->states('join')->create([
+            'user_id' => $this->user->user_id,
+            'match_id' => $this->publicMatch->match_id,
+        ]);
+
         $this
             ->actingAs($this->user)
             ->get($this->publicMatchRoute)
@@ -69,7 +79,6 @@ class MatchesControllerTest extends TestCase
     public function testPrivateMatchLoggedOut() // Access Denied
     {
         $this
-            ->actingAs($this->user)
             ->get($this->privateMatchRoute)
             ->assertStatus(403);
     }

--- a/tests/Controllers/MatchesControllerTest.php
+++ b/tests/Controllers/MatchesControllerTest.php
@@ -1,0 +1,97 @@
+<?php
+
+/**
+ *    Copyright (c) ppy Pty Ltd <contact@ppy.sh>.
+ *
+ *    This file is part of osu!web. osu!web is distributed with the hope of
+ *    attracting more community contributions to the core ecosystem of osu!.
+ *
+ *    osu!web is free software: you can redistribute it and/or modify
+ *    it under the terms of the Affero GNU General Public License version 3
+ *    as published by the Free Software Foundation.
+ *
+ *    osu!web is distributed WITHOUT ANY WARRANTY; without even the implied
+ *    warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *    See the GNU Affero General Public License for more details.
+ *
+ *    You should have received a copy of the GNU Affero General Public License
+ *    along with osu!web.  If not, see <http://www.gnu.org/licenses/>.
+ */
+use App\Models\Multiplayer\Event;
+use App\Models\Multiplayer\Match;
+use App\Models\User;
+
+class MatchesControllerTest extends TestCase
+{
+    public function setUp()
+    {
+        parent::setUp();
+
+        $this->user = factory(User::class)->create();
+
+        $this->publicMatch = factory(Match::class)->create();
+        factory(Event::class)->states('create')->create([
+            'match_id' => $this->publicMatch->match_id,
+        ]);
+        $this->publicMatchRoute = route('matches.show', $this->publicMatch->match_id);
+
+        $this->privateMatch = factory(Match::class)->states('private')->create();
+        factory(Event::class)->states('create')->create([
+            'match_id' => $this->privateMatch->match_id,
+        ]);
+        $this->privateMatchRoute = route('matches.show', $this->privateMatch->match_id);
+    }
+
+    public function testPublicMatchLoggedOut() // OK
+    {
+        $this
+            ->actingAs($this->user)
+            ->get($this->publicMatchRoute)
+            ->assertStatus(200);
+    }
+
+    public function testPublicMatchLoggedInNotParticipated() // OK
+    {
+        $this
+            ->actingAs($this->user)
+            ->get($this->publicMatchRoute)
+            ->assertStatus(200);
+    }
+
+    public function testPublicMatchLoggedInParticipated() // OK
+    {
+        $this
+            ->actingAs($this->user)
+            ->get($this->publicMatchRoute)
+            ->assertStatus(200);
+    }
+
+    public function testPrivateMatchLoggedOut() // Access Denied
+    {
+        $this
+            ->actingAs($this->user)
+            ->get($this->privateMatchRoute)
+            ->assertStatus(403);
+    }
+
+    public function testPrivateMatchLoggedInNotParticipated() // Access Denied
+    {
+        $this
+            ->actingAs($this->user)
+            ->get($this->privateMatchRoute)
+            ->assertStatus(403);
+    }
+
+    public function testPrivateMatchLoggedInParticipated() // OK
+    {
+        factory(Event::class)->states('join')->create([
+            'user_id' => $this->user->user_id,
+            'match_id' => $this->privateMatch->match_id,
+        ]);
+
+        $this
+            ->actingAs($this->user)
+            ->get($this->privateMatchRoute)
+            ->assertStatus(200);
+    }
+}


### PR DESCRIPTION
A private match that doesn't have 'public match history' enabled requires a user to have participated in the match to view the history.

NOTE: a bancho/client update and manual sql migration is required before this goes live.

fixes #4491