### PR TITLE
Add some defaults for placeholder changelog entry

### DIFF
--- a/app/Models/ChangelogEntry.php
+++ b/app/Models/ChangelogEntry.php
@@ -108,6 +108,9 @@ class ChangelogEntry extends Model
     {
         return new static([
             'title' => trans('changelog.generic'),
+            'private' => false,
+            'major' => false,
+            'created_at' => Carbon::createFromTimestamp(0),
             'githubUser' => new GithubUser([
                 'username' => 'peppy',
                 'user_id' => null,


### PR DESCRIPTION
Should fix #4573 though it looks like some fields are marked as non-nullable even though they are.

- `repository`
- `github_url`
- `url`
- `message_html`

Also APIChangelogBuild got typo in it - `VersionNatigation`.