### PR TITLE
Fix empty pages on iOS 10 

### DIFF
--- a/resources/assets/lib/react-turbolinks.coffee
+++ b/resources/assets/lib/react-turbolinks.coffee
@@ -54,7 +54,7 @@ export class ReactTurbolinks
 
   deleteLoadedMarker: =>
     @allTargets ({ target }) =>
-      delete target.dataset.reactTurbolinksLoaded
+      delete target.dataset.reactTurbolinksLoaded if target.dataset.reactTurbolinksLoaded?
 
 
   destroy: =>


### PR DESCRIPTION
fixes #4604

Apparently iOS10 can't delete dataset attributes that aren't set yet.