### PR TITLE
Move webpack runtime to commons chunk

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,7 +1,7 @@
 const webpackConfig = require('./webpack.config.js');
 webpackConfig['mode'] = 'development';
 webpackConfig['devtool'] = 'inline-source-map';
-delete webpackConfig.optimization.splitChunks; // karma doesn't work with splitChunks
+delete webpackConfig.optimization; // karma doesn't work with splitChunks...or runtimeChunk
 delete webpackConfig.entry; // test runner doesn't use the entry points
 
 const testIndex = './tests/karma/index.ts';

--- a/webpack.mix.js
+++ b/webpack.mix.js
@@ -102,6 +102,9 @@ let webpackConfig = {
     })
   ],
   optimization: {
+    runtimeChunk: {
+      name: "/js/commons",
+    },
     splitChunks: {
       cacheGroups: {
         commons: {


### PR DESCRIPTION
By default each entry point has a copy of the webpack runtime; a side-effect of this is that each entry point has its own module cache, meaning imports resolved via different entry points ended up being different instances. This led to things like:
- singletons only being singletons within their entry point instead of app wide.
- Definitions in the same module being considered 'different' resulting in weird things like `[mobx] Cannot obtain atom from [object Object]`, especially if mobx devtools are loaded.

Moving the runtime to `commons` means there's only a single module cache and importing the same module results in the same instance across all entry points. Overall bundle size is also a tiny bit smaller since the runtime isn't duplicated everywhere.