### PR TITLE
Add default stream name for older builds

### DIFF
--- a/app/helpers.php
+++ b/app/helpers.php
@@ -599,7 +599,7 @@ function issue_icon($issue)
 
 function build_url($build)
 {
-    return route('changelog.build', [$build->updateStream->name, $build->version]);
+    return route('changelog.build', [optional($build->updateStream)->name ?? 'unknown', $build->version]);
 }
 
 function post_url($topicId, $postId, $jumpHash = true, $tail = false)


### PR DESCRIPTION
It will point to nowhere but better than completely failing?