### PR TITLE
Fix incorrect sentry report

### DIFF
--- a/config/sentry.php
+++ b/config/sentry.php
@@ -5,4 +5,17 @@ return [
 
     // capture release as git sha
     'release' => config('osu.git-sha'),
+
+    // Copied from [1] to prevent E_NOTICE and E_WARNING (and maybe others)
+    // from either being reported twice or incorrectly reported after caught.
+    // There's probably better set of types but it's easier to just copy whatever
+    // used by the old library.
+    // [1] https://github.com/getsentry/raven-php/blob/a90cdcf681a373b5150ee2b430db28d9f670abea/lib/Raven/ErrorHandler.php#L71
+    'error_types' => E_ERROR
+        | E_PARSE
+        | E_CORE_ERROR
+        | E_CORE_WARNING
+        | E_COMPILE_ERROR
+        | E_COMPILE_WARNING
+        | E_STRICT,
 ];


### PR DESCRIPTION
When an error isn't an exception, laravel throws its own exception. It's usually dealt by catching it or just letting it be reported by exception handler.

Unfortunately in the latest update sentry also reports non-aborting errors, and as it's different to what laravel throws, it results in either duplicated report or caught report being incorrectly reported (as you can't usually catch non-aborting errors).