### PR TITLE
Fix profile page not rendering on users with repeated username change

### DIFF
--- a/app/Transformers/UserTransformer.php
+++ b/app/Transformers/UserTransformer.php
@@ -227,7 +227,7 @@ class UserTransformer extends Fractal\TransformerAbstract
     public function includePreviousUsernames(User $user)
     {
         return $this->item($user, function ($user) {
-            return $user->previousUsernames()->unique()->toArray();
+            return $user->previousUsernames()->unique()->values()->toArray();
         });
     }
 


### PR DESCRIPTION
Make sure array is actually array as `->unique()` may transform array into something that's not quite array.

    >>> json_encode(collect(['a','a','b'])->unique()->toArray())
    => "{"0":"a","2":"b"}"
    >>> json_encode(collect(['a','a','b'])->unique()->values()->toArray())
    => "["a","b"]"