### PR TITLE
Fix auto focus of some text boxes

### DIFF
--- a/resources/assets/coffee/react/_components/comment-editor.coffee
+++ b/resources/assets/coffee/react/_components/comment-editor.coffee
@@ -60,7 +60,7 @@ export class CommentEditor extends React.PureComponent
 
       el TextareaAutosize,
         className: "#{bn}__message"
-        innerRef: @textarea
+        ref: @textarea
         value: @state.message
         placeholder: osu.trans("comments.placeholder.#{@mode()}")
         onChange: @onChange

--- a/resources/assets/coffee/react/beatmap-discussions/new-discussion.coffee
+++ b/resources/assets/coffee/react/beatmap-discussions/new-discussion.coffee
@@ -120,7 +120,7 @@ export class NewDiscussion extends React.PureComponent
                   onChange: @setMessage
                   onKeyDown: @handleKeyDown
                   onFocus: @onFocus
-                  innerRef: @inputBox
+                  ref: @inputBox
                   placeholder: @messagePlaceholder()
 
                 el MessageLengthCounter,

--- a/resources/assets/coffee/react/beatmap-discussions/new-reply.coffee
+++ b/resources/assets/coffee/react/beatmap-discussions/new-reply.coffee
@@ -75,7 +75,7 @@ export class NewReply extends React.PureComponent
             onChange: @setMessage
             onKeyDown: @handleKeyDown
             placeholder: osu.trans 'beatmaps.discussions.reply_placeholder'
-            innerRef: @box
+            ref: @box
 
       div
         className: "#{bn}__footer #{bn}__footer--notice"

--- a/resources/assets/coffee/react/beatmap-discussions/post.coffee
+++ b/resources/assets/coffee/react/beatmap-discussions/post.coffee
@@ -168,7 +168,7 @@ export class Post extends React.PureComponent
         onChange: @setMessage
         onKeyDown: @handleKeyDown
         value: @state.message
-        innerRef: @textarea
+        ref: @textarea
       el MessageLengthCounter, message: @state.message, isTimeline: @isTimeline()
 
       div className: "#{bn}__actions",


### PR DESCRIPTION
The wording on changelog was confusing - it's not `innerRef` now supports `React.createRef` but instead passing `ref` works as expected.

Fixes #4643.