### PR TITLE
Fix user link in mobile forum

### DIFF
--- a/resources/assets/less/bem/forum-post.less
+++ b/resources/assets/less/bem/forum-post.less
@@ -335,6 +335,13 @@
     margin: 5px 0;
   }
 
+  &__user-link-xs {
+    // Overrides the ".forum-post a" above.
+    && {
+      color: #fff;
+    }
+  }
+
   &__username {
     .default-text-shadow();
     display: block;

--- a/resources/views/forum/topics/_post_info.blade.php
+++ b/resources/views/forum/topics/_post_info.blade.php
@@ -104,7 +104,7 @@
 
         <div class="forum-post__info-panel-xs-main">
             <div class="forum-post__info-panel-xs-name">
-                <a class="link--white" href="{{ route("users.show", $user) }}">
+                <a class="forum-post__user-link-xs" href="{{ route("users.show", $user) }}">
                     {{ $user->username }}
                 </a>
 


### PR DESCRIPTION
".link--white" has lower priority than ".forum-post a". As ".link--white" itself is used somewhere else, add new style instead.

Fixes #4656.