### PR TITLE
Fix users with duplicate previous or reverted usernames not being indexed

### DIFF
--- a/app/Models/Beatmapset.php
+++ b/app/Models/Beatmapset.php
@@ -875,7 +875,7 @@ class Beatmapset extends Model implements AfterCommit, Commentable
 
     public function playmodes()
     {
-        return $this->beatmaps->pluck('playmode')->unique();
+        return $this->beatmaps->pluck('playmode')->unique()->values();
     }
 
     public function playmodeCount()

--- a/app/Models/Elasticsearch/UserTrait.php
+++ b/app/Models/Elasticsearch/UserTrait.php
@@ -44,7 +44,7 @@ trait UserTrait
 
         $values['is_old'] = $this->isOld();
 
-        $values['previous_usernames'] = $this->previousUsernames(true)->unique();
+        $values['previous_usernames'] = $this->previousUsernames(true)->unique()->values();
 
         return $values;
     }


### PR DESCRIPTION
Because `unique()` may return an associative array instead.
There's a bunch of other places where we should be calling `values()` after `unique()` but they're not affected by the same issue because their result is just passed into a `whereIn` in the query builder which gets the values anyway.

closes #4645

user will show up again after being indexed.