### PR TITLE
Search design updates

### DIFF
--- a/resources/assets/less/bem-index.less
+++ b/resources/assets/less/bem-index.less
@@ -277,6 +277,7 @@
 @import "bem/search-highlight";
 @import "bem/search-result";
 @import "bem/search-result-entry";
+@import "bem/search-wiki-page";
 @import "bem/show-more-link";
 @import "bem/simple-form";
 @import "bem/simple-menu";

--- a/resources/assets/less/bem/search-entry.less
+++ b/resources/assets/less/bem/search-entry.less
@@ -27,6 +27,18 @@
 
   &:hover {
     border: 2px solid @osu-colour-l1;
+
+    .search-result--beatmapset & {
+      border-color: @pink-dark;
+    }
+
+    .search-result--forum_post & {
+      border-color: @yellow-dark;
+    }
+
+    .search-result--wiki_page & {
+      border-color: @purple-dark;
+    }
   }
 
   &__row {

--- a/resources/assets/less/bem/search-entry.less
+++ b/resources/assets/less/bem/search-entry.less
@@ -26,7 +26,7 @@
   border: 2px solid transparent;
 
   &:hover {
-    border: 2px solid @osu-colour-h1;
+    border: 2px solid @osu-colour-l1;
   }
 
   &__row {
@@ -34,21 +34,20 @@
     padding: 0;
     line-height: 1.5;
     word-wrap: break-word;
+    color: white;
 
     &--title {
       margin-top: 0;
-      color: #fff;
       font-size: @font-size--title-small-2;
     }
 
     &--excerpt {
-      color: #ddd;
       font-size: @font-size--small-2;
       word-break: break-word;
     }
 
     &--footer {
-      color: #999;
+      color: @osu-colour-f1;
       font-size: @font-size--small;
     }
   }

--- a/resources/assets/less/bem/search-forum-post.less
+++ b/resources/assets/less/bem/search-forum-post.less
@@ -65,8 +65,10 @@
   &__poster {
     display: inline-block;
     margin-right: 1em;
-    color: #999;
     pointer-events: auto;
+
+    .link-default();
+    color: @osu-colour-f1;
 
     @media @mobile {
       display: block;
@@ -74,18 +76,18 @@
   }
 
   &__text {
+    color: white;
+
     &--excerpt {
-      color: #ddd;
       font-size: @font-size--small-2;
     }
 
     &--footer {
-      color: #999;
+      color: @osu-colour-f1;
       font-size: @font-size--small;
     }
 
     &--title {
-      color: #fff;
       font-size: @font-size--title-small-2;
       margin-bottom: @margin;
     }

--- a/resources/assets/less/bem/search-result.less
+++ b/resources/assets/less/bem/search-result.less
@@ -65,7 +65,8 @@
   &__more-button {
     flex: none;
     .link-plain();
-    .link-gray-light();
+    .link-default();
+    color: @osu-colour-f1;
     .center-content();
     font-size: 20px; // icon size
     padding: 5px;
@@ -89,11 +90,12 @@
     &--notice {
       font-size: @font-size--title-small;
       text-align: center;
-      color: #ccc;
     }
 
     &--more {
-      .link-gray-light();
+      .link-default();
+      .link-plain();
+      color: @osu-colour-f1;
       font-size: @font-size--normal;
       display: block;
       text-align: center;
@@ -105,7 +107,7 @@
 
     &--title {
       font-size: @font-size--title-small-2;
-      color: #fff;
+      color: white;
       font-style: italic;
       margin: 0;
     }

--- a/resources/assets/less/bem/search-wiki-page.less
+++ b/resources/assets/less/bem/search-wiki-page.less
@@ -1,0 +1,28 @@
+/**
+ *    Copyright (c) ppy Pty Ltd <contact@ppy.sh>.
+ *
+ *    This file is part of osu!web. osu!web is distributed with the hope of
+ *    attracting more community contributions to the core ecosystem of osu!.
+ *
+ *    osu!web is free software: you can redistribute it and/or modify
+ *    it under the terms of the Affero GNU General Public License version 3
+ *    as published by the Free Software Foundation.
+ *
+ *    osu!web is distributed WITHOUT ANY WARRANTY; without even the implied
+ *    warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *    See the GNU Affero General Public License for more details.
+ *
+ *    You should have received a copy of the GNU Affero General Public License
+ *    along with osu!web.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+.search-wiki-page {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+
+  &__more {
+    color: @osu-colour-f1;
+    .link-hover({ color: @osu-colour-f1 });
+  }
+}

--- a/resources/assets/less/bem/user-card.less
+++ b/resources/assets/less/bem/user-card.less
@@ -48,7 +48,7 @@
     .@{top}:hover&, .@{top}--active& {
       .full-size();
       content: '';
-      border: 2px solid @osu-colour-h1;
+      border: 2px solid @osu-colour-l1;
       border-radius: @card-border-radius;
       pointer-events: none;
     }

--- a/resources/assets/less/bem/user-card.less
+++ b/resources/assets/less/bem/user-card.less
@@ -51,6 +51,10 @@
       border: 2px solid @osu-colour-l1;
       border-radius: @card-border-radius;
       pointer-events: none;
+
+      .search-result--user & {
+        border-color: @blue-dark;
+      }
     }
   }
 

--- a/resources/views/home/_search_result_wiki_page.blade.php
+++ b/resources/views/home/_search_result_wiki_page.blade.php
@@ -25,22 +25,29 @@
             class="search-entry"
             href="{{ $url }}"
         >
-            <h1 class="search-entry__row search-entry__row--title">
-                <span class="search-highlight">
-                    {!! $entry->highlightedTitle() !!}
-                </span>
+            <div class="search-wiki-page">
+                <div class="search-wiki-page__content">
+                    <h1 class="search-entry__row search-entry__row--title">
+                        <span class="search-highlight">
+                            {!! $entry->highlightedTitle() !!}
+                        </span>
 
-            </h1>
+                    </h1>
 
-            <p class="search-entry__row search-entry__row--excerpt">
-                <span class="search-highlight">
-                    {!! $entry->highlights() !!}
-                </span>
-            </p>
+                    <p class="search-entry__row search-entry__row--excerpt">
+                        <span class="search-highlight">
+                            {!! $entry->highlights() !!}
+                        </span>
+                    </p>
 
-            <p class="search-entry__row search-entry__row--footer">
-                {{ $url }}
-            </p>
+                    <p class="search-entry__row search-entry__row--footer">
+                        {{ $url }}
+                    </p>
+                </div>
+                <div class="search-wiki-page__more">
+                    <span class="fas fa-angle-right"></span>
+                </div>
+            </div>
         </a>
     </div>
 @endforeach


### PR DESCRIPTION
Fixes neutral grey usages and updates wiki search result design to match forum post results.

Also adds a splash of colour to the search result on-hover outlines.

Side note: the result sections should probably eventually match the site section colours... but right now 3/4 of them (user, forum, beatmaps)  use the same colour, so... _yeeeah_.