### PR TITLE
Adjust recommended star difficulty for users with no ranked plays

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -1490,7 +1490,7 @@ class User extends Model implements AuthenticatableContract
             return pow($stats->rank_score, 0.4) * 0.195;
         }
 
-        return 0.0;
+        return 1.0;
     }
 
     public function refreshForumCache($forum = null, $postsChangeCount = 0)


### PR DESCRIPTION
Fixes #4544.

For cases where the recommended star difficulty would be zero stars, the website now recommends one start.