### PR TITLE
Base user support level on contributed supporter tags

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -1443,7 +1443,7 @@ class User extends Model implements AuthenticatableContract
         if (!array_key_exists(__FUNCTION__, $this->memoized)) {
             $supportLength = 0;
 
-            foreach ($this->supporterTags as $support) {
+            foreach ($this->supporterTagPurchases as $support) {
                 if ($support->cancel === true) {
                     $supportLength -= $support->length;
                 } else {


### PR DESCRIPTION
Previously it was based on how long user has active tag for themselves (including given by others). This changes it to include tags given to others and exclude tags given by others.

Incoming complains from people who mainly receive tags ( '_')a

(they'll still get level 1 at the minimum though)