### PR TITLE
Show which beatmap packs have been cleared & update "clear" badge design

### DIFF
--- a/app/Http/Controllers/BeatmapPacksController.php
+++ b/app/Http/Controllers/BeatmapPacksController.php
@@ -20,7 +20,6 @@
 
 namespace App\Http\Controllers;
 
-use App\Models\Beatmap;
 use App\Models\BeatmapPack;
 use Auth;
 use Request;
@@ -45,14 +44,12 @@ class BeatmapPacksController extends Controller
     public function show($id)
     {
         $pack = BeatmapPack::findOrFail($id);
-        $mode = Beatmap::modeStr($pack->playmode ?? 0);
-
         $sets = $pack
             ->beatmapsets()
             ->select()
             ->withHasCompleted($pack->playmode ?? 0, Auth::user())
             ->get();
 
-        return view('packs.show', compact('pack', 'sets', 'mode'));
+        return view('packs.show', compact('pack', 'sets'));
     }
 }

--- a/app/Http/Controllers/BeatmapPacksController.php
+++ b/app/Http/Controllers/BeatmapPacksController.php
@@ -31,7 +31,7 @@ class BeatmapPacksController extends Controller
     public function index()
     {
         $type = presence(Request::input('type')) ?? BeatmapPack::DEFAULT_TYPE;
-        $packs = BeatmapPack::getPacks($type);
+        $packs = BeatmapPack::getPacks($type)->with('items');
         if ($packs === null) {
             abort(404);
         }

--- a/app/Models/BeatmapPack.php
+++ b/app/Models/BeatmapPack.php
@@ -66,6 +66,23 @@ class BeatmapPack extends Model
         return $this->downloadUrls()[0];
     }
 
+    public function clearedBy(User $user) : bool
+    {
+        if ($user === null) {
+            return false;
+        }
+
+        $mapsCleared = $this
+            ->beatmapsets()
+            ->withHasCompleted($this->playmode ?? 0, $user)
+            ->get()
+            ->reduce(function ($clearedSets, $set) {
+                return $clearedSets + ($set->count > 0);
+            }, 0);
+
+        return $mapsCleared === $this->items->count();
+    }
+
     public static function getPacks($type)
     {
         if (!in_array($type, array_keys(static::$tagMappings), true)) {

--- a/resources/assets/less/bem/beatmap-pack-items.less
+++ b/resources/assets/less/bem/beatmap-pack-items.less
@@ -22,15 +22,34 @@
   padding: @beatmappack-listing--gutter;
 
   &__artist {
-    margin-left: 8px;
+    margin-left: 1em;
     font-weight: 600;
   }
 
-  &__icon {
-    color: @osu-colour-b5;
-    &--cleared {
-      color: @osu-colour-l1;
-    }
+  &__clear {
+    color: #fff;
+    font-size: 80%;
+    font-style: normal;
+    font-weight: 600;
+    text-shadow: 0 1px 2px fade(#000, 75%);
+    text-transform: uppercase;
+    vertical-align: text-top;
+    visibility: hidden;
+  }
+
+  &__set--cleared &__clear {
+    visibility: visible;
+  }
+
+  &__status {
+    background-color: @osu-colour-b5;
+    border-radius: 10000px;
+    display: inline-block;
+    padding: 0 0.5em;
+  }
+
+  &__set--cleared &__status {
+    background-color: @osu-colour-l1;
   }
 
   &__link {
@@ -40,5 +59,9 @@
   &__set {
     list-style: none;
     font-style: italic;
+
+    & + & {
+      margin-top: 0.5em;
+    }
   }
 }

--- a/resources/assets/less/bem/beatmap-pack.less
+++ b/resources/assets/less/bem/beatmap-pack.less
@@ -23,6 +23,7 @@
 
   &__body {
     background-color: @osu-colour-b3;
+    margin-left: 4px;
   }
 
   &__header {
@@ -51,11 +52,24 @@
     font-size: 90%;
   }
 
+  &__clear {
+    color: @osu-colour-l1;
+    font-weight: 600;
+
+    &.beatmap-packs__cell {
+      flex-grow: 1;
+    }
+  }
+
   &__name {
     color: white;
 
-    &.beatmap-packs__cell {
-      flex-grow: 4;
+    .beatmap-packs__cell& {
+      flex-grow: 1;
+
+      &--clear {
+        flex-grow: 0;
+      }
     }
 
     .js-accordion__item--expanded & {

--- a/resources/assets/less/bem/beatmap-packs.less
+++ b/resources/assets/less/bem/beatmap-packs.less
@@ -77,5 +77,17 @@
 
   &__row {
     display: flex;
+    margin-left: 4px;
+  }
+
+  &__stripe {
+    background-color: @osu-colour-b5;
+    height: 100%;
+    position: absolute;
+    width: 4px;
+
+    &--clear {
+      background-color: @osu-colour-l1;
+    }
   }
 }

--- a/resources/lang/en/beatmappacks.php
+++ b/resources/lang/en/beatmappacks.php
@@ -39,6 +39,7 @@ return [
     ],
 
     'show' => [
+        'all_cleared' => 'All cleared!',
         'download' => 'Download',
         'item' => [
             'clear' => 'clear',

--- a/resources/lang/en/beatmappacks.php
+++ b/resources/lang/en/beatmappacks.php
@@ -41,8 +41,7 @@ return [
     'show' => [
         'download' => 'Download',
         'item' => [
-            'cleared' => 'cleared',
-            'not_cleared' => 'not cleared',
+            'clear' => 'clear',
         ],
     ],
 

--- a/resources/views/packs/index.blade.php
+++ b/resources/views/packs/index.blade.php
@@ -51,9 +51,19 @@
         <div class="osu-layout__row">
             <div class="beatmap-packs__list js-accordion">
                 @foreach ($packs as $pack)
+                    @php
+                        $cleared = $pack->clearedBy(Auth::user());
+                    @endphp
                     <div class="beatmap-pack js-beatmap-pack js-accordion__item" data-pack-id="{{ $pack['pack_id'] }}">
+                        <div class="beatmap-packs__stripe {{ $cleared ? 'beatmap-packs__stripe--clear' : '' }}"></div>
                         <div class="beatmap-packs__row beatmap-pack__header js-accordion__item-header">
-                            <div class="beatmap-packs__cell beatmap-pack__name">{{ $pack['name'] }}</div>
+                            <div class="beatmap-packs__cell beatmap-pack__name {{ $cleared ? 'beatmap-pack__name--clear' : '' }}">{{ $pack['name'] }}</div>
+                            @if ($cleared)
+                                <div class="beatmap-packs__cell beatmap-pack__clear">
+                                    <span class="fas fa-check"></span>
+                                    {{ trans('beatmappacks.show.all_cleared') }}
+                                </div>
+                            @endif
                             <div class="beatmap-packs__cell beatmap-packs__cell--right">
                                 <span class="beatmap-pack__date">{{ $pack['date']->formatLocalized('%Y-%m-%d') }}</span>
                                 <span class="beatmap-pack__author">by </span>

--- a/resources/views/packs/show.blade.php
+++ b/resources/views/packs/show.blade.php
@@ -27,13 +27,14 @@
 </div>
 <ul class="beatmap-pack-items">
     @foreach ($sets as $set)
-        <li class="beatmap-pack-items__set">
-            <span class="fal fa-extra-mode-{{$mode}} beatmap-pack-items__icon {{ $set->count > 0 ? 'beatmap-pack-items__icon--cleared' : '' }}"
-                  title="{{ $set->count > 0 ? trans('beatmappacks.show.item.cleared') : trans('beatmappacks.show.item.not_cleared') }}"
-            ></span>
+        <li class="beatmap-pack-items__set {{ $set->count > 0 ? 'beatmap-pack-items__set--cleared' : '' }}">
+            <span class="beatmap-pack-items__status">
+                <span class="beatmap-pack-items__clear">{{ trans('beatmappacks.show.item.clear') }}</span>
+            </span>
             <a href="{{ route('beatmapsets.show', ['beatmapset' => $set->getKey()]) }}" class="beatmap-pack-items__link">
                 <span class="beatmap-pack-items__artist">{{ $set->artist }}</span>
                 <span class="beatmap-pack-items__title"> - {{ $set->title }}</span>
             </a>
+        </li>
     @endforeach
 </ul>


### PR DESCRIPTION
closes #2548, fixes #2758
![17ec74](https://user-images.githubusercontent.com/9954349/61996500-c4101400-b049-11e9-9e54-a33e6f364cc8.png)
![11023d](https://user-images.githubusercontent.com/9954349/61996501-c5d9d780-b049-11e9-81f6-2e86fa3043eb.png)


the clear badges keep their width between cleared/uncleared by making the text invisible... not sure if there was a better way to do that

for logged out users all of the empty badges and gray stripes look strange I think I'll hide them