### PR TITLE
Add fonts specific to zh-tw

### DIFF
--- a/resources/assets/less/layout.less
+++ b/resources/assets/less/layout.less
@@ -33,6 +33,7 @@
   --font-default: @font-default;
   --font-default-vi: @font-default-vi;
   --font-default-zh: @font-default-zh;
+  --font-default-zh-tw: @font-default-zh-tw;
   --font-content: @font-content;
 }
 

--- a/resources/assets/less/variables.less
+++ b/resources/assets/less/variables.less
@@ -22,7 +22,7 @@
 @font-default: 'Exo 2', 'Helvetica Neue', Tahoma, Arial, 'Hiragino Kaku Gothic ProN', Meiryo, 'Microsoft YaHei', 'Apple SD Gothic Neo', sans-serif;
 @font-default-vi: Exo, 'Exo 2', 'Helvetica Neue', Tahoma, Arial, 'Hiragino Kaku Gothic ProN', Meiryo, 'Microsoft YaHei', 'Apple SD Gothic Neo', sans-serif;
 @font-default-zh: 'Exo 2', 'Helvetica Neue', Tahoma, Arial, 'Hiragino Sans GB', 'Microsoft YaHei', 'Apple SD Gothic Neo', system-ui, sans-serif;
-@font-default-zh-tw: 'Exo 2', 'Helvetica Neue', Tahoma, Arial, 'Hiragino Sans TC', 'Microsoft JhengHei', 'Apple SD Gothic Neo', system-ui, sans-serif;
+@font-default-zh-tw: 'Exo 2', 'Helvetica Neue', Tahoma, Arial, 'PingFang TC', 'Microsoft JhengHei', 'Apple SD Gothic Neo', system-ui, sans-serif;
 
 @screen-mobile-max: (@screen-sm-min - 1px);
 @desktop: ~"(min-width: @{screen-sm-min})";

--- a/resources/assets/less/variables.less
+++ b/resources/assets/less/variables.less
@@ -22,6 +22,7 @@
 @font-default: 'Exo 2', 'Helvetica Neue', Tahoma, Arial, 'Hiragino Kaku Gothic ProN', Meiryo, 'Microsoft YaHei', 'Apple SD Gothic Neo', sans-serif;
 @font-default-vi: Exo, 'Exo 2', 'Helvetica Neue', Tahoma, Arial, 'Hiragino Kaku Gothic ProN', Meiryo, 'Microsoft YaHei', 'Apple SD Gothic Neo', sans-serif;
 @font-default-zh: 'Exo 2', 'Helvetica Neue', Tahoma, Arial, 'Hiragino Sans GB', 'Microsoft YaHei', 'Apple SD Gothic Neo', system-ui, sans-serif;
+@font-default-zh-tw: 'Exo 2', 'Helvetica Neue', Tahoma, Arial, 'Hiragino Sans TC', 'Microsoft JhengHei', 'Apple SD Gothic Neo', system-ui, sans-serif;
 
 @screen-mobile-max: (@screen-sm-min - 1px);
 @desktop: ~"(min-width: @{screen-sm-min})";

--- a/resources/views/layout/metadata.blade.php
+++ b/resources/views/layout/metadata.blade.php
@@ -47,10 +47,16 @@
             --font-default-override: var(--font-default-vi);
         }
     </style>
-@elseif (App::getLocale() === 'zh' || App::getLocale() === 'zh-tw')
+@elseif (App::getLocale() === 'zh')
     <style>
         :root {
             --font-default-override: var(--font-default-zh);
+        }
+    </style>
+@elseif (App::getLocale() === 'zh-tw')
+    <style>
+        :root {
+            --font-default-override: var(--font-default-zh-tw);
         }
     </style>
 @endif


### PR DESCRIPTION
This commit makes the website use Microsoft JhengHei instead of Microsoft YaHei for Traditional Chinese (`zh-tw`).

I'm not sure what `Hiragino Sans GB` is, but the equivalent for Traditional Chinese is `Hiragino Sans TC`, apparently.

The glyphs for JhengHei adhere to the standards that Taiwan has put out. In general, the font is lighter and increases readability (in my opinion) for Traditional Chinese.

Note for historical purposes: #3560 is the commit that added the `zh` fonts for both Simplified and Traditional Chinese.