### PR TITLE
Fix store cart wrapping

### DIFF
--- a/resources/assets/less/bem/osu-layout.less
+++ b/resources/assets/less/bem/osu-layout.less
@@ -355,6 +355,10 @@
       margin-left: -20px;
       margin-right: -20px;
       padding: 20px 40px;
+
+      @media @narrow {
+        padding: 20px 10px;
+      }
     }
 
     &--lg1-compact {

--- a/resources/assets/less/bem/store-order-item.less
+++ b/resources/assets/less/bem/store-order-item.less
@@ -40,24 +40,27 @@
     align-items: center;
     justify-content: space-between;
 
-    flex-wrap: wrap;
+    @media @narrow {
+      flex-direction: column;
+    }
   }
 
   &__options {
     display: flex;
+    align-self: flex-end;
     justify-content: flex-end;
   }
 
   &__quantity {
-    flex: 0 0 100px;
+    min-width: 100px;
   }
 
   &__name {
-    flex: 0 1 auto;
+    align-self: flex-start;
   }
 
   &__subtotal {
-    flex: 0 0 150px;
+    min-width: 150px;
     padding: 0 20px;
   }
 }


### PR DESCRIPTION
Makes it so the line item doesn't spill off the edge when viewed on narrower widths.

Doesn't do anything about the Xsolla logo as it'd probably have to be made a separate image to move properly