### PR TITLE
Check if score class exists for type

### DIFF
--- a/app/Exceptions/ClassNotFoundException.php
+++ b/app/Exceptions/ClassNotFoundException.php
@@ -1,0 +1,29 @@
+<?php
+
+/**
+ *    Copyright (c) ppy Pty Ltd <contact@ppy.sh>.
+ *
+ *    This file is part of osu!web. osu!web is distributed with the hope of
+ *    attracting more community contributions to the core ecosystem of osu!.
+ *
+ *    osu!web is free software: you can redistribute it and/or modify
+ *    it under the terms of the Affero GNU General Public License version 3
+ *    as published by the Free Software Foundation.
+ *
+ *    osu!web is distributed WITHOUT ANY WARRANTY; without even the implied
+ *    warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *    See the GNU Affero General Public License for more details.
+ *
+ *    You should have received a copy of the GNU Affero General Public License
+ *    along with osu!web.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace App\Exceptions;
+
+class ClassNotFoundException extends SilencedException
+{
+    public function getStatusCode()
+    {
+        return 404;
+    }
+}

--- a/app/Http/Controllers/RankingController.php
+++ b/app/Http/Controllers/RankingController.php
@@ -58,7 +58,7 @@ class RankingController extends Controller
                 return ujs_redirect(route('rankings', ['mode' => 'osu', 'type' => 'performance']));
             }
 
-            if (!array_key_exists($mode, Beatmap::MODES)) {
+            if (!Beatmap::isModeValid($mode)) {
                 abort(404);
             }
 

--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -263,7 +263,7 @@ class UsersController extends Controller
 
         $currentMode = $mode ?? $user->playmode;
 
-        if (!array_key_exists($currentMode, Beatmap::MODES)) {
+        if (!Beatmap::isModeValid($currentMode)) {
             abort(404);
         }
 
@@ -368,7 +368,7 @@ class UsersController extends Controller
         }
 
         $this->mode = Request::route('mode') ?? Request::input('mode') ?? $this->user->playmode;
-        if (!array_key_exists($this->mode, Beatmap::MODES)) {
+        if (!Beatmap::isModeValid($this->mode)) {
             abort(404);
         }
 

--- a/app/Libraries/Search/BeatmapsetSearchRequestParams.php
+++ b/app/Libraries/Search/BeatmapsetSearchRequestParams.php
@@ -74,7 +74,7 @@ class BeatmapsetSearchRequestParams extends BeatmapsetSearchParams
             );
 
             $this->mode = get_int($request['m']);
-            if (!in_array($this->mode, Beatmap::MODES, true)) {
+            if (!Beatmap::isModeValid($this->mode)) {
                 $this->mode = null;
             }
 

--- a/app/Libraries/Search/BeatmapsetSearchRequestParams.php
+++ b/app/Libraries/Search/BeatmapsetSearchRequestParams.php
@@ -74,7 +74,7 @@ class BeatmapsetSearchRequestParams extends BeatmapsetSearchParams
             );
 
             $this->mode = get_int($request['m']);
-            if (!Beatmap::isModeValid($this->mode)) {
+            if (!in_array($this->mode, Beatmap::MODES, true)) {
                 $this->mode = null;
             }
 

--- a/app/Models/Beatmap.php
+++ b/app/Models/Beatmap.php
@@ -189,7 +189,7 @@ class Beatmap extends Model
     {
         $mode ?? ($mode = $this->mode);
 
-        if (!array_key_exists($mode, static::MODES)) {
+        if (!static::isModeValid($mode)) {
             throw new ScoreRetrievalException(trans('errors.beatmaps.invalid_mode'));
         }
 

--- a/app/Models/Beatmap.php
+++ b/app/Models/Beatmap.php
@@ -79,6 +79,11 @@ class Beatmap extends Model
         'mania' => 3,
     ];
 
+    public static function isModeValid(?string $mode)
+    {
+        return array_key_exists($mode, static::MODES);
+    }
+
     public static function modeInt($str)
     {
         return static::MODES[$str] ?? null;

--- a/app/Models/Score/Model.php
+++ b/app/Models/Score/Model.php
@@ -20,6 +20,7 @@
 
 namespace App\Models\Score;
 
+use App\Exceptions\ClassNotFoundException;
 use App\Models\Beatmap;
 use App\Models\Model as BaseModel;
 use App\Models\User;
@@ -82,6 +83,8 @@ abstract class Model extends BaseModel
         if (class_exists($className)) {
             return $className;
         }
+
+        throw new ClassNotFoundException();
     }
 
     public static function getMode() : string

--- a/app/Models/Score/Model.php
+++ b/app/Models/Score/Model.php
@@ -78,7 +78,7 @@ abstract class Model extends BaseModel
 
     public static function getClassByString(string $mode)
     {
-        $className = get_class_namespace(static::class).'\\'.studly_case($mode);
+        $className = get_class_namespace(static::class).'\\'.studly_case(str_replace('\\', '', $mode));
         if (class_exists($className)) {
             return $className;
         }

--- a/app/Models/Score/Model.php
+++ b/app/Models/Score/Model.php
@@ -79,12 +79,11 @@ abstract class Model extends BaseModel
 
     public static function getClassByString(string $mode)
     {
-        $className = get_class_namespace(static::class).'\\'.studly_case(str_replace('\\', '', $mode));
-        if (class_exists($className)) {
-            return $className;
+        if (!Beatmap::isModeValid($mode)) {
+            throw new ClassNotFoundException();
         }
 
-        throw new ClassNotFoundException();
+        return get_class_namespace(static::class).'\\'.studly_case($mode);
     }
 
     public static function getMode() : string

--- a/app/Models/Score/Model.php
+++ b/app/Models/Score/Model.php
@@ -78,7 +78,10 @@ abstract class Model extends BaseModel
 
     public static function getClassByString(string $mode)
     {
-        return get_class_namespace(static::class).'\\'.studly_case($mode);
+        $className = get_class_namespace(static::class).'\\'.studly_case($mode);
+        if (class_exists($className)) {
+            return $className;
+        }
     }
 
     public static function getMode() : string

--- a/app/Models/UserStatistics/Model.php
+++ b/app/Models/UserStatistics/Model.php
@@ -21,6 +21,7 @@
 namespace App\Models\UserStatistics;
 
 use App\Exceptions\ClassNotFoundException;
+use App\Models\Beatmap;
 use App\Models\Model as BaseModel;
 use App\Models\User;
 
@@ -78,16 +79,11 @@ abstract class Model extends BaseModel
 
     public static function getClass($modeStr)
     {
-        if ($modeStr === null) {
-            return;
+        if (!Beatmap::isModeValid($modeStr)) {
+            throw new ClassNotFoundException();
         }
 
-        $class = get_class_namespace(static::class).'\\'.studly_case(str_replace('\\', '', $modeStr));
-        if (class_exists($class)) {
-            return $class;
-        }
-
-        throw new ClassNotFoundException();
+        return get_class_namespace(static::class).'\\'.studly_case($modeStr);
     }
 
     public function __construct($attributes = [], $zeroInsteadOfNull = true)

--- a/app/Models/UserStatistics/Model.php
+++ b/app/Models/UserStatistics/Model.php
@@ -20,6 +20,7 @@
 
 namespace App\Models\UserStatistics;
 
+use App\Exceptions\ClassNotFoundException;
 use App\Models\Model as BaseModel;
 use App\Models\User;
 
@@ -81,7 +82,12 @@ abstract class Model extends BaseModel
             return;
         }
 
-        return get_class_namespace(static::class).'\\'.studly_case($modeStr);
+        $class = get_class_namespace(static::class).'\\'.studly_case(str_replace('\\', '', $modeStr));
+        if (class_exists($class)) {
+            return $class;
+        }
+
+        throw new ClassNotFoundException();
     }
 
     public function __construct($attributes = [], $zeroInsteadOfNull = true)

--- a/tests/Controllers/BeatmapControllerTest.php
+++ b/tests/Controllers/BeatmapControllerTest.php
@@ -30,6 +30,13 @@ class BeatmapControllerTest extends TestCase
         $this->beatmap = factory(Beatmap::class)->states('approved')->create();
     }
 
+    public function testInvalidMode()
+    {
+        $this->json('GET', route('beatmaps.scores', ['id' => $this->beatmap->beatmap_id]), [
+            'mode' => 'nope',
+        ])->assertStatus(404);
+    }
+
     /**
      * Checks whether HTTP 403 is thrown when a logged out
      * user tries to access the non-general (country or friend ranking)

--- a/tests/Controllers/RankingsControllerTest.php
+++ b/tests/Controllers/RankingsControllerTest.php
@@ -17,7 +17,6 @@
  *    You should have received a copy of the GNU Affero General Public License
  *    along with osu!web.  If not, see <http://www.gnu.org/licenses/>.
  */
-
 class RankingsControllerTest extends TestCase
 {
     public function testIndex()

--- a/tests/Controllers/RankingsControllerTest.php
+++ b/tests/Controllers/RankingsControllerTest.php
@@ -1,0 +1,50 @@
+<?php
+
+/**
+ *    Copyright (c) ppy Pty Ltd <contact@ppy.sh>.
+ *
+ *    This file is part of osu!web. osu!web is distributed with the hope of
+ *    attracting more community contributions to the core ecosystem of osu!.
+ *
+ *    osu!web is free software: you can redistribute it and/or modify
+ *    it under the terms of the Affero GNU General Public License version 3
+ *    as published by the Free Software Foundation.
+ *
+ *    osu!web is distributed WITHOUT ANY WARRANTY; without even the implied
+ *    warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *    See the GNU Affero General Public License for more details.
+ *
+ *    You should have received a copy of the GNU Affero General Public License
+ *    along with osu!web.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+class RankingsControllerTest extends TestCase
+{
+    public function testIndex()
+    {
+        $this
+            ->get(route('rankings', ['mode' => 'osu', 'type' => 'performance']))
+            ->assertSuccessful();
+    }
+
+    public function testIndexRedirect()
+    {
+        $this
+            ->get(route('rankings', ['mode' => 'osu']))
+            ->assertRedirect(route('rankings', ['mode' => 'osu', 'type' => 'performance']));
+    }
+
+    public function testIndexInvalidMode()
+    {
+        $this
+            ->get(route('rankings', ['mode' => 'nope', 'type' => 'performance']))
+            ->assertStatus(404);
+    }
+
+    public function testIndexInvalidType()
+    {
+        $this
+            ->get(route('rankings', ['mode' => 'osu', 'type' => 'notatype']))
+            ->assertStatus(404);
+    }
+}

--- a/tests/Controllers/ScoresControllerTest.php
+++ b/tests/Controllers/ScoresControllerTest.php
@@ -1,0 +1,78 @@
+<?php
+
+/**
+ *    Copyright (c) ppy Pty Ltd <contact@ppy.sh>.
+ *
+ *    This file is part of osu!web. osu!web is distributed with the hope of
+ *    attracting more community contributions to the core ecosystem of osu!.
+ *
+ *    osu!web is free software: you can redistribute it and/or modify
+ *    it under the terms of the Affero GNU General Public License version 3
+ *    as published by the Free Software Foundation.
+ *
+ *    osu!web is distributed WITHOUT ANY WARRANTY; without even the implied
+ *    warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *    See the GNU Affero General Public License for more details.
+ *
+ *    You should have received a copy of the GNU Affero General Public License
+ *    along with osu!web.  If not, see <http://www.gnu.org/licenses/>.
+ */
+use App\Models\Score\Best\Osu;
+use App\Models\User;
+
+class ScoresControllerTest extends TestCase
+{
+    private $score;
+    private $user;
+
+    public function setUp()
+    {
+        parent::setUp();
+        $this->user = factory(User::class)->create();
+        $this->score = factory(Osu::class)->create();
+    }
+
+    public function testDownload()
+    {
+        $this
+            ->actingAs($this->user)
+            ->json(
+                'POST',
+                route('scores.report', ['mode' => 'osu', 'score' => $this->score->getKey()])
+            )
+            ->assertSuccessful();
+    }
+
+    public function testDownloadInvalidMode()
+    {
+        $this
+            ->actingAs($this->user)
+            ->json(
+                'GET',
+                route('scores.download', ['mode' => 'nope', 'score' => $this->score->getKey()])
+            )
+            ->assertStatus(404);
+    }
+
+    public function testReport()
+    {
+        $this
+            ->actingAs($this->user)
+            ->json(
+                'POST',
+                route('scores.report', ['mode' => 'osu', 'score' => $this->score->getKey()])
+            )
+            ->assertSuccessful();
+    }
+
+    public function testReportInvalidMode()
+    {
+        $this
+            ->actingAs($this->user)
+            ->json(
+                'POST',
+                route('scores.report', ['mode' => 'nope', 'score' => $this->score->getKey()])
+            )
+            ->assertStatus(404);
+    }
+}

--- a/tests/Models/Score/ModelTest.php
+++ b/tests/Models/Score/ModelTest.php
@@ -36,19 +36,22 @@ class ModelTest extends TestCase
         }
     }
 
-    public function testGetClassByStringThrowsExceptionIfModeDoesNotExist()
+    /**
+     * @dataProvider modes
+     */
+    public function testGetClassByStringThrowsExceptionIfModeDoesNotExist($mode)
     {
-        $modes = ['does', 'not exist', 'not_real', 'best\\_osu'];
-        $errored = [];
-        foreach ($modes as $mode) {
-            try {
-                Model::getClassByString($mode);
-            } catch (ClassNotFoundException $_e) {
-                $errored[] = $mode;
-            }
-        }
+        $this->expectException(ClassNotFoundException::class);
+        Model::getClassByString($mode);
+    }
 
-        // assert with canonicalize = true to print the missing error
-        $this->assertEquals($modes, $errored, '', 0, 10, true);
+    public function modes()
+    {
+        return [
+            ['does'],
+            ['not exist'],
+            ['not_real'],
+            ['best\\_osu'],
+        ];
     }
 }

--- a/tests/Models/Score/ModelTest.php
+++ b/tests/Models/Score/ModelTest.php
@@ -17,6 +17,7 @@
  *    You should have received a copy of the GNU Affero General Public License
  *    along with osu!web.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 namespace Tests\Score;
 
 use App\Exceptions\ClassNotFoundException;

--- a/tests/Models/Score/ModelTest.php
+++ b/tests/Models/Score/ModelTest.php
@@ -1,0 +1,53 @@
+<?php
+
+/**
+ *    Copyright (c) ppy Pty Ltd <contact@ppy.sh>.
+ *
+ *    This file is part of osu!web. osu!web is distributed with the hope of
+ *    attracting more community contributions to the core ecosystem of osu!.
+ *
+ *    osu!web is free software: you can redistribute it and/or modify
+ *    it under the terms of the Affero GNU General Public License version 3
+ *    as published by the Free Software Foundation.
+ *
+ *    osu!web is distributed WITHOUT ANY WARRANTY; without even the implied
+ *    warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *    See the GNU Affero General Public License for more details.
+ *
+ *    You should have received a copy of the GNU Affero General Public License
+ *    along with osu!web.  If not, see <http://www.gnu.org/licenses/>.
+ */
+namespace Tests\Score;
+
+use App\Exceptions\ClassNotFoundException;
+use App\Models\Beatmap;
+use App\Models\Score\Model;
+use TestCase;
+
+class ModelTest extends TestCase
+{
+    public function testGetClassByString()
+    {
+        $modes = array_keys(Beatmap::MODES);
+        foreach ($modes as $mode) {
+            $class = Model::getClassByString($mode);
+            $this->assertInstanceOf(Model::class, new $class);
+        }
+    }
+
+    public function testGetClassByStringThrowsExceptionIfModeDoesNotExist()
+    {
+        $modes = ['does', 'not exist', 'not_real', 'best\\_osu'];
+        $errored = [];
+        foreach ($modes as $mode) {
+            try {
+                Model::getClassByString($mode);
+            } catch (ClassNotFoundException $_e) {
+                $errored[] = $mode;
+            }
+        }
+
+        // assert with canonicalize = true to print the missing error
+        $this->assertEquals($modes, $errored, '', 0, 10, true);
+    }
+}

--- a/tests/Models/UserStatistics/ModelTest.php
+++ b/tests/Models/UserStatistics/ModelTest.php
@@ -1,0 +1,53 @@
+<?php
+
+/**
+ *    Copyright (c) ppy Pty Ltd <contact@ppy.sh>.
+ *
+ *    This file is part of osu!web. osu!web is distributed with the hope of
+ *    attracting more community contributions to the core ecosystem of osu!.
+ *
+ *    osu!web is free software: you can redistribute it and/or modify
+ *    it under the terms of the Affero GNU General Public License version 3
+ *    as published by the Free Software Foundation.
+ *
+ *    osu!web is distributed WITHOUT ANY WARRANTY; without even the implied
+ *    warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *    See the GNU Affero General Public License for more details.
+ *
+ *    You should have received a copy of the GNU Affero General Public License
+ *    along with osu!web.  If not, see <http://www.gnu.org/licenses/>.
+ */
+namespace Tests\UserStatistics;
+
+use App\Exceptions\ClassNotFoundException;
+use App\Models\Beatmap;
+use App\Models\UserStatistics\Model;
+use TestCase;
+
+class ModelTest extends TestCase
+{
+    public function testGetClass()
+    {
+        $modes = array_keys(Beatmap::MODES);
+        foreach ($modes as $mode) {
+            $class = Model::getClass($mode);
+            $this->assertInstanceOf(Model::class, new $class);
+        }
+    }
+
+    public function testGetClassByThrowsExceptionIfModeDoesNotExist()
+    {
+        $modes = ['does', 'not exist', 'not_real', 'best\\_osu'];
+        $errored = [];
+        foreach ($modes as $mode) {
+            try {
+                Model::getClass($mode);
+            } catch (ClassNotFoundException $_e) {
+                $errored[] = $mode;
+            }
+        }
+
+        // assert with canonicalize = true to print the missing error
+        $this->assertEquals($modes, $errored, '', 0, 10, true);
+    }
+}

--- a/tests/Models/UserStatistics/ModelTest.php
+++ b/tests/Models/UserStatistics/ModelTest.php
@@ -17,6 +17,7 @@
  *    You should have received a copy of the GNU Affero General Public License
  *    along with osu!web.  If not, see <http://www.gnu.org/licenses/>.
  */
+
 namespace Tests\UserStatistics;
 
 use App\Exceptions\ClassNotFoundException;

--- a/tests/Models/UserStatistics/ModelTest.php
+++ b/tests/Models/UserStatistics/ModelTest.php
@@ -36,19 +36,22 @@ class ModelTest extends TestCase
         }
     }
 
-    public function testGetClassByThrowsExceptionIfModeDoesNotExist()
+    /**
+     * @dataProvider modes
+     */
+    public function testGetClassByThrowsExceptionIfModeDoesNotExist($mode)
     {
-        $modes = ['does', 'not exist', 'not_real', 'best\\_osu'];
-        $errored = [];
-        foreach ($modes as $mode) {
-            try {
-                Model::getClass($mode);
-            } catch (ClassNotFoundException $_e) {
-                $errored[] = $mode;
-            }
-        }
+        $this->expectException(ClassNotFoundException::class);
+        Model::getClass($mode);
+    }
 
-        // assert with canonicalize = true to print the missing error
-        $this->assertEquals($modes, $errored, '', 0, 10, true);
+    public function modes()
+    {
+        return [
+            ['does'],
+            ['not exist'],
+            ['not_real'],
+            ['best\\_osu'],
+        ];
     }
 }


### PR DESCRIPTION
Throws an exception that triggers a 404 if trying to do a lookup with a mode that doesn't have a corresponding model class.