### PR TITLE
Allow setting non-user-default mode for /me

### DIFF
--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -225,9 +225,9 @@ class UsersController extends Controller
         return response($json, is_null($json['error'] ?? null) ? 200 : 504);
     }
 
-    public function me()
+    public function me($mode = null)
     {
-        return self::show(Auth::user()->user_id);
+        return static::show(auth()->user()->user_id, $mode);
     }
 
     public function show($id, $mode = null)

--- a/routes/web.php
+++ b/routes/web.php
@@ -370,7 +370,7 @@ Route::group(['as' => 'api.', 'prefix' => 'api', 'middleware' => ['auth-custom-a
         Route::resource('friends', 'FriendsController', ['only' => ['index']]);
 
         //  GET /api/v2/me
-        Route::get('me', 'UsersController@me');
+        Route::get('me/{mode?}', 'UsersController@me');
         //  GET /api/v2/me/download-quota-check
         Route::get('me/download-quota-check', 'HomeController@downloadQuotaCheck');
 

--- a/tests/RouteScopesTest.php
+++ b/tests/RouteScopesTest.php
@@ -23,7 +23,7 @@ class RouteScopesTest extends TestCase
     {
         $expected = [
             'api/v2/friends' => ['friends.read'],
-            'api/v2/me' => ['identify'],
+            'api/v2/me/{mode?}' => ['identify'],
         ];
 
         $loaded = [];


### PR DESCRIPTION
Similar to `users/:id/:mode`, it's `me/:mode`