### PR TITLE
Fix changelog redirect handling

### DIFF
--- a/app/Http/Controllers/ChangelogController.php
+++ b/app/Http/Controllers/ChangelogController.php
@@ -111,9 +111,21 @@ class ChangelogController extends Controller
         if (request('key') === 'id') {
             $build = Build::default()->findOrFail($version);
         } else {
+            // Search by exact version first.
             $build = Build::default()->where('version', '=', $version)->first();
         }
 
+        // Failing that, check if $version is actually a stream name.
+        if ($build === null) {
+            $stream = UpdateStream::where('name', '=', $version)->first();
+
+            if ($stream !== null) {
+                $build = $stream->builds()->default()->orderBy('build_id', 'desc')->first();
+            }
+        }
+
+        // When there's no build found, strip everything but numbers and dots then search again.
+        // 404 if still nothing found.
         if ($build === null) {
             $normalizedVersion = preg_replace('#[^0-9.]#', '', $version);
 
@@ -146,14 +158,6 @@ class ChangelogController extends Controller
         } else {
             return view('changelog.build', compact('build', 'buildJson', 'chartConfig', 'commentBundle'));
         }
-    }
-
-    public function stream($streamName)
-    {
-        $stream = UpdateStream::where('name', '=', $streamName)->firstOrFail();
-        $build = $stream->builds()->default()->orderBy('build_id', 'desc')->firstOrFail();
-
-        return ujs_redirect(build_url($build));
     }
 
     private function getUpdateStreams()

--- a/resources/views/vendor/apidoc/partials/info.blade.php
+++ b/resources/views/vendor/apidoc/partials/info.blade.php
@@ -58,7 +58,7 @@ You must replace <code>@{{token}}</code> with your OAuth2 token.
 # Changelog
 
 For a full list of changes, see the
-[Changelog on the site]({{ route('changelog.stream', ['stream' => 'web']) }}).
+[Changelog on the site]({{ route('changelog.show', ['version' => 'web']) }}).
 
 ## Breaking Changes
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -183,7 +183,6 @@ Route::group(['prefix' => 'home'], function () {
     Route::get('search', 'HomeController@search')->name('search');
     Route::post('bbcode-preview', 'HomeController@bbcodePreview')->name('bbcode-preview');
     Route::get('changelog/{stream}/{build}', 'ChangelogController@build')->name('changelog.build');
-    Route::get('changelog/{stream}', 'ChangelogController@stream')->name('changelog.stream');
     Route::post('changelog/github', 'ChangelogController@github');
     Route::resource('changelog', 'ChangelogController', ['only' => ['index', 'show']]);
     Route::get('download', 'HomeController@getDownload')->name('download');


### PR DESCRIPTION
The recently added route overlaps with existing route.
This merges both actions and handle the best it can.