### PR TITLE
Add new column for beatmap discussion sorting order

### DIFF
--- a/app/Models/BeatmapDiscussion.php
+++ b/app/Models/BeatmapDiscussion.php
@@ -58,7 +58,7 @@ class BeatmapDiscussion extends Model
         'resolved' => 'boolean',
     ];
 
-    protected $dates = ['deleted_at'];
+    protected $dates = ['deleted_at', 'last_reply_at'];
 
     const KUDOSU_STEPS = [1, 2, 5];
 
@@ -585,11 +585,7 @@ class BeatmapDiscussion extends Model
                 BeatmapsetEvent::log(BeatmapsetEvent::DISCUSSION_RESTORE, $restoredBy, $this)->saveOrExplode();
             }
 
-            $timestamps = $this->timestamps;
-            $this->timestamps = false;
             $this->update(['deleted_at' => null]);
-            $this->timestamps = $timestamps;
-
             $this->refreshKudosu('restore');
         });
     }
@@ -610,24 +606,17 @@ class BeatmapDiscussion extends Model
 
     public function softDeleteOrExplode($deletedBy)
     {
-        $timestamps = $this->timestamps;
+        DB::transaction(function () use ($deletedBy) {
+            if ($deletedBy->getKey() !== $this->user_id) {
+                BeatmapsetEvent::log(BeatmapsetEvent::DISCUSSION_DELETE, $deletedBy, $this)->saveOrExplode();
+            }
 
-        try {
-            DB::transaction(function () use ($deletedBy) {
-                if ($deletedBy->getKey() !== $this->user_id) {
-                    BeatmapsetEvent::log(BeatmapsetEvent::DISCUSSION_DELETE, $deletedBy, $this)->saveOrExplode();
-                }
-
-                $this->timestamps = false;
-                $this->fill([
-                    'deleted_by_id' => $deletedBy->user_id ?? null,
-                    'deleted_at' => Carbon::now(),
-                ])->saveOrExplode();
-                $this->refreshKudosu('delete');
-            });
-        } finally {
-            $this->timestamps = $timestamps;
-        }
+            $this->fill([
+                'deleted_by_id' => $deletedBy->user_id ?? null,
+                'deleted_at' => Carbon::now(),
+            ])->saveOrExplode();
+            $this->refreshKudosu('delete');
+        });
     }
 
     public function trashed()

--- a/app/Models/BeatmapDiscussion.php
+++ b/app/Models/BeatmapDiscussion.php
@@ -58,7 +58,7 @@ class BeatmapDiscussion extends Model
         'resolved' => 'boolean',
     ];
 
-    protected $dates = ['deleted_at', 'last_reply_at'];
+    protected $dates = ['deleted_at', 'last_post_at'];
 
     const KUDOSU_STEPS = [1, 2, 5];
 

--- a/app/Models/BeatmapDiscussionPost.php
+++ b/app/Models/BeatmapDiscussionPost.php
@@ -216,7 +216,7 @@ class BeatmapDiscussionPost extends Model
         try {
             return $this->getConnection()->transaction(function () use ($options) {
                 if (!$this->exists) {
-                    $this->beatmapDiscussion->update(['last_reply_at' => Carbon::now()]);
+                    $this->beatmapDiscussion->update(['last_post_at' => Carbon::now()]);
                 }
 
                 if (!parent::save($options)) {

--- a/app/Models/BeatmapDiscussionVote.php
+++ b/app/Models/BeatmapDiscussionVote.php
@@ -34,6 +34,8 @@ use Carbon\Carbon;
  */
 class BeatmapDiscussionVote extends Model
 {
+    protected $touches = ['beatmapDiscussion'];
+
     public static function recentlyReceivedByUser($userId, $timeframeMonths = 3)
     {
         $query = static::with('user')->where('created_at', '>', Carbon::now()->subMonth($timeframeMonths));

--- a/app/Transformers/BeatmapDiscussionTransformer.php
+++ b/app/Transformers/BeatmapDiscussionTransformer.php
@@ -51,6 +51,7 @@ class BeatmapDiscussionTransformer extends Fractal\TransformerAbstract
             'created_at' => json_time($discussion->created_at),
             'updated_at' => json_time($discussion->updated_at),
             'deleted_at' => json_time($discussion->deleted_at),
+            'last_reply_at' => json_time($discussion->last_reply_at),
             'votes' => $discussion->votesSummary(),
 
             'kudosu_denied' => $discussion->kudosu_denied,

--- a/app/Transformers/BeatmapDiscussionTransformer.php
+++ b/app/Transformers/BeatmapDiscussionTransformer.php
@@ -51,7 +51,7 @@ class BeatmapDiscussionTransformer extends Fractal\TransformerAbstract
             'created_at' => json_time($discussion->created_at),
             'updated_at' => json_time($discussion->updated_at),
             'deleted_at' => json_time($discussion->deleted_at),
-            'last_reply_at' => json_time($discussion->last_reply_at),
+            'last_post_at' => json_time($discussion->last_post_at),
             'votes' => $discussion->votesSummary(),
 
             'kudosu_denied' => $discussion->kudosu_denied,

--- a/database/migrations/2019_08_07_070216_add_last_post_at_to_beatmap_discussions.php
+++ b/database/migrations/2019_08_07_070216_add_last_post_at_to_beatmap_discussions.php
@@ -15,7 +15,6 @@ class AddLastPostAtToBeatmapDiscussions extends Migration
     {
         Schema::table('beatmap_discussions', function (Blueprint $table) {
             $table->timestamp('last_post_at')->nullable();
-            $table->index(['user_id', 'updated_at']);
         });
 
         // use the current updated_at timestamp as last_post_at's initial value

--- a/database/migrations/2019_08_07_070216_add_last_post_at_to_beatmap_discussions.php
+++ b/database/migrations/2019_08_07_070216_add_last_post_at_to_beatmap_discussions.php
@@ -4,7 +4,7 @@ use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;
 
-class AddLastReplyAtToBeatmapDiscussions extends Migration
+class AddLastPostAtToBeatmapDiscussions extends Migration
 {
     /**
      * Run the migrations.
@@ -14,12 +14,12 @@ class AddLastReplyAtToBeatmapDiscussions extends Migration
     public function up()
     {
         Schema::table('beatmap_discussions', function (Blueprint $table) {
-            $table->timestamp('last_reply_at')->nullable();
+            $table->timestamp('last_post_at')->nullable();
             $table->index(['user_id', 'updated_at']);
         });
 
-        // use the current updated_at timestamp as last_reply_at's initial value
-        DB::statement('UPDATE beatmap_discussions SET last_reply_at = updated_at');
+        // use the current updated_at timestamp as last_post_at's initial value
+        DB::statement('UPDATE beatmap_discussions SET last_post_at = updated_at');
     }
 
     /**
@@ -30,7 +30,7 @@ class AddLastReplyAtToBeatmapDiscussions extends Migration
     public function down()
     {
         Schema::table('beatmap_discussions', function (Blueprint $table) {
-            $table->dropColumn('last_reply_at');
+            $table->dropColumn('last_post_at');
         });
     }
 }

--- a/database/migrations/2019_08_07_070216_add_last_reply_at_to_beatmap_discussions.php
+++ b/database/migrations/2019_08_07_070216_add_last_reply_at_to_beatmap_discussions.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddLastReplyAtToBeatmapDiscussions extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('beatmap_discussions', function (Blueprint $table) {
+            $table->timestamp('last_reply_at')->nullable();
+        });
+
+        // use the current updated_at timestamp as last_reply_at's initial value
+        DB::statement('UPDATE beatmap_discussions SET last_reply_at = updated_at');
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('beatmap_discussions', function (Blueprint $table) {
+            $table->dropColumn('last_reply_at');
+        });
+    }
+}

--- a/database/migrations/2019_08_07_070216_add_last_reply_at_to_beatmap_discussions.php
+++ b/database/migrations/2019_08_07_070216_add_last_reply_at_to_beatmap_discussions.php
@@ -15,6 +15,7 @@ class AddLastReplyAtToBeatmapDiscussions extends Migration
     {
         Schema::table('beatmap_discussions', function (Blueprint $table) {
             $table->timestamp('last_reply_at')->nullable();
+            $table->index(['user_id', 'updated_at']);
         });
 
         // use the current updated_at timestamp as last_reply_at's initial value

--- a/resources/assets/coffee/react/beatmap-discussions/discussions.coffee
+++ b/resources/assets/coffee/react/beatmap-discussions/discussions.coffee
@@ -29,10 +29,10 @@ sortPresets =
   updated_at:
     text: osu.trans('beatmaps.discussions.sort.updated_at')
     sort: (a, b) ->
-      if a.last_reply_at == b.last_reply_at
+      if a.last_post_at == b.last_post_at
         b.id - a.id
       else
-        Date.parse(b.last_reply_at) - Date.parse(a.last_reply_at)
+        Date.parse(b.last_post_at) - Date.parse(a.last_post_at)
 
   created_at:
     text: osu.trans('beatmaps.discussions.sort.created_at')

--- a/resources/assets/coffee/react/beatmap-discussions/discussions.coffee
+++ b/resources/assets/coffee/react/beatmap-discussions/discussions.coffee
@@ -29,10 +29,10 @@ sortPresets =
   updated_at:
     text: osu.trans('beatmaps.discussions.sort.updated_at')
     sort: (a, b) ->
-      if a.updated_at == b.updated_at
+      if a.last_reply_at == b.last_reply_at
         b.id - a.id
       else
-        Date.parse(b.updated_at) - Date.parse(a.updated_at)
+        Date.parse(b.last_reply_at) - Date.parse(a.last_reply_at)
 
   created_at:
     text: osu.trans('beatmaps.discussions.sort.created_at')


### PR DESCRIPTION
Should stop editing/deleting/restoring posts from bumping discussions in 'last updated' view.

(also lays the groundwork for some future optimisations)