### PR TITLE
Fix mode tab using incorrect colours when disabled

### DIFF
--- a/resources/assets/less/bem/page-mode-link.less
+++ b/resources/assets/less/bem/page-mode-link.less
@@ -43,8 +43,12 @@
   }
 
   &--is-disabled {
-    .link-gray-555();
+    color: @osu-colour-f1;
     cursor: default;
+
+    .link-hover({
+      color: @osu-colour-f1;
+    });
 
     &.@{top}--white {
       .link-white();


### PR DESCRIPTION
This thing: ![](https://puu.sh/E2Hx3/dd94cc1b28.png)