### PR TITLE
Fix wrong user card tooltip on keyed components

### DIFF
--- a/resources/assets/lib/user-card-tooltip.tsx
+++ b/resources/assets/lib/user-card-tooltip.tsx
@@ -122,7 +122,10 @@ function onMouseOver(event: JQueryEventObject) {
   if (el._tooltip !== el.dataset.userId) {
     // wrong userId, destroy current tooltip
     const qtip = $(el).qtip('api');
-    if (qtip != null) { qtip.destroy(); }
+    if (qtip != null) {
+      qtip.destroy();
+      delete el._tooltip;
+    }
   }
 }
 

--- a/resources/assets/lib/user-card-tooltip.tsx
+++ b/resources/assets/lib/user-card-tooltip.tsx
@@ -137,9 +137,16 @@ function hideEffect() {
   $(this).fadeTo(110, 0);
 }
 
-function shouldShow(event: JQueryEventObject) {
+function shouldShow(event: JQueryEventObject, api: any) {
   if (tooltipWithActiveMenu != null || osu.isMobile()) {
+    return event.preventDefault();
+  }
+
+  // keyed React components can end up with reused DOM elements with a previously set tooltip.
+  const target = api.target[0] as HTMLElement;
+  if (target._tooltip !== target.dataset.userId) {
     event.preventDefault();
+    $(target).trigger('mouseover');
   }
 }
 


### PR DESCRIPTION
Wrong tooltip gets shown on reused DOM elements since there's already a tooltip bound to them