### PR TITLE
Fix component not unmounted when removing user card tooltip

### DIFF
--- a/resources/assets/lib/user-card-tooltip.tsx
+++ b/resources/assets/lib/user-card-tooltip.tsx
@@ -18,6 +18,7 @@
 
 import * as _ from 'lodash';
 import * as React from 'react';
+import { unmountComponentAtNode } from 'react-dom';
 import { activeKeyDidChange as contextActiveKeyDidChange, ContainerContext, KeyContext, State as ActiveKeyState } from 'stateful-activation-context';
 import { TooltipContext } from 'tooltip-context';
 import { UserCard } from 'user-card';
@@ -123,6 +124,7 @@ function onMouseOver(event: JQueryEventObject) {
     // wrong userId, destroy current tooltip
     const qtip = $(el).qtip('api');
     if (qtip != null) {
+      unmountComponentAtNode(qtip.tooltip.find('.js-react--user-card-tooltip')[0]);
       qtip.destroy();
       delete el._tooltip;
     }

--- a/resources/assets/lib/user-card-tooltip.tsx
+++ b/resources/assets/lib/user-card-tooltip.tsx
@@ -124,7 +124,10 @@ function onMouseOver(event: JQueryEventObject) {
     // wrong userId, destroy current tooltip
     const qtip = $(el).qtip('api');
     if (qtip != null) {
-      unmountComponentAtNode(qtip.tooltip.find('.js-react--user-card-tooltip')[0]);
+      if (qtip.tooltip != null) {
+        unmountComponentAtNode(qtip.tooltip.find('.js-react--user-card-tooltip')[0]);
+      }
+
       qtip.destroy();
       delete el._tooltip;
     }


### PR DESCRIPTION
Fixes navigation dying after a tooltip gets replaced on a reused DOM element.
