### PR TITLE
Modding profile fixes and optimisations

### DIFF
--- a/app/Http/Controllers/Users/ModdingHistoryController.php
+++ b/app/Http/Controllers/Users/ModdingHistoryController.php
@@ -59,10 +59,7 @@ class ModdingHistoryController extends Controller
             $this->searchParams = array_merge(['user' => $this->user->user_id], request()->query());
             $this->searchParams['is_moderator'] = $this->isModerator;
             $this->searchParams['is_kudosu_moderator'] = $this->isKudosuModerator;
-
-            if (!$this->isModerator) {
-                $this->searchParams['with_deleted'] = false;
-            }
+            $this->searchParams['with_deleted'] = $this->isModerator;
 
             return $next($request);
         });
@@ -76,30 +73,37 @@ class ModdingHistoryController extends Controller
 
         $this->searchParams['limit'] = 10;
         $this->searchParams['sort'] = 'id_desc';
-        $this->searchParams['with_deleted'] = $this->isModerator;
 
         $discussions = BeatmapDiscussion::search($this->searchParams);
-        $discussions['items'] = $discussions['query']->with([
+        $discussions['query']->with([
             'beatmap',
             'beatmapDiscussionVotes',
             'beatmapset',
             'startingPost',
-        ])->get();
+        ]);
+
+        if ($this->isModerator) {
+            $discussions['query']->visibleWithTrashed();
+        } else {
+            $discussions['query']->visible();
+        }
+
+        $discussions['items'] = $discussions['query']->get();
 
         $posts = BeatmapDiscussionPost::search($this->searchParams);
-        $posts['items'] = $posts['query']->with([
+        $posts['query']->with([
             'beatmapDiscussion.beatmap',
             'beatmapDiscussion.beatmapset',
-        ])->get();
+        ]);
+
+        if (!$this->isModerator) {
+            $posts['query']->visible();
+        }
+
+        $posts['items'] = $posts['query']->get();
 
         $events = BeatmapsetEvent::search($this->searchParams);
-        if ($this->isModerator) {
-            $events['items'] = $events['query']->with(['beatmapset' => function ($query) {
-                $query->withTrashed();
-            }])->with('beatmapDiscussion')->get();
-        } else {
-            $events['items'] = $events['query']->with(['beatmapset', 'beatmapDiscussion'])->get();
-        }
+        $events['items'] = $events['query']->with(['beatmapset', 'beatmapDiscussion'])->whereHas('beatmapset')->get();
 
         $votes['items'] = BeatmapDiscussionVote::recentlyGivenByUser($user->getKey());
         $receivedVotes['items'] = BeatmapDiscussionVote::recentlyReceivedByUser($user->getKey());

--- a/app/Http/Controllers/Users/ModdingHistoryController.php
+++ b/app/Http/Controllers/Users/ModdingHistoryController.php
@@ -103,7 +103,11 @@ class ModdingHistoryController extends Controller
         $posts['items'] = $posts['query']->get();
 
         $events = BeatmapsetEvent::search($this->searchParams);
-        $events['items'] = $events['query']->with(['beatmapset', 'beatmapDiscussion'])->whereHas('beatmapset')->get();
+        $events['items'] = $events['query']->with([
+            'beatmapset',
+            'beatmapDiscussion.beatmapset',
+            'beatmapDiscussion.startingPost',
+        ])->whereHas('beatmapset')->get();
 
         $votes['items'] = BeatmapDiscussionVote::recentlyGivenByUser($user->getKey());
         $receivedVotes['items'] = BeatmapDiscussionVote::recentlyReceivedByUser($user->getKey());
@@ -188,7 +192,7 @@ class ModdingHistoryController extends Controller
             'events' => json_collection(
                 $events['items'],
                 'BeatmapsetEvent',
-                ['user', 'discussion.starting_post', 'beatmapset', 'beatmapset.user']
+                ['discussion.starting_post', 'beatmapset.user']
             ),
             'posts' => json_collection(
                 $posts['items'],

--- a/app/Libraries/OsuAuthorize.php
+++ b/app/Libraries/OsuAuthorize.php
@@ -570,13 +570,8 @@ class OsuAuthorize
      * @param Beatmapset $beatmapset
      * @return string
      */
-    public function checkBeatmapsetShow(?User $user, ?Beatmapset $beatmapset) : string
+    public function checkBeatmapsetShow(?User $user, Beatmapset $beatmapset) : string
     {
-        // FIXME: will return incorrect result if it's soft deleted and the caller passed null.
-        if ($beatmapset === null) {
-            return 'unauthorized';
-        }
-
         if (!$beatmapset->trashed()) {
             return 'ok';
         }

--- a/app/Models/Beatmap.php
+++ b/app/Models/Beatmap.php
@@ -96,7 +96,7 @@ class Beatmap extends Model
 
     public function beatmapset()
     {
-        return $this->belongsTo(Beatmapset::class, 'beatmapset_id');
+        return $this->belongsTo(Beatmapset::class, 'beatmapset_id')->withTrashed();
     }
 
     public function beatmapDiscussions()

--- a/app/Models/BeatmapDiscussion.php
+++ b/app/Models/BeatmapDiscussion.php
@@ -654,4 +654,19 @@ class BeatmapDiscussion extends Model
     {
         $query->whereNull('deleted_at');
     }
+
+    public function scopeVisible($query)
+    {
+        $query->visibleWithTrashed()
+            ->withoutTrashed();
+    }
+
+    public function scopeVisibleWithTrashed($query)
+    {
+        $query->whereHas('visibleBeatmapset')
+            ->where(function ($q) {
+                $q->whereNull('beatmap_id')
+                    ->orWhereHas('visibleBeatmap');
+            });
+    }
 }

--- a/app/Models/BeatmapDiscussionPost.php
+++ b/app/Models/BeatmapDiscussionPost.php
@@ -153,6 +153,11 @@ class BeatmapDiscussionPost extends Model
         return $this->belongsTo(BeatmapDiscussion::class);
     }
 
+    public function visibleBeatmapDiscussion()
+    {
+        return $this->beatmapDiscussion()->visible();
+    }
+
     public function user()
     {
         return $this->belongsTo(User::class, 'user_id');
@@ -337,5 +342,11 @@ class BeatmapDiscussionPost extends Model
     public function scopeWithoutSystem($query)
     {
         $query->where('system', '=', false);
+    }
+
+    public function scopeVisible($query)
+    {
+        $query->withoutTrashed()
+            ->whereHas('visibleBeatmapDiscussion');
     }
 }

--- a/database/migrations/2019_08_21_104727_add_index_to_beatmapset_events.php
+++ b/database/migrations/2019_08_21_104727_add_index_to_beatmapset_events.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddIndexToBeatmapsetEvents extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('beatmapset_events', function (Blueprint $table) {
+            $table->index('user_id');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('beatmapset_events', function (Blueprint $table) {
+            $table->dropIndex('user_id');
+        });
+    }
+}


### PR DESCRIPTION
This replaces the authorisation hotfix from #4804 and adds some further query optimisations to the modding profile page.

As a side-note, this fix means moderators will stop seeing events/discussions/posts from deleted beatmaps/beatmapsets on the modding profile page. (If you need them for moderation/investigation purposes, they'll still be visible under the 'see more' links)