### PR TITLE
Fix ranking stats getting cut on mobile views

### DIFF
--- a/resources/assets/coffee/react/modding-profile/detail-bar.coffee
+++ b/resources/assets/coffee/react/modding-profile/detail-bar.coffee
@@ -66,7 +66,7 @@ export class DetailBar extends React.PureComponent
 
         @renderExtraMenu()
 
-      div className: "#{bn}__column #{bn}__column--right",
+      div className: "#{bn}__column #{bn}__column--right #{bn}__column--modding",
         div className: "#{bn}__entry #{bn}__entry--ranking",
           el Rank, type: 'global', stats: @props.stats
 

--- a/resources/assets/less/bem/profile-detail-bar.less
+++ b/resources/assets/less/bem/profile-detail-bar.less
@@ -53,6 +53,13 @@
         min-width: @profile-stats-box-width-desktop;
       }
     }
+
+    &--modding {
+      @media @mobile {
+        overflow-x: auto; // level badge overflows on screens like iPhone SE/5
+        padding-bottom: 20px;
+      }
+    }
   }
 
   &__entry {


### PR DESCRIPTION
Resolves #4795 

Fixes 2 problems:
- ranking stats touching border of the box

![image](https://user-images.githubusercontent.com/19843905/63640028-a01d0e00-c69b-11e9-8819-afdc781a8bdc.png)

- level badge overflowing on smaller screens

![image](https://user-images.githubusercontent.com/19843905/63640031-af9c5700-c69b-11e9-9b28-06da3e0656b9.png)

---