### PR TITLE
Fix some errors not being shown when editing account settings

### DIFF
--- a/resources/views/accounts/_edit_entry_simple.blade.php
+++ b/resources/views/accounts/_edit_entry_simple.blade.php
@@ -15,7 +15,7 @@
     You should have received a copy of the GNU Affero General Public License
     along with osu!web.  If not, see <http://www.gnu.org/licenses/>.
 --}}
-<div class="account-edit-entry js-account-edit js-form-error" data-account-edit-auto-submit="1" data-skip-ajax-error-popup="1">
+<div class="account-edit-entry js-account-edit js-form-error js-form-error--field" data-account-edit-auto-submit="1" data-skip-ajax-error-popup="1">
     <input
         class="account-edit-entry__input js-account-edit__input"
         name="user[{{ $field }}]"


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/1694544/63680417-98da3980-c82e-11e9-9a2a-97b705556c5a.png)

probably broken by `37b05d`