### PR TITLE
Fix urlPresence to return null on blank/null string

### DIFF
--- a/resources/assets/coffee/osu_common.coffee
+++ b/resources/assets/coffee/osu_common.coffee
@@ -245,7 +245,7 @@
 
 
   urlPresence: (url) ->
-    "url(#{url})" if osu.presence(url)?
+    if osu.present(url) then "url(#{url})" else null
 
 
   # TODO: add support for multiple badges and/or move server side?


### PR DESCRIPTION
Can't reset attribute by assigning undefined:

    someDom.style.backgroundImage = undefined

doesn't do anything.