### PR TITLE
Revert "force index to make mysql do the smaller query first"

### DIFF
--- a/app/Http/Controllers/RankingController.php
+++ b/app/Http/Controllers/RankingController.php
@@ -25,7 +25,6 @@ use App\Models\CountryStatistics;
 use App\Models\Spotlight;
 use App\Models\User;
 use App\Models\UserStatistics;
-use DB;
 use Illuminate\Pagination\LengthAwarePaginator;
 
 class RankingController extends Controller
@@ -111,9 +110,7 @@ class RankingController extends Controller
                 static::MAX_RESULTS
             );
 
-            $class = UserStatistics\Model::getClass($mode);
-            $table = (new $class)->getTable();
-            $stats = $class
+            $stats = UserStatistics\Model::getClass($mode)
                 ::on('mysql-readonly')
                 ->with(['user', 'user.country'])
                 ->whereHas('user', function ($userQuery) {
@@ -125,13 +122,9 @@ class RankingController extends Controller
             }
 
             if ($type === 'performance') {
-                $stats
-                    ->orderBy('rank_score', 'desc')
-                    ->from(DB::raw("{$table} FORCE INDEX (rank_score)"));
+                $stats->orderBy('rank_score', 'desc');
             } else { // 'score'
-                $stats
-                    ->orderBy('ranked_score', 'desc')
-                    ->from(DB::raw("{$table} FORCE INDEX (ranked_score)"));
+                $stats->orderBy('ranked_score', 'desc');
             }
         }
 


### PR DESCRIPTION
before:
```
mysql> explain select * from osu_user_stats FORCE INDEX (rank_score) where exists (select * from `phpbb_users` where `osu_user_stats`.`user_id` = `phpbb_users`.`user_id` and (`user_warnings` = 0 and `user_type` = 0)) and `osu_user_stats`.`country_acronym` = 'KW' order by `rank_score` desc limit 50 offset 2550;
+----+-------------+----------------+------------+--------+------------------------+------------+---------+----------------------------+-------+----------+----------------------------------+
| id | select_type | table          | partitions | type   | possible_keys          | key        | key_len | ref                        | rows  | filtered | Extra                            |
+----+-------------+----------------+------------+--------+------------------------+------------+---------+----------------------------+-------+----------+----------------------------------+
|  1 | SIMPLE      | osu_user_stats | NULL       | index  | NULL                   | rank_score | 4       | NULL                       | 51999 |    10.00 | Using where; Backward index scan |
|  1 | SIMPLE      | phpbb_users    | NULL       | eq_ref | PRIMARY,country_lookup | PRIMARY    | 4       | osu.osu_user_stats.user_id |     1 |     5.00 | Using where                      |
+----+-------------+----------------+------------+--------+------------------------+------------+---------+----------------------------+-------+----------+----------------------------------+
2 rows in set, 2 warnings (0.00 sec)
```

after:
```
mysql> explain select * from osu_user_stats where exists (select * from `phpbb_users` where `osu_user_stats`.`user_id` = `phpbb_users`.`user_id` and (`user_warnings` = 0 and `user_type` = 0)) and `country_acronym` = 'KW' order by `rank_score` desc limit 50 offset 2550;
+----+-------------+----------------+------------+--------+---------------------------+-------------------+---------+----------------------------+------+----------+---------------------+
| id | select_type | table          | partitions | type   | possible_keys             | key               | key_len | ref                        | rows | filtered | Extra               |
+----+-------------+----------------+------------+--------+---------------------------+-------------------+---------+----------------------------+------+----------+---------------------+
|  1 | SIMPLE      | osu_user_stats | NULL       | ref    | PRIMARY,country_acronym_2 | country_acronym_2 | 6       | const                      | 3372 |   100.00 | Backward index scan |
|  1 | SIMPLE      | phpbb_users    | NULL       | eq_ref | PRIMARY,country_lookup    | PRIMARY           | 4       | osu.osu_user_stats.user_id |    1 |     5.00 | Using where         |
+----+-------------+----------------+------------+--------+---------------------------+-------------------+---------+----------------------------+------+----------+---------------------+
2 rows in set, 2 warnings (0.00 sec)
```

Seems we are getting hugely suboptimal queries with this force index addition now.