### PR TITLE
Add pdo_sqlite extension to php container

### DIFF
--- a/docker/php/Dockerfile
+++ b/docker/php/Dockerfile
@@ -15,6 +15,7 @@ RUN apk update && \
     php7-mcrypt \
     php7-mysqli \
     php7-pdo_mysql \
+    php7-pdo_sqlite \
     php7-phar \
     php7-redis \
     php7-session \


### PR DESCRIPTION
Used by clockwork when set to use sqlite