### PR TITLE
Faster revoking of refresh tokens when revoking client permissions

### DIFF
--- a/app/Models/OAuth/Client.php
+++ b/app/Models/OAuth/Client.php
@@ -22,6 +22,7 @@ namespace App\Models\OAuth;
 
 use App\Exceptions\InvariantException;
 use App\Models\User;
+use DB;
 use Laravel\Passport\Client as PassportClient;
 use Laravel\Passport\Token;
 
@@ -68,7 +69,9 @@ class Client extends PassportClient
             ]);
 
             $user->getConnection()
-                ->table('oauth_refresh_tokens')
+                // force mysql optimizer to optimize properly with a fake multi-table update
+                // https://dev.mysql.com/doc/refman/8.0/en/subquery-optimization.html
+                ->table(DB::raw('oauth_refresh_tokens, (SELECT 1) dummy'))
                 ->whereIn('access_token_id', (clone $clientTokens)->select('id'))
                 ->update(['revoked' => true]);
         });


### PR DESCRIPTION
maybe fixes #4801

```
mysql> explain update `oauth_refresh_tokens` set `revoked` = 1 where `access_token_id` in (select `id` from `oauth_access_tokens` where `user_id` = 2387883 and `client_id` = 5);
+----+--------------------+----------------------+------------+-----------------+-------------------------------------------+---------+---------+------+---------+----------+-------------+
| id | select_type        | table                | partitions | type            | possible_keys                             | key     | key_len | ref  | rows    | filtered | Extra       |
+----+--------------------+----------------------+------------+-----------------+-------------------------------------------+---------+---------+------+---------+----------+-------------+
|  1 | UPDATE             | oauth_refresh_tokens | NULL       | index           | NULL                                      | PRIMARY | 402     | NULL | 2854548 |   100.00 | Using where |
|  2 | DEPENDENT SUBQUERY | oauth_access_tokens  | NULL       | unique_subquery | PRIMARY,oauth_access_tokens_user_id_index | PRIMARY | 402     | func |       1 |     5.00 | Using where |
+----+--------------------+----------------------+------------+-----------------+-------------------------------------------+---------+---------+------+---------+----------+-------------+
2 rows in set, 1 warning (0.01 sec)

mysql> explain select * from `oauth_refresh_tokens` where `access_token_id` in (select `id` from `oauth_access_tokens` where `user_id` = 2387883 and `client_id` = 8);
+----+-------------+----------------------+------------+------+--------------------------------------------+--------------------------------------------+---------+----------------------------+------+----------+-------------+
| id | select_type | table                | partitions | type | possible_keys                              | key                                        | key_len | ref                        | rows | filtered | Extra       |
+----+-------------+----------------------+------------+------+--------------------------------------------+--------------------------------------------+---------+----------------------------+------+----------+-------------+
|  1 | SIMPLE      | oauth_access_tokens  | NULL       | ref  | PRIMARY,oauth_access_tokens_user_id_index  | oauth_access_tokens_user_id_index          | 5       | const                      |    8 |    10.00 | Using where |
|  1 | SIMPLE      | oauth_refresh_tokens | NULL       | ref  | oauth_refresh_tokens_access_token_id_index | oauth_refresh_tokens_access_token_id_index | 402     | osu.oauth_access_tokens.id |    1 |   100.00 | NULL        |
+----+-------------+----------------------+------------+------+--------------------------------------------+--------------------------------------------+---------+----------------------------+------+----------+-------------+
2 rows in set, 1 warning (0.01 sec)

mysql> explain update `oauth_refresh_tokens`, (SELECT 1) dummy set `revoked` = 1 where `access_token_id` in (select `id` from `oauth_access_tokens` where `user_id` = 2387883 and `client_id` = 5);
+----+-------------+----------------------+------------+--------+--------------------------------------------+--------------------------------------------+---------+----------------------------+------+----------+----------------+
| id | select_type | table                | partitions | type   | possible_keys                              | key                                        | key_len | ref                        | rows | filtered | Extra          |
+----+-------------+----------------------+------------+--------+--------------------------------------------+--------------------------------------------+---------+----------------------------+------+----------+----------------+
|  1 | PRIMARY     | <derived2>           | NULL       | system | NULL                                       | NULL                                       | NULL    | NULL                       |    1 |   100.00 | NULL           |
|  1 | PRIMARY     | oauth_access_tokens  | NULL       | ref    | PRIMARY,oauth_access_tokens_user_id_index  | oauth_access_tokens_user_id_index          | 5       | const                      |    8 |    10.00 | Using where    |
|  1 | UPDATE      | oauth_refresh_tokens | NULL       | ref    | oauth_refresh_tokens_access_token_id_index | oauth_refresh_tokens_access_token_id_index | 402     | osu.oauth_access_tokens.id |    1 |   100.00 | NULL           |
|  2 | DERIVED     | NULL                 | NULL       | NULL   | NULL                                       | NULL                                       | NULL    | NULL                       | NULL |     NULL | No tables used |
+----+-------------+----------------------+------------+--------+--------------------------------------------+--------------------------------------------+---------+----------------------------+------+----------+----------------+
4 rows in set, 1 warning (0.00 sec)
```

(why is this a thing?)