### PR TITLE
Add ability to sort friends by rank

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -988,6 +988,15 @@ class User extends Model implements AuthenticatableContract
         return $this->belongsTo(Country::class, 'country_acronym');
     }
 
+    public function getModeRank($mode)
+    {
+        $users = self::with("Statistics{$mode}");
+
+        foreach ($users as $user) {
+            return $user->statistics($mode, true)->rank;
+        }
+    }
+
     public function statisticsOsu()
     {
         return $this->statistics('osu', true);

--- a/app/Transformers/UserCompactTransformer.php
+++ b/app/Transformers/UserCompactTransformer.php
@@ -48,7 +48,7 @@ class UserCompactTransformer extends Fractal\TransformerAbstract
             'is_supporter' => $user->isSupporter(),
             'last_visit' => json_time($user->displayed_last_visit),
             'pm_friends_only' => $user->pm_friends_only,
-            'default_gamemode_rank' => $user->statistics($user->getPlaymodeAttribute($user->playmode), true)->rank ?? -1,
+            'default_gamemode_rank' => $user->getModeRank($user->getPlaymodeAttribute($user->playmode)) ?? -1,
         ];
     }
 

--- a/app/Transformers/UserCompactTransformer.php
+++ b/app/Transformers/UserCompactTransformer.php
@@ -48,7 +48,7 @@ class UserCompactTransformer extends Fractal\TransformerAbstract
             'is_supporter' => $user->isSupporter(),
             'last_visit' => json_time($user->displayed_last_visit),
             'pm_friends_only' => $user->pm_friends_only,
-            'user_gamemode_rank' => $user->statistics($user->getPlaymodeAttribute($user->osu_playmode), 'true')->rank,
+            'default_gamemode_rank' => $user->statistics($user->getPlaymodeAttribute($user->playmode), true)->rank ?? -1,
         ];
     }
 

--- a/app/Transformers/UserCompactTransformer.php
+++ b/app/Transformers/UserCompactTransformer.php
@@ -48,6 +48,7 @@ class UserCompactTransformer extends Fractal\TransformerAbstract
             'is_supporter' => $user->isSupporter(),
             'last_visit' => json_time($user->displayed_last_visit),
             'pm_friends_only' => $user->pm_friends_only,
+            'user_gamemode_rank' => $user->statistics($user->getPlaymodeAttribute($user->osu_playmode), 'true')->rank,
         ];
     }
 

--- a/resources/assets/lib/globals.d.ts
+++ b/resources/assets/lib/globals.d.ts
@@ -93,6 +93,7 @@ interface User {
   country?: Country;
   country_code?: string;
   cover: Cover;
+  default_gamemode_rank: number;
   default_group: string;
   id: number;
   is_active: boolean;

--- a/resources/assets/lib/user-card.tsx
+++ b/resources/assets/lib/user-card.tsx
@@ -49,6 +49,7 @@ export class UserCard extends React.PureComponent<Props, State> {
 
   static userLoading: User = {
     cover: {},
+    default_gamemode_rank: 0,
     default_group: '',
     id: 0,
     is_active: false,

--- a/resources/assets/lib/user-list.tsx
+++ b/resources/assets/lib/user-list.tsx
@@ -40,12 +40,17 @@ interface State {
   viewMode: ViewMode;
 }
 
-function usernameSortAscending(x: User, y: User) {
-  return x.username.localeCompare(y.username);
+function rankSortDescending(x: User, y: User) {
+ if (x.default_gamemode_rank == -1 || y.default_gamemode_rank == -1) {
+   return -1;
+ }
+ else {
+   return x.default_gamemode_rank - y.default_gamemode_rank;
+ }
 }
 
-function rankSortDescending(x: User, y: User) {
- return x.user_gamemode_rank > y.user_gamemode_rank; 
+function usernameSortAscending(x: User, y: User) {
+  return x.username.localeCompare(y.username);
 }
 
 export class UserList extends React.PureComponent<Props> {
@@ -65,11 +70,11 @@ export class UserList extends React.PureComponent<Props> {
     const users = this.getFilteredUsers(this.state.filter).slice();
 
     switch (this.state.sortMode) {
-      case 'username':
-        return users.sort(usernameSortAscending);
       case 'rank':
         return users.sort(rankSortDescending);
-
+      case 'username':
+        return users.sort(usernameSortAscending);
+      
       default:
         return users.sort((x, y) => {
           if (x.is_online && y.is_online) {

--- a/resources/assets/lib/user-list.tsx
+++ b/resources/assets/lib/user-list.tsx
@@ -41,10 +41,9 @@ interface State {
 }
 
 function rankSortDescending(x: User, y: User) {
- if (x.default_gamemode_rank == -1 || y.default_gamemode_rank == -1) {
+ if (x.default_gamemode_rank === -1 || y.default_gamemode_rank === -1) {
    return -1;
- }
- else {
+ } else {
    return x.default_gamemode_rank - y.default_gamemode_rank;
  }
 }
@@ -72,9 +71,10 @@ export class UserList extends React.PureComponent<Props> {
     switch (this.state.sortMode) {
       case 'rank':
         return users.sort(rankSortDescending);
+
       case 'username':
         return users.sort(usernameSortAscending);
-      
+
       default:
         return users.sort((x, y) => {
           if (x.is_online && y.is_online) {

--- a/resources/assets/lib/user-list.tsx
+++ b/resources/assets/lib/user-list.tsx
@@ -23,10 +23,10 @@ import { ViewMode } from 'user-card';
 import { UserCards } from 'user-cards';
 
 type Filter = 'all' | 'online' | 'offline';
-type SortMode = 'last_visit' | 'username';
+type SortMode = 'last_visit' | 'username' | 'rank';
 
 const filters: Filter[] = ['all', 'online', 'offline'];
-const sortModes: SortMode[] = ['last_visit', 'username'];
+const sortModes: SortMode[] = ['last_visit', 'username', 'rank'];
 const viewModes: ViewMode[] = ['card', 'list'];
 
 interface Props {
@@ -42,6 +42,10 @@ interface State {
 
 function usernameSortAscending(x: User, y: User) {
   return x.username.localeCompare(y.username);
+}
+
+function rankSortDescending(x: User, y: User) {
+ return x.user_gamemode_rank > y.user_gamemode_rank; 
 }
 
 export class UserList extends React.PureComponent<Props> {
@@ -63,6 +67,8 @@ export class UserList extends React.PureComponent<Props> {
     switch (this.state.sortMode) {
       case 'username':
         return users.sort(usernameSortAscending);
+      case 'rank':
+        return users.sort(rankSortDescending);
 
       default:
         return users.sort((x, y) => {

--- a/resources/lang/en/sort.php
+++ b/resources/lang/en/sort.php
@@ -26,6 +26,7 @@ return [
     'old' => 'Old',
     'top' => 'Top',
     'username' => 'Username',
+    'rank' => 'Rank',
 
     'forum_topics' => [
         'new' => 'Last reply',

--- a/resources/lang/en/sort.php
+++ b/resources/lang/en/sort.php
@@ -24,9 +24,9 @@ return [
     'last_visit' => 'Recently active',
     'new' => 'Recent',
     'old' => 'Old',
+    'rank' => 'Rank',
     'top' => 'Top',
     'username' => 'Username',
-    'rank' => 'Rank',
 
     'forum_topics' => [
         'new' => 'Last reply',


### PR DESCRIPTION
Adds an option to sort friends by default gamemode rank 
TODO: make eager-load work properly

fixes https://github.com/ppy/osu-web/issues/4759