### PR TITLE
Force better indices when listing rankings

### DIFF
--- a/app/Http/Controllers/RankingController.php
+++ b/app/Http/Controllers/RankingController.php
@@ -129,15 +129,15 @@ class RankingController extends Controller
                     ->from(DB::raw("{$table} FORCE INDEX (ranked_score)"))
                     ->orderBy('ranked_score', 'desc');
             }
+
+            if (is_api_request()) {
+                $stats->with(['user.userProfileCustomization']);
+            }
         }
 
         $maxResults = $this->maxResults($modeInt);
         $maxPages = ceil($maxResults / static::PAGE_SIZE);
         $page = clamp(get_int(request('page')), 1, $maxPages);
-
-        if (is_api_request()) {
-            $stats->with(['user.userProfileCustomization']);
-        }
 
         $stats = $stats->limit(static::PAGE_SIZE)
             ->offset(static::PAGE_SIZE * ($page - 1))

--- a/app/Http/Controllers/RankingController.php
+++ b/app/Http/Controllers/RankingController.php
@@ -97,20 +97,11 @@ class RankingController extends Controller
         $modeInt = Beatmap::modeInt($mode);
 
         if ($type === 'country') {
-            $maxResults = CountryStatistics::where('display', 1)
-                ->where('mode', $modeInt)
-                ->count();
-
             $stats = CountryStatistics::where('display', 1)
                 ->with('country')
                 ->where('mode', $modeInt)
                 ->orderBy('performance', 'desc');
         } else {
-            $maxResults = min(
-                $this->country !== null ? $this->country->usercount : static::MAX_RESULTS,
-                static::MAX_RESULTS
-            );
-
             $class = UserStatistics\Model::getClass($mode);
             $table = (new $class)->getTable();
             $stats = $class
@@ -120,29 +111,27 @@ class RankingController extends Controller
                     $userQuery->default();
                 });
 
-            if ($this->country !== null) {
-                $stats->where('country_acronym', $this->country['acronym']);
-            }
-
             if ($type === 'performance') {
-                $stats
-                    ->orderBy('rank_score', 'desc');
-
-                if ($this->country === null) {
+                if ($this->country !== null) {
+                    $stats
+                        ->where('country_acronym', $this->country['acronym'])
+                        // preferrable to rank_score when filtering by country
+                        ->from(DB::raw("{$table} FORCE INDEX (country_acronym_2)"));
+                } else {
                     // force to order by rank_score instead of sucking down entire users table first.
                     $stats->from(DB::raw("{$table} FORCE INDEX (rank_score)"));
-                } else {
-                    // preferrable to rank_score when filtering by country
-                    $stats->from(DB::raw("{$table} FORCE INDEX (country_acronym_2)"));
                 }
+
+                $stats->orderBy('rank_score', 'desc');
             } else { // 'score'
                 $stats
-                    ->orderBy('ranked_score', 'desc')
                     // force to order by ranked_score instead of sucking down entire users table first.
-                    ->from(DB::raw("{$table} FORCE INDEX (ranked_score)"));
+                    ->from(DB::raw("{$table} FORCE INDEX (ranked_score)"))
+                    ->orderBy('ranked_score', 'desc');
             }
         }
 
+        $maxResults = $this->maxResults($modeInt);
         $maxPages = ceil($maxResults / static::PAGE_SIZE);
         $page = clamp(get_int(request('page')), 1, $maxPages);
 
@@ -224,5 +213,19 @@ class RankingController extends Controller
     private function optionFromSpotlight(Spotlight $spotlight) : array
     {
         return ['id' => $spotlight->chart_id, 'text' => $spotlight->name];
+    }
+
+    private function maxResults($modeInt)
+    {
+        if (request('type') === 'country') {
+            return CountryStatistics::where('display', 1)
+                ->where('mode', $modeInt)
+                ->count();
+        }
+
+        return min(
+            $this->country !== null ? $this->country->usercount : static::MAX_RESULTS,
+            static::MAX_RESULTS
+        );
     }
 }

--- a/app/Http/Controllers/RankingController.php
+++ b/app/Http/Controllers/RankingController.php
@@ -126,11 +126,19 @@ class RankingController extends Controller
 
             if ($type === 'performance') {
                 $stats
-                    ->orderBy('rank_score', 'desc')
-                    ->from(DB::raw("{$table} FORCE INDEX (rank_score)"));
+                    ->orderBy('rank_score', 'desc');
+
+                if ($this->country === null) {
+                    // force to order by rank_score instead of sucking down entire users table first.
+                    $stats->from(DB::raw("{$table} FORCE INDEX (rank_score)"));
+                } else {
+                    // preferrable to rank_score when filtering by country
+                    $stats->from(DB::raw("{$table} FORCE INDEX (country_acronym_2)"));
+                }
             } else { // 'score'
                 $stats
                     ->orderBy('ranked_score', 'desc')
+                    // force to order by ranked_score instead of sucking down entire users table first.
                     ->from(DB::raw("{$table} FORCE INDEX (ranked_score)"));
             }
         }


### PR DESCRIPTION
# Performance ranking

When listing the performance ranking, because of the sub select, mysql is deciding to query the entire users table first:
```
mysql> explain select * from osu_user_stats where exists (select * from `phpbb_users` where `osu_user_stats`.`user_id` = `phpbb_users`.`user_id` and (`user_warnings` = 0 and `user_type` = 0)) order by `rank_score` desc limit 50 offset 2550;
+----+-------------+----------------+------------+--------+------------------------+---------+---------+-------------------------+----------+----------+----------------------------------------------+
| id | select_type | table          | partitions | type   | possible_keys          | key     | key_len | ref                     | rows     | filtered | Extra                                        |
+----+-------------+----------------+------------+--------+------------------------+---------+---------+-------------------------+----------+----------+----------------------------------------------+
|  1 | SIMPLE      | phpbb_users    | NULL       | ALL    | PRIMARY,country_lookup | NULL    | NULL    | NULL                    | 13152553 |     1.00 | Using where; Using temporary; Using filesort |
|  1 | SIMPLE      | osu_user_stats | NULL       | eq_ref | PRIMARY                | PRIMARY | 4       | osu.phpbb_users.user_id |        1 |   100.00 | NULL                                         |
+----+-------------+----------------+------------+--------+------------------------+---------+---------+-------------------------+----------+----------+----------------------------------------------+
2 rows in set, 2 warnings (0.00 sec)
```

Without the sub select, it's fine:
```
mysql> explain select * from osu_user_stats order by `rank_score` desc limit 50 offset 2550;
+----+-------------+----------------+------------+-------+---------------+------------+---------+------+------+----------+---------------------+
| id | select_type | table          | partitions | type  | possible_keys | key        | key_len | ref  | rows | filtered | Extra               |
+----+-------------+----------------+------------+-------+---------------+------------+---------+------+------+----------+---------------------+
|  1 | SIMPLE      | osu_user_stats | NULL       | index | NULL          | rank_score | 4       | NULL | 2600 |   100.00 | Backward index scan |
+----+-------------+----------------+------------+-------+---------------+------------+---------+------+------+----------+---------------------+
1 row in set, 1 warning (0.00 sec)
```

Forcing the index to `rank_score` since the results are ordered by `rank_score`:
```
mysql> explain select * from osu_user_stats FORCE INDEX (rank_score) where exists (select * from `phpbb_users` where `osu_user_stats`.`user_id` = `phpbb_users`.`user_id` and (`user_warnings` = 0 and `user_type` = 0)) order by `rank_score` desc limit 50 offset 2550;
+----+-------------+----------------+------------+--------+------------------------+------------+---------+----------------------------+-------+----------+---------------------+
| id | select_type | table          | partitions | type   | possible_keys          | key        | key_len | ref                        | rows  | filtered | Extra               |
+----+-------------+----------------+------------+--------+------------------------+------------+---------+----------------------------+-------+----------+---------------------+
|  1 | SIMPLE      | osu_user_stats | NULL       | index  | NULL                   | rank_score | 4       | NULL                       | 51999 |   100.00 | Backward index scan |
|  1 | SIMPLE      | phpbb_users    | NULL       | eq_ref | PRIMARY,country_lookup | PRIMARY    | 4       | osu.osu_user_stats.user_id |     1 |     5.00 | Using where         |
+----+-------------+----------------+------------+--------+------------------------+------------+---------+----------------------------+-------+----------+---------------------+
2 rows in set, 2 warnings (0.01 sec)
```

# Score ranking
Score ranking has the same issue as performance ranking.
```
mysql> explain select * from osu_user_stats where exists (select * from `phpbb_users` where `osu_user_stats`.`user_id` = `phpbb_users`.`user_id` and (`user_warnings` = 0 and `user_type` = 0)) order by `ranked_score` desc limit 50 offset 2550;
+----+-------------+----------------+------------+--------+------------------------+---------+---------+-------------------------+----------+----------+----------------------------------------------+
| id | select_type | table          | partitions | type   | possible_keys          | key     | key_len | ref                     | rows     | filtered | Extra                                        |
+----+-------------+----------------+------------+--------+------------------------+---------+---------+-------------------------+----------+----------+----------------------------------------------+
|  1 | SIMPLE      | phpbb_users    | NULL       | ALL    | PRIMARY,country_lookup | NULL    | NULL    | NULL                    | 13152553 |     1.00 | Using where; Using temporary; Using filesort |
|  1 | SIMPLE      | osu_user_stats | NULL       | eq_ref | PRIMARY                | PRIMARY | 4       | osu.phpbb_users.user_id |        1 |   100.00 | NULL                                         |
+----+-------------+----------------+------------+--------+------------------------+---------+---------+-------------------------+----------+----------+----------------------------------------------+
2 rows in set, 2 warnings (0.01 sec)
```

Without sub select:
```
mysql> explain select * from osu_user_stats order by `ranked_score` desc limit 50 offset 2550;
+----+-------------+----------------+------------+-------+---------------+--------------+---------+------+------+----------+---------------------+
| id | select_type | table          | partitions | type  | possible_keys | key          | key_len | ref  | rows | filtered | Extra               |
+----+-------------+----------------+------------+-------+---------------+--------------+---------+------+------+----------+---------------------+
|  1 | SIMPLE      | osu_user_stats | NULL       | index | NULL          | ranked_score | 8       | NULL | 2600 |   100.00 | Backward index scan |
+----+-------------+----------------+------------+-------+---------------+--------------+---------+------+------+----------+---------------------+
1 row in set, 1 warning (0.01 sec)
```

Force index:
```
mysql> explain select * from osu_user_stats FORCE INDEX (ranked_score) where exists (select * from `phpbb_users` where `osu_user_stats`.`user_id` = `phpbb_users`.`user_id` and (`user_warnings` = 0 and `user_type` = 0)) order by `ranked_score` desc limit 50 offset 2550;
+----+-------------+----------------+------------+--------+------------------------+--------------+---------+----------------------------+-------+----------+---------------------+
| id | select_type | table          | partitions | type   | possible_keys          | key          | key_len | ref                        | rows  | filtered | Extra               |
+----+-------------+----------------+------------+--------+------------------------+--------------+---------+----------------------------+-------+----------+---------------------+
|  1 | SIMPLE      | osu_user_stats | NULL       | index  | NULL                   | ranked_score | 8       | NULL                       | 51999 |   100.00 | Backward index scan |
|  1 | SIMPLE      | phpbb_users    | NULL       | eq_ref | PRIMARY,country_lookup | PRIMARY      | 4       | osu.osu_user_stats.user_id |     1 |     5.00 | Using where         |
+----+-------------+----------------+------------+--------+------------------------+--------------+---------+----------------------------+-------+----------+---------------------+
2 rows in set, 2 warnings (0.00 sec)
```

# Performance ranking filtered by country
In most cases it's fine:
```
mysql> explain select * from osu_user_stats where exists (select * from `phpbb_users` where `osu_user_stats`.`user_id` = `phpbb_users`.`user_id` and (`user_warnings` = 0 and `user_type` = 0)) and `osu_user_stats`.`country_acronym` = 'KW' order by `rank_score` desc limit 50 offset 2550;
+----+-------------+----------------+------------+--------+---------------------------+-------------------+---------+----------------------------+------+----------+---------------------+
| id | select_type | table          | partitions | type   | possible_keys             | key               | key_len | ref                        | rows | filtered | Extra               |
+----+-------------+----------------+------------+--------+---------------------------+-------------------+---------+----------------------------+------+----------+---------------------+
|  1 | SIMPLE      | osu_user_stats | NULL       | ref    | PRIMARY,country_acronym_2 | country_acronym_2 | 6       | const                      | 3356 |   100.00 | Backward index scan |
|  1 | SIMPLE      | phpbb_users    | NULL       | eq_ref | PRIMARY,country_lookup    | PRIMARY           | 4       | osu.osu_user_stats.user_id |    1 |     5.00 | Using where         |
+----+-------------+----------------+------------+--------+---------------------------+-------------------+---------+----------------------------+------+----------+---------------------+
2 rows in set, 2 warnings (0.00 sec)
```
without sub select:
```
mysql> explain select * from osu_user_stats where `osu_user_stats`.`country_acronym` = 'KW' order by `rank_score` desc limit 50 offset 2550;
+----+-------------+----------------+------------+------+-------------------+-------------------+---------+-------+------+----------+---------------------+
| id | select_type | table          | partitions | type | possible_keys     | key               | key_len | ref   | rows | filtered | Extra               |
+----+-------------+----------------+------------+------+-------------------+-------------------+---------+-------+------+----------+---------------------+
|  1 | SIMPLE      | osu_user_stats | NULL       | ref  | country_acronym_2 | country_acronym_2 | 6       | const | 3356 |   100.00 | Backward index scan |
+----+-------------+----------------+------------+------+-------------------+-------------------+---------+-------+------+----------+---------------------+
1 row in set, 1 warning (0.00 sec)
```

But in some weird case on dev it gets confused:
```
mysql> explain select * from osu_user_stats where exists (select * from `phpbb_users` where `osu_user_stats`.`user_id` = `phpbb_users`.`user_id` and (`user_warnings` = 0 and `user_type` = 0)) and `osu_user_stats`.`country_acronym` = 'US' order by `rank_score` desc limit 50 offset 2550;
+----+-------------+----------------+------------+--------+---------------------------+---------+---------+-------------------------+----------+----------+----------------------------------------------+
| id | select_type | table          | partitions | type   | possible_keys             | key     | key_len | ref                     | rows     | filtered | Extra                                        |
+----+-------------+----------------+------------+--------+---------------------------+---------+---------+-------------------------+----------+----------+----------------------------------------------+
|  1 | SIMPLE      | phpbb_users    | NULL       | ALL    | PRIMARY,country_lookup    | NULL    | NULL    | NULL                    | 13152553 |     1.00 | Using where; Using temporary; Using filesort |
|  1 | SIMPLE      | osu_user_stats | NULL       | eq_ref | PRIMARY,country_acronym_2 | PRIMARY | 4       | osu.phpbb_users.user_id |        1 |    20.71 | Using where                                  |
+----+-------------+----------------+------------+--------+---------------------------+---------+---------+-------------------------+----------+----------+----------------------------------------------+
2 rows in set, 2 warnings (0.01 sec)
```

also includes the change from #4813 so closes #4794