### PR TITLE
Only use inter for pages using torus

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,6 @@
     "clipboard-polyfill": "^2.3.0",
     "d3": "^5.7.0",
     "imagesloaded": "^4.1.3",
-    "inter-ui": "^3.9.0",
     "jquery": "^3.3.0",
     "jquery-ui": "^1.12.0",
     "jquery-ujs": "^1.2.2",

--- a/resources/assets/less/app.less
+++ b/resources/assets/less/app.less
@@ -22,7 +22,6 @@
 @import "@{node_root}/@fortawesome/fontawesome-free/less/solid";
 @import "@{node_root}/@fortawesome/fontawesome-free/less/regular";
 @import "@{node_root}/@fortawesome/fontawesome-free/less/brands";
-@import "~inter-ui/inter.css";
 
 @import "@{node_root}/bootstrap/less/bootstrap";
 @import 'bootstrap-overrides';

--- a/resources/assets/less/variables.less
+++ b/resources/assets/less/variables.less
@@ -18,7 +18,7 @@
 
 @import "app";
 
-@font-content: 'Inter', sans-serif;
+@font-content: 'Open Sans', sans-serif;
 @font-default-torus: Torus, 'Helvetica Neue', Tahoma, Arial, 'Hiragino Kaku Gothic ProN', Meiryo, 'Microsoft YaHei', 'Apple SD Gothic Neo', sans-serif;
 @font-default: 'Exo 2', 'Helvetica Neue', Tahoma, Arial, 'Hiragino Kaku Gothic ProN', Meiryo, 'Microsoft YaHei', 'Apple SD Gothic Neo', sans-serif;
 @font-default-vi: Exo, 'Exo 2', 'Helvetica Neue', Tahoma, Arial, 'Hiragino Kaku Gothic ProN', Meiryo, 'Microsoft YaHei', 'Apple SD Gothic Neo', sans-serif;

--- a/resources/views/layout/metadata.blade.php
+++ b/resources/views/layout/metadata.blade.php
@@ -38,6 +38,7 @@
 @endif
 
 <link href='//fonts.googleapis.com/css?family=Exo+2:300,300italic,200,200italic,400,400italic,500,500italic,600,600italic,700,700italic,900' rel='stylesheet' type='text/css'>
+<link href='https://fonts.googleapis.com/css?family=Open+Sans:400,400i,700,700i' rel='stylesheet' type='text/css'>
 
 @if (App::getLocale() === 'vi')
     <link href='//fonts.googleapis.com/css?family=Exo:300,300italic,200,200italic,400,400italic,500,500italic,600,600italic,700,700italic,900' rel='stylesheet' type='text/css'>

--- a/yarn.lock
+++ b/yarn.lock
@@ -4797,11 +4797,6 @@ inline-source-map@~0.6.0:
   dependencies:
     source-map "~0.5.3"
 
-inter-ui@^3.9.0:
-  version "3.9.0"
-  resolved "https://registry.yarnpkg.com/inter-ui/-/inter-ui-3.9.0.tgz#40648d1e447f68fcaaa7de3c503e88f30fe01c84"
-  integrity sha512-zvjPVqDj5+wMCNnxGc/9owWXOWN88SYI+hIvY0bKpqleJvAanQYgwyhvGbbfY7tnFexaxN5kIFHID2UppKciXw==
-
 internal-ip@^4.3.0:
   version "4.3.0"
   resolved "https://registry.yarnpkg.com/internal-ip/-/internal-ip-4.3.0.tgz#845452baad9d2ca3b69c635a137acb9a0dad0907"


### PR DESCRIPTION
Revert "Use "Inter" for content font"

This reverts commit 845a0eb34640767f1f17d7b2c80db34336ea9ba6.

(current forum listing pages don't use content font afair)