### PR TITLE
Adjust header z-index

### DIFF
--- a/resources/assets/less/bem/nav2-header.less
+++ b/resources/assets/less/bem/nav2-header.less
@@ -25,6 +25,7 @@
 
   &__body {
     width: 100%;
+    z-index: 1; // local to its block element
   }
 
   &__menu-bg {

--- a/resources/assets/less/bem/nav2.less
+++ b/resources/assets/less/bem/nav2.less
@@ -30,7 +30,6 @@
   display: flex;
   font-size: @font-size--title-small;
   font-weight: 500;
-  z-index: @z-index--nav2;
   transition: height @header-pinned-animation-duration;
 
   .@{header-pinned} & {

--- a/resources/assets/less/bem/navbar-mobile.less
+++ b/resources/assets/less/bem/navbar-mobile.less
@@ -75,7 +75,7 @@
     max-height: calc((var(--vh, 1vh) * 100) - @navbar-height);
     overflow-y: scroll;
     -webkit-overflow-scrolling: touch;
-    z-index: @z-index--nav2;
+    z-index: @z-index--nav-bar;
 
     &:focus,
     &:hover,

--- a/resources/assets/less/variables.less
+++ b/resources/assets/less/variables.less
@@ -104,7 +104,6 @@
 @z-index--profile-page-cover-selector: 5;
 @z-index--profile-previous-usernames: 10;
 @z-index--profile-tournament-banner: 11;
-@z-index--nav2: 100;
 @z-index--simple-menu: 101;
 @z-index--admin-menu: 499;
 @z-index--back-to-top: 500;


### PR DESCRIPTION
- nav2 is inside nav2-header so the z-index in nav2 isn't really useful and doesn't quite work for non-legacy menu when combined with another floating header: the background will be underneath the additional floating header while the menu on top of everything
- change navbar-mobile to use the same z-index as nav2-header. Should be fine. Maybe

Previous:
```
[nav2-header: z-index 500]
  [nav2-header body]
    [nav2-header menubg] ← underneath sticky header when nav2 popup menu is shown
    [nav2: z-index 501] ← popup menu on top of sticky header
  [sticky header]
```

New:
```
[nav2-header: z-index 500]
  [nav2-header body: z-index 1]
    [nav2-header menubg]
    [nav2]
  [sticky header]
```