### PR TITLE
Set fixed bar z-index above nav bar

### DIFF
--- a/resources/assets/less/variables.less
+++ b/resources/assets/less/variables.less
@@ -108,8 +108,8 @@
 @z-index--simple-menu: 101;
 @z-index--admin-menu: 499;
 @z-index--back-to-top: 500;
-@z-index--fixed-bar: 501;
-@z-index--nav-bar: 502;
+@z-index--nav-bar: 501;
+@z-index--fixed-bar: 502;
 @z-index--user-card-tooltip: 509;
 @z-index--blackout: 510;
 @z-index--blackout-visible: 511;


### PR DESCRIPTION
Will be needed for full screen reply box. They shouldn't overlap in normal case.