### PR TITLE
Change default username check to use empty string

### DIFF
--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -80,7 +80,7 @@ class UsersController extends Controller
 
     public function checkUsernameAvailability()
     {
-        $username = Request::input('username');
+        $username = Request::input('username') ?? '';
 
         $errors = Auth::user()->validateChangeUsername($username);
 


### PR DESCRIPTION
Use empty string instead of null if post data is missing. 
Most of the username validation methods are typed not to allow null, so this change will make it return a validation error response.