### PR TITLE
Fix missing null check on modding profile page

### DIFF
--- a/resources/assets/coffee/react/modding-profile/events.coffee
+++ b/resources/assets/coffee/react/modding-profile/events.coffee
@@ -55,7 +55,7 @@ export class Events extends React.Component
                           __html: osu.trans "beatmapset_events.event.#{@typeForTranslation(event)}",
                             user: @props.users[event.user_id].username
                             discussion: (if discussionId then "<a href='#{discussionLink}'>##{discussionId}</a>" else '')
-                            text: (if event.discussion then _.truncate(event.discussion.starting_post.message, {length: 100}) else '[no preview]')
+                            text: (if event.discussion?.starting_post? then _.truncate(event.discussion.starting_post.message, {length: 100}) else '[no preview]')
 
                       div
                         className: 'beatmap-discussion-post__info'


### PR DESCRIPTION
Not actually directly related to permissions - GMTs/etc can see more event types which pushed the offending event(s) off the page.

fixes #4925