### PR TITLE
Set volume of audio tags within news posts to 45% on page load

### DIFF
--- a/resources/assets/lib/news-show/main.tsx
+++ b/resources/assets/lib/news-show/main.tsx
@@ -32,6 +32,22 @@ interface Props {
 }
 
 export default class Main extends React.Component<Props> {
+  private contentContainer = React.createRef<HTMLDivElement>();
+
+  componentDidMount() {
+    const container = this.contentContainer.current;
+
+    if (!container) {
+      return;
+    }
+
+    const audioTags = container.getElementsByTagName('audio');
+
+    _.each(audioTags, (audio) => {
+      audio.volume = 0.45;
+    });
+  }
+
   render() {
     const {content, author} = this.processContent();
     const titleTrans = {
@@ -51,6 +67,7 @@ export default class Main extends React.Component<Props> {
             {this.renderHeader({author})}
 
             <div
+              ref={this.contentContainer}
               dangerouslySetInnerHTML={{
                 __html: content,
               }}


### PR DESCRIPTION
fixes #4781

`<audio>` doesn't have a volume attribute, go figure. 🤷‍♂