### PR TITLE
Switch song title and artist in page title

### DIFF
--- a/resources/views/beatmapsets/show.blade.php
+++ b/resources/views/beatmapsets/show.blade.php
@@ -25,7 +25,7 @@
 @extends('master', [
     'currentSection' => 'beatmaps',
     'pageDescription' => $beatmapset->toMetaDescription(),
-    'titlePrepend' => "{$beatmapset->title} - {$beatmapset->artist}",
+    'titlePrepend' => "{$beatmapset->artist} - {$beatmapset->title}",
     'extraFooterLinks' => $extraFooterLinks ?? [],
 ])
 


### PR DESCRIPTION
when both are in the same line, it's a lot more common to read _artist - title_ instead of _title - artist_ (current)

also fixes the inconsistent formats in discord embeds (line 1 is t-a, line 2 is a-t)
![image](https://user-images.githubusercontent.com/31551350/64726632-edff8780-d48b-11e9-9f96-0d22365b78dc.png)


was going to submit as an issue but the change is so simple that i might as well pr