### PR TITLE
Add action tag to Datadog request-time metrics

### DIFF
--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -44,7 +44,7 @@ class Kernel extends HttpKernel
         Middleware\VerifyPrivilegedUser::class,
         Middleware\CheckUserBanStatus::class,
         Middleware\TurbolinksSupport::class,
-        \ChaseConey\LaravelDatadogHelper\Middleware\LaravelDatadogMiddleware::class,
+        Middleware\DatadogMetrics::class,
     ];
 
     protected $middlewareGroups = [

--- a/app/Http/Middleware/DatadogMetrics.php
+++ b/app/Http/Middleware/DatadogMetrics.php
@@ -1,0 +1,48 @@
+<?php
+
+/**
+ *    Copyright (c) ppy Pty Ltd <contact@ppy.sh>.
+ *
+ *    This file is part of osu!web. osu!web is distributed with the hope of
+ *    attracting more community contributions to the core ecosystem of osu!.
+ *
+ *    osu!web is free software: you can redistribute it and/or modify
+ *    it under the terms of the Affero GNU General Public License version 3
+ *    as published by the Free Software Foundation.
+ *
+ *    osu!web is distributed WITHOUT ANY WARRANTY; without even the implied
+ *    warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *    See the GNU Affero General Public License for more details.
+ *
+ *    You should have received a copy of the GNU Affero General Public License
+ *    along with osu!web.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace App\Http\Middleware;
+
+use ChaseConey\LaravelDatadogHelper\Middleware\LaravelDatadogMiddleware;
+use Datadog;
+use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\HttpFoundation\Response;
+
+class DatadogMetrics extends LaravelDatadogMiddleware
+{
+    /**
+     * Logs the duration of a specific request through the application
+     *
+     * @param Request $request
+     * @param Response $response
+     * @param double $startTime
+     */
+    protected static function logDuration(Request $request, Response $response, $startTime)
+    {
+        $duration = microtime(true) - $startTime;
+
+        $tags = [
+            'action' => $request->route()->getActionName(),
+            'status_code' => $response->getStatusCode(),
+        ];
+
+        Datadog::timing('request_time', $duration, 1, $tags);
+    }
+}

--- a/app/Http/Middleware/DatadogMetrics.php
+++ b/app/Http/Middleware/DatadogMetrics.php
@@ -32,7 +32,7 @@ class DatadogMetrics extends LaravelDatadogMiddleware
      *
      * @param Request $request
      * @param Response $response
-     * @param double $startTime
+     * @param float $startTime
      */
     protected static function logDuration(Request $request, Response $response, $startTime)
     {


### PR DESCRIPTION
Lets us see request-time at a per-action level