### PR TITLE
Add polymorphic mapping name for BeatmapDiscussion

### DIFF
--- a/app/Libraries/MorphMap.php
+++ b/app/Libraries/MorphMap.php
@@ -20,6 +20,7 @@
 
 namespace App\Libraries;
 
+use App\Models\BeatmapDiscussion;
 use App\Models\Beatmapset;
 use App\Models\Build;
 use App\Models\Chat\Channel;
@@ -32,6 +33,7 @@ use App\Models\User;
 class MorphMap
 {
     const MAP = [
+        BeatmapDiscussion::class => 'beatmapset_discussion',
         Beatmapset::class => 'beatmapset',
         Build::class => 'build',
         Channel::class => 'channel',


### PR DESCRIPTION
The class really should be called BeatmapsetDiscussion.
Actual column update will be done separately as it should still work with full class name.

Currently used by KudosuHistory.