### PR TITLE
"Automatic" width for upload image button

### DIFF
--- a/resources/assets/less/bem/btn-osu-big.less
+++ b/resources/assets/less/bem/btn-osu-big.less
@@ -51,8 +51,7 @@
   }
 
   &--account-edit {
-    display: inline-block;
-    max-width: @avatar-size--base;
+    min-width: @avatar-size--base;
     padding: 7px 10px;
     text-align: left;
   }

--- a/resources/assets/less/bem/btn-osu-big.less
+++ b/resources/assets/less/bem/btn-osu-big.less
@@ -51,8 +51,8 @@
   }
 
   &--account-edit {
-    display: block;
-    width: @avatar-size--base;
+    display: inline-block;
+    max-width: @avatar-size--base;
     padding: 7px 10px;
     text-align: left;
   }


### PR DESCRIPTION
This makes the upload image button grow to as large as it needs, but keeping a minimum size of `@avatar-size--base`.

It fixes #5016

This might cause issues with design consistency, though.