### PR TITLE
Exclude revoked OAuth clients from client list

### DIFF
--- a/app/Http/Controllers/OAuth/ClientsController.php
+++ b/app/Http/Controllers/OAuth/ClientsController.php
@@ -45,7 +45,7 @@ class ClientsController extends Controller
 
     public function index()
     {
-        return json_collection(auth()->user()->oauthClients()->get(), 'OAuth\Client');
+        return json_collection(auth()->user()->oauthClients()->where('revoked', false)->get(), 'OAuth\Client');
     }
 
     public function store()


### PR DESCRIPTION
Just don't show the client instead of having `revoked: true`. This brings the behaviour in-line with the one on the account settings page.