### PR TITLE
Add version of Cache::remember with callback mutex

### DIFF
--- a/app/Models/Beatmapset.php
+++ b/app/Models/Beatmapset.php
@@ -378,7 +378,7 @@ class Beatmapset extends Model implements AfterCommit, Commentable
             }
 
             return $mostPlayed;
-        }) ?? [];
+        }, []);
     }
 
     public static function coverSizes()

--- a/app/Models/Beatmapset.php
+++ b/app/Models/Beatmapset.php
@@ -364,7 +364,7 @@ class Beatmapset extends Model implements AfterCommit, Commentable
     public static function mostPlayedToday($mode = 'osu', $count = 5)
     {
         // TODO: this only returns based on osu mode plays for now, add other game modes after mode-toggle UI/UX happens
-        return cache_remember_mutexed("beatmapsets_most_played_today_{$mode}_{$count}", 60, function () use ($count) {
+        return cache_remember_mutexed("beatmapsets_most_played_today_{$mode}_{$count}", 60, [], function () use ($count) {
             $counts = Score\Osu::selectRaw('beatmapset_id, count(*) as playcount')
                     ->whereNotIn('beatmapset_id', self::BUNDLED_IDS)
                     ->groupBy('beatmapset_id')
@@ -378,7 +378,7 @@ class Beatmapset extends Model implements AfterCommit, Commentable
             }
 
             return $mostPlayed;
-        }, []);
+        });
     }
 
     public static function coverSizes()

--- a/app/Models/Beatmapset.php
+++ b/app/Models/Beatmapset.php
@@ -364,8 +364,7 @@ class Beatmapset extends Model implements AfterCommit, Commentable
     public static function mostPlayedToday($mode = 'osu', $count = 5)
     {
         // TODO: this only returns based on osu mode plays for now, add other game modes after mode-toggle UI/UX happens
-
-        return Cache::remember("beatmapsets_most_played_today_{$mode}_{$count}", 60, function () use ($mode, $count) {
+        return cache_remember_mutexed("beatmapsets_most_played_today_{$mode}_{$count}", 60, function () use ($count) {
             $counts = Score\Osu::selectRaw('beatmapset_id, count(*) as playcount')
                     ->whereNotIn('beatmapset_id', self::BUNDLED_IDS)
                     ->groupBy('beatmapset_id')
@@ -379,7 +378,7 @@ class Beatmapset extends Model implements AfterCommit, Commentable
             }
 
             return $mostPlayed;
-        });
+        }) ?? [];
     }
 
     public static function coverSizes()

--- a/app/Models/UserScoreable.php
+++ b/app/Models/UserScoreable.php
@@ -86,7 +86,7 @@ trait UserScoreable
         $key = "search-cache:beatmapBestScores:{$this->getKey()}:{$mode}";
         $ids = cache_remember_mutexed($key, config('osu.scores.es_cache_duration'), function () use ($mode) {
             return $this->beatmapBestScoreIds($mode, 100);
-        }) ?? [];
+        }, []);
 
         $ids = array_slice($ids, $offset, $limit);
         $clazz = Best\Model::getClassByString($mode);

--- a/app/Models/UserScoreable.php
+++ b/app/Models/UserScoreable.php
@@ -84,9 +84,9 @@ trait UserScoreable
         // aggregations do not support regular pagination.
         // always fetching 100 to cache; we're not supporting beyond 100, either.
         $key = "search-cache:beatmapBestScores:{$this->getKey()}:{$mode}";
-        $ids = cache_remember_mutexed($key, config('osu.scores.es_cache_duration'), function () use ($mode) {
+        $ids = cache_remember_mutexed($key, config('osu.scores.es_cache_duration'), [], function () use ($mode) {
             return $this->beatmapBestScoreIds($mode, 100);
-        }, []);
+        });
 
         $ids = array_slice($ids, $offset, $limit);
         $clazz = Best\Model::getClassByString($mode);

--- a/app/Models/UserScoreable.php
+++ b/app/Models/UserScoreable.php
@@ -84,9 +84,9 @@ trait UserScoreable
         // aggregations do not support regular pagination.
         // always fetching 100 to cache; we're not supporting beyond 100, either.
         $key = "search-cache:beatmapBestScores:{$this->getKey()}:{$mode}";
-        $ids = Cache::remember($key, config('osu.scores.es_cache_duration'), function () use ($mode) {
+        $ids = cache_remember_mutexed($key, config('osu.scores.es_cache_duration'), function () use ($mode) {
             return $this->beatmapBestScoreIds($mode, 100);
-        });
+        }) ?? [];
 
         $ids = array_slice($ids, $offset, $limit);
         $clazz = Best\Model::getClassByString($mode);

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -65,7 +65,7 @@ function broadcast_notification(...$arguments)
 /**
  * Like cache_remember_with_fallback but with a mutex that only allows a single process to run the callback.
  */
-function cache_remember_mutexed(string $key, $minutes, callable $callback, $default)
+function cache_remember_mutexed(string $key, $minutes, $default, callable $callback)
 {
     static $oneMonthInMinutes = 30 * 24 * 60;
     $fullKey = "{$key}:with_fallback";

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -63,6 +63,39 @@ function broadcast_notification(...$arguments)
 }
 
 /**
+ * Like cache_remember_with_fallback but with a mutex that only allows a single process to run the callback.
+ */
+function cache_remember_mutexed(string $key, $minutes, callable $callback)
+{
+    static $oneMonthInMinutes = 30 * 24 * 60;
+    $fullKey = "{$key}:with_fallback";
+    $data = cache()->get($fullKey);
+
+    if ($data === null || $data['expires_at']->isPast()) {
+        $lockKey = "{$key}:lock";
+        // this is arbitrary, but you've got other problems if it takes more than 5 minutes.
+        // the max is because cache()->add() doesn't work so well with funny values.
+        $lockTime = min(max($minutes, 1), 5);
+
+        // only the first caller that manages to setnx runs this.
+        if (cache()->add($lockKey, 1, $lockTime)) {
+            try {
+                $data = [
+                    'expires_at' => Carbon\Carbon::now()->addMinutes($minutes),
+                    'value' => $callback(),
+                ];
+
+                cache()->put($fullKey, $data, max($oneMonthInMinutes, $minutes * 10));
+            } finally {
+                cache()->forget($lockKey);
+            }
+        }
+    }
+
+    return $data['value'] ?? null;
+}
+
+/**
  * Like Cache::remember but always save for one month or 10 * $minutes (whichever is longer)
  * and return old value if failed getting the value after it expires.
  */

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -65,7 +65,7 @@ function broadcast_notification(...$arguments)
 /**
  * Like cache_remember_with_fallback but with a mutex that only allows a single process to run the callback.
  */
-function cache_remember_mutexed(string $key, $minutes, callable $callback)
+function cache_remember_mutexed(string $key, $minutes, callable $callback, $default)
 {
     static $oneMonthInMinutes = 30 * 24 * 60;
     $fullKey = "{$key}:with_fallback";
@@ -92,7 +92,7 @@ function cache_remember_mutexed(string $key, $minutes, callable $callback)
         }
     }
 
-    return $data['value'] ?? null;
+    return $data['value'] ?? $default;
 }
 
 /**

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -86,6 +86,9 @@ function cache_remember_mutexed(string $key, $minutes, callable $callback, $defa
                 ];
 
                 cache()->put($fullKey, $data, max($oneMonthInMinutes, $minutes * 10));
+            } catch (Exception $e) {
+                // Log and continue with data from the first ::get.
+                log_error($e);
             } finally {
                 cache()->forget($lockKey);
             }


### PR DESCRIPTION
closes #5039 

Allows at most one caller to run the cache remember callback within the duration of the lock.

It's not a direct drop in replacement for `cache_remember_with_fallback` as callers will need to handle the case where the value doesn't exist yet instead of assuming the callback always runs.

`cache()->add()` is conveniently atomic so there shouldn't be any race conditions unlike getting and setting keys across multiple calls.

There are more efficient and lower latency ways to implement this using `set ex nx`, `mutli` and `ttl` but that involves a bit more low level handling