### PR TITLE
Hide votes summary for deleted discussions

### DIFF
--- a/app/Transformers/BeatmapDiscussionTransformer.php
+++ b/app/Transformers/BeatmapDiscussionTransformer.php
@@ -86,6 +86,10 @@ class BeatmapDiscussionTransformer extends Fractal\TransformerAbstract
 
     public function includeVotes(BeatmapDiscussion $discussion)
     {
+        if (!$this->isVisible($discussion)) {
+            return;
+        }
+
         return $this->primitive($discussion->votesSummary());
     }
 


### PR DESCRIPTION
Having votes summary in otherwise empty object (deleted discussion) confuses the filter. Resolves #4988.