### PR TITLE
Fix featured artist tracks sort order

### DIFF
--- a/app/Http/Controllers/ArtistsController.php
+++ b/app/Http/Controllers/ArtistsController.php
@@ -57,7 +57,7 @@ class ArtistsController extends Controller
                 $query->orderBy('display_order', 'ASC');
             }])->get();
 
-        $tracks = $artist->tracks()->whereNull('album_id')->orderBy('display_order', 'asc')->get();
+        $tracks = $artist->tracks()->whereNull('album_id')->orderBy('id', 'desc')->get();
 
         $images = [
             'header_url' => $artist->header_url,

--- a/app/Http/Controllers/ArtistsController.php
+++ b/app/Http/Controllers/ArtistsController.php
@@ -57,7 +57,7 @@ class ArtistsController extends Controller
                 $query->orderBy('display_order', 'ASC');
             }])->get();
 
-        $tracks = $artist->tracks()->whereNull('album_id')->orderBy('display_order', 'ASC NULLS LAST')->get();
+        $tracks = $artist->tracks()->whereNull('album_id')->orderBy('display_order', 'asc')->get();
 
         $images = [
             'header_url' => $artist->header_url,


### PR DESCRIPTION
MySQL doesn't support repositioning null values and laravel has been silently converting it to desc (and they changed it in 5.8 to throw error instead).