### PR TITLE
Improve phpunit wrapper

### DIFF
--- a/bin/phpunit
+++ b/bin/phpunit
@@ -1,8 +1,5 @@
-#!/usr/bin/env php
-<?php
+#!/bin/sh
 
-require_once __DIR__.'/../app/framework_helper_overrides.php';
+cd "$(dirname "$0")/.."
 
-// This will print the first shebang line in the file because it's called
-// from here instead of shell.
-require_once __DIR__.'/../vendor/bin/phpunit';
+exec vendor/bin/phpunit --prepend=app/framework_helper_overrides.php "$@"


### PR DESCRIPTION
Use shell script instead of php for preloading framework override before starting test. They added this ability in 7.4.

Also it fixes problem in phpunit 8 as the start script can't be run using `require` because of `strict_types` declaration being on second line.

As a bonus, it removes the appearance of shebang line in test due to how `require` works.