### PR TITLE
Always generate sourcemap

### DIFF
--- a/webpack.mix.js
+++ b/webpack.mix.js
@@ -86,6 +86,7 @@ vendor.forEach(function (script) {
 
 
 let webpackConfig = {
+  devtool: '#source-map',
   externals: {
     "lodash": "_",
     "moment": "moment",
@@ -168,8 +169,6 @@ if (mix.inProduction()) {
     }),
   ];
 }
-
-webpackConfig.devtool = '#source-map';
 
 if (process.env.SENTRY_RELEASE == 1) {
   webpackConfig['plugins'].push(

--- a/webpack.mix.js
+++ b/webpack.mix.js
@@ -169,9 +169,7 @@ if (mix.inProduction()) {
   ];
 }
 
-if (!mix.inProduction() || process.env.SENTRY_RELEASE == 1) {
-  webpackConfig['devtool'] = '#source-map';
-}
+webpackConfig.devtool = '#source-map';
 
 if (process.env.SENTRY_RELEASE == 1) {
   webpackConfig['plugins'].push(


### PR DESCRIPTION
Having one server generate sourcemap and the other not will result in different files being generated.

So generate them everywhere to make sure compiled files have same hash and stuff.