### PR TITLE
Fix visibility and return type of test setup and teardown

### DIFF
--- a/tests/Browser/SanityTest.php
+++ b/tests/Browser/SanityTest.php
@@ -16,19 +16,6 @@ class SanityTest extends DuskTestCase
     protected $failed = 0;
     protected $skipped = 0;
 
-    public function setUp()
-    {
-        parent::setUp();
-
-        $this->createScaffolding();
-
-        $this->beforeApplicationDestroyed(function () {
-            // We do this here while we can still access laravel,
-            // tearDown/tearDownAfterClass runs after laravel is torn down
-            $this->cleanup();
-        });
-    }
-
     public function createScaffolding()
     {
         if (!isset(self::$scaffolding)) {
@@ -423,5 +410,18 @@ class SanityTest extends DuskTestCase
         if ($count > 0) {
             return $matches[1][count($matches[1]) - 1];
         }
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->createScaffolding();
+
+        $this->beforeApplicationDestroyed(function () {
+            // We do this here while we can still access laravel,
+            // tearDown/tearDownAfterClass runs after laravel is torn down
+            $this->cleanup();
+        });
     }
 }

--- a/tests/Controllers/AccountControllerTest.php
+++ b/tests/Controllers/AccountControllerTest.php
@@ -8,13 +8,6 @@ class AccountControllerTest extends TestCase
 {
     private $user;
 
-    public function setUp()
-    {
-        parent::setUp();
-
-        $this->user = factory(User::class)->create();
-    }
-
     /**
      * Checks whether an OK status is returned when the
      * profile order update request is valid.
@@ -185,6 +178,13 @@ class AccountControllerTest extends TestCase
                 ],
             ])
             ->assertStatus(422);
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->user = factory(User::class)->create();
     }
 
     private function user()

--- a/tests/Controllers/BeatmapControllerTest.php
+++ b/tests/Controllers/BeatmapControllerTest.php
@@ -22,14 +22,6 @@ use App\Models\User;
 
 class BeatmapControllerTest extends TestCase
 {
-    public function setUp()
-    {
-        parent::setUp();
-
-        $this->user = factory(User::class)->create();
-        $this->beatmap = factory(Beatmap::class)->states('approved')->create();
-    }
-
     public function testInvalidMode()
     {
         $this->json('GET', route('beatmaps.scores', $this->beatmap), [
@@ -69,5 +61,13 @@ class BeatmapControllerTest extends TestCase
             ->json('GET', route('beatmaps.scores', $this->beatmap), [
                 'type' => 'country',
             ])->assertStatus(200);
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->user = factory(User::class)->create();
+        $this->beatmap = factory(Beatmap::class)->states('approved')->create();
     }
 }

--- a/tests/Controllers/BeatmapDiscussionPostsControllerTest.php
+++ b/tests/Controllers/BeatmapDiscussionPostsControllerTest.php
@@ -11,30 +11,6 @@ use App\Models\UserNotification;
 
 class BeatmapDiscussionPostsControllerTest extends TestCase
 {
-    public function setUp()
-    {
-        parent::setUp();
-
-        $this->mapper = factory(User::class)->create();
-        $this->user = factory(User::class)->create();
-        $this->beatmapset = factory(Beatmapset::class)->create([
-            'user_id' => $this->mapper->getKey(),
-        ]);
-        $this->beatmap = $this->beatmapset->beatmaps()->save(factory(Beatmap::class)->make());
-        $this->beatmapDiscussion = factory(BeatmapDiscussion::class, 'timeline')->create([
-            'beatmapset_id' => $this->beatmapset->getKey(),
-            'beatmap_id' => $this->beatmap->getKey(),
-            'user_id' => $this->user->getKey(),
-        ]);
-        $post = factory(BeatmapDiscussionPost::class, 'timeline')->make([
-            'user_id' => $this->user->getKey(),
-        ]);
-        $this->beatmapDiscussionPost = $this->beatmapDiscussion->beatmapDiscussionPosts()->save($post);
-
-        $this->otherBeatmapset = factory(Beatmapset::class)->states('no_discussion')->create();
-        $this->otherBeatmap = $this->otherBeatmapset->beatmaps()->save(factory(Beatmap::class)->make());
-    }
-
     public function testPostStoreNewDiscussion()
     {
         $currentDiscussions = BeatmapDiscussion::count();
@@ -512,6 +488,30 @@ class BeatmapDiscussionPostsControllerTest extends TestCase
         $this->deletePost($reply2, $this->user)->assertStatus(403);
         $this->assertFalse($reply1->fresh()->trashed());
         $this->assertFalse($reply2->fresh()->trashed());
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->mapper = factory(User::class)->create();
+        $this->user = factory(User::class)->create();
+        $this->beatmapset = factory(Beatmapset::class)->create([
+            'user_id' => $this->mapper->getKey(),
+        ]);
+        $this->beatmap = $this->beatmapset->beatmaps()->save(factory(Beatmap::class)->make());
+        $this->beatmapDiscussion = factory(BeatmapDiscussion::class, 'timeline')->create([
+            'beatmapset_id' => $this->beatmapset->getKey(),
+            'beatmap_id' => $this->beatmap->getKey(),
+            'user_id' => $this->user->getKey(),
+        ]);
+        $post = factory(BeatmapDiscussionPost::class, 'timeline')->make([
+            'user_id' => $this->user->getKey(),
+        ]);
+        $this->beatmapDiscussionPost = $this->beatmapDiscussion->beatmapDiscussionPosts()->save($post);
+
+        $this->otherBeatmapset = factory(Beatmapset::class)->states('no_discussion')->create();
+        $this->otherBeatmap = $this->otherBeatmapset->beatmaps()->save(factory(Beatmap::class)->make());
     }
 
     private function deletePost(BeatmapDiscussionPost $post, ?User $user = null)

--- a/tests/Controllers/BeatmapDiscussionsControllerTest.php
+++ b/tests/Controllers/BeatmapDiscussionsControllerTest.php
@@ -9,32 +9,6 @@ use App\Models\UserGroup;
 
 class BeatmapDiscussionsControllerTest extends TestCase
 {
-    public function setUp()
-    {
-        parent::setUp();
-
-        $this->mapper = factory(User::class)->create();
-        $this->user = factory(User::class)->create();
-        $this->anotherUser = factory(User::class)->create();
-        $this->bngUser = factory(User::class)->create();
-        $this->bngUserGroup($this->bngUser);
-        $this->beatmapset = factory(Beatmapset::class)->create([
-            'user_id' => $this->mapper->user_id,
-            'discussion_enabled' => true,
-            'approved' => Beatmapset::STATES['pending'],
-        ]);
-        $this->beatmap = $this->beatmapset->beatmaps()->save(factory(Beatmap::class)->make([
-            'user_id' => $this->mapper->user_id,
-        ]));
-        $this->discussion = BeatmapDiscussion::create([
-            'beatmapset_id' => $this->beatmapset->getKey(),
-            'timestamp' => 0,
-            'message_type' => 'problem',
-            'beatmap_id' => $this->beatmap->beatmap_id,
-            'user_id' => $this->user->user_id,
-        ]);
-    }
-
     // normal vote
     public function testPutVoteInitial()
     {
@@ -189,6 +163,32 @@ class BeatmapDiscussionsControllerTest extends TestCase
 
         $this->assertSame($currentVotes + 1, BeatmapDiscussionVote::count());
         $this->assertSame($currentScore - 1, $this->currentScore($this->discussion));
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->mapper = factory(User::class)->create();
+        $this->user = factory(User::class)->create();
+        $this->anotherUser = factory(User::class)->create();
+        $this->bngUser = factory(User::class)->create();
+        $this->bngUserGroup($this->bngUser);
+        $this->beatmapset = factory(Beatmapset::class)->create([
+            'user_id' => $this->mapper->user_id,
+            'discussion_enabled' => true,
+            'approved' => Beatmapset::STATES['pending'],
+        ]);
+        $this->beatmap = $this->beatmapset->beatmaps()->save(factory(Beatmap::class)->make([
+            'user_id' => $this->mapper->user_id,
+        ]));
+        $this->discussion = BeatmapDiscussion::create([
+            'beatmapset_id' => $this->beatmapset->getKey(),
+            'timestamp' => 0,
+            'message_type' => 'problem',
+            'beatmap_id' => $this->beatmap->beatmap_id,
+            'user_id' => $this->user->user_id,
+        ]);
     }
 
     private function bngUserGroup($user)

--- a/tests/Controllers/Chat/Channels/MessagesControllerTest.php
+++ b/tests/Controllers/Chat/Channels/MessagesControllerTest.php
@@ -31,26 +31,9 @@ class MessagesControllerTest extends TestCase
 {
     protected static $faker;
 
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         self::$faker = Faker\Factory::create();
-    }
-
-    public function setUp()
-    {
-        parent::setUp();
-
-        $this->user = factory(User::class)->create();
-        $this->anotherUser = factory(User::class)->create();
-        $this->restrictedUser = factory(User::class)->states('restricted')->create();
-        // TODO: convert $this->silencedUser to use afterCreatingState after upgrading to Laraval 5.6
-        $this->silencedUser = factory(User::class)->create();
-        $this->silencedUser->accountHistories()->save(
-            factory(\App\Models\UserAccountHistory::class)->states('silence')->make()
-        );
-        $this->publicChannel = factory(Chat\Channel::class)->states('public')->create();
-        $this->privateChannel = factory(Chat\Channel::class)->states('private')->create();
-        $this->pmChannel = factory(Chat\Channel::class)->states('pm')->create();
     }
 
     //region GET /chat/channels/[channel_id] - Get Channel Messages (public)
@@ -365,4 +348,21 @@ class MessagesControllerTest extends TestCase
     }
 
     //endregion
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->user = factory(User::class)->create();
+        $this->anotherUser = factory(User::class)->create();
+        $this->restrictedUser = factory(User::class)->states('restricted')->create();
+        // TODO: convert $this->silencedUser to use afterCreatingState after upgrading to Laraval 5.6
+        $this->silencedUser = factory(User::class)->create();
+        $this->silencedUser->accountHistories()->save(
+            factory(\App\Models\UserAccountHistory::class)->states('silence')->make()
+        );
+        $this->publicChannel = factory(Chat\Channel::class)->states('public')->create();
+        $this->privateChannel = factory(Chat\Channel::class)->states('private')->create();
+        $this->pmChannel = factory(Chat\Channel::class)->states('pm')->create();
+    }
 }

--- a/tests/Controllers/Chat/ChannelsControllerTest.php
+++ b/tests/Controllers/Chat/ChannelsControllerTest.php
@@ -28,21 +28,9 @@ class ChannelsControllerTest extends TestCase
 {
     protected static $faker;
 
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         self::$faker = Faker\Factory::create();
-    }
-
-    public function setUp()
-    {
-        parent::setUp();
-
-        $this->user = factory(User::class)->create();
-        $this->anotherUser = factory(User::class)->create();
-        $this->publicChannel = factory(Chat\Channel::class)->states('public')->create();
-        $this->privateChannel = factory(Chat\Channel::class)->states('private')->create();
-        $this->pmChannel = factory(Chat\Channel::class)->states('pm')->create();
-        $this->publicMessage = factory(Chat\Message::class)->create(['channel_id' => $this->publicChannel->channel_id]);
     }
 
     //region GET /chat/channels - Get Channel List
@@ -348,4 +336,16 @@ class ChannelsControllerTest extends TestCase
     }
 
     //endregion
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->user = factory(User::class)->create();
+        $this->anotherUser = factory(User::class)->create();
+        $this->publicChannel = factory(Chat\Channel::class)->states('public')->create();
+        $this->privateChannel = factory(Chat\Channel::class)->states('private')->create();
+        $this->pmChannel = factory(Chat\Channel::class)->states('pm')->create();
+        $this->publicMessage = factory(Chat\Message::class)->create(['channel_id' => $this->publicChannel->channel_id]);
+    }
 }

--- a/tests/Controllers/Chat/ChatControllerTest.php
+++ b/tests/Controllers/Chat/ChatControllerTest.php
@@ -27,34 +27,9 @@ class ChatControllerTest extends TestCase
 
     protected static $faker;
 
-    public static function setUpBeforeClass()
+    public static function setUpBeforeClass(): void
     {
         self::$faker = Faker\Factory::create();
-    }
-
-    public function setUp()
-    {
-        parent::setUp();
-
-        $trx = [];
-        $db = $this->app->make('db');
-        foreach (array_keys(config('database.connections')) as $name) {
-            $connection = $db->connection($name);
-
-            // connections with different names but to the same database share the same pdo connection.
-            $id = $connection->select('SELECT CONNECTION_ID() as connection_id')[0]->connection_id;
-            // Avoid setting isolation level or starting transaction more than once on a pdo connection.
-            if (!in_array($id, $trx, true)) {
-                $trx[] = $id;
-
-                // allow uncommitted changes be visible across connections.
-                $connection->statement('SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED');
-                $connection->beginTransaction();
-            }
-        }
-
-        $this->user = factory(User::class)->create();
-        $this->anotherUser = factory(User::class)->create();
     }
 
     //region POST /chat/new - Create New PM
@@ -464,4 +439,29 @@ class ChatControllerTest extends TestCase
     }
 
     //endregion
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $trx = [];
+        $db = $this->app->make('db');
+        foreach (array_keys(config('database.connections')) as $name) {
+            $connection = $db->connection($name);
+
+            // connections with different names but to the same database share the same pdo connection.
+            $id = $connection->select('SELECT CONNECTION_ID() as connection_id')[0]->connection_id;
+            // Avoid setting isolation level or starting transaction more than once on a pdo connection.
+            if (!in_array($id, $trx, true)) {
+                $trx[] = $id;
+
+                // allow uncommitted changes be visible across connections.
+                $connection->statement('SET TRANSACTION ISOLATION LEVEL READ UNCOMMITTED');
+                $connection->beginTransaction();
+            }
+        }
+
+        $this->user = factory(User::class)->create();
+        $this->anotherUser = factory(User::class)->create();
+    }
 }

--- a/tests/Controllers/ForumTopicsControllerTest.php
+++ b/tests/Controllers/ForumTopicsControllerTest.php
@@ -7,15 +7,6 @@ use App\Models\UserStatistics\Osu as StatisticsOsu;
 
 class ForumTopicsControllerTest extends TestCase
 {
-    public function setUp()
-    {
-        parent::setUp();
-
-        // initial user for forum posts and stuff
-        // FIXME: this is actually a hidden dependency
-        factory(User::class)->create();
-    }
-
     public function testReply()
     {
         $forum = factory(Forum\Forum::class, 'child')->create();
@@ -178,6 +169,15 @@ class ForumTopicsControllerTest extends TestCase
             ->assertStatus(422);
 
         $this->assertSame($initialTitle, $topic->fresh()->topic_title);
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // initial user for forum posts and stuff
+        // FIXME: this is actually a hidden dependency
+        factory(User::class)->create();
     }
 
     private function defaultUserGroup($user)

--- a/tests/Controllers/MatchesControllerTest.php
+++ b/tests/Controllers/MatchesControllerTest.php
@@ -29,25 +29,6 @@ class MatchesControllerTest extends TestCase
     private $publicMatchRoute;
     private $user;
 
-    public function setUp()
-    {
-        parent::setUp();
-
-        $this->user = factory(User::class)->create();
-
-        $this->publicMatch = factory(Match::class)->create();
-        factory(Event::class)->states('create')->create([
-            'match_id' => $this->publicMatch->match_id,
-        ]);
-        $this->publicMatchRoute = route('matches.show', $this->publicMatch->match_id);
-
-        $this->privateMatch = factory(Match::class)->states('private')->create();
-        factory(Event::class)->states('create')->create([
-            'match_id' => $this->privateMatch->match_id,
-        ]);
-        $this->privateMatchRoute = route('matches.show', $this->privateMatch->match_id);
-    }
-
     public function testPublicMatchLoggedOut() // OK
     {
         $this
@@ -116,5 +97,24 @@ class MatchesControllerTest extends TestCase
             ->actingAs($this->user)
             ->get($this->privateMatchRoute)
             ->assertStatus(200);
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->user = factory(User::class)->create();
+
+        $this->publicMatch = factory(Match::class)->create();
+        factory(Event::class)->states('create')->create([
+            'match_id' => $this->publicMatch->match_id,
+        ]);
+        $this->publicMatchRoute = route('matches.show', $this->publicMatch->match_id);
+
+        $this->privateMatch = factory(Match::class)->states('private')->create();
+        factory(Event::class)->states('create')->create([
+            'match_id' => $this->privateMatch->match_id,
+        ]);
+        $this->privateMatchRoute = route('matches.show', $this->privateMatch->match_id);
     }
 }

--- a/tests/Controllers/OAuth/ClientsControllerTest.php
+++ b/tests/Controllers/OAuth/ClientsControllerTest.php
@@ -31,14 +31,6 @@ class ClientsControllerTest extends TestCase
     private $client;
     private $owner;
 
-    public function setUp()
-    {
-        parent::setUp();
-
-        $this->owner = factory(User::class)->create();
-        $this->client = factory(Client::class)->create(['user_id' => $this->owner->getKey()]);
-    }
-
     public function testGuestCannotDeleteClient()
     {
         $this
@@ -160,5 +152,13 @@ class ClientsControllerTest extends TestCase
             ['', 'https://nowhere.local'],
             [' ', 'https://nowhere.local'],
         ];
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->owner = factory(User::class)->create();
+        $this->client = factory(Client::class)->create(['user_id' => $this->owner->getKey()]);
     }
 }

--- a/tests/Controllers/Passport/AuthorizationControllerTest.php
+++ b/tests/Controllers/Passport/AuthorizationControllerTest.php
@@ -29,23 +29,6 @@ class AuthorizationControllerTest extends TestCase
 {
     private $controller;
 
-    public function setUp()
-    {
-        parent::setUp();
-
-        $this->controller = new AuthorizationController(
-            Mockery::mock('\League\OAuth2\Server\AuthorizationServer'),
-            Mockery::mock('\Illuminate\Contracts\Routing\ResponseFactory')
-        );
-    }
-
-    public function tearDown()
-    {
-        parent::tearDown();
-
-        Mockery::close();
-    }
-
     public function testAuthorizeNormalizes()
     {
         $request = new ServerRequest(
@@ -96,5 +79,22 @@ class AuthorizationControllerTest extends TestCase
         $actual = $this->invokeMethod($this->controller, 'normalizeScopes', [$scopes]);
 
         $this->assertSame($actual, ['identify', 'read']);
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->controller = new AuthorizationController(
+            Mockery::mock('\League\OAuth2\Server\AuthorizationServer'),
+            Mockery::mock('\Illuminate\Contracts\Routing\ResponseFactory')
+        );
+    }
+
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+
+        Mockery::close();
     }
 }

--- a/tests/Controllers/Payments/CentiliControllerTest.php
+++ b/tests/Controllers/Payments/CentiliControllerTest.php
@@ -28,15 +28,6 @@ use TestCase;
 
 class CentiliControllerTest extends TestCase
 {
-    public function setUp()
-    {
-        parent::setUp();
-        Config::set('payments.centili.secret_key', 'secret_key');
-        Config::set('payments.centili.api_key', 'api_key');
-        Config::set('payments.centili.conversion_rate', 120.00);
-        $this->order = factory(Order::class)->states('checkout')->create();
-    }
-
     public function testWhenEverythingIsFine()
     {
         $data = $this->getPostData();
@@ -63,6 +54,15 @@ class CentiliControllerTest extends TestCase
         );
 
         $response->assertStatus(406);
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        Config::set('payments.centili.secret_key', 'secret_key');
+        Config::set('payments.centili.api_key', 'api_key');
+        Config::set('payments.centili.conversion_rate', 120.00);
+        $this->order = factory(Order::class)->states('checkout')->create();
     }
 
     private function getPostData(array $overrides = [])

--- a/tests/Controllers/Payments/ShopifyControllerTest.php
+++ b/tests/Controllers/Payments/ShopifyControllerTest.php
@@ -27,14 +27,6 @@ use TestCase;
 
 class ShopifyControllerTest extends TestCase
 {
-    public function setUp()
-    {
-        parent::setUp();
-        config()->set('payments.shopify.webhook_key', 'magic');
-
-        $this->url = route('payments.shopify.callback');
-    }
-
     public function testWebhookOrdersIdIsRequired()
     {
         $this->payload = [
@@ -151,6 +143,14 @@ class ShopifyControllerTest extends TestCase
         $this->assertSame($order->status, 'shipped');
         $this->assertEquals($order->updated_at, $oldUpdatedAt);
         $this->assertSame(Order::withoutGlobalScopes()->count(), 1);
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        config()->set('payments.shopify.webhook_key', 'magic');
+
+        $this->url = route('payments.shopify.callback');
     }
 
     private function sendCallbackRequest(array $extraHeaders = [])

--- a/tests/Controllers/Payments/XsollaControllerTest.php
+++ b/tests/Controllers/Payments/XsollaControllerTest.php
@@ -27,13 +27,6 @@ use TestCase;
 
 class XsollaControllerTest extends TestCase
 {
-    public function setUp()
-    {
-        parent::setUp();
-        Config::set('payments.xsolla.secret_key', 'magic');
-        $this->order = factory(Order::class)->states('checkout')->create();
-    }
-
     public function testWhenEverythingIsFine()
     {
         $data = $this->getPostData();
@@ -82,6 +75,13 @@ class XsollaControllerTest extends TestCase
         );
 
         $response->assertStatus(422);
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        Config::set('payments.xsolla.secret_key', 'magic');
+        $this->order = factory(Order::class)->states('checkout')->create();
     }
 
     private function getPostData(array $overrides = [])

--- a/tests/Controllers/ScoresControllerTest.php
+++ b/tests/Controllers/ScoresControllerTest.php
@@ -25,13 +25,6 @@ class ScoresControllerTest extends TestCase
     private $score;
     private $user;
 
-    public function setUp()
-    {
-        parent::setUp();
-        $this->user = factory(User::class)->create();
-        $this->score = factory(Osu::class)->create();
-    }
-
     public function testDownload()
     {
         $this
@@ -74,5 +67,12 @@ class ScoresControllerTest extends TestCase
                 route('scores.report', ['mode' => 'nope', 'score' => $this->score->getKey()])
             )
             ->assertStatus(404);
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->user = factory(User::class)->create();
+        $this->score = factory(Osu::class)->create();
     }
 }

--- a/tests/Libraries/AcceptHttpLanguage/ParserTest.php
+++ b/tests/Libraries/AcceptHttpLanguage/ParserTest.php
@@ -33,11 +33,6 @@ class ParserTest extends TestCase
     /** @var Parser */
     private $parser;
 
-    public function setUp()
-    {
-        $this->parser = new Parser('en-us,en-gb;q=0.8,en;q=0.6,es-419');
-    }
-
     public function testShouldReturnEmptyArray()
     {
         $this->parser->header = null;
@@ -96,5 +91,10 @@ class ParserTest extends TestCase
     {
         $this->parser->header = 'ja,en-gb,en-us,fr-fr';
         $this->assertSame('ja-JP', $this->parser->languageRegionCompatibleFrom(['en-UK', 'en-US', 'ja-JP']));
+    }
+
+    protected function setUp(): void
+    {
+        $this->parser = new Parser('en-us,en-gb;q=0.8,en;q=0.6,es-419');
     }
 }

--- a/tests/Libraries/Fulfillments/BannerFulfillmentTest.php
+++ b/tests/Libraries/Fulfillments/BannerFulfillmentTest.php
@@ -34,25 +34,6 @@ use TestCase;
 
 class BannerFulfillmentTest extends TestCase
 {
-    public function setUp()
-    {
-        parent::setUp();
-
-        $this->user = factory(User::class)->create([
-            'osu_featurevotes' => 0,
-            'osu_subscriptionexpiry' => Carbon::now(),
-        ]);
-
-        $this->order = factory(Order::class, 'paid')->create([
-            'user_id' => $this->user->user_id,
-        ]);
-
-        // crap test
-        $this->tournament = factory(Tournament::class)->create();
-        $this->product = Product::customClass('mwc7-supporter')->orderBy('product_id', 'desc')->first();
-        $this->findOrSeed();
-    }
-
     private function findOrSeed()
     {
         // TODO: factory that creates related items properly? or just use fixtures.
@@ -122,6 +103,25 @@ class BannerFulfillmentTest extends TestCase
 
         $this->expectException(\App\Libraries\Fulfillments\InvalidFulfillerException::class);
         $subjects = FulfillmentFactory::createFulfillersFor($this->order);
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->user = factory(User::class)->create([
+            'osu_featurevotes' => 0,
+            'osu_subscriptionexpiry' => Carbon::now(),
+        ]);
+
+        $this->order = factory(Order::class, 'paid')->create([
+            'user_id' => $this->user->user_id,
+        ]);
+
+        // crap test
+        $this->tournament = factory(Tournament::class)->create();
+        $this->product = Product::customClass('mwc7-supporter')->orderBy('product_id', 'desc')->first();
+        $this->findOrSeed();
     }
 
     private function createOrderItem($product)

--- a/tests/Libraries/Fulfillments/SupporterTagFulfillmentTest.php
+++ b/tests/Libraries/Fulfillments/SupporterTagFulfillmentTest.php
@@ -34,20 +34,6 @@ use TestCase;
 
 class SupporterTagFulfillmentTest extends TestCase
 {
-    public function setUp()
-    {
-        parent::setUp();
-
-        $this->user = factory(User::class)->create([
-            'osu_featurevotes' => 0,
-            'osu_subscriptionexpiry' => Carbon::today(),
-        ]);
-
-        $this->order = factory(Order::class, 'paid')->create([
-            'user_id' => $this->user->user_id,
-        ]);
-    }
-
     public function testDonateSupporterTagToSelf()
     {
         $donor = $this->user;
@@ -264,6 +250,20 @@ class SupporterTagFulfillmentTest extends TestCase
         $this->assertTrue($donor->osu_subscriber);
         $this->assertTrue($expectedExpiry->equalTo($donor->osu_subscriptionexpiry));
         $this->assertSame(2, $donor->osu_featurevotes);
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->user = factory(User::class)->create([
+            'osu_featurevotes' => 0,
+            'osu_subscriptionexpiry' => Carbon::today(),
+        ]);
+
+        $this->order = factory(Order::class, 'paid')->create([
+            'user_id' => $this->user->user_id,
+        ]);
     }
 
     private function createDonationOrderItem($order, $giftee, $cancelled = false, $run = false)

--- a/tests/Libraries/Fulfillments/UsernameChangeFulfillmentTest.php
+++ b/tests/Libraries/Fulfillments/UsernameChangeFulfillmentTest.php
@@ -32,14 +32,6 @@ use TestCase;
 
 class UsernameChangeFulfillmentTest extends TestCase
 {
-    public function setUp()
-    {
-        parent::setUp();
-
-        $this->user = factory(User::class)->create(['osu_subscriptionexpiry' => Carbon::now()]);
-        $this->order = factory(Order::class, 'paid')->create(['user_id' => $this->user->user_id]);
-    }
-
     public function testRun()
     {
         $oldUsername = $this->user->username;
@@ -140,5 +132,13 @@ class UsernameChangeFulfillmentTest extends TestCase
 
         $this->expectException(FulfillmentException::class);
         $fulfiller->run();
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->user = factory(User::class)->create(['osu_subscriptionexpiry' => Carbon::now()]);
+        $this->order = factory(Order::class, 'paid')->create(['user_id' => $this->user->user_id]);
     }
 }

--- a/tests/Libraries/Payments/CentiliPaymentProcessorTest.php
+++ b/tests/Libraries/Payments/CentiliPaymentProcessorTest.php
@@ -32,14 +32,6 @@ use TestCase;
 
 class CentiliPaymentProcessorTest extends TestCase
 {
-    public function setUp()
-    {
-        parent::setUp();
-        Config::set('payments.centili.api_key', 'api_key');
-        Config::set('payments.centili.conversion_rate', 120.00);
-        $this->order = factory(Order::class)->states('checkout')->create();
-    }
-
     public function testWhenEverythingIsFine()
     {
         $params = $this->getTestParams();
@@ -154,6 +146,14 @@ class CentiliPaymentProcessorTest extends TestCase
 
         $this->expectException(InvalidSignatureException::class);
         $this->runSubject($subject);
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        Config::set('payments.centili.api_key', 'api_key');
+        Config::set('payments.centili.conversion_rate', 120.00);
+        $this->order = factory(Order::class)->states('checkout')->create();
     }
 
     private function getTestParams(array $overrides = [])

--- a/tests/Libraries/Payments/CentiliSignatureTest.php
+++ b/tests/Libraries/Payments/CentiliSignatureTest.php
@@ -26,12 +26,6 @@ use TestCase;
 
 class CentiliSignatureTest extends TestCase
 {
-    public function setUp()
-    {
-        parent::setUp();
-        Config::set('payments.centili.secret_key', 'magic');
-    }
-
     public function testStringifyInput()
     {
         // sorts params and excludes 'sign'
@@ -68,5 +62,11 @@ class CentiliSignatureTest extends TestCase
         $signature = CentiliSignature::calculateSignature($params);
 
         $this->assertSame($expected, $signature);
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        Config::set('payments.centili.secret_key', 'magic');
     }
 }

--- a/tests/Libraries/Payments/ShopifySignatureTest.php
+++ b/tests/Libraries/Payments/ShopifySignatureTest.php
@@ -26,17 +26,17 @@ use TestCase;
 
 class ShopifySignatureTest extends TestCase
 {
-    public function setUp()
-    {
-        parent::setUp();
-        Config::set('payments.shopify.webhook_key', 'magic');
-    }
-
     public function testCalculateSignature()
     {
         static $expected = 'Syw+KdQu/p0kqe9g2ttEdLFCRDb13IKygoZhQO4KO1w=';
         $signature = ShopifySignature::calculateSignature(file_get_contents(__DIR__.'/content.json'));
 
         $this->assertSame($expected, $signature);
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        Config::set('payments.shopify.webhook_key', 'magic');
     }
 }

--- a/tests/Libraries/Payments/XsollaPaymentProcessorTest.php
+++ b/tests/Libraries/Payments/XsollaPaymentProcessorTest.php
@@ -31,13 +31,6 @@ use TestCase;
 
 class XsollaPaymentProcessorTest extends TestCase
 {
-    public function setUp()
-    {
-        parent::setUp();
-        Config::set('payments.xsolla.api_key', 'api_key');
-        $this->order = factory(Order::class)->states('checkout')->create();
-    }
-
     public function testWhenEverythingIsFine()
     {
         $params = $this->getTestParams();
@@ -140,6 +133,13 @@ class XsollaPaymentProcessorTest extends TestCase
         $errors = $subject->validationErrors()->all();
         $this->assertTrue($thrown);
         $this->assertArrayHasKey('order.items', $errors);
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        Config::set('payments.xsolla.api_key', 'api_key');
+        $this->order = factory(Order::class)->states('checkout')->create();
     }
 
     private function getTestParams(array $overrides = [])

--- a/tests/Libraries/Payments/XsollaSignatureTest.php
+++ b/tests/Libraries/Payments/XsollaSignatureTest.php
@@ -26,17 +26,17 @@ use TestCase;
 
 class XsollaSignatureTest extends TestCase
 {
-    public function setUp()
-    {
-        parent::setUp();
-        Config::set('payments.xsolla.secret_key', 'magic');
-    }
-
     public function testCalculateSignature()
     {
         static $expected = 'e61077e203eb692b6eb29fff47ccec989089118f';
         $signature = XsollaSignature::calculateSignature("{'notification_type':'payment'}");
 
         $this->assertSame($expected, $signature);
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        Config::set('payments.xsolla.secret_key', 'magic');
     }
 }

--- a/tests/Libraries/ReportCommentTest.php
+++ b/tests/Libraries/ReportCommentTest.php
@@ -26,12 +26,6 @@ class ReportCommentTest extends TestCase
 {
     private $reporter;
 
-    public function setUp()
-    {
-        parent::setUp();
-        $this->reporter = factory(User::class)->create();
-    }
-
     public function testCannotReportOwnComment()
     {
         $comment = $this->createComment($this->reporter);
@@ -64,6 +58,12 @@ class ReportCommentTest extends TestCase
         $this->assertSame($reportsCount + 1, $this->reporter->reportsMade()->count());
         $this->assertSame($report->user_id, $report->user_id);
         $this->assertTrue($report->reportable->is($comment));
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->reporter = factory(User::class)->create();
     }
 
     private function createComment($user)

--- a/tests/Libraries/ReportScoreTest.php
+++ b/tests/Libraries/ReportScoreTest.php
@@ -26,12 +26,6 @@ class ReportScoreTest extends TestCase
 {
     private $reporter;
 
-    public function setUp()
-    {
-        parent::setUp();
-        $this->reporter = factory(User::class)->create();
-    }
-
     public function testCannotReportOwnScore()
     {
         $score = Best\Osu::create(['user_id' => $this->reporter->getKey()]);
@@ -65,5 +59,11 @@ class ReportScoreTest extends TestCase
         $this->assertSame($score->getKey(), $report->score_id);
         $this->assertSame($score->user_id, $report->user_id);
         $this->assertTrue($report->reportable->is($score));
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->reporter = factory(User::class)->create();
     }
 }

--- a/tests/Libraries/ReportUserTest.php
+++ b/tests/Libraries/ReportUserTest.php
@@ -24,12 +24,6 @@ class ReportUserTest extends TestCase
 {
     private $reporter;
 
-    public function setUp()
-    {
-        parent::setUp();
-        $this->reporter = factory(User::class)->create();
-    }
-
     public function testCannotReportSelf()
     {
         $this->expectException(ValidationException::class);
@@ -57,5 +51,11 @@ class ReportUserTest extends TestCase
         $this->assertSame($reportsCount + 1, $this->reporter->reportsMade()->count());
         $this->assertSame($report->user_id, $report->user_id);
         $this->assertTrue($report->reportable->is($user));
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->reporter = factory(User::class)->create();
     }
 }

--- a/tests/Libraries/Transactions/AfterCommitTest.php
+++ b/tests/Libraries/Transactions/AfterCommitTest.php
@@ -36,35 +36,6 @@ class AfterCommitTest extends TestCase
 
     private $exceptionMessage = 'it should not run afterCommit';
 
-    public function setUp()
-    {
-        parent::setUp();
-
-        // not ideal to create the table between every test
-        // but Laravel's resolvers do not work in the
-        // setUpBeforeClass/tearDownAfterClass methods.
-
-        // force cleanup
-        if (Schema::hasTable('test_after_commit')) {
-            Schema::drop('test_after_commit');
-        }
-
-        // create a dummy table
-        Schema::create('test_after_commit', function ($table) {
-            $table->charset = 'utf8mb4';
-            $table->increments('id');
-            $table->timestamp('created_at')->nullable();
-            $table->timestamp('updated_at')->nullable();
-        });
-    }
-
-    public function tearDown()
-    {
-        Schema::drop('test_after_commit');
-
-        parent::tearDown();
-    }
-
     public function testModelAfterCommitSupportDoesEnlist()
     {
         $model = $this->afterCommittable();
@@ -248,6 +219,35 @@ class AfterCommitTest extends TestCase
         $this->assertSame(0, count($this->getPendingCommits('mysql')));
         $this->assertSame(0, $model->afterCommitCount);
         $this->assertSame(1, $model->afterRollbackCount);
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        // not ideal to create the table between every test
+        // but Laravel's resolvers do not work in the
+        // setUpBeforeClass/tearDownAfterClass methods.
+
+        // force cleanup
+        if (Schema::hasTable('test_after_commit')) {
+            Schema::drop('test_after_commit');
+        }
+
+        // create a dummy table
+        Schema::create('test_after_commit', function ($table) {
+            $table->charset = 'utf8mb4';
+            $table->increments('id');
+            $table->timestamp('created_at')->nullable();
+            $table->timestamp('updated_at')->nullable();
+        });
+    }
+
+    protected function tearDown(): void
+    {
+        Schema::drop('test_after_commit');
+
+        parent::tearDown();
     }
 
     private function getPendingCommits(string $connection)

--- a/tests/Models/Multiplayer/UserScoreAggregateTest.php
+++ b/tests/Models/Multiplayer/UserScoreAggregateTest.php
@@ -31,13 +31,6 @@ class UserScoreAggregateTest extends TestCase
 {
     private $room;
 
-    public function setUp()
-    {
-        parent::setUp();
-
-        $this->room = factory(Room::class)->create();
-    }
-
     public function testStartingPlayIncreasesAttempts()
     {
         $user = factory(User::class)->create();
@@ -185,6 +178,13 @@ class UserScoreAggregateTest extends TestCase
 
         $this->assertSame(0.65, $result['pp']);
         $this->assertSame(0.65, $result['accuracy']);
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->room = factory(Room::class)->create();
     }
 
     private function playlistItem()

--- a/tests/Models/OAuth/ClientTest.php
+++ b/tests/Models/OAuth/ClientTest.php
@@ -24,14 +24,6 @@ class ClientTest extends TestCase
 {
     protected $repository;
 
-    public function setUp()
-    {
-        parent::setUp();
-
-        $this->owner = factory(User::class)->create();
-        $this->client = factory(Client::class)->create(['user_id' => $this->owner->getKey()]);
-    }
-
     public function testScopesFromTokensAreAggregated()
     {
         $user = factory(User::class)->create();
@@ -202,5 +194,13 @@ class ClientTest extends TestCase
         $this->assertTrue($client->exists);
         $client->revoke();
         $this->assertTrue($client->fresh()->revoked);
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->owner = factory(User::class)->create();
+        $this->client = factory(Client::class)->create(['user_id' => $this->owner->getKey()]);
     }
 }

--- a/tests/RequireScopesTest.php
+++ b/tests/RequireScopesTest.php
@@ -28,16 +28,6 @@ class RequireScopesTest extends TestCase
     protected $next;
     protected $request;
 
-    public function setUp()
-    {
-        parent::setUp();
-
-        $this->request = Request::create('/', 'GET');
-        $this->next = static function () {
-            // just an empty closure.
-        };
-    }
-
     public function testSingleton()
     {
         $this->assertSame(app(RequireScopes::class), app(RequireScopes::class));
@@ -212,6 +202,16 @@ class RequireScopesTest extends TestCase
 
             return $route;
         });
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->request = Request::create('/', 'GET');
+        $this->next = static function () {
+            // just an empty closure.
+        };
     }
 
     protected function setUser(?array $scopes = null)

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -48,7 +48,7 @@ class TestCase extends Illuminate\Foundation\Testing\TestCase
         return $app;
     }
 
-    public function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Transformers/OAuth/ClientTransformerTest.php
+++ b/tests/Transformers/OAuth/ClientTransformerTest.php
@@ -31,14 +31,6 @@ class ClientTransformerTest extends TestCase
     private $client;
     private $owner;
 
-    public function setUp()
-    {
-        parent::setUp();
-
-        $this->owner = factory(User::class)->create();
-        $this->client = factory(Client::class)->make(['user_id' => $this->owner->getKey()]);
-    }
-
     public function testRedirectAndSecretVisibleToOwner()
     {
         auth()->setUser($this->owner);
@@ -56,5 +48,13 @@ class ClientTransformerTest extends TestCase
 
         $this->assertArrayNotHasKey('redirect', $json);
         $this->assertArrayNotHasKey('secret', $json);
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->owner = factory(User::class)->create();
+        $this->client = factory(Client::class)->make(['user_id' => $this->owner->getKey()]);
     }
 }


### PR DESCRIPTION
It's been changed to `protected` since 5.2 :dancer: 

Additionally add return type so it'll be compatible with the one in laravel 5.8 and later.