### PR TITLE
Remove scoreRanks from user statistics response

### DIFF
--- a/app/Http/Controllers/Users/ModdingHistoryController.php
+++ b/app/Http/Controllers/Users/ModdingHistoryController.php
@@ -179,7 +179,6 @@ class ModdingHistoryController extends Controller
                     'previous_usernames',
                     'ranked_and_approved_beatmapset_count',
                     'statistics.rank',
-                    'statistics.scoreRanks',
                     'support_level',
                     'unranked_beatmapset_count',
                 ]

--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -271,7 +271,6 @@ class UsersController extends Controller
             'ranked_and_approved_beatmapset_count',
             'replays_watched_counts',
             'statistics.rank',
-            'statistics.scoreRanks',
             'support_level',
             'unranked_beatmapset_count',
             'user_achievements',

--- a/app/Transformers/UserStatisticsTransformer.php
+++ b/app/Transformers/UserStatisticsTransformer.php
@@ -27,7 +27,6 @@ class UserStatisticsTransformer extends Fractal\TransformerAbstract
 {
     protected $availableIncludes = [
         'rank',
-        'scoreRanks',
         'user',
     ];
 
@@ -74,23 +73,6 @@ class UserStatisticsTransformer extends Fractal\TransformerAbstract
             return [
                 'global' => $stats->globalRank(),
                 'country' => $stats->countryRank(),
-            ];
-        });
-    }
-
-    public function includeScoreRanks(UserStatistics\Model $stats = null)
-    {
-        if ($stats === null) {
-            $stats = new UserStatistics\Osu();
-        }
-
-        return $this->item($stats, function ($stats) {
-            return [
-                'XH' => $stats->xh_rank_count,
-                'SH' => $stats->sh_rank_count,
-                'X' => $stats->x_rank_count,
-                'S' => $stats->s_rank_count,
-                'A' => $stats->a_rank_count,
             ];
         });
     }

--- a/resources/assets/coffee/react/profile-page/rank-count.coffee
+++ b/resources/assets/coffee/react/profile-page/rank-count.coffee
@@ -19,18 +19,23 @@
 import * as React from 'react'
 import { div } from 'react-dom-factories'
 el = React.createElement
-ranks = ['XH', 'X', 'SH', 'S', 'A']
+ranks =
+  XH: 'ssh'
+  X: 'ss'
+  SH: 'sh'
+  S: 's'
+  A: 'a'
 
 export class RankCount extends React.PureComponent
   render: =>
     div className: 'profile-rank-count',
-      ranks.map @renderRankCountEntry
+      @renderRankCountEntry(name, grade) for name, grade of ranks
 
 
-  renderRankCountEntry: (name) =>
+  renderRankCountEntry: (name, grade) =>
     div
       key: name
       className: 'profile-rank-count__item'
       div
         className: "score-rank score-rank--#{name} score-rank--profile-page"
-      osu.formatNumber(@props.stats.scoreRanks[name])
+      osu.formatNumber(@props.stats.grade_counts[grade])


### PR DESCRIPTION
prefer grade_counts instead; closes #5025.

It doesn't do anything about events still using `XH` instead of `ssh` or any of the css names