### PR TITLE
Featured Artists pages updates

### DIFF
--- a/app/Http/Controllers/ArtistsController.php
+++ b/app/Http/Controllers/ArtistsController.php
@@ -56,9 +56,14 @@ class ArtistsController extends Controller
             ->orderBy('id', 'desc')
             ->with(['tracks' => function ($query) {
                 $query->orderBy('display_order', 'ASC');
-            }])->get();
+            }, 'tracks.artist'])->get();
 
-        $tracks = $artist->tracks()->whereNull('album_id')->orderBy('id', 'desc')->get();
+        $tracks = $artist
+            ->tracks()
+            ->whereNull('album_id')
+            ->with('artist')
+            ->orderBy('id', 'desc')
+            ->get();
 
         $images = [
             'header_url' => $artist->header_url,

--- a/app/Http/Controllers/ArtistsController.php
+++ b/app/Http/Controllers/ArtistsController.php
@@ -56,7 +56,9 @@ class ArtistsController extends Controller
             ->orderBy('id', 'desc')
             ->with(['tracks' => function ($query) {
                 $query->orderBy('display_order', 'ASC');
-            }, 'tracks.artist'])->get();
+            }])
+            ->with('tracks.artist')
+            ->get();
 
         $tracks = $artist
             ->tracks()

--- a/app/Http/Controllers/ArtistsController.php
+++ b/app/Http/Controllers/ArtistsController.php
@@ -53,6 +53,7 @@ class ArtistsController extends Controller
 
         $albums = $artist->albums()
             ->where('visible', true)
+            ->orderBy('id', 'desc')
             ->with(['tracks' => function ($query) {
                 $query->orderBy('display_order', 'ASC');
             }])->get();

--- a/app/Models/Artist.php
+++ b/app/Models/Artist.php
@@ -47,7 +47,7 @@ use Carbon\Carbon;
  */
 class Artist extends Model
 {
-    static $memoized = [];
+    private static $memoized = [];
 
     public function label()
     {
@@ -78,6 +78,6 @@ class Artist extends Model
                 });
         }
 
-        return in_array($this->id, self::$memoized['recentlyUpdatedArtists']);
+        return in_array($this->id, self::$memoized['recentlyUpdatedArtists'], true);
     }
 }

--- a/app/Models/Artist.php
+++ b/app/Models/Artist.php
@@ -20,6 +20,8 @@
 
 namespace App\Models;
 
+use Carbon\Carbon;
+
 /**
  * @property \Illuminate\Database\Eloquent\Collection $albums ArtistAlbum
  * @property string|null $bandcamp
@@ -58,5 +60,10 @@ class Artist extends Model
     public function tracks()
     {
         return $this->hasMany(ArtistTrack::class);
+    }
+
+    public function isNew()
+    {
+        return $this->created_at->diffInDays() < Carbon::now()->subMonth(1)->diffInDays();
     }
 }

--- a/app/Models/ArtistAlbum.php
+++ b/app/Models/ArtistAlbum.php
@@ -20,8 +20,6 @@
 
 namespace App\Models;
 
-use Carbon\Carbon;
-
 /**
  * @property Artist $artist
  * @property int|null $artist_id

--- a/app/Models/ArtistAlbum.php
+++ b/app/Models/ArtistAlbum.php
@@ -49,6 +49,6 @@ class ArtistAlbum extends Model
 
     public function isNew()
     {
-        return $this->created_at->diffInDays() < Carbon::now()->subMonth(1)->diffInDays();
+        return $this->created_at->isAfter(now()->subMonth(1));
     }
 }

--- a/app/Models/ArtistAlbum.php
+++ b/app/Models/ArtistAlbum.php
@@ -20,6 +20,8 @@
 
 namespace App\Models;
 
+use Carbon\Carbon;
+
 /**
  * @property Artist $artist
  * @property int|null $artist_id
@@ -43,5 +45,10 @@ class ArtistAlbum extends Model
     public function tracks()
     {
         return $this->hasMany(ArtistTrack::class, 'album_id', 'id');
+    }
+
+    public function isNew()
+    {
+        return $this->created_at->diffInDays() < Carbon::now()->subMonth(1)->diffInDays();
     }
 }

--- a/app/Models/ArtistTrack.php
+++ b/app/Models/ArtistTrack.php
@@ -65,6 +65,6 @@ class ArtistTrack extends Model
 
     public function isNew()
     {
-        return $this->created_at->diffInDays() < Carbon::now()->subMonth(1)->diffInDays();
+        return $this->created_at->isAfter(now()->subMonth(1));
     }
 }

--- a/app/Models/ArtistTrack.php
+++ b/app/Models/ArtistTrack.php
@@ -54,6 +54,15 @@ class ArtistTrack extends Model
         return $this->belongsTo(ArtistAlbum::class);
     }
 
+    public function getCoverUrlAttribute($value)
+    {
+        if (present($value)) {
+            return $value;
+        }
+
+        return $this->album_id ? $this->album->cover_url : $this->artist->cover_url;
+    }
+
     public function isNew()
     {
         return $this->created_at->diffInDays() < Carbon::now()->subMonth(1)->diffInDays();

--- a/app/Models/ArtistTrack.php
+++ b/app/Models/ArtistTrack.php
@@ -20,6 +20,8 @@
 
 namespace App\Models;
 
+use Carbon\Carbon;
+
 /**
  * @property ArtistAlbum $album
  * @property int|null $album_id
@@ -50,5 +52,10 @@ class ArtistTrack extends Model
     public function album()
     {
         return $this->belongsTo(ArtistAlbum::class);
+    }
+
+    public function isNew()
+    {
+        return $this->created_at->diffInDays() < Carbon::now()->subMonth(1)->diffInDays();
     }
 }

--- a/app/Models/ArtistTrack.php
+++ b/app/Models/ArtistTrack.php
@@ -20,8 +20,6 @@
 
 namespace App\Models;
 
-use Carbon\Carbon;
-
 /**
  * @property ArtistAlbum $album
  * @property int|null $album_id

--- a/app/Transformers/ArtistAlbumTransformer.php
+++ b/app/Transformers/ArtistAlbumTransformer.php
@@ -37,6 +37,7 @@ class ArtistAlbumTransformer extends Fractal\TransformerAbstract
             'title' => $album->title,
             'title_romanized' => $album->title_romanized,
             'genre' => $album->genre,
+            'is_new' => $album->isNew(),
             'cover_url' => $album->cover_url,
         ];
     }

--- a/app/Transformers/ArtistTrackTransformer.php
+++ b/app/Transformers/ArtistTrackTransformer.php
@@ -34,6 +34,7 @@ class ArtistTrackTransformer extends Fractal\TransformerAbstract
             'version' => $track->version,
             'length' => format_duration_for_display($track->length),
             'exclusive' => $track->exclusive,
+            'is_new' => $track->isNew(),
             'bpm' => $track->bpm,
             'genre' => $track->genre,
             'preview' => $track->preview,

--- a/resources/assets/coffee/react/_components/track-preview.coffee
+++ b/resources/assets/coffee/react/_components/track-preview.coffee
@@ -39,10 +39,7 @@ export class TrackPreview extends React.Component
 
 
   render: ->
-    if @props.track.cover_url
-      coverStyle = backgroundImage: osu.urlPresence(@props.track.cover_url)
-
-    div className: 'tracklist__cover', style: coverStyle,
+    div className: 'tracklist__cover', style: { backgroundImage: osu.urlPresence(@props.track.cover_url) },
       a
         className: 'tracklist__preview js-audio--play'
         href: '#'

--- a/resources/assets/coffee/react/_components/track-preview.coffee
+++ b/resources/assets/coffee/react/_components/track-preview.coffee
@@ -39,7 +39,7 @@ export class TrackPreview extends React.Component
 
 
   render: ->
-    if @props.track.cover_url && !@props.track.album_id
+    if @props.track.cover_url
       coverStyle = backgroundImage: osu.urlPresence(@props.track.cover_url)
 
     div className: 'tracklist__cover', style: coverStyle,

--- a/resources/assets/coffee/react/_components/tracklist-track.coffee
+++ b/resources/assets/coffee/react/_components/tracklist-track.coffee
@@ -31,6 +31,10 @@ export class TracklistTrack extends React.Component
         span className: 'tracklist__name u-ellipsis-overflow',
           "#{@props.track.title} "
           span className: 'tracklist__version', @props.track.version
+        if @props.track.is_new
+          span className: 'tracklist__new',
+            span className: 'pill-badge pill-badge--yellow pill-badge--with-shadow', osu.trans('common.badges.new')
+
       td className: 'tracklist__length', @props.track.length
       td className: 'tracklist__bpm', "#{@props.track.bpm}bpm"
       td className: 'tracklist__genre u-ellipsis-overflow', @props.track.genre

--- a/resources/assets/less/bem-index.less
+++ b/resources/assets/less/bem-index.less
@@ -27,6 +27,7 @@
 @import "bem/artist";
 @import "bem/artist-album";
 @import "bem/artist-link-button";
+@import "bem/artist-sidebar-album";
 @import "bem/avatar";
 @import "bem/avatar-ribbon";
 @import "bem/back-to-top";

--- a/resources/assets/less/bem-index.less
+++ b/resources/assets/less/bem-index.less
@@ -25,6 +25,7 @@
 @import "bem/admin-menu";
 @import "bem/admin-menu-item";
 @import "bem/artist";
+@import "bem/artist-album";
 @import "bem/artist-link-button";
 @import "bem/avatar";
 @import "bem/avatar-ribbon";

--- a/resources/assets/less/bem-index.less
+++ b/resources/assets/less/bem-index.less
@@ -248,6 +248,7 @@
 @import "bem/page-title";
 @import "bem/pagination-v2";
 @import "bem/password-reset";
+@import "bem/pill-badge";
 @import "bem/play-detail";
 @import "bem/popup-menu";
 @import "bem/post-box";

--- a/resources/assets/less/bem/artist-album.less
+++ b/resources/assets/less/bem/artist-album.less
@@ -48,10 +48,6 @@
     -webkit-filter: blur(20px);
     opacity: 0.5;
     top: 0;
-    // Hide this overlay in Internet Explorer
-    @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
-      display: none;
-    }
 
     &--new {
       &::after {

--- a/resources/assets/less/bem/artist-album.less
+++ b/resources/assets/less/bem/artist-album.less
@@ -55,7 +55,9 @@
 
     &--new {
       &::after {
-        display: block;
+        .full-size();
+        content: '';
+        background: linear-gradient(to left, @osu-colour-orange-1 0%, transparent 30%)
       }
     }
   }

--- a/resources/assets/less/bem/artist-album.less
+++ b/resources/assets/less/bem/artist-album.less
@@ -1,0 +1,94 @@
+/**
+ *    Copyright (c) ppy Pty Ltd <contact@ppy.sh>.
+ *
+ *    This file is part of osu!web. osu!web is distributed with the hope of
+ *    attracting more community contributions to the core ecosystem of osu!.
+ *
+ *    osu!web is free software: you can redistribute it and/or modify
+ *    it under the terms of the Affero GNU General Public License version 3
+ *    as published by the Free Software Foundation.
+ *
+ *    osu!web is distributed WITHOUT ANY WARRANTY; without even the implied
+ *    warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *    See the GNU Affero General Public License for more details.
+ *
+ *    You should have received a copy of the GNU Affero General Public License
+ *    along with osu!web.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+.artist-album {
+  background-color: @osu-colour-b4;
+  padding: 20px;
+  align-items: center;
+  .default-box-shadow();
+  overflow: hidden;
+  @media @desktop {
+    margin-bottom: 10px;
+  }
+
+  &__cover {
+    width: 64px;
+    height: 64px;
+    .default-box-shadow();
+
+    &--sidebar {
+      width: 128px;
+      height: 128px;
+    }
+  }
+
+  &__header {
+    display: flex;
+    align-items: center;
+    margin-bottom: 20px;
+  }
+
+  &__header-overlay {
+    background-size: cover;
+    background-position: center;
+    width: 100%;
+    height: 100%;
+    position: absolute;
+    filter: blur(20px);
+    -webkit-filter: blur(20px);
+    opacity: 0.5;
+    transition: 1s ease-in-out;
+    top: 0;
+    // Hide this overlay in Internet Explorer
+    @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
+      display: none;
+    }
+    &--sidebar {
+      opacity: 0;
+    }
+
+    &::after {
+      .full-size();
+      content: 'NEW';
+      .pill-badge();
+      display: none;
+    }
+
+    &--new {
+      &::after {
+        display: block;
+      }
+    }
+  }
+
+  &__spacer {
+    flex-grow: 1;
+  }
+
+  &__title {
+    padding: 10px;
+    font-size: 2em;
+    color: white;
+    .default-text-shadow();
+    &--sidebar {
+      padding: 0;
+      font-size: 14px;
+      margin-top: 5px;
+    }
+  }
+}

--- a/resources/assets/less/bem/artist-sidebar-album.less
+++ b/resources/assets/less/bem/artist-sidebar-album.less
@@ -48,7 +48,7 @@
     .default-box-shadow();
 
     .@{top}--new & {
-      box-shadow: 25px -10px 50px .osu-hsla(@osu-colour-orange-1, 0.2)[@hsla];
+      box-shadow: 15px -10px 50px .osu-hsla(@osu-colour-orange-1, 0.2)[@hsla];
     }
   }
 

--- a/resources/assets/less/bem/artist-sidebar-album.less
+++ b/resources/assets/less/bem/artist-sidebar-album.less
@@ -16,57 +16,63 @@
  *    along with osu!web.  If not, see <http://www.gnu.org/licenses/>.
  */
 
-.artist-album {
-  background-color: @osu-colour-b4;
-  padding: 20px;
+.artist-sidebar-album {
+  @top: artist-sidebar-album;
+  text-align: center;
+  margin: 20px;
+  color: white;
+  display: flex;
+  flex-direction: column;
   align-items: center;
-  .default-box-shadow();
-  overflow: hidden;
-  @media @desktop {
-    margin-bottom: 10px;
+
+  &:hover, &:active {
+    color: white;
+    text-decoration: none;
+  }
+
+  &:hover {
+    .@{top}__glow {
+      opacity: 0.4;
+    }
+  }
+
+  &__badge-wrapper {
+    position: absolute;
+    top: 10px;
+    right: 10px;
   }
 
   &__cover {
-    width: 64px;
-    height: 64px;
+    width: 128px;
+    height: 128px;
     .default-box-shadow();
+
+    .@{top}--new & {
+      box-shadow: 25px -10px 50px .osu-hsla(@osu-colour-orange-1, 0.2)[@hsla];
+    }
   }
 
-  &__header {
-    display: flex;
-    align-items: center;
-    margin-bottom: 20px;
+  &__cover-wrapper {
+    width: 128px;
+    height: 128px;
   }
 
-  &__header-overlay {
+  &__glow {
+    .full-size();
     background-size: cover;
     background-position: center;
-    width: 100%;
-    height: 100%;
-    position: absolute;
     filter: blur(20px);
-    -webkit-filter: blur(20px);
-    opacity: 0.5;
-    top: 0;
+    opacity: 0;
+    transition: 1s ease-in-out;
     // Hide this overlay in Internet Explorer
     @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
       display: none;
     }
-
-    &--new {
-      &::after {
-        display: block;
-      }
-    }
-  }
-
-  &__spacer {
-    flex-grow: 1;
   }
 
   &__title {
-    padding: 10px;
-    font-size: 2em;
+    font-size: 14px;
+    margin-top: 5px;
     color: white;
     .default-text-shadow();
   }

--- a/resources/assets/less/bem/artist-sidebar-album.less
+++ b/resources/assets/less/bem/artist-sidebar-album.less
@@ -64,10 +64,6 @@
     filter: blur(20px);
     opacity: 0;
     transition: 1s ease-in-out;
-    // Hide this overlay in Internet Explorer
-    @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
-      display: none;
-    }
   }
 
   &__title {

--- a/resources/assets/less/bem/artist.less
+++ b/resources/assets/less/bem/artist.less
@@ -23,11 +23,11 @@
     padding: 10px;
     font-weight: 300;
     .default-box-shadow();
-
     display: flex;
     justify-content: space-around;
     flex-direction: row;
     flex-wrap: wrap;
+    overflow: hidden;
   }
 
   &__badge-wrapper {

--- a/resources/assets/less/bem/artist.less
+++ b/resources/assets/less/bem/artist.less
@@ -44,23 +44,6 @@
     }
   }
 
-  &__sidebar-album-link {
-    display: block;
-    text-align: center;
-    margin: 20px;
-    color: white;
-    &:hover, &:active {
-      color: white;
-      text-decoration: none;
-    }
-
-    &:hover {
-      .artist-album__header-overlay {
-        opacity: 0.2;
-      }
-    }
-  }
-
   &__admin-note {
     background-color: @osu-colour-h2;
     color: black;
@@ -175,6 +158,11 @@
     }
 
     &--albums {
+      overflow: hidden;
+      display: flex;
+      flex-direction: column;
+      align-items: center;
+
       @media @mobile {
         display: none;
       }

--- a/resources/assets/less/bem/artist.less
+++ b/resources/assets/less/bem/artist.less
@@ -30,6 +30,12 @@
     flex-wrap: wrap;
   }
 
+  &__badge-wrapper {
+    position: absolute;
+    top: 10px;
+    right: 10px;
+  }
+
   &__box {
     margin: 10px;
 
@@ -111,6 +117,7 @@
   &__portrait-wrapper {
     width: 250px;
     height: 250px;
+
     &--index {
       width: 200px;
       height: 200px;
@@ -140,6 +147,10 @@
       @media @desktop {
         margin: 0;
       }
+    }
+
+    &--new {
+      box-shadow: 25px -10px 50px .osu-hsla(@osu-colour-orange-1, 0.2)[@hsla];
     }
   }
 

--- a/resources/assets/less/bem/artist.less
+++ b/resources/assets/less/bem/artist.less
@@ -38,54 +38,6 @@
     }
   }
 
-  &__album {
-    background-color: @osu-colour-b4;
-    padding: 20px;
-    align-items: center;
-    .default-box-shadow();
-    overflow: hidden;
-    @media @desktop {
-      margin-bottom: 10px;
-    }
-  }
-
-  &__album-header {
-    display: flex;
-    align-items: center;
-    margin-bottom: 20px;
-  }
-
-  &__album-header-overlay {
-    background-size: cover;
-    background-position: center;
-    width: 100%;
-    height: 100%;
-    position: absolute;
-    filter: blur(20px);
-    -webkit-filter: blur(20px);
-    opacity: 0.5;
-    transition: 1s ease-in-out;
-    top: 0;
-    // Hide this overlay in Internet Explorer
-    @media all and (-ms-high-contrast: none), (-ms-high-contrast: active) {
-      display: none;
-    }
-    &--sidebar {
-      opacity: 0;
-    }
-  }
-
-  &__album-cover {
-    width: 64px;
-    height: 64px;
-    .default-box-shadow();
-
-    &--sidebar {
-      width: 128px;
-      height: 128px;
-    }
-  }
-
   &__sidebar-album-link {
     display: block;
     text-align: center;
@@ -97,7 +49,7 @@
     }
 
     &:hover {
-      .@{_top}__album-header-overlay {
+      .artist-album__header-overlay {
         opacity: 0.2;
       }
     }
@@ -114,18 +66,6 @@
 
     @media @desktop {
       .default-box-shadow();
-    }
-  }
-
-  &__album-title {
-    padding: 10px;
-    font-size: 2em;
-    color: white;
-    .default-text-shadow();
-    &--sidebar {
-      padding: 0;
-      font-size: 14px;
-      margin-top: 5px;
     }
   }
 

--- a/resources/assets/less/bem/artist.less
+++ b/resources/assets/less/bem/artist.less
@@ -34,6 +34,7 @@
     position: absolute;
     top: 10px;
     right: 10px;
+    pointer-events: none;
   }
 
   &__box {

--- a/resources/assets/less/bem/pill-badge.less
+++ b/resources/assets/less/bem/pill-badge.less
@@ -18,7 +18,7 @@
 
 .pill-badge {
   padding: 2px 8px;
-  border-radius: 13px;
+  border-radius: 10000px;
   font-size: 10px;
   font-weight: bold;
   background: @osu-colour-b6;

--- a/resources/assets/less/bem/pill-badge.less
+++ b/resources/assets/less/bem/pill-badge.less
@@ -1,0 +1,35 @@
+/**
+ *    Copyright (c) ppy Pty Ltd <contact@ppy.sh>.
+ *
+ *    This file is part of osu!web. osu!web is distributed with the hope of
+ *    attracting more community contributions to the core ecosystem of osu!.
+ *
+ *    osu!web is free software: you can redistribute it and/or modify
+ *    it under the terms of the Affero GNU General Public License version 3
+ *    as published by the Free Software Foundation.
+ *
+ *    osu!web is distributed WITHOUT ANY WARRANTY; without even the implied
+ *    warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *    See the GNU Affero General Public License for more details.
+ *
+ *    You should have received a copy of the GNU Affero General Public License
+ *    along with osu!web.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+.pill-badge {
+  padding: 2px 8px;
+  border-radius: 13px;
+  font-size: 10px;
+  font-weight: bold;
+  background: @osu-colour-b6;
+  color: @osu-colour-f1;
+
+  &--with-shadow {
+    .default-box-shadow();
+  }
+
+  &--yellow {
+    background: @osu-colour-orange-1;
+    color: @osu-colour-b6;
+  }
+}

--- a/resources/assets/less/bem/tracklist.less
+++ b/resources/assets/less/bem/tracklist.less
@@ -44,11 +44,6 @@
     &:last-child {
       border-bottom: none;
     }
-
-    &--exclusive {
-      background-color: rgba(255, 102, 170, 0.44);
-      color: white;
-    }
   }
 
   &__row--header {

--- a/resources/lang/en/common.php
+++ b/resources/lang/en/common.php
@@ -29,6 +29,10 @@ return [
         'last_word_connector' => ', and ',
     ],
 
+    'badges' => [
+        'new' => 'NEW',
+    ],
+
     'buttons' => [
         'admin' => 'Admin',
         'back_to_previous' => 'Return to previous position',

--- a/resources/views/artists/index.blade.php
+++ b/resources/views/artists/index.blade.php
@@ -37,9 +37,14 @@
                     @foreach ($artists as $artist)
                         <div class="artist__box{{$artist->visible ? '' : ' artist__box--hidden'}}">
                             <div class="artist__portrait-wrapper artist__portrait-wrapper--index">
-                                <a href="{{route('artists.show', $artist)}}" class="artist__portrait artist__portrait--index" style="{{$artist->cover_url ? 'background-image: url(' . $artist->cover_url . ')' : ''}}"></a>
+                                <a href="{{route('artists.show', $artist)}}" class="artist__portrait artist__portrait--index {{$artist->isNew() ? ' artist__portrait--new' : ''}}" style="{{$artist->cover_url ? 'background-image: url(' . $artist->cover_url . ')' : ''}}"></a>
                                 @if($artist->label !== null)
                                     <a class="artist__label-overlay artist__label-overlay--index" href="{{$artist->label->website}}" style="background-image: url('{{$artist->label->icon_url}}')"></a>
+                                @endif
+                                @if($artist->isNew())
+                                    <span class="artist__badge-wrapper">
+                                        <span class="pill-badge pill-badge--yellow pill-badge--with-shadow">{{trans('common.badges.new')}}</span>
+                                    </span>
                                 @endif
                             </div>
                             <a href="{{route('artists.show', $artist)}}" class="artist__name">{{$artist->name}}</a>

--- a/resources/views/artists/index.blade.php
+++ b/resources/views/artists/index.blade.php
@@ -37,11 +37,11 @@
                     @foreach ($artists as $artist)
                         <div class="artist__box{{$artist->visible ? '' : ' artist__box--hidden'}}">
                             <div class="artist__portrait-wrapper artist__portrait-wrapper--index">
-                                <a href="{{route('artists.show', $artist)}}" class="artist__portrait artist__portrait--index {{$artist->isNew() ? ' artist__portrait--new' : ''}}" style="{{$artist->cover_url ? 'background-image: url(' . $artist->cover_url . ')' : ''}}"></a>
+                                <a href="{{route('artists.show', $artist)}}" class="artist__portrait artist__portrait--index {{$artist->hasNewTracks() ? ' artist__portrait--new' : ''}}" style="{{$artist->cover_url ? 'background-image: url(' . $artist->cover_url . ')' : ''}}"></a>
                                 @if($artist->label !== null)
                                     <a class="artist__label-overlay artist__label-overlay--index" href="{{$artist->label->website}}" style="background-image: url('{{$artist->label->icon_url}}')"></a>
                                 @endif
-                                @if($artist->isNew())
+                                @if($artist->hasNewTracks())
                                     <span class="artist__badge-wrapper">
                                         <span class="pill-badge pill-badge--yellow pill-badge--with-shadow">{{trans('common.badges.new')}}</span>
                                     </span>

--- a/resources/views/artists/show.blade.php
+++ b/resources/views/artists/show.blade.php
@@ -45,12 +45,16 @@
                 @if (count($albums) > 0)
                     <div class="artist__albums">
                         @foreach ($albums as $album)
-                            <div class="artist__album">
+                            <div class="artist-album">
                                 <a class="fragment-target" name="album-{{$album['id']}}" id="album-{{$album['id']}}"></a>
-                                <div class="artist__album-header">
-                                    <div class="artist__album-header-overlay" style="background-image: url({{$album['cover_url']}});"></div>
-                                    <img class="artist__album-cover" src="{{$album['cover_url']}}">
-                                    <span class="artist__album-title">{{$album['title']}}</span>
+                                <div class="artist-album__header">
+                                    <div class="artist-album__header-overlay" style="background-image: url({{$album['cover_url']}});"></div>
+                                    <img class="artist-album__cover" src="{{$album['cover_url']}}">
+                                    <span class="artist-album__title">{{$album['title']}}</span>
+                                    <span class="artist-album__spacer"></span>
+                                    @if ($album['is_new'])
+                                        <span class="artist-album__badge">{{trans('common.badges.new')}}</span>
+                                    @endif
                                 </div>
                                 <div class="js-react--artistTracklist" data-src="album-json-{{$album['id']}}"></div>
                                 <script id="album-json-{{$album['id']}}" type="application/json">
@@ -61,10 +65,10 @@
                     </div>
                 @endif
                 @if (count($tracks) > 0)
-                    <div class="artist__album">
-                        <div class="artist__album-header">
-                            <div class="artist__album-header-overlay" style="background-image: url({{$images['header_url']}});"></div>
-                            <span class="artist__album-title">{{trans('artist.songs._')}}</span>
+                    <div class="artist-album">
+                        <div class="artist-album__header">
+                            <div class="artist-album__header-overlay" style="background-image: url({{$images['header_url']}});"></div>
+                            <span class="artist-album__title">{{trans('artist.songs._')}}</span>
                         </div>
                         <div class="js-react--artistTracklist" data-src="singles-json-{{$artist->id}}"></div>
                         <script id="singles-json-{{$artist->id}}" type="application/json">
@@ -93,9 +97,9 @@
                     <div class="artist__links-area artist__links-area--albums">
                         @foreach ($albums as $album)
                             <a class="artist__sidebar-album-link" href="#album-{{$album['id']}}" data-turbolinks="false">
-                                <div class="artist__album-header-overlay artist__album-header-overlay--sidebar" style="background-image: url({{$album['cover_url']}});"></div>
-                                <img class="artist__album-cover artist__album-cover--sidebar" src="{{$album['cover_url']}}">
-                                <div class="artist__album-title artist__album-title--sidebar">{{$album['title']}}</div>
+                                <div class="artist-album__header-overlay artist-album__header-overlay--sidebar" style="background-image: url({{$album['cover_url']}});"></div>
+                                <img class="artist-album__cover artist-album__cover--sidebar" src="{{$album['cover_url']}}">
+                                <div class="artist-album__title artist-album__title--sidebar">{{$album['title']}}</div>
                             </a>
                         @endforeach
                     </div>

--- a/resources/views/artists/show.blade.php
+++ b/resources/views/artists/show.blade.php
@@ -53,7 +53,7 @@
                                     <span class="artist-album__title">{{$album['title']}}</span>
                                     <span class="artist-album__spacer"></span>
                                     @if ($album['is_new'])
-                                        <span class="artist-album__badge">{{trans('common.badges.new')}}</span>
+                                        <span class="pill-badge pill-badge--yellow pill-badge--with-shadow">{{trans('common.badges.new')}}</span>
                                     @endif
                                 </div>
                                 <div class="js-react--artistTracklist" data-src="album-json-{{$album['id']}}"></div>
@@ -97,7 +97,7 @@
                     <div class="artist__links-area artist__links-area--albums">
                         @foreach ($albums as $album)
                             <a class="artist__sidebar-album-link" href="#album-{{$album['id']}}" data-turbolinks="false">
-                                <div class="artist-album__header-overlay artist-album__header-overlay--sidebar" style="background-image: url({{$album['cover_url']}});"></div>
+                                <div class="artist-album__header-overlay artist-album__header-overlay--sidebar{{$album['is_new'] ? ' artist-album__header-overlay--new' : ''}}" style="background-image: url({{$album['cover_url']}});"></div>
                                 <img class="artist-album__cover artist-album__cover--sidebar" src="{{$album['cover_url']}}">
                                 <div class="artist-album__title artist-album__title--sidebar">{{$album['title']}}</div>
                             </a>

--- a/resources/views/artists/show.blade.php
+++ b/resources/views/artists/show.blade.php
@@ -48,7 +48,7 @@
                             <div class="artist-album">
                                 <a class="fragment-target" name="album-{{$album['id']}}" id="album-{{$album['id']}}"></a>
                                 <div class="artist-album__header">
-                                    <div class="artist-album__header-overlay" style="background-image: url({{$album['cover_url']}});"></div>
+                                    <div class="artist-album__header-overlay{{$album['is_new'] ? ' artist-album__header-overlay--new' : ''}}" style="background-image: url({{$album['cover_url']}});"></div>
                                     <img class="artist-album__cover" src="{{$album['cover_url']}}">
                                     <span class="artist-album__title">{{$album['title']}}</span>
                                     <span class="artist-album__spacer"></span>

--- a/resources/views/artists/show.blade.php
+++ b/resources/views/artists/show.blade.php
@@ -96,10 +96,17 @@
                 @if (count($albums) > 0)
                     <div class="artist__links-area artist__links-area--albums">
                         @foreach ($albums as $album)
-                            <a class="artist__sidebar-album-link" href="#album-{{$album['id']}}" data-turbolinks="false">
-                                <div class="artist-album__header-overlay artist-album__header-overlay--sidebar{{$album['is_new'] ? ' artist-album__header-overlay--new' : ''}}" style="background-image: url({{$album['cover_url']}});"></div>
-                                <img class="artist-album__cover artist-album__cover--sidebar" src="{{$album['cover_url']}}">
-                                <div class="artist-album__title artist-album__title--sidebar">{{$album['title']}}</div>
+                            <a class="artist-sidebar-album{{$album['is_new'] ? ' artist-sidebar-album--new' : ''}}" href="#album-{{$album['id']}}" data-turbolinks="false">
+                                <div class="artist-sidebar-album__cover-wrapper">
+                                    <div class="artist-sidebar-album__glow" style="background-image: url({{$album['cover_url']}});"></div>
+                                    <img class="artist-sidebar-album__cover" src="{{$album['cover_url']}}">
+                                    @if ($album['is_new'])
+                                        <span class="artist__badge-wrapper">
+                                            <span class="pill-badge pill-badge--yellow pill-badge--with-shadow">{{trans('common.badges.new')}}</span>
+                                        </span>
+                                    @endif
+                                </div>
+                                <div class="artist-sidebar-album__title">{{$album['title']}}</div>
                             </a>
                         @endforeach
                     </div>


### PR DESCRIPTION
Few tweaks to the pages:

Artist Listing:
 - Adds a 'new' badge and glow effect to artists that have had new tracks added in the last month (or who are new featured artists)
![](https://puu.sh/EoiEp/9e61e64061.png)

Artist Page:
 - Adds a 'new' badge and glow effect to albums added within the last month (in headers+sidebar)
 - Adds a 'new' badge to tracks added within the last month
 - Change sort order of albums to show the latest at the top
 - Change sort order of tracks (singles/outside albums) to show the latest at the top
 - Adds cover image fallback for tracks that don't have covers defined (uses album cover if present, otherwise falls back to artist profile image)
![](https://puu.sh/EoiGE/8e8ee41a4f.png)

resolves #5046