### PR TITLE
Rename scope to not override laravel builtin

### DIFF
--- a/app/Http/Controllers/StoreController.php
+++ b/app/Http/Controllers/StoreController.php
@@ -62,7 +62,7 @@ class StoreController extends Controller
     {
         return view('store.index')
             ->with('cart', $this->userCart())
-            ->with('products', Store\Product::latest()->get());
+            ->with('products', Store\Product::listing()->get());
     }
 
     public function getInvoice($id = null)

--- a/app/Models/Store/Product.php
+++ b/app/Models/Store/Product.php
@@ -175,7 +175,7 @@ class Product extends Model
         return $query->where('available_until', '<', Carbon::now());
     }
 
-    public function scopeLatest($query)
+    public function scopeListing($query)
     {
         return $query
             ->available()


### PR DESCRIPTION
~~It stops overriding in laravel 6 it seems.~~ They added eloquent builder function with same name in 5.7 so it takes higher priority. Previously it was only in query builder.