### PR TITLE
Give topics the option to allow double posting

### DIFF
--- a/app/Libraries/OsuAuthorize.php
+++ b/app/Libraries/OsuAuthorize.php
@@ -1236,7 +1236,7 @@ class OsuAuthorize
             return $prefix.'locked';
         }
 
-        if ($topic->isDoublePostBy($user)) {
+        if (!$topic->allowsDoublePosting() && $topic->isDoublePostBy($user)) {
             return $prefix.'double_post';
         }
 

--- a/app/Models/Forum/Topic.php
+++ b/app/Models/Forum/Topic.php
@@ -820,6 +820,14 @@ class Topic extends Model implements AfterCommit
         return $this->topic_last_post_time > Carbon::now()->subHours($minHours);
     }
 
+    // TODO: Remove when the "Report a Qualified beatmap here!" thread is
+    //       migrated away from the forum
+    // https://github.com/ppy/osu-web/issues/4784
+    public function allowsDoublePosting() : bool
+    {
+        return $this->topic_bumped === 2;
+    }
+
     public function isFeatureTopic()
     {
         return $this->topic_type === static::TYPES['normal'] && $this->forum->isFeatureForum();


### PR DESCRIPTION
closes #4537

not sure if something temporary like this is wanted at all, figured I'd make a PR anyway since it only takes a minute. the idea is you'd set [this thread](https://osu.ppy.sh/community/forums/topics/447428)'s `topic_bumped` to 2 and then people can double post