### PR TITLE
Fix Xsolla payment widget not working

### DIFF
--- a/resources/assets/lib/turbolinks-reload.ts
+++ b/resources/assets/lib/turbolinks-reload.ts
@@ -59,6 +59,6 @@ export default class TurbolinksReload {
 
     el.src = src;
     document.body.appendChild(el);
-    this.loaded[src] = true;
+    return this.loaded[src] = true;
   }
 }


### PR DESCRIPTION
`TurbolinksReload.load` should return true if loading a new script. Previously, this was returned implicitly due to coffeescript.