### PR TITLE
Include total and cursor in ranking api response

### DIFF
--- a/app/Http/Controllers/RankingController.php
+++ b/app/Http/Controllers/RankingController.php
@@ -141,7 +141,7 @@ class RankingController extends Controller
 
         $maxResults = $this->maxResults($modeInt);
         $maxPages = ceil($maxResults / static::PAGE_SIZE);
-        $page = clamp(get_int(request('page')), 1, $maxPages);
+        $page = clamp(get_int(request('cursor.page') ?? request('page')), 1, $maxPages);
 
         $stats = $stats->limit(static::PAGE_SIZE)
             ->offset(static::PAGE_SIZE * ($page - 1))

--- a/app/Http/Controllers/RankingController.php
+++ b/app/Http/Controllers/RankingController.php
@@ -157,6 +157,8 @@ class RankingController extends Controller
             }
 
             return [
+                // TODO: switch to offset?
+                'cursor' => empty($ranking) || ($page >= $maxPages) ? null : ['page' => $page + 1],
                 'ranking' => $ranking,
                 'total' => $maxResults,
             ];

--- a/app/Http/Controllers/RankingController.php
+++ b/app/Http/Controllers/RankingController.php
@@ -150,11 +150,16 @@ class RankingController extends Controller
         if (is_api_request()) {
             switch ($type) {
                 case 'country':
-                    return json_collection($stats, 'CountryStatistics', ['country']);
+                    $ranking = json_collection($stats, 'CountryStatistics', ['country']);
 
                 default:
-                    return json_collection($stats, 'UserStatistics', ['user', 'user.cover', 'user.country']);
+                    $ranking = json_collection($stats, 'UserStatistics', ['user', 'user.cover', 'user.country']);
             }
+
+            return [
+                'ranking' => $ranking,
+                'total' => $maxResults,
+            ];
         }
 
         $scores = new LengthAwarePaginator($stats, $maxPages * static::PAGE_SIZE, static::PAGE_SIZE, $page, [

--- a/resources/views/vendor/apidoc/partials/info.blade.php
+++ b/resources/views/vendor/apidoc/partials/info.blade.php
@@ -68,5 +68,8 @@ For a full list of changes, see the
 
 ## Breaking Changes
 
+### 2019-10-09
+- Ranking API response no longer returns an array at the top level; an object with keys is now returned.
+
 ### 2019-07-18
 - [`User`](#user) now returns counts directly as primitives instead of numbers wrapped in an array.


### PR DESCRIPTION
includes total and next page as a cursor value in the response. Cursor is `null` if there are no more pages.

closes #4917

now returns
```json
{
  "cursor": {
    "page": 2
  },
  "ranking": [...stats in rank order],
  "total": 1243
}
```