### PR TITLE
Hotfix route generation for null beatmapset on modding event.

### DIFF
--- a/resources/views/beatmapset_events/_item.blade.php
+++ b/resources/views/beatmapset_events/_item.blade.php
@@ -17,7 +17,7 @@
 --}}
 @php
     $discussionId = isset($event->comment['beatmap_discussion_id']) ? $event->comment['beatmap_discussion_id'] : null;
-    $discussionLink = route('beatmapsets.discussion', $event->beatmapset);
+    $discussionLink = route('beatmapsets.discussion', ['beatmapset' => $event->beatmapset]);
     if ($discussionId) {
         $discussionLink .= '#/'.$discussionId;
     }


### PR DESCRIPTION
Laravel 6 route doesn't allow null value if the route parameter is required, but is fine with it if
the parameter is keyed with the parameter name; then it generates the
same route as 5.5 did.

A proper fix is to not have the link if the beatmapset is null, but fixing that is a bit more involved than this