### PR TITLE
Fix error on invalid parameter on paypal decline

### DIFF
--- a/app/Http/Controllers/Payments/PaypalController.php
+++ b/app/Http/Controllers/Payments/PaypalController.php
@@ -91,9 +91,12 @@ class PaypalController extends Controller
         $orderId = Request::input('order_id');
 
         $order = Order::where('user_id', Auth::user()->user_id)->processing()->find($orderId);
-        if ($order) {
-            (new OrderCheckout($order, Order::PROVIDER_PAYPAL))->failCheckout();
+
+        if ($order === null) {
+            return ujs_redirect(route('store.cart.show'));
         }
+
+        (new OrderCheckout($order, Order::PROVIDER_PAYPAL))->failCheckout();
 
         return $this->setAndRedirectCheckoutError($order, trans('store.checkout.declined'));
     }


### PR DESCRIPTION
It didn't work previously (405 after first redirect) and it doesn't work at the moment (exploding thanks to null order) and not sure if the fix should be redirecting to cart or just 404.