### PR TITLE
Fix double escaping of beatmap search

### DIFF
--- a/resources/assets/coffee/react/beatmapset-page/header.coffee
+++ b/resources/assets/coffee/react/beatmapset-page/header.coffee
@@ -137,12 +137,12 @@ export class Header extends React.Component
 
           a
             className: 'beatmapset-header__details-text beatmapset-header__details-text--title u-ellipsis-overflow'
-            href: laroute.route 'beatmapsets.index', q: encodeURIComponent(@props.beatmapset.title)
+            href: laroute.route 'beatmapsets.index', q: @props.beatmapset.title
             @props.beatmapset.title
 
           a
             className: 'beatmapset-header__details-text beatmapset-header__details-text--artist'
-            href: laroute.route 'beatmapsets.index', q: encodeURIComponent(@props.beatmapset.artist)
+            href: laroute.route 'beatmapsets.index', q: @props.beatmapset.artist
             @props.beatmapset.artist
 
           el BeatmapsetMapping, beatmapset: @props.beatmapset


### PR DESCRIPTION
Workaround for older library no longer needed.

Fixes #5090.