### PR TITLE
Add basic opengraph support

### DIFF
--- a/resources/lang/en/layout.php
+++ b/resources/lang/en/layout.php
@@ -254,6 +254,12 @@ return [
         'reference' => "Just in case, here's a code you can give to support!",
     ],
 
+    'opengraph' => [
+        'site-name' => [
+            'users' => 'users',
+        ],
+    ],
+
     'popup_login' => [
         'login' => [
             'email' => 'email address',

--- a/resources/views/artists/index.blade.php
+++ b/resources/views/artists/index.blade.php
@@ -20,6 +20,7 @@
     'currentAction' => 'artists',
     'title' => trans('artist.title'),
     'pageDescription' => trans('artist.page_description'),
+    'opghCategory' => "osu! » {{ trans('layout.menu.beatmaps.artists') }}",
 ])
 
 @section('content')

--- a/resources/views/artists/show.blade.php
+++ b/resources/views/artists/show.blade.php
@@ -20,6 +20,7 @@
     'currentAction' => 'artists',
     'title' => "Featured Artist: $artist->name",
     'pageDescription' => $artist->description,
+    'opghCategory' => "osu! » {{ trans('layout.menu.beatmaps.artists') }}",
 ])
 
 @section('content')

--- a/resources/views/beatmaps/index.blade.php
+++ b/resources/views/beatmaps/index.blade.php
@@ -20,6 +20,7 @@
   'currentAction' => 'index',
   'title' => trans('beatmapsets.index.title'),
   'pageDescription' => trans('beatmapsets.index.title'),
+  'opghCategory' => "osu! » {{ trans('layout.menu.beatmaps._') }}",
 ])
 
 @section('content')

--- a/resources/views/beatmapset_watches/index.blade.php
+++ b/resources/views/beatmapset_watches/index.blade.php
@@ -15,7 +15,9 @@
     You should have received a copy of the GNU Affero General Public License
     along with osu!web.  If not, see <http://www.gnu.org/licenses/>.
 --}}
-@extends('master')
+@extends('master', [
+    'opghCategory' => "osu! » {{ trans('layout.menu.beatmaps._') }}",
+])
 
 @section('content')
     <div class="osu-layout__row osu-layout__row--page-compact osu-layout__row--sm1 osu-layout__row--full t-forum-category-osu">

--- a/resources/views/beatmapsets/discussion.blade.php
+++ b/resources/views/beatmapsets/discussion.blade.php
@@ -20,6 +20,7 @@
         'title' => $beatmapset->title,
         'mapper' => $beatmapset->user->username ?? '?',
     ]),
+    'opghCategory' => "osu! » {{ trans('layout.menu.beatmaps._') }}",
 ])
 
 @section('content')

--- a/resources/views/beatmapsets/show.blade.php
+++ b/resources/views/beatmapsets/show.blade.php
@@ -27,6 +27,7 @@
     'pageDescription' => $beatmapset->toMetaDescription(),
     'titlePrepend' => "{$beatmapset->artist} - {$beatmapset->title}",
     'extraFooterLinks' => $extraFooterLinks ?? [],
+    'opghCategory' => "osu! » {{ trans('layout.menu.beatmaps._') }}",
 ])
 
 @section('content')

--- a/resources/views/changelog/build.blade.php
+++ b/resources/views/changelog/build.blade.php
@@ -18,6 +18,7 @@
 @extends('master', [
     'legacyNav' => false,
     'title' => trans('changelog.build.title', ['version' => "{$build['update_stream']['display_name']} {$build['version']}"]),
+    'opghCategory' => "osu! » {{ trans('layout.menu.home.changelog-index') }}",
 ])
 
 @section('content')

--- a/resources/views/changelog/index.blade.php
+++ b/resources/views/changelog/index.blade.php
@@ -37,6 +37,7 @@
 @extends('master', [
     'legacyNav' => false,
     'title' => $title,
+    'opghCategory' => "osu! » {{ trans('layout.menu.home.changelog-index') }}",
 ])
 
 @section('content')

--- a/resources/views/chat/index.blade.php
+++ b/resources/views/chat/index.blade.php
@@ -20,6 +20,7 @@
     'currentSection' => 'community',
     'legacyNav' => false,
     'title' => trans('chat.title'),
+    'opghCategory' => "osu! » {{ trans('layout.menu.community._') }}",
 ])
 
 @section("content")

--- a/resources/views/comments/index.blade.php
+++ b/resources/views/comments/index.blade.php
@@ -17,6 +17,7 @@
 --}}
 @extends('master', [
     'legacyNav' => false,
+    'opghCategory' => "osu! » {{ trans('layout.menu.community.comments-index'') }}",
 ])
 
 @section('content')

--- a/resources/views/comments/show.blade.php
+++ b/resources/views/comments/show.blade.php
@@ -17,6 +17,7 @@
 --}}
 @extends('master', [
     'legacyNav' => false,
+    'opghCategory' => "osu! » {{ trans('layout.menu.community.comments-index'') }}",
 ])
 
 @section('content')

--- a/resources/views/contests/base.blade.php
+++ b/resources/views/contests/base.blade.php
@@ -20,6 +20,7 @@
     'currentAction' => 'contests',
     'title' => "Contest: {$contestMeta->name}",
     'pageDescription' => strip_tags(markdown($contestMeta->currentDescription())),
+    'opghCategory' => "osu! » {{ trans('layout.menu.community.contests') }}",
 ])
 
 @section('content')

--- a/resources/views/contests/index.blade.php
+++ b/resources/views/contests/index.blade.php
@@ -20,6 +20,7 @@
     'currentSection' => 'community',
     'currentAction' => 'contests',
     'title' => "Contests",
+    'opghCategory' => "osu! » {{ trans('layout.menu.community.contests') }}",
 ])
 
 @section('content')

--- a/resources/views/forum/forums/index.blade.php
+++ b/resources/views/forum/forums/index.blade.php
@@ -20,6 +20,7 @@
     'legacyNav' => false,
     'pageDescription' => trans('forum.title'),
     'searchParams' => ['mode' => 'forum_post'],
+    'opghCategory' => "osu! » {{ trans('layout.menu.community.getForum') }}",
 ])
 
 @section('content')

--- a/resources/views/forum/forums/show.blade.php
+++ b/resources/views/forum/forums/show.blade.php
@@ -24,6 +24,7 @@
         'mode' => 'forum_post',
     ],
     'titlePrepend' => $forum->forum_name,
+    'opghCategory' => "osu! » {{ trans('layout.menu.community.getForum') }}",
 ])
 
 @section('content')

--- a/resources/views/forum/topic_watches/index.blade.php
+++ b/resources/views/forum/topic_watches/index.blade.php
@@ -15,7 +15,9 @@
     You should have received a copy of the GNU Affero General Public License
     along with osu!web.  If not, see <http://www.gnu.org/licenses/>.
 --}}
-@extends('master')
+@extends('master', [
+    'opghCategory' => "osu! » {{ trans('layout.menu.community.getForum') }}",
+])
 
 @section('content')
     <div class="osu-layout__row osu-layout__row--page-compact osu-layout__row--sm1 osu-layout__row--full">

--- a/resources/views/forum/topics/show.blade.php
+++ b/resources/views/forum/topics/show.blade.php
@@ -27,6 +27,7 @@
     'pageDescription' => $topic->toMetaDescription(),
     'legacyNav' => false,
     'legacyFont' => false,
+    'opghCategory' => "osu! » {{ trans('layout.menu.community.getForum') }}",
 ])
 
 @php

--- a/resources/views/friends/index.blade.php
+++ b/resources/views/friends/index.blade.php
@@ -17,6 +17,7 @@
 --}}
 @extends('master', [
     'legacyNav' => false,
+    'opghCategory' => "osu! » {{ trans('layout.menu.profile.friends') }}",
 ])
 
 @section('content')

--- a/resources/views/groups/show.blade.php
+++ b/resources/views/groups/show.blade.php
@@ -17,6 +17,7 @@
 --}}
 @extends('master', [
     'legacyNav' => false,
+    'opghCategory' => "osu! » {{ trans('layout.menu.home.groups-show') }}",
 ])
 
 @section('content')

--- a/resources/views/layout/metadata.blade.php
+++ b/resources/views/layout/metadata.blade.php
@@ -28,6 +28,12 @@
 <meta name="keywords" content="osu, peppy, ouendan, elite, beat, agents, ds, windows, game, taiko, tatsujin, simulator, sim, xna, ddr, beatmania, osu!, osume">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
+<meta property="og:title" content="osu!">
+<meta property="og:description" content="{{ trans('layout.defaults.page_description') }}">
+<meta property="og:type" content="website">
+<meta property="og:site_name" content="{{ $opghCategory ?? 'osu!' }}">
+<meta property="og:image" content="config('osu.static') }}/images/layout/osu-logo.png">
+
 <meta name="csrf-param" content="_token">
 <meta name="csrf-token" content="{{ csrf_token() }}">
 

--- a/resources/views/livestreams/index.blade.php
+++ b/resources/views/livestreams/index.blade.php
@@ -15,7 +15,9 @@
     You should have received a copy of the GNU Affero General Public License
     along with osu!web.  If not, see <http://www.gnu.org/licenses/>.
 --}}
-@extends('master')
+@extends('master', [
+    'opghCategory' => "osu! » {{ trans('layout.menu.community._') }}",
+])
 
 @section('content')
     <div class="osu-layout__row osu-layout__row--page-compact">

--- a/resources/views/master.blade.php
+++ b/resources/views/master.blade.php
@@ -36,7 +36,7 @@
     $currentHue = $currentHue ?? section_to_hue_map($currentSection);
 @endphp
 <!DOCTYPE html>
-<html>
+<html prefix="og: http://ogp.me/ns#">
     <head>
         @include("layout.metadata")
         <title>{{ $title }}</title>

--- a/resources/views/multiplayer/match.blade.php
+++ b/resources/views/multiplayer/match.blade.php
@@ -15,7 +15,9 @@
     You should have received a copy of the GNU Affero General Public License
     along with osu!web.  If not, see <http://www.gnu.org/licenses/>.
 --}}
-@extends('master')
+@extends('master', [
+    'opghCategory' => "osu! » {{ trans('layout.menu.multiplayer._') }}",
+])
 
 @section('content')
     <div class="js-react--mp-history"></div>

--- a/resources/views/news/index.blade.php
+++ b/resources/views/news/index.blade.php
@@ -18,6 +18,7 @@
 @extends('master', [
     'legacyNav' => false,
     'title' => trans('news.index.title_page'),
+    'opghCategory' => "osu! » {{ trans('layout.menu.home.news-index') }}",
 ])
 
 @section('content')

--- a/resources/views/news/show.blade.php
+++ b/resources/views/news/show.blade.php
@@ -18,6 +18,7 @@
 @extends('master', [
     'legacyNav' => false,
     'titlePrepend' => $post->title(),
+    'opghCategory' => "osu! » {{ trans('layout.menu.home.news-index') }}",
 ])
 
 @section('content')

--- a/resources/views/packs/index.blade.php
+++ b/resources/views/packs/index.blade.php
@@ -19,6 +19,7 @@
     'currentAction' => 'packs',
     'title' => trans('beatmappacks.index.title'),
     'pageDescription' => trans('beatmappacks.index.description'),
+    'opghCategory' => "osu! » {{ trans('layout.menu.beatmaps._') }}",
 ])
 
 @section('content')

--- a/resources/views/rankings/index.blade.php
+++ b/resources/views/rankings/index.blade.php
@@ -15,7 +15,9 @@
     You should have received a copy of the GNU Affero General Public License
     along with osu!web.  If not, see <http://www.gnu.org/licenses/>.
 --}}
-@extends('master')
+@extends('master', [
+    'opghCategory' => "osu! » {{ trans('layout.menu.rankings._') }}",
+])
 
 @section('content')
     @php

--- a/resources/views/tournaments/index.blade.php
+++ b/resources/views/tournaments/index.blade.php
@@ -19,6 +19,7 @@
     'currentSection' => 'community',
     'currentAction' => 'tournaments',
     'title' => trans('tournament.index.header.title'),
+    'opghCategory' => "osu! » {{ trans('layout.menu.community.tournaments') }}",
 ])
 
 @section('content')

--- a/resources/views/tournaments/show.blade.php
+++ b/resources/views/tournaments/show.blade.php
@@ -19,6 +19,7 @@
     'currentSection' => 'community',
     'currentAction' => 'tournaments',
     'title' => $tournament->name,
+    'opghCategory' => "osu! » {{ trans('layout.menu.community.tournaments') }}",
 ])
 
 @section('content')

--- a/resources/views/users/beatmapset_activities.blade.php
+++ b/resources/views/users/beatmapset_activities.blade.php
@@ -24,6 +24,7 @@
     'title' => trans('users.show.title', ['username' => $user->username]),
     'pageDescription' => trans('users.show.page_description', ['username' => $user->username]),
     'legacyNav' => $legacyNav,
+    'opghCategory' => "osu! » {{ trans('layout.opengraph.site-name.users') }}",
 ])
 
 @section('content')

--- a/resources/views/users/posts.blade.php
+++ b/resources/views/users/posts.blade.php
@@ -19,6 +19,7 @@
     'currentSection' => 'community',
     'currentAction' => 'profile',
     'title' => trans('users.posts.title', ['username' => $user->username]),
+    'opghCategory' => "osu! » {{ trans('layout.opengraph.site-name.users') }}",
 ])
 
 @section('content')

--- a/resources/views/users/show.blade.php
+++ b/resources/views/users/show.blade.php
@@ -24,6 +24,7 @@
     'title' => trans('users.show.title', ['username' => $user->username]),
     'pageDescription' => trans('users.show.page_description', ['username' => $user->username]),
     'legacyNav' => $legacyNav,
+    'opghCategory' => "osu! » {{ trans('layout.opengraph.site-name.users') }}",
 ])
 
 @section('content')

--- a/resources/views/users/verify.blade.php
+++ b/resources/views/users/verify.blade.php
@@ -19,6 +19,7 @@
     // Verification doesn't inherit from App\Controller, thus these variables aren't set. Thus we set them here:
     'currentSection' => 'error',
     'currentAction' => '401',
+    'opghCategory' => "osu! » {{ trans('layout.opengraph.site-name.users') }}",
 ])
 
 @section('content')

--- a/resources/views/wiki/main.blade.php
+++ b/resources/views/wiki/main.blade.php
@@ -16,7 +16,9 @@
     along with osu!web.  If not, see <http://www.gnu.org/licenses/>.
 --}}
 
-@extends('master')
+@extends('master', [
+    'opghCategory' => "osu! » {{ trans('layout.menu.help.getWiki') }}",
+])
 
 @section('content')
     <div class="osu-layout osu-layout__row">

--- a/resources/views/wiki/show.blade.php
+++ b/resources/views/wiki/show.blade.php
@@ -19,6 +19,7 @@
 @extends('master', [
     'title' => null,
     'titlePrepend' => $page->title(true),
+    'opghCategory' => "osu! » {{ trans('layout.menu.help.getWiki') }}",
 ])
 
 @section('content')


### PR DESCRIPTION
**important: opening in the early stage to get feedback if it's a correct way to implement opengraph**

Related to #1295

Adds basic opengraph support to the website:

`og:site_name`: Basic breadcrumb
`og:image`: osu! logo as default, shall be beatmap thumbnail or profile avatar for related pages
`og:title`:  Title of the page; shall be extension of site_name
`og:description`: page_description as default, shall show basic information about the page

Q: should unaccessable for everyone pages have no custom opengraph?

---