### PR TITLE
Send notification to NATs and BNs when a problem is posted on a qualified beatmap

### DIFF
--- a/app/Events/BeatmapsetDiscussionQualifiedProblemNotificationEvent.php
+++ b/app/Events/BeatmapsetDiscussionQualifiedProblemNotificationEvent.php
@@ -24,22 +24,25 @@ use App\Models\Notification;
 use Illuminate\Broadcasting\Channel;
 use Illuminate\Queue\SerializesModels;
 
-class NewNotificationEvent extends NotificationEventBase
+class BeatmapsetDiscussionQualifiedProblemNotificationEvent extends NotificationEventBase
 {
     use SerializesModels;
 
     public $notification;
+
+    private $receiverIds;
 
     /**
      * Create a new event instance.
      *
      * @return void
      */
-    public function __construct(Notification $notification)
+    public function __construct(Notification $notification, array $receiverIds)
     {
         parent::__construct();
 
         $this->notification = $notification;
+        $this->receiverIds = $receiverIds;
     }
 
     public function broadcastAs()
@@ -54,7 +57,9 @@ class NewNotificationEvent extends NotificationEventBase
      */
     public function broadcastOn()
     {
-        return new Channel($this->notification->channelName());
+        return array_map(function ($userId) {
+            return new Channel("private:user:{$userId}");
+        }, $this->receiverIds);
     }
 
     public function broadcastWith()

--- a/app/Events/NewNotificationEvent.php
+++ b/app/Events/NewNotificationEvent.php
@@ -20,7 +20,6 @@
 
 namespace App\Events;
 
-use App\Libraries\MorphMap;
 use App\Models\Notification;
 use Illuminate\Broadcasting\Channel;
 use Illuminate\Queue\SerializesModels;

--- a/app/Events/NewNotificationEvent.php
+++ b/app/Events/NewNotificationEvent.php
@@ -20,6 +20,7 @@
 
 namespace App\Events;
 
+use App\Libraries\MorphMap;
 use App\Models\Notification;
 use Illuminate\Broadcasting\Channel;
 use Illuminate\Queue\SerializesModels;
@@ -54,11 +55,19 @@ class NewNotificationEvent extends NotificationEventBase
      */
     public function broadcastOn()
     {
-        return new Channel($this->notification->channelName());
+        return new Channel($this->channelName());
     }
 
     public function broadcastWith()
     {
         return json_item($this->notification, 'Notification');
+    }
+
+    private function channelName()
+    {
+        return static::generateChannelName(
+            $this->notification->notifiable,
+            Notification::SUBTYPES[$this->notification->name] ?? null
+        );
     }
 }

--- a/app/Events/NewPrivateNotificationEvent.php
+++ b/app/Events/NewPrivateNotificationEvent.php
@@ -24,11 +24,9 @@ use App\Models\Notification;
 use Illuminate\Broadcasting\Channel;
 use Illuminate\Queue\SerializesModels;
 
-class BeatmapsetDiscussionQualifiedProblemNotificationEvent extends NotificationEventBase
+class NewPrivateNotificationEvent extends NewNotificationEvent
 {
     use SerializesModels;
-
-    public $notification;
 
     private $receiverIds;
 
@@ -39,15 +37,9 @@ class BeatmapsetDiscussionQualifiedProblemNotificationEvent extends Notification
      */
     public function __construct(Notification $notification, array $receiverIds)
     {
-        parent::__construct();
+        parent::__construct($notification);
 
-        $this->notification = $notification;
         $this->receiverIds = $receiverIds;
-    }
-
-    public function broadcastAs()
-    {
-        return 'new';
     }
 
     /**
@@ -60,10 +52,5 @@ class BeatmapsetDiscussionQualifiedProblemNotificationEvent extends Notification
         return array_map(function ($userId) {
             return new Channel("private:user:{$userId}");
         }, $this->receiverIds);
-    }
-
-    public function broadcastWith()
-    {
-        return json_item($this->notification, 'Notification');
     }
 }

--- a/app/Events/NotificationEventBase.php
+++ b/app/Events/NotificationEventBase.php
@@ -20,11 +20,22 @@
 
 namespace App\Events;
 
+use App\Libraries\MorphMap;
+use App\Models\Notification;
 use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
 
 abstract class NotificationEventBase implements ShouldBroadcast
 {
     public $broadcastQueue;
+
+    public static function generateChannelName($notifiable, $subtype)
+    {
+        return 'new:'.
+            MorphMap::getType($notifiable).
+            ':'.
+            $notifiable->getKey().
+            (in_array($subtype, Notification::SUBTYPES, true) ? ":{$subtype}" : '');
+    }
 
     public function __construct()
     {

--- a/app/Events/UserSubscriptionChangeEvent.php
+++ b/app/Events/UserSubscriptionChangeEvent.php
@@ -21,7 +21,6 @@
 namespace App\Events;
 
 use App\Models\Follow;
-use App\Models\Notification;
 use Illuminate\Broadcasting\Channel;
 
 class UserSubscriptionChangeEvent extends NotificationEventBase
@@ -47,7 +46,7 @@ class UserSubscriptionChangeEvent extends NotificationEventBase
             $subtype = $notifiable->subtype;
             $notifiable = $notifiable->notifiable;
         }
-        $this->channelName = Notification::generateChannelName($notifiable, $subtype ?? null);
+        $this->channelName = static::generateChannelName($notifiable, $subtype ?? null);
     }
 
     public function broadcastAs()

--- a/app/Http/Controllers/BeatmapDiscussionPostsController.php
+++ b/app/Http/Controllers/BeatmapDiscussionPostsController.php
@@ -179,6 +179,12 @@ class BeatmapDiscussionPostsController extends Controller
         $beatmapset = $discussion->beatmapset;
 
         BeatmapsetWatch::markRead($beatmapset, Auth::user());
+
+        if ($discussion->message_type === 'problem' && $beatmapset->isQualified()) {
+            // TODO: should work out how have the new post notification be able to handle this instead.
+            broadcast_notification(Notification::BEATMAPSET_DISCUSSION_QUALIFIED_PROBLEM, $post, auth()->user());
+        }
+
         broadcast_notification(Notification::BEATMAPSET_DISCUSSION_POST_NEW, $post, Auth::user());
         (new NotifyBeatmapsetUpdate([
             'user' => Auth::user(),

--- a/app/Jobs/BroadcastNotification.php
+++ b/app/Jobs/BroadcastNotification.php
@@ -89,7 +89,7 @@ class BroadcastNotification implements ShouldQueue
             $this->receiverIds = $this->receiverIds->all();
         }
 
-        $this->receiverIds = array_values(array_diff($this->receiverIds, optional($this->source)->getKey()));
+        $this->receiverIds = array_values(array_diff($this->receiverIds, [optional($this->source)->getKey()]));
         if (empty($this->receiverIds)) {
             return;
         }

--- a/app/Jobs/BroadcastNotification.php
+++ b/app/Jobs/BroadcastNotification.php
@@ -54,7 +54,7 @@ class BroadcastNotification implements ShouldQueue
             ->all();
     }
 
-    public function __construct($name, $object, $source = null)
+    public function __construct(string $name, $object, ?User $source = null)
     {
         $this->name = $name;
         $this->object = $object;

--- a/app/Jobs/BroadcastNotification.php
+++ b/app/Jobs/BroadcastNotification.php
@@ -20,8 +20,8 @@
 
 namespace App\Jobs;
 
-use App\Events\NewPrivateNotificationEvent;
 use App\Events\NewNotificationEvent;
+use App\Events\NewPrivateNotificationEvent;
 use App\Exceptions\InvalidNotificationException;
 use App\Models\Chat\Channel;
 use App\Models\Follow;

--- a/app/Jobs/BroadcastNotification.php
+++ b/app/Jobs/BroadcastNotification.php
@@ -20,7 +20,7 @@
 
 namespace App\Jobs;
 
-use App\Events\BeatmapsetDiscussionQualifiedProblemNotificationEvent;
+use App\Events\NewPrivateNotificationEvent;
 use App\Events\NewNotificationEvent;
 use App\Exceptions\InvalidNotificationException;
 use App\Models\Chat\Channel;
@@ -161,7 +161,7 @@ class BroadcastNotification implements ShouldQueue
             'cover_url' => $this->notifiable->coverURL('card'),
         ];
 
-        return BeatmapsetDiscussionQualifiedProblemNotificationEvent::class;
+        return NewPrivateNotificationEvent::class;
     }
 
     private function onBeatmapsetDisqualify()

--- a/app/Models/Notification.php
+++ b/app/Models/Notification.php
@@ -20,8 +20,6 @@
 
 namespace App\Models;
 
-use App\Libraries\MorphMap;
-
 class Notification extends Model
 {
     const BEATMAPSET_DISCUSSION_LOCK = 'beatmapset_discussion_lock';
@@ -47,15 +45,6 @@ class Notification extends Model
         'details' => 'array',
     ];
 
-    public static function generateChannelName($notifiable, $subtype)
-    {
-        return 'new:'.
-            MorphMap::getType($notifiable).
-            ':'.
-            $notifiable->getKey().
-            (in_array($subtype, static::SUBTYPES, true) ? ":{$subtype}" : '');
-    }
-
     public function notifiable()
     {
         return $this->morphTo();
@@ -69,13 +58,5 @@ class Notification extends Model
     public function userNotifications()
     {
         return $this->hasMany(UserNotification::class);
-    }
-
-    /**
-     * Doesn't get used for beatmapset_discussion_qualified_problem; channel names there are generated in the event itself.
-     */
-    public function channelName()
-    {
-        return static::generateChannelName($this->notifiable, static::SUBTYPES[$this->name] ?? null);
     }
 }

--- a/app/Models/Notification.php
+++ b/app/Models/Notification.php
@@ -26,6 +26,7 @@ class Notification extends Model
 {
     const BEATMAPSET_DISCUSSION_LOCK = 'beatmapset_discussion_lock';
     const BEATMAPSET_DISCUSSION_POST_NEW = 'beatmapset_discussion_post_new';
+    const BEATMAPSET_DISCUSSION_QUALIFIED_PROBLEM = 'beatmapset_discussion_qualified_problem';
     const BEATMAPSET_DISCUSSION_UNLOCK = 'beatmapset_discussion_unlock';
     const BEATMAPSET_DISQUALIFY = 'beatmapset_disqualify';
     const BEATMAPSET_LOVE = 'beatmapset_love';
@@ -70,6 +71,9 @@ class Notification extends Model
         return $this->hasMany(UserNotification::class);
     }
 
+    /**
+     * Doesn't get used for beatmapset_discussion_qualified_problem; channel names there are generated in the event itself.
+     */
     public function channelName()
     {
         return static::generateChannelName($this->notifiable, static::SUBTYPES[$this->name] ?? null);

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -79,3 +79,13 @@ $factory->state(App\Models\User::class, 'restricted', function (Faker\Generator 
         'user_warnings' => 1,
     ];
 });
+
+$factory->state(App\Models\User::class, 'bng', function (Faker\Generator $faker) {
+    return [
+        'group_id' => App\Models\UserGroup::GROUPS['bng'],
+    ];
+});
+
+$factory->afterCreatingState(App\Models\User::class, 'bng', function ($user, $faker) {
+    $user->userGroups()->create(['group_id' => App\Models\UserGroup::GROUPS['bng']]);
+});

--- a/resources/assets/lib/notification-maps/category.ts
+++ b/resources/assets/lib/notification-maps/category.ts
@@ -37,6 +37,7 @@ export function categoryGroupKey(item: Notification) {
 export const nameToCategory: CategoryMap = {
   beatmapset_discussion_lock: 'beatmapset_discussion',
   beatmapset_discussion_post_new: 'beatmapset_discussion',
+  beatmapset_discussion_qualified_problem: 'beatmapset_discussion',
   beatmapset_discussion_unlock: 'beatmapset_discussion',
   beatmapset_disqualify: 'beatmapset_state',
   beatmapset_love: 'beatmapset_state',

--- a/resources/assets/lib/notification-maps/icons.ts
+++ b/resources/assets/lib/notification-maps/icons.ts
@@ -32,6 +32,7 @@ export const categoryToIcons: IconsMap = {
 export const nameToIcons: IconsMap = {
   beatmapset_discussion_lock: ['fas fa-drafting-compass', 'fas fa-lock'],
   beatmapset_discussion_post_new: ['fas fa-drafting-compass', 'fas fa-comment-medical'],
+  beatmapset_discussion_qualified_problem: ['fas fa-drafting-compass', 'fas fa-exclamation-circle'],
   beatmapset_discussion_unlock: ['fas fa-drafting-compass', 'fas fa-unlock'],
   beatmapset_disqualify: ['fas fa-drafting-compass', 'far fa-times-circle'],
   beatmapset_love: ['fas fa-drafting-compass', 'fas fa-heart'],
@@ -49,6 +50,7 @@ export const nameToIcons: IconsMap = {
 export const nameToIconsCompact: IconsMap = {
   beatmapset_discussion_lock: ['fas fa-lock'],
   beatmapset_discussion_post_new: ['fas fa-comment-medical'],
+  beatmapset_discussion_qualified_problem: ['fas fa-exclamation-circle'],
   beatmapset_discussion_unlock: ['fas fa-unlock'],
   beatmapset_disqualify: ['far fa-times-circle'],
   beatmapset_love: ['fas fa-heart'],

--- a/resources/assets/lib/notification-maps/url.ts
+++ b/resources/assets/lib/notification-maps/url.ts
@@ -57,6 +57,7 @@ export function urlSingular(item: Notification) {
     case 'beatmapset_reset_nominations':
       return route('beatmapsets.discussion', { beatmapset: item.objectId });
     case 'beatmapset_discussion_post_new':
+    case 'beatmapset_discussion_qualified_problem':
       return BeatmapDiscussionHelper.url({
         beatmapId: item.details.beatmapId,
         beatmapsetId: item.objectId,

--- a/resources/lang/en/notifications.php
+++ b/resources/lang/en/notifications.php
@@ -32,6 +32,8 @@ return [
                 'beatmapset_discussion_lock_compact' => 'Discussion was locked',
                 'beatmapset_discussion_post_new' => 'New post on ":title" by :username',
                 'beatmapset_discussion_post_new_compact' => 'New post by :username',
+                'beatmapset_discussion_qualified_problem' => 'Problem reported on qualified beatmap :title',
+                'beatmapset_discussion_qualified_problem_compact' => 'Problem on qualified beatmap',
                 'beatmapset_discussion_unlock' => 'Discussion on ":title" has been unlocked',
                 'beatmapset_discussion_unlock_compact' => 'Discussion was unlocked',
             ],

--- a/tests/Controllers/BeatmapDiscussionPostsControllerTest.php
+++ b/tests/Controllers/BeatmapDiscussionPostsControllerTest.php
@@ -2,7 +2,7 @@
 
 namespace Tests\Controllers;
 
-use App\Events\BeatmapsetDiscussionQualifiedProblemNotificationEvent;
+use App\Events\NewPrivateNotificationEvent;
 use App\Models\Beatmap;
 use App\Models\BeatmapDiscussion;
 use App\Models\BeatmapDiscussionPost;
@@ -516,7 +516,7 @@ class BeatmapDiscussionPostsControllerTest extends TestCase
                 ],
             ]);
 
-        $assertMethod(BeatmapsetDiscussionQualifiedProblemNotificationEvent::class);
+        $assertMethod(NewPrivateNotificationEvent::class);
     }
 
     public function problemDataProvider()

--- a/tests/Controllers/BeatmapDiscussionPostsControllerTest.php
+++ b/tests/Controllers/BeatmapDiscussionPostsControllerTest.php
@@ -2,6 +2,7 @@
 
 namespace Tests\Controllers;
 
+use App\Events\NewNotificationEvent;
 use App\Events\NewPrivateNotificationEvent;
 use App\Models\Beatmap;
 use App\Models\BeatmapDiscussion;
@@ -43,6 +44,9 @@ class BeatmapDiscussionPostsControllerTest extends TestCase
         $this->assertSame($currentDiscussionPosts + 1, BeatmapDiscussionPost::count());
         $this->assertSame($currentNotifications + 1, Notification::count());
         $this->assertSame($currentUserNotifications + 1, UserNotification::count());
+
+        Event::assertDispatched(NewNotificationEvent::class);
+        Event::assertNotDispatched(NewPrivateNotificationEvent::class);
     }
 
     public function testPostStoreNewDiscussionInactiveBeatmapset()
@@ -502,7 +506,6 @@ class BeatmapDiscussionPostsControllerTest extends TestCase
     {
         $this->beatmapset->update($updateParams);
         factory(User::class)->states('bng')->create(); // event doesn't get dispatched if there are no users in the group.
-        Event::fake();
 
         $this
             ->actingAs($this->user)
@@ -530,6 +533,8 @@ class BeatmapDiscussionPostsControllerTest extends TestCase
     protected function setUp(): void
     {
         parent::setUp();
+
+        Event::fake();
 
         $this->mapper = factory(User::class)->create();
         $this->user = factory(User::class)->create();


### PR DESCRIPTION
requires
- [x] ppy/osu-notification-server#24

First step for #4784.

Just sends a notification to BNs and NATs when a problem is posted on a qualified beatmapset. There are no options for it yet.
