### PR TITLE
Fix beatmap discussion post listing

### DIFF
--- a/app/Http/Controllers/BeatmapDiscussionPostsController.php
+++ b/app/Http/Controllers/BeatmapDiscussionPostsController.php
@@ -30,7 +30,7 @@ use App\Models\BeatmapsetWatch;
 use App\Models\Notification;
 use Auth;
 use DB;
-use Illuminate\Pagination\LengthAwarePaginator;
+use Illuminate\Pagination\Paginator;
 use Request;
 
 class BeatmapDiscussionPostsController extends Controller
@@ -69,20 +69,22 @@ class BeatmapDiscussionPostsController extends Controller
         }
 
         $search = BeatmapDiscussionPost::search($params);
-        $posts = new LengthAwarePaginator(
-            $search['query']->with([
-                    'user',
-                    'beatmapset',
-                    'beatmapDiscussion',
-                    'beatmapDiscussion.beatmapset',
-                    'beatmapDiscussion.user',
-                    'beatmapDiscussion.startingPost',
-                ])->get(),
-            $search['query']->realCount(),
+
+        $query = $search['query']->with([
+            'user',
+            'beatmapset',
+            'beatmapDiscussion',
+            'beatmapDiscussion.beatmapset',
+            'beatmapDiscussion.user',
+            'beatmapDiscussion.startingPost',
+        ])->limit($search['params']['limit'] + 1);
+
+        $posts = new Paginator(
+            $query->get(),
             $search['params']['limit'],
             $search['params']['page'],
             [
-                'path' => LengthAwarePaginator::resolveCurrentPath(),
+                'path' => Paginator::resolveCurrentPath(),
                 'query' => $search['params'],
             ]
         );

--- a/app/Models/BeatmapDiscussionPost.php
+++ b/app/Models/BeatmapDiscussionPost.php
@@ -145,7 +145,14 @@ class BeatmapDiscussionPost extends Model
 
     public function beatmapset()
     {
-        return $this->beatmapDiscussion->beatmapset();
+        return $this->hasOneThrough(
+            Beatmapset::class,
+            BeatmapDiscussion::class,
+            'id',
+            'beatmapset_id',
+            'beatmap_discussion_id',
+            'beatmapset_id'
+        )->withTrashed();
     }
 
     public function beatmapDiscussion()

--- a/resources/views/beatmap_discussion_posts/index.blade.php
+++ b/resources/views/beatmap_discussion_posts/index.blade.php
@@ -31,7 +31,7 @@
                     @include('beatmap_discussion_posts._item', compact('post'))
                 @endforeach
 
-                @include('objects._pagination_v2', ['object' => $posts])
+                @include('objects._pagination_simple', ['object' => $posts])
             </div>
         </div>
     </div>

--- a/resources/views/objects/_pagination_simple.blade.php
+++ b/resources/views/objects/_pagination_simple.blade.php
@@ -1,0 +1,90 @@
+{{--
+    Copyright (c) ppy Pty Ltd <contact@ppy.sh>.
+
+    This file is part of osu!web. osu!web is distributed with the hope of
+    attracting more community contributions to the core ecosystem of osu!.
+
+    osu!web is free software: you can redistribute it and/or modify
+    it under the terms of the Affero GNU General Public License version 3
+    as published by the Free Software Foundation.
+
+    osu!web is distributed WITHOUT ANY WARRANTY; without even the implied
+    warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+    See the GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with osu!web.  If not, see <http://www.gnu.org/licenses/>.
+--}}
+@if ($object->currentPage() !== 1 || $object->hasMorePages())
+    @php
+        $currentPage = $object->currentPage();
+    @endphp
+    <nav class="{{ class_with_modifiers('pagination-v2', $modifiers ?? []) }}">
+        <div class="pagination-v2__col">
+            @if ($currentPage === 1)
+                <span class="pagination-v2__link pagination-v2__link--quick pagination-v2__link--disabled">
+                    <i class="fas fa-angle-left"></i>
+                    <span class="hidden-xs">
+                        {{ trans('common.pagination.previous') }}
+                    </span>
+                </span>
+            @else
+                <a class="pagination-v2__link pagination-v2__link--link pagination-v2__link--quick" href="{{ $object->url($currentPage - 1) }}">
+                    <i class="fas fa-angle-left"></i>
+                    <span class="hidden-xs">
+                        {{ trans('common.pagination.previous') }}
+                    </span>
+                </a>
+            @endif
+        </div>
+
+        <ul class="pagination-v2__col pagination-v2__col--pages">
+            {{-- decide if we're showing first page link separately --}}
+            @if ($currentPage > 3)
+                <li class="pagination-v2__item">
+                    <a class="pagination-v2__link pagination-v2__link--link" href="{{ $object->url(1) }}">1</a>
+                </li>
+            @endif
+
+            @if ($currentPage > 4)
+                <li class="pagination-v2__item">
+                    <span class="pagination-v2__link">...</span>
+                </li>
+            @endif
+
+            @foreach(range(max($currentPage - 2, 1), ($object->hasMorePages() ? $currentPage + 1 : $currentPage)) as $page)
+                <li class="pagination-v2__item">
+                    @if ($page === $currentPage)
+                        <span class="pagination-v2__link pagination-v2__link--active">{{ $page }}</span>
+                    @else
+                        <a class="pagination-v2__link pagination-v2__link--link" href="{{ $object->url($page) }}">{{ $page }}</a>
+                    @endif
+                </li>
+            @endforeach
+
+            @if ($object->hasMorePages())
+                <li class="pagination-v2__item">
+                    <span class="pagination-v2__link">...</span>
+                </li>
+            @endif
+        </ul>
+
+        <div class="pagination-v2__col">
+            @if ($object->hasMorePages())
+                <a class="pagination-v2__link pagination-v2__link--link pagination-v2__link--quick" href="{{ $object->url($currentPage + 1) }}">
+                    <span class="hidden-xs">
+                        {{ trans('common.pagination.next') }}
+                    </span>
+                    <i class="fas fa-angle-right"></i>
+                </a>
+            @else
+                <span class="pagination-v2__link pagination-v2__link--quick pagination-v2__link--disabled">
+                    <span class="hidden-xs">
+                        {{ trans('common.pagination.next') }}
+                    </span>
+                    <i class="fas fa-angle-right"></i>
+                </span>
+            @endif
+        </div>
+    </nav>
+@endif


### PR DESCRIPTION
- preload being broken after update to laravel 6
- it has been pretty slow mainly thanks to counting the total, so I switched it to pagination-without-total