### PR TITLE
Correctly decrement user favourite count

### DIFF
--- a/app/Models/Beatmapset.php
+++ b/app/Models/Beatmapset.php
@@ -760,10 +760,10 @@ class Beatmapset extends Model implements AfterCommit, Commentable
         }
 
         DB::transaction(function () use ($user) {
-            $this->favourites()->where('user_id', $user->user_id)
+            $deleted = $this->favourites()->where('user_id', $user->user_id)
                 ->delete();
 
-            $this->favourite_count = db_unsigned_increment('favourite_count', -1);
+            $this->favourite_count = db_unsigned_increment('favourite_count', -$deleted);
             $this->save();
         });
     }


### PR DESCRIPTION
It may delete no row so use the return of `delete()` call instead.