### PR TITLE
Fix double escaping of beatmap search url

### DIFF
--- a/resources/assets/lib/beatmaps/beatmapset-search-controller.ts
+++ b/resources/assets/lib/beatmaps/beatmapset-search-controller.ts
@@ -175,7 +175,7 @@ export class BeatmapsetSearchController {
   }
 
   private filterChangedSearch() {
-    const url = encodeURI(route('beatmapsets.index', this.filters.queryParams));
+    const url = route('beatmapsets.index', this.filters.queryParams);
     Turbolinks.controller.advanceHistory(url);
 
     this.search();


### PR DESCRIPTION
Possibly another leftover from old routing library can't escape things.