### PR TITLE
Fix header image colour in Edge

### DIFF
--- a/resources/assets/less/bem/nav2-header.less
+++ b/resources/assets/less/bem/nav2-header.less
@@ -76,7 +76,7 @@
     background-image: url('/images/layout/nav2-background-hue0.png');
     background-position: bottom center;
     background-repeat: repeat-x;
-    filter: hue-rotate(calc(var(--base-hue) * 1deg)) saturate(0.6);
+    filter: hue-rotate(var(--base-hue-deg)) saturate(0.6);
 
     .@{_top}--restricted & {
       .at2x-simple('/images/layout/nav2-bg/red.png');

--- a/resources/views/master.blade.php
+++ b/resources/views/master.blade.php
@@ -58,6 +58,7 @@
                     --font-content-override: var(--font-content-inter);
                 @endif
                 --base-hue: {{ $currentHue }};
+                --base-hue-deg: {{ $currentHue }}deg;
             }
         </style>
         <div id="overlay" class="blackout blackout--overlay" style="display: none;"></div>


### PR DESCRIPTION
Edge doesn't seem to like `calc()` within `hue-rotate()`

fixes #5118