### PR TITLE
Remove facebook link from header

### DIFF
--- a/config/osu.php
+++ b/config/osu.php
@@ -162,7 +162,6 @@ return [
         'youtube-tutorial-playlist' => 'PLmWVQsxi34bMYwAawZtzuptfMmszUa_tl',
 
         'social' => [
-            'facebook' => 'https://facebook.com/osugame',
             'twitter' => '/help/wiki/Twitter',
         ],
         'user' => [

--- a/resources/assets/less/bem/landing-footer-social.less
+++ b/resources/assets/less/bem/landing-footer-social.less
@@ -29,13 +29,6 @@
     margin: 0 5px;
     font-size: 16px;
 
-    &--facebook {
-      &:hover,
-      &:focus {
-        color: @facebook-colour;
-      }
-    }
-
     &--support {
       &:hover,
       &:focus {

--- a/resources/views/home/landing.blade.php
+++ b/resources/views/home/landing.blade.php
@@ -214,9 +214,6 @@
             <a href="{{ osu_url("social.twitter") }}" class="landing-footer-social__icon landing-footer-social__icon--twitter">
                 <span class="fab fa-twitter"></span>
             </a>
-            <a href="{{ osu_url("social.facebook") }}" class="landing-footer-social__icon landing-footer-social__icon--facebook">
-                <span class="fab fa-facebook"></span>
-            </a>
         </div>
 
         @include('layout.footer', ['modifiers' => ['landing'], 'withLinks' => false])

--- a/resources/views/layout/_nav2.blade.php
+++ b/resources/views/layout/_nav2.blade.php
@@ -93,16 +93,6 @@
             </a>
         </div>
 
-        <div class="nav2__col js-nav-button--item">
-            <a
-                href="{{ osu_url('social.facebook') }}"
-                class="nav-button nav-button--social"
-                title="Facebook"
-            >
-                <span class="fab fa-facebook"></span>
-            </a>
-        </div>
-
         <div class="nav2__col">
             <a
                 href="{{ route('support-the-game') }}"


### PR DESCRIPTION
- We don't update the facebook page near as often as we should.
- We can use extra header space.
- Facebook just generally sucks.