### PR TITLE
Fix cookie cleanup sometimes not working

### DIFF
--- a/app/Http/Middleware/StripCookies.php
+++ b/app/Http/Middleware/StripCookies.php
@@ -32,7 +32,11 @@ class StripCookies
             session()->forget('_strip_cookies');
             // strip all cookies from response
             foreach ($result->headers->getCookies() as $cookie) {
-                $result->headers->removeCookie($cookie->getName());
+                $result->headers->removeCookie(
+                    $cookie->getName(),
+                    $cookie->getPath(),
+                    $cookie->getDomain()
+                );
             }
         }
 


### PR DESCRIPTION
Make sure domain and path matches while removing cookies.
Why the function doesn't accept Cookie object while setCookie accepts (requires) one is a bit beyond me.