### PR TITLE
Prevent long artist names from breaking the featured-artist index/grid alignment

### DIFF
--- a/resources/assets/less/bem/artist.less
+++ b/resources/assets/less/bem/artist.less
@@ -39,6 +39,10 @@
 
   &__box {
     margin: 10px;
+    width: 200px;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
 
     &--hidden {
       opacity: 0.25;
@@ -60,7 +64,7 @@
   }
 
   &__name {
-    text-align: center;
+    white-space: nowrap;
     color: @osu-colour-l1;
     font-size: 14px;
     margin-top: 5px;
@@ -99,13 +103,8 @@
   }
 
   &__portrait-wrapper {
-    width: 250px;
-    height: 250px;
-
-    &--index {
-      width: 200px;
-      height: 200px;
-    }
+    width: 200px;
+    height: 200px;
   }
 
   &__portrait {

--- a/resources/views/artists/index.blade.php
+++ b/resources/views/artists/index.blade.php
@@ -36,7 +36,7 @@
                 <div class="artist__index">
                     @foreach ($artists as $artist)
                         <div class="artist__box{{$artist->visible ? '' : ' artist__box--hidden'}}">
-                            <div class="artist__portrait-wrapper artist__portrait-wrapper--index">
+                            <div class="artist__portrait-wrapper">
                                 <a href="{{route('artists.show', $artist)}}" class="artist__portrait artist__portrait--index {{$artist->hasNewTracks() ? ' artist__portrait--new' : ''}}" style="{{$artist->cover_url ? 'background-image: url(' . $artist->cover_url . ')' : ''}}"></a>
                                 @if($artist->label !== null)
                                     <a class="artist__label-overlay artist__label-overlay--index" href="{{$artist->label->website}}" style="background-image: url('{{$artist->label->icon_url}}')"></a>


### PR DESCRIPTION
lets the name overflow instead

![](https://puu.sh/EvUo1/eacf1b6e12.png)

(hopefully this should be a rare occurrence and we don't end up with a page of overlapping artist names...)