### PR TITLE
Create helper to make using group colours less tedious.

### DIFF
--- a/resources/assets/less/bem/beatmap-discussion-post.less
+++ b/resources/assets/less/bem/beatmap-discussion-post.less
@@ -317,45 +317,11 @@
     flex: none;
     width: 2px;
 
-    .@{_top}--ppy & {
-      background-color: @osu-colour-group-ppy;
-    }
-
-    .@{_top}--bot & {
-      background-color: @osu-colour-group-bot;
-    }
-
-    .@{_top}--dev & {
-      background-color: @osu-colour-group-dev;
-    }
-
-    .@{_top}--gmt & {
-      background-color: @osu-colour-group-gmt;
-    }
-
-    .@{_top}--nat & {
-      background-color: @osu-colour-group-nat;
-    }
-
-    .@{_top}--bng & {
-      background-color: @osu-colour-group-bng;
-    }
-
-    .@{_top}--bng_limited & {
-      background-color: @osu-colour-group-bng;
-    }
-
-    .@{_top}--alumni & {
-      background-color: @osu-colour-group-alumni;
-    }
-
-    .@{_top}--support & {
-      background-color: @osu-colour-group-support;
-    }
-
-    .@{_top}--mapper & {
-      background-color: @osu-colour-blue-1;
-    }
+    .osu-group-colours({
+      .@{_top}--@{group} & {
+        background-color: @@colour;
+      }
+    });
   }
 
   &__user-text {

--- a/resources/assets/less/bem/beatmap-discussions-user-filter.less
+++ b/resources/assets/less/bem/beatmap-discussions-user-filter.less
@@ -28,54 +28,11 @@
   }
 
   &__item {
-    &--ppy {
-      .link-hover({ color: @osu-colour-group-ppy });
-      color: @osu-colour-group-ppy;
-    }
-
-    &--bot {
-      .link-hover({ color: @osu-colour-group-bot });
-      color: @osu-colour-group-bot;
-    }
-
-    &--dev {
-      .link-hover({ color: @osu-colour-group-dev });
-      color: @osu-colour-group-dev;
-    }
-
-    &--gmt {
-      .link-hover({ color: @osu-colour-group-gmt });
-      color: @osu-colour-group-gmt;
-    }
-
-    &--nat {
-      .link-hover({ color: @osu-colour-group-nat });
-      color: @osu-colour-group-nat;
-    }
-
-    &--bng {
-      .link-hover({ color: @osu-colour-group-bng });
-      color: @osu-colour-group-bng;
-    }
-
-    &--bng_limited {
-      .link-hover({ color: @osu-colour-group-bng });
-      color: @osu-colour-group-bng;
-    }
-
-    &--alumni {
-      .link-hover({ color: @osu-colour-group-alumni });
-      color: @osu-colour-group-alumni;
-    }
-
-    &--support {
-      .link-hover({ color: @osu-colour-group-support });
-      color: @osu-colour-group-support;
-    }
-
-    &--mapper {
-      .link-hover({ color: @osu-colour-blue-1 });
-      color: @osu-colour-blue-1;
-    }
+    .osu-group-colours({
+      &--@{group} {
+        .link-hover({ color: @@colour });
+        color: @@colour;
+      }
+    });
   }
 }

--- a/resources/assets/less/bem/modding-profile-vote-card.less
+++ b/resources/assets/less/bem/modding-profile-vote-card.less
@@ -100,45 +100,11 @@
     flex: none;
     width: 2px;
 
-    .@{_top}--ppy & {
-      background-color: @osu-colour-group-ppy;
-    }
-
-    .@{_top}--bot & {
-      background-color: @osu-colour-group-bot;
-    }
-
-    .@{_top}--dev & {
-      background-color: @osu-colour-group-dev;
-    }
-
-    .@{_top}--gmt & {
-      background-color: @osu-colour-group-gmt;
-    }
-
-    .@{_top}--nat & {
-      background-color: @osu-colour-group-nat;
-    }
-
-    .@{_top}--bng & {
-      background-color: @osu-colour-group-bng;
-    }
-
-    .@{_top}--bng_limited & {
-      background-color: @osu-colour-group-bng;
-    }
-
-    .@{_top}--alumni & {
-      background-color: @osu-colour-group-alumni;
-    }
-
-    .@{_top}--support & {
-      background-color: @osu-colour-group-support;
-    }
-
-    .@{_top}--mapper & {
-      background-color: @osu-colour-blue-1;
-    }
+    .osu-group-colours({
+      .@{_top}--@{group} & {
+        background-color: @@colour;
+      }
+    });
   }
 
   &__user-text {

--- a/resources/assets/less/bem/user-group-badge.less
+++ b/resources/assets/less/bem/user-group-badge.less
@@ -27,87 +27,67 @@
   justify-content: center;
   align-items: center;
 
-  &--alumni {
-    color: @osu-colour-group-alumni;
-    &::before {
-      content: 'OLD';
+  // mapping group to display-name
+  .osu-group-names() {
+    @alumni: {
+      full: 'ALUMNI';
+      short: 'OLD';
+    }
+    @bng: {
+      full: 'BN';
+      short: 'BN';
+    }
+    @bng_limited: {
+      full: 'BN';
+      short: 'BN';
+    }
+    @bot: {
+      full: 'BOT';
+      short: 'BOT';
+    }
+    @dev: {
+      full: 'DEV';
+      short: 'DEV';
+    }
+    @gmt: {
+      full: 'GMT';
+      short: 'GMT';
+    }
+    @mapper: {
+      full: 'MAP';
+      short: 'MAPPER';
+    }
+    @nat: {
+      full: 'NAT';
+      short: 'NAT';
+    }
+    @ppy: {
+      full: 'PPY';
+      short: 'PPY';
+    }
+    @support: {
+      full: 'SPT';
+      short: 'SUPPORT';
+    }
+  }
 
-      @media @desktop {
-        content: 'ALUMNI';
+  .osu-group-colours({
+    &--@{group} {
+      color: @@colour;
+
+      &::before {
+        content: .osu-group-names[@@group][short];
+        @media @desktop {
+          content: .osu-group-names[@@group][full];
+        }
       }
     }
-  }
+  });
 
-  &--bng {
-    color: @osu-colour-group-bng;
-    &::before {
-      content: 'BN';
-    }
-  }
-
-  &--bng_limited {
-    color: @osu-colour-group-bng;
-    &::before {
-      content: 'BN';
-    }
-  }
-
+  // we need to override this, as bot badge colours are inverted
   &--bot {
-    background-color: @osu-colour-group-bot;
     color: .osu-hsla(@osu-colour-b6, 0.75)[@hsla];
-    &::before {
-      content: 'BOT';
-    }
-  }
-
-  &--dev {
-    color: @osu-colour-group-dev;
-    &::before {
-      content: 'DEV';
-    }
-  }
-
-  &--gmt {
-    color: @osu-colour-group-gmt;
-    &::before {
-      content: 'GMT';
-    }
-  }
-
-  &--mapper {
-    color: @osu-colour-blue-1;
-    &::before {
-      content: 'MAP';
-
-      @media @desktop {
-        content: 'MAPPER';
-      }
-    }
-  }
-
-  &--nat {
-    color: @osu-colour-group-nat;
-    &::before {
-      content: 'NAT';
-    }
-  }
-
-  &--ppy {
-    color: @osu-colour-group-ppy;
-    &::before {
-      content: 'PPY';
-    }
-  }
-
-  &--support {
-    color: @osu-colour-group-support;
-    &::before {
-      content: 'SPT';
-
-      @media @desktop {
-        content: 'SUPPORT';
-      }
-    }
+    background-color: @osu-colour-group-bot;
   }
 
   // actual modifiers start here

--- a/resources/assets/less/colors.less
+++ b/resources/assets/less/colors.less
@@ -189,7 +189,7 @@
 //  .user-card--dev {
 //    ... etc
 .osu-group-colours(@rules) {
-  @groups: ppy, bot, dev, gmt, nat, bng, bng_limited, alumni, support;
+  @groups: ppy, bot, dev, gmt, nat, bng, bng_limited, alumni, support, mapper;
   each(@groups, {
     @group: @value;
     @colour: %('osu-colour-group-%s', @value);

--- a/resources/assets/less/colors.less
+++ b/resources/assets/less/colors.less
@@ -152,14 +152,16 @@
 // New group colours (as of 2019)
 // TODO: replace group_colour in phpbb_groups and use that instead?
 //
-@osu-colour-group-bot: @osu-colour-f1; // note: bot badges are inverted, so this is actually the background colour
+@osu-colour-group-bot: @osu-colour-f1; // Note that for bot badges, the colours are inverted. i.e. this is actually the background colour of the badge
 @osu-colour-group-ppy: #0066FF;
 @osu-colour-group-dev: #EB47D0;
 @osu-colour-group-gmt: #99EB47;
 @osu-colour-group-nat: #EB8C47;
 @osu-colour-group-bng: #A347EB;
+@osu-colour-group-bng_limited: @osu-colour-group-bng;
 @osu-colour-group-alumni: #999999;
 @osu-colour-group-support: #EBD047;
+@osu-colour-group-mapper: @osu-colour-blue-1; // Technically this isn't a 'group' colour, but gets used in multiple places...
 
 // Use this instead of fade(colour, amount) - LESS tries to parse the css var as a colour and fails.
 // This is not ideal, but not sure of a better way to do this (without modifying LESS at least)
@@ -167,6 +169,34 @@
   @string: replace("@{colour}", "hsl\(([^,]+), ([^,]+), ([^,]+)\)", "hsla($1, $2, $3, @{alpha})");
   @hsla: ~"@{string}";
 }
+
+// Use this to save having to repeatedly define each group's colour, e.g.:
+//  .user-card {
+//    .osu-group-colours({
+//      &--@{group} {
+//        border-top: 2px solid @@colour;
+//      }
+//    });
+//  }
+//
+// Generates:
+//  .user-card--ppy {
+//    border-top: 2px solid #0066FF;
+//  }
+//  .user-card--bot {
+//    border-top: 2px solid hsl(var(--base-hue), 10%, 60%);
+//  }
+//  .user-card--dev {
+//    ... etc
+.osu-group-colours(@rules) {
+  @groups: ppy, bot, dev, gmt, nat, bng, bng_limited, alumni, support;
+  each(@groups, {
+    @group: @value;
+    @colour: %('osu-colour-group-%s', @value);
+
+    @rules();
+  })
+};
 
 @pink-text: @pink-dark;
 @green-text: @green-darker;


### PR DESCRIPTION
Figured it was worthwhile after seeing how many places we've duplicated this logic in.

Not sure about whether the group names should live in `user-group-badge.less` or not though...(should eventually stop being defined in CSS anyway... right?)