### PR TITLE
Allow guest access to comments via API

### DIFF
--- a/app/Http/Middleware/AuthApi.php
+++ b/app/Http/Middleware/AuthApi.php
@@ -30,7 +30,8 @@ class AuthApi
     {
         $path = "{$request->decodedPath()}/";
 
-        return starts_with($path, 'api/v2/changelog/');
+        return starts_with($path, 'api/v2/changelog/')
+            || (starts_with($path, 'api/v2/comments/') && $request->isMethod('GET'));
     }
 
     public function handle(Request $request, Closure $next)

--- a/app/Http/Middleware/AuthApi.php
+++ b/app/Http/Middleware/AuthApi.php
@@ -26,6 +26,7 @@ use Illuminate\Http\Request;
 
 class AuthApi
 {
+    // TODO: this should be definable per-controller or action.
     public static function skipAuth($request)
     {
         $path = "{$request->decodedPath()}/";

--- a/tests/Controllers/CommentsControllerTest.php
+++ b/tests/Controllers/CommentsControllerTest.php
@@ -68,4 +68,41 @@ class CommentsControllerTest extends TestCase
 
         $this->assertSame($currentComments + 1, $beatmapset->comments()->count());
     }
+
+    public function testApiUnauthenticatedUserCanViewIndex()
+    {
+        $this
+            ->json('GET', route('api.comments.index'))
+            ->assertSuccessful();
+    }
+
+    public function testApiUnauthenticatedUserCanViewComment()
+    {
+        $comment = factory(Comment::class)->create();
+
+        $this
+            ->json('GET', route('api.comments.show', ['comment' => $comment->getKey()]))
+            ->assertSuccessful();
+    }
+
+    /**
+     * @dataProvider apiRequiresAuthenticationDataProvider
+     */
+    public function testApiRequiresAuthentication($method, $routeName)
+    {
+        $this
+            ->json($method, route("api.{$routeName}", ['comment' => 1]))
+            ->assertUnauthorized();
+    }
+
+    public function apiRequiresAuthenticationDataProvider()
+    {
+        return [
+            ['DELETE', 'comments.vote'],
+            ['POST', 'comments.vote'],
+            ['POST', 'comments.store'],
+            ['PUT', 'comments.update'],
+            ['DELETE', 'comments.destroy'],
+        ];
+    }
 }


### PR DESCRIPTION
closes #5225

Adding the path and method check is currently the easiest way, but probably not what we want to keep doing in the future.