### PR TITLE
Fix travis giving up too early waiting for elasticsearch to start

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -57,7 +57,7 @@ install:
 
   # elasticsearch setup (part 2)
   # wait until es server is up
-  - wget -q --waitretry=1 --retry-connrefused -T 60 -O - http://127.0.0.1:9200
+  - wget -q --waitretry=10 --retry-connrefused -T 60 -O - http://127.0.0.1:9200
   - php artisan es:create-search-blacklist
   - php artisan es:index-documents --yes
 


### PR DESCRIPTION
When elasticsearch starts booting, the port is not open yet, which causes connection refused to get returned immediately. wget defaults to 20 retries and with `--waitretry=1` it was pretty much always only waiting for about 20 seconds, ignoring the other timeout value 🥇 