### PR TITLE
Fix user verification instance cache

### DIFF
--- a/app/Libraries/UserVerification.php
+++ b/app/Libraries/UserVerification.php
@@ -33,7 +33,7 @@ class UserVerification
 
     public static function fromCurrentRequest()
     {
-        $verification = request()->attributes->get('user-verification');
+        $verification = request()->attributes->get('user_verification');
 
         if ($verification === null) {
             $verification = new static(
@@ -41,7 +41,7 @@ class UserVerification
                 request(),
                 UserVerificationState::fromCurrentRequest()
             );
-            request()->attributes->set('user-verification', $verification);
+            request()->attributes->set('user_verification', $verification);
         }
 
         return $verification;

--- a/app/Libraries/UserVerification.php
+++ b/app/Libraries/UserVerification.php
@@ -33,17 +33,11 @@ class UserVerification
 
     public static function fromCurrentRequest()
     {
-        static $verification;
-
-        if ($verification === null) {
-            $verification = new static(
-                auth()->user(),
-                request(),
-                UserVerificationState::fromCurrentRequest()
-            );
-        }
-
-        return $verification;
+        return new static(
+            auth()->user(),
+            request(),
+            UserVerificationState::fromCurrentRequest()
+        );
     }
 
     private function __construct($user, $request, $state)

--- a/app/Libraries/UserVerification.php
+++ b/app/Libraries/UserVerification.php
@@ -33,11 +33,18 @@ class UserVerification
 
     public static function fromCurrentRequest()
     {
-        return new static(
-            auth()->user(),
-            request(),
-            UserVerificationState::fromCurrentRequest()
-        );
+        $verification = request()->attributes->get('user-verification');
+
+        if ($verification === null) {
+            $verification = new static(
+                auth()->user(),
+                request(),
+                UserVerificationState::fromCurrentRequest()
+            );
+            request()->attributes->set('user-verification', $verification);
+        }
+
+        return $verification;
     }
 
     private function __construct($user, $request, $state)


### PR DESCRIPTION
Static variable "cache"s stay across tests.