### PR TITLE
Fix locale files not being resolved in mix build

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -19,24 +19,6 @@ Mix.paths.setRootPath(currentPath);
 let ComponentFactory = require(path.resolve(mixPath, 'src/components/ComponentFactory'));
 new ComponentFactory().installAll();
 
-require(Mix.paths.mix());
-
-/**
- * Just in case the user needs to hook into this point
- * in the build process, we'll make an announcement.
- */
-
-Mix.dispatch('init', Mix);
-
-/**
- * Now that we know which build tasks are required by the
- * user, we can dynamically create a configuration object
- * for Webpack. And that's all there is to it. Simple!
- */
-
-let WebpackConfig = require(path.resolve(mixPath, 'src/builder/WebpackConfig'));
-const config = new WebpackConfig().build();
-
 const routesFile = path.resolve(__dirname, 'routes/web.php');
 const langDir = path.resolve(__dirname, 'resources/lang');
 
@@ -63,6 +45,14 @@ const watches = [
   },
 ]
 
+function buildConfig() {
+  require(Mix.paths.mix());
+  Mix.dispatch('init', Mix);
+  const WebpackConfig = require(path.resolve(mixPath, 'src/builder/WebpackConfig'));
+
+  return new WebpackConfig().build();
+}
+
 function configPromise(env, argv) {
   return new Promise((resolve) => {
     const options = {
@@ -77,7 +67,7 @@ function configPromise(env, argv) {
         watched.callback();
       })
 
-      return resolve(config);
+      return resolve(buildConfig());
     }
 
     const wp = new Watchpack(options);
@@ -104,7 +94,7 @@ function configPromise(env, argv) {
       // let webpack run after the first build.
       if (!resolved && watches.reduce((value, watched) => value && watched.ranOnce, true)) {
         resolved = true;
-        resolve(config);
+        resolve(buildConfig());
       }
     });
   });

--- a/webpack.mix.js
+++ b/webpack.mix.js
@@ -236,6 +236,10 @@ mix
 
 // include locales in manifest
 const locales = glob.sync('resources/assets/build/locales/*.js');
+if (locales.length === 0) {
+  throw new Error('missing locale files.');
+}
+
 for (const locale of locales) {
   mix.scripts([locale], `public/js/locales/${path.basename(locale)}`);
 }


### PR DESCRIPTION
fixes issue with #5240

The `mix` config is loaded during `require(Mix.paths.mix())`, so that needs to be done after the locale files are built, otherwise mix can't find them. This fix delays the loading until the promise is ready to be resolved.

(the issue didn't happen if the files from a previous build already existed)