### PR TITLE
Simplify user model's friend/block caching

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -1334,11 +1334,7 @@ class User extends Model implements AuthenticatableContract
 
     public function blockedUserIds()
     {
-        if (!array_key_exists('blocks', $this->memoized)) {
-            $this->memoized['blocks'] = $this->blocks;
-        }
-
-        return $this->memoized['blocks']->pluck('user_id');
+        return $this->blocks->pluck('user_id');
     }
 
     public function groupBadge()
@@ -1360,20 +1356,12 @@ class User extends Model implements AuthenticatableContract
 
     public function hasBlocked(self $user)
     {
-        if (!array_key_exists('blocks', $this->memoized)) {
-            $this->memoized['blocks'] = $this->blocks;
-        }
-
-        return $this->memoized['blocks']->where('user_id', $user->user_id)->count() > 0;
+        return $this->blocks->where('user_id', $user->user_id)->count() > 0;
     }
 
     public function hasFriended(self $user)
     {
-        if (!array_key_exists('friends', $this->memoized)) {
-            $this->memoized['friends'] = $this->friends;
-        }
-
-        return $this->memoized['friends']->where('user_id', $user->user_id)->count() > 0;
+        return $this->friends->where('user_id', $user->user_id)->count() > 0;
     }
 
     public function hasFavourited($beatmapset)


### PR DESCRIPTION
Accessing relation using `->relation` already caches it.