### PR TITLE
Less confusing verification log

### DIFF
--- a/app/Exceptions/UserVerificationException.php
+++ b/app/Exceptions/UserVerificationException.php
@@ -24,15 +24,22 @@ use Exception;
 
 class UserVerificationException extends Exception
 {
+    private $reasonKey;
     private $shouldReissue;
 
     public function __construct(string $reasonKey, bool $shouldReissue)
     {
+        $this->reasonKey = $reasonKey;
         $this->shouldReissue = $shouldReissue;
 
         $message = trans("user_verification.errors.{$reasonKey}");
 
         parent::__construct($message);
+    }
+
+    public function reasonKey()
+    {
+        return $this->reasonKey;
     }
 
     public function shouldReissue()

--- a/app/Http/Controllers/AccountController.php
+++ b/app/Http/Controllers/AccountController.php
@@ -248,12 +248,12 @@ class AccountController extends Controller
         $state = UserVerificationState::fromVerifyLink(request('key'));
 
         if ($state === null) {
-            UserVerification::logAttempt('link', false, 'incorrect_key');
+            UserVerification::logAttempt('link', 'fail', 'incorrect_key');
 
             return response()->view('accounts.verification_invalid')->setStatusCode(404);
         }
 
-        UserVerification::logAttempt('link', true);
+        UserVerification::logAttempt('link', 'success');
         $state->markVerified();
 
         return view('accounts.verification_completed');

--- a/app/Libraries/UserVerification.php
+++ b/app/Libraries/UserVerification.php
@@ -51,7 +51,7 @@ class UserVerification
     public static function logAttempt(string $source, bool $success, string $reason = null) : void
     {
         Datadog::increment(
-            config('datadog-halper.prefix_web').'verification.attempt',
+            config('datadog-helper.prefix_web').'.verification.attempt',
             1,
             [
                 'reason' => $reason,

--- a/app/Libraries/UserVerification.php
+++ b/app/Libraries/UserVerification.php
@@ -139,7 +139,7 @@ class UserVerification
         try {
             $this->state->verify($key);
         } catch (UserVerificationException $e) {
-            static::logAttempt('input', false, $e->getMessage());
+            static::logAttempt('input', false, $e->reasonKey());
 
             if ($e->shouldReissue()) {
                 $this->issue();

--- a/app/Libraries/UserVerification.php
+++ b/app/Libraries/UserVerification.php
@@ -53,7 +53,11 @@ class UserVerification
         Datadog::increment(
             config('datadog-halper.prefix_web').'verification.attempt',
             1,
-            compact('source', 'success', 'reason')
+            [
+                'reason' => $reason,
+                'source' => $source,
+                'success' => (int) $success,
+            ]
         );
     }
 

--- a/app/Libraries/UserVerification.php
+++ b/app/Libraries/UserVerification.php
@@ -51,7 +51,7 @@ class UserVerification
     public static function logAttempt(string $source, string $type, string $reason = null) : void
     {
         Datadog::increment(
-            config('datadog-helper.prefix_web').'.verification.attempt',
+            config('datadog-helper.prefix_web').'.verification.attempts',
             1,
             compact('reason', 'source', 'success')
         );


### PR DESCRIPTION
- as it turned out empty string is empty, so cast to integer first
- use message key instead of its translation