### PR TITLE
Fix wrong exception being thrown from authorization check

### DIFF
--- a/app/Libraries/AuthorizationResult.php
+++ b/app/Libraries/AuthorizationResult.php
@@ -21,6 +21,7 @@
 namespace App\Libraries;
 
 use App\Exceptions\AuthorizationException;
+use App\Exceptions\VerificationRequiredException;
 use Illuminate\Auth\AuthenticationException;
 
 class AuthorizationResult
@@ -52,6 +53,11 @@ class AuthorizationResult
             ends_with($this->rawMessage(), '.require_login');
     }
 
+    public function requireVerification()
+    {
+        return $this->rawMessage() === 'require_verification';
+    }
+
     public function message()
     {
         if ($this->can()) {
@@ -69,6 +75,8 @@ class AuthorizationResult
 
         if ($this->requireLogin()) {
             $class = AuthenticationException::class;
+        } elseif ($this->requireVerification()) {
+            $class = VerificationRequiredException::class;
         } else {
             $class = AuthorizationException::class;
         }

--- a/app/Libraries/OsuAuthorize.php
+++ b/app/Libraries/OsuAuthorize.php
@@ -1185,11 +1185,11 @@ class OsuAuthorize
                 return $prefix.'too_many_help_posts';
             }
         } else {
-            $this->ensureHasPlayed($user);
-
             if ($plays < config('osu.forum.minimum_plays') && $plays < $posts + 1) {
                 return $prefix.'play_more';
             }
+
+            $this->ensureHasPlayed($user);
         }
 
         return 'ok';

--- a/app/Libraries/OsuAuthorize.php
+++ b/app/Libraries/OsuAuthorize.php
@@ -21,7 +21,6 @@
 namespace App\Libraries;
 
 use App\Exceptions\AuthorizationException;
-use App\Exceptions\VerificationRequiredException;
 use App\Models\Beatmap;
 use App\Models\BeatmapDiscussion;
 use App\Models\BeatmapDiscussionPost;
@@ -1664,6 +1663,6 @@ class OsuAuthorize
             return;
         }
 
-        throw new VerificationRequiredException;
+        throw new AuthorizationException('require_verification');
     }
 }

--- a/resources/lang/en/authorization.php
+++ b/resources/lang/en/authorization.php
@@ -20,6 +20,7 @@
 
 return [
     'require_login' => 'Please sign in to proceed.',
+    'require_verification' => 'Please verify to proceed.',
     'restricted' => "Can't do that while restricted.",
     'silenced' => "Can't do that while silenced.",
     'unauthorized' => 'Access denied.',

--- a/tests/Controllers/ForumTopicsControllerTest.php
+++ b/tests/Controllers/ForumTopicsControllerTest.php
@@ -75,6 +75,24 @@ class ForumTopicsControllerTest extends TestCase
             ->assertStatus(200);
     }
 
+    public function testShowNewUser()
+    {
+        $forum = factory(Forum\Forum::class, 'child')->create();
+        $topic = factory(Forum\Topic::class)->create([
+            'forum_id' => $forum->forum_id,
+        ]);
+        $post = factory(Forum\Post::class)->create([
+            'forum_id' => $forum->forum_id,
+            'topic_id' => $topic->topic_id,
+        ]);
+        $user = factory(User::class)->create();
+
+        $this
+            ->be($user)
+            ->get(route('forum.topics.show', $topic->topic_id))
+            ->assertSuccessful();
+    }
+
     public function testStore()
     {
         $forum = factory(Forum\Forum::class, 'child')->create();


### PR DESCRIPTION
The message will be a bit confusing in some places as there's currently no way to manually trigger verification...

![](https://s.myconan.net/2019-12/firefox_2019-12-02_11-04-46.png)