### PR TITLE
Use Redis instead of DB for chat message throttling

### DIFF
--- a/app/Models/Chat/Channel.php
+++ b/app/Models/Chat/Channel.php
@@ -137,7 +137,7 @@ class Channel extends Model
         }
 
         $key = "message_throttle:{$sender->user_id}:{$keySuffix}";
-        $now = Carbon::now();
+        $now = now();
 
         // This works by keeping a sorted set of when the last messages were sent by the user (per message type).
         // The timestamp of the message is used as the score, which allows for zremrangebyscore to cull old messages
@@ -149,7 +149,7 @@ class Channel extends Model
             ->expire($key, $window)
             ->exec();
 
-        if (count($sent) > $limit) {
+        if (count($sent) >= $limit) {
             throw new API\ExcessiveChatMessagesException(trans('api.error.chat.limit_exceeded'));
         }
 

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -18,8 +18,9 @@
         <env name="ALLOW_REGISTRATION" value="true"/>
         <env name="APP_ENV" value="testing"/>
         <env name="BEATMAPSET_REQUIRED_HYPE" value="0"/>
-        <env name="CACHE_DRIVER" value="array"/>
-        <env name="SESSION_DRIVER" value="array"/>
         <env name="BROADCAST_DRIVER" value="log"/>
+        <env name="CACHE_DRIVER" value="array"/>
+        <env name="CHAT_PRIVATE_LIMIT" value="2"/>
+        <env name="SESSION_DRIVER" value="array"/>
     </php>
 </phpunit>


### PR DESCRIPTION
This also changes the order of precedence a bit, meaning invalid messages will now also count towards the limit