### PR TITLE
Skip fetching user details when generating notifications

### DIFF
--- a/app/Jobs/BroadcastNotification.php
+++ b/app/Jobs/BroadcastNotification.php
@@ -111,10 +111,8 @@ class BroadcastNotification implements ShouldQueue
         event(new $eventClass($notification, $this->receiverIds));
 
         DB::transaction(function () use ($notification) {
-            $receivers = User::whereIn('user_id', $this->receiverIds)->get();
-
-            foreach ($receivers as $receiver) {
-                $notification->userNotifications()->create(['user_id' => $receiver->getKey()]);
+            foreach ($this->receiverIds as $id) {
+                $notification->userNotifications()->create(['user_id' => $id]);
             }
         });
     }


### PR DESCRIPTION
This is the closest thing I can see on causing issue #5380.
If I remember correctly it's done to make sure the ids are valid but it's probably fine to skip it as it shouldn't cause too much harm and the number may get pretty big and thus will take a while to finish (if at all).