### PR TITLE
Clears notifications when a channel/pm is marked as read

### DIFF
--- a/app/Http/Controllers/Chat/ChannelsController.php
+++ b/app/Http/Controllers/Chat/ChannelsController.php
@@ -23,7 +23,6 @@ namespace App\Http\Controllers\Chat;
 use App\Models\Chat\Channel;
 use App\Models\Chat\UserChannel;
 use Auth;
-use DB;
 
 /**
  * @group Chat
@@ -161,12 +160,12 @@ class ChannelsController extends Controller
      */
     public function markAsRead($channel_id, $message_id)
     {
-        $userChannelQuery = UserChannel::where(['user_id' => Auth::user()->user_id, 'channel_id' => $channel_id]);
-        $userChannel = $userChannelQuery->firstOrFail();
-        $message_id = get_int($message_id);
-
-        // this prevents the read marker going backwards
-        $userChannelQuery->update(['last_read_id' => DB::raw("GREATEST(COALESCE(last_read_id, 0), $message_id)")]);
+        UserChannel::where([
+            'user_id' => Auth::user()->user_id,
+            'channel_id' => $channel_id
+        ])
+        ->firstOrFail()
+        ->markAsRead(get_int($message_id));
 
         return response([], 204);
     }

--- a/app/Http/Controllers/Chat/ChannelsController.php
+++ b/app/Http/Controllers/Chat/ChannelsController.php
@@ -158,14 +158,14 @@ class ChannelsController extends Controller
      *
      * @response 204
      */
-    public function markAsRead($channel_id, $message_id)
+    public function markAsRead($channelId, $messageId)
     {
         UserChannel::where([
             'user_id' => Auth::user()->user_id,
-            'channel_id' => $channel_id,
+            'channel_id' => $channelId,
         ])
         ->firstOrFail()
-        ->markAsRead(get_int($message_id));
+        ->markAsRead(get_int($messageId));
 
         return response([], 204);
     }

--- a/app/Http/Controllers/Chat/ChannelsController.php
+++ b/app/Http/Controllers/Chat/ChannelsController.php
@@ -162,7 +162,7 @@ class ChannelsController extends Controller
     {
         UserChannel::where([
             'user_id' => Auth::user()->user_id,
-            'channel_id' => $channel_id
+            'channel_id' => $channel_id,
         ])
         ->firstOrFail()
         ->markAsRead(get_int($message_id));

--- a/app/Models/Chat/UserChannel.php
+++ b/app/Models/Chat/UserChannel.php
@@ -21,6 +21,7 @@
 namespace App\Models\Chat;
 
 use App\Models\User;
+use App\Models\UserNotification;
 use App\Models\UserRelation;
 use DB;
 use Illuminate\Database\Eloquent\Builder;
@@ -62,7 +63,12 @@ class UserChannel extends Model
         // this prevents the read marker from going backwards
         $this->update(['last_read_id' => DB::raw("GREATEST(COALESCE(last_read_id, 0), $maxId)")]);
 
-        // TODO: notification clearing goes here
+        $params = [
+            'category' => 'channel',
+            'object_type' => 'channel',
+            'object_id' => $this->channel_id,
+        ];
+        UserNotification::markAsReadByNotificationIdentifier($this->user, $params);
     }
 
     public static function presenceForUser(User $user)

--- a/app/Models/Chat/UserChannel.php
+++ b/app/Models/Chat/UserChannel.php
@@ -22,6 +22,7 @@ namespace App\Models\Chat;
 
 use App\Models\User;
 use App\Models\UserRelation;
+use DB;
 use Illuminate\Database\Eloquent\Builder;
 
 /**
@@ -52,6 +53,16 @@ class UserChannel extends Model
     public function channel()
     {
         return $this->belongsTo(Channel::class, 'channel_id');
+    }
+
+    public function markAsRead($message_id = null)
+    {
+        $maxId = get_int($message_id ?? Message::where('channel_id', $this->channel_id)->max('message_id'));
+
+        // this prevents the read marker from going backwards
+        $this->update(['last_read_id' => DB::raw("GREATEST(COALESCE(last_read_id, 0), $maxId)")]);
+
+        // TODO: notification clearing goes here
     }
 
     public static function presenceForUser(User $user)

--- a/app/Models/Chat/UserChannel.php
+++ b/app/Models/Chat/UserChannel.php
@@ -56,9 +56,9 @@ class UserChannel extends Model
         return $this->belongsTo(Channel::class, 'channel_id');
     }
 
-    public function markAsRead($message_id = null)
+    public function markAsRead($messageId = null)
     {
-        $maxId = get_int($message_id ?? Message::where('channel_id', $this->channel_id)->max('message_id'));
+        $maxId = get_int($messageId ?? Message::where('channel_id', $this->channel_id)->max('message_id'));
 
         // this prevents the read marker from going backwards
         $this->update(['last_read_id' => DB::raw("GREATEST(COALESCE(last_read_id, 0), $maxId)")]);

--- a/routes/web.php
+++ b/routes/web.php
@@ -421,6 +421,7 @@ Route::group(['prefix' => '_lio', 'middleware' => 'lio'], function () {
     Route::post('user-achievement/{user}/{achievement}/{beatmap?}', 'LegacyInterOpController@userAchievement')->name('lio.user-achievement');
     Route::post('/user-best-scores-check/{user}', 'LegacyInterOpController@userBestScoresCheck');
     Route::post('user-send-message', 'LegacyInterOpController@userSendMessage');
+    Route::post('user-batch-mark-channel-as-read', 'LegacyInterOpController@userBatchMarkChannelAsRead');
     Route::post('user-batch-send-message', 'LegacyInterOpController@userBatchSendMessage');
     Route::delete('/user-sessions/{user}', 'LegacyInterOpController@userSessionsDestroy');
     Route::post('user-index/{user}', 'LegacyInterOpController@userIndex');


### PR DESCRIPTION
Also adds a LIO endpoint for batch marking channels as read (for bancho).

This is mainly to fix the issue where players chat a bunch in-game, then later load up the website to a bunch of notifications for the conversations they had earlier in-game.

There's some known-issues with mark-as-read for chat on the web, but they will be fixed separately:
 - when initially loading the chat page, a mark-as-read for the starting channel is not always sent
 - while actively looking at a channel, mark-as-read isn't always sent reliably

(this partially addresses #4896, but needs the above needs to be fixed before the issue can be closed)