### PR TITLE
Update default button colour

### DIFF
--- a/resources/assets/less/bem/btn-osu-big.less
+++ b/resources/assets/less/bem/btn-osu-big.less
@@ -26,7 +26,7 @@
 
   display: inline-block;
 
-  background-color: @osu-colour-h2;
+  background-color: @osu-colour-l4;
   transition: background-color 120ms;
 
   padding: 5px;
@@ -42,7 +42,7 @@
   &:hover,
   &:active {
     color: #fff;
-    background-color: @osu-colour-h1;
+    background-color: @osu-colour-l3;
   }
 
   &[disabled] {


### PR DESCRIPTION
Current one is a bit bright. It doesn't even use "primary button color" in the color file.

![](https://s.myconan.net/2019-12/firefox_2019-12-16_15-21-31.png)