### PR TITLE
Put back bpm in beatmapset api

### DIFF
--- a/app/Transformers/BeatmapsetTransformer.php
+++ b/app/Transformers/BeatmapsetTransformer.php
@@ -70,6 +70,7 @@ class BeatmapsetTransformer extends Fractal\TransformerAbstract
             'ranked_date' => json_time($beatmapset->approved_date),
             'creator' => $beatmapset->creator,
             'user_id' => $beatmapset->user_id,
+            'bpm' => $beatmapset->bpm,
             'source' => $beatmapset->source,
             'covers' => $beatmapset->allCoverURLs(),
             'preview_url' => $beatmapset->previewURL(),


### PR DESCRIPTION
Apparently tournament client requires this or something.