### PR TITLE
Correctly trigger mark-as-read behaviour on message send

### DIFF
--- a/app/Models/Chat/Channel.php
+++ b/app/Models/Chat/Channel.php
@@ -196,7 +196,7 @@ class Channel extends Model
         ])->first();
 
         if ($userChannel) {
-            $userChannel->update(['last_read_id' => $message->message_id]);
+            $userChannel->markAsRead($message->message_id);
         }
 
         if ($this->isPM()) {


### PR DESCRIPTION
Should be using the markAsRead function instead of manually updating user channel