### PR TITLE
Fix header menu and title overlap

### DIFF
--- a/resources/assets/coffee/_classes/sticky-header.coffee
+++ b/resources/assets/coffee/_classes/sticky-header.coffee
@@ -77,7 +77,7 @@ class @StickyHeader
 
 
   shouldPin: (offset = window.pageYOffset) =>
-    offset > window._styles.header.height || @shouldStick()
+    offset > 30 || @shouldStick()
 
 
   shouldStick: =>


### PR DESCRIPTION
Some arbitrary low number because it's kind of per-design specific. I think ideally it should be (`header_height - ((menu_height - overlap_allowance) + title_height)`) except there's no specific number defined for `title_height` and `overlap_allowance`\* at the moment.

\* `overlap_allowance` is the transparent bottom part of the menu.