### PR TITLE
Filter out blank pages from wiki search

### DIFF
--- a/app/Libraries/Search/WikiSearch.php
+++ b/app/Libraries/Search/WikiSearch.php
@@ -113,7 +113,10 @@ class WikiSearch extends RecordSearch
             }
         }
 
+        $visibilityQuery = ['exists' => ['field' => 'page']];
+
         return (new BoolQuery)
+            ->must($visibilityQuery)
             ->must($langQuery)
             ->must($matchQuery);
     }


### PR DESCRIPTION
After fixing caching 404, those caches end up included in search because the path now matches.

Resolves #5366.