### PR TITLE
Fix marking api sessions verified

### DIFF
--- a/app/Http/Middleware/AuthApi.php
+++ b/app/Http/Middleware/AuthApi.php
@@ -41,6 +41,12 @@ class AuthApi
             return $next($request);
         }
 
-        return app(Authenticate::class)->handle($request, $next, 'api');
+        $handler = function ($request) use ($next) {
+            optional(auth()->user())->markSessionVerified();
+
+            return $next($request);
+        };
+
+        return app(Authenticate::class)->handle($request, $handler, 'api');
     }
 }

--- a/app/Http/Middleware/VerifyUserAlways.php
+++ b/app/Http/Middleware/VerifyUserAlways.php
@@ -32,13 +32,11 @@ class VerifyUserAlways extends VerifyUser
 
     public function requiresVerification($request)
     {
-        $user = auth()->user();
-
         if (is_api_request()) {
-            optional($user)->markSessionVerified();
-
             return false;
         }
+
+        $user = auth()->user();
 
         if ($user === null) {
             return false;


### PR DESCRIPTION
API auth middleware is run after global middleware so the one in VerifyUserAlways (global) has been doing nothing.

Resolves https://github.com/ppy/osu/issues/7341.