### PR TITLE
Assume controller is already resolved or null when sending performance metrics

### DIFF
--- a/app/Http/Middleware/DatadogMetrics.php
+++ b/app/Http/Middleware/DatadogMetrics.php
@@ -48,7 +48,7 @@ class DatadogMetrics extends LaravelDatadogMiddleware
 
         $route = $request->route();
         if ($route !== null) {
-            $controller = $route->getController();
+            $controller = $route->controller;
             if ($controller !== null) {
                 $className = get_class($controller);
 


### PR DESCRIPTION
Avoids case where laravel tries to `mb_strpos` a non-string without checking if it's a string