### PR TITLE
Fix user_votes not included in comments API response

### DIFF
--- a/app/Http/Middleware/AuthApi.php
+++ b/app/Http/Middleware/AuthApi.php
@@ -37,7 +37,10 @@ class AuthApi
 
     public function handle(Request $request, Closure $next)
     {
-        if (static::skipAuth($request)) {
+        // Calling user() on the guard will set auth()->user()
+        $user = auth()->guard('api')->user();
+
+        if ($user === null && static::skipAuth($request)) {
             return $next($request);
         }
 

--- a/app/Http/Middleware/AuthApi.php
+++ b/app/Http/Middleware/AuthApi.php
@@ -37,19 +37,13 @@ class AuthApi
 
     public function handle(Request $request, Closure $next)
     {
-        // Calling user() on the guard will set auth()->user()
-        $user = auth()->guard('api')->user();
+        auth()->shouldUse('api');
+        optional(auth()->user())->markSessionVerified();
 
-        if ($user === null && static::skipAuth($request)) {
+        if (static::skipAuth($request)) {
             return $next($request);
         }
 
-        $handler = function ($request) use ($next) {
-            optional(auth()->user())->markSessionVerified();
-
-            return $next($request);
-        };
-
-        return app(Authenticate::class)->handle($request, $handler, 'api');
+        return app(Authenticate::class)->handle($request, $next, 'api');
     }
 }


### PR DESCRIPTION
closes #5378

Also fixes user always being null on API endpoints that don't require authentication.