### PR TITLE
Prevent null when fetching login attempt record

### DIFF
--- a/app/Models/LoginAttempt.php
+++ b/app/Models/LoginAttempt.php
@@ -61,6 +61,8 @@ class LoginAttempt extends Model
             if (is_sql_unique_exception($e)) {
                 return static::findOrDefault($ip);
             }
+
+            throw $e;
         }
     }
 


### PR DESCRIPTION
Looks like there's an unexpected error when saving the record but not sure what because it's caught but not handled.