### PR TITLE
Generate sourcemaps for css files

### DIFF
--- a/webpack.mix.js
+++ b/webpack.mix.js
@@ -86,7 +86,6 @@ vendor.forEach(function (script) {
 
 
 let webpackConfig = {
-  devtool: '#source-map',
   externals: {
     "lodash": "_",
     "moment": "moment",
@@ -195,6 +194,7 @@ if (process.env.SENTRY_RELEASE == 1) {
 
 mix
 .webpackConfig(webpackConfig)
+.sourceMaps(true, 'source-map', 'source-map')
 .js([
   'resources/assets/app.js'
 ], 'js/app.js')


### PR DESCRIPTION
Just setting it in webpackConfig doesn't work for css as the loaders need to be passed similar options and mix only passes it if we call `.sourceMaps()` to it.

devtool in webpackConfig is redundant as sourceMaps also set whatever it's getting as default config. Except the dev default (eval-source-map) is not working for css files so it needs to be set to the correct type.

Also explicitly set the type for production so they are always the same between environments and not rely on defaults.