### PR TITLE
Fix missing hit_accuracy in spotlight ranking API

### DIFF
--- a/app/Models/UserStatistics/Fruits.php
+++ b/app/Models/UserStatistics/Fruits.php
@@ -33,6 +33,7 @@ namespace App\Models\UserStatistics;
  * @property string $country_acronym
  * @property int $exit_count
  * @property int $fail_count
+ * @property float $hit_accuracy
  * @property \Carbon\Carbon $last_played
  * @property \Carbon\Carbon $last_update
  * @property float $level

--- a/app/Models/UserStatistics/Mania.php
+++ b/app/Models/UserStatistics/Mania.php
@@ -33,6 +33,7 @@ namespace App\Models\UserStatistics;
  * @property string $country_acronym
  * @property int $exit_count
  * @property int $fail_count
+ * @property float $hit_accuracy
  * @property \Carbon\Carbon $last_played
  * @property \Carbon\Carbon $last_update
  * @property float $level

--- a/app/Models/UserStatistics/Model.php
+++ b/app/Models/UserStatistics/Model.php
@@ -58,6 +58,11 @@ abstract class Model extends BaseModel
         return presence($value);
     }
 
+    public function getHitAccuracyAttribute($value)
+    {
+        return $this->accuracy_new ?? round($this->accuracy * 100, 2);
+    }
+
     public function currentLevelProgress()
     {
         return fmod($this->level, 1);

--- a/app/Models/UserStatistics/Osu.php
+++ b/app/Models/UserStatistics/Osu.php
@@ -33,6 +33,7 @@ namespace App\Models\UserStatistics;
  * @property string $country_acronym
  * @property int $exit_count
  * @property int $fail_count
+ * @property float $hit_accuracy
  * @property \Carbon\Carbon $last_played
  * @property \Carbon\Carbon $last_update
  * @property float $level

--- a/app/Models/UserStatistics/Taiko.php
+++ b/app/Models/UserStatistics/Taiko.php
@@ -33,6 +33,7 @@ namespace App\Models\UserStatistics;
  * @property string $country_acronym
  * @property int $exit_count
  * @property int $fail_count
+ * @property float $hit_accuracy
  * @property \Carbon\Carbon $last_played
  * @property \Carbon\Carbon $last_update
  * @property float $level

--- a/app/Transformers/UserStatisticsTransformer.php
+++ b/app/Transformers/UserStatisticsTransformer.php
@@ -45,7 +45,7 @@ class UserStatisticsTransformer extends Fractal\TransformerAbstract
             'pp' => $stats->rank_score,
             'pp_rank' => $stats->rank_score_index,
             'ranked_score' => $stats->ranked_score,
-            'hit_accuracy' => $stats->accuracy_new,
+            'hit_accuracy' => $stats->hit_accuracy,
             'play_count' => $stats->playcount,
             'play_time' => $stats->total_seconds_played,
             'total_score' => $stats->total_score,

--- a/resources/views/rankings/_spotlight_rankings_table.blade.php
+++ b/resources/views/rankings/_spotlight_rankings_table.blade.php
@@ -61,7 +61,7 @@
                     </div>
                 </td>
                 <td class="ranking-page-table__column ranking-page-table__column--dimmed">
-                    {{ format_percentage($score->accuracy * 100) }}
+                    {{ format_percentage($score->hit_accuracy) }}
                 </td>
                 <td class="ranking-page-table__column ranking-page-table__column--dimmed">
                     {{ i18n_number_format($score->playcount) }}


### PR DESCRIPTION
closes #5252

Adds new attribute that uses `accuracy` if `accuracy_new` doesn't exist.
Not sure if should just change all uses of `accuracy_new` to `hit_accuracy`, though