### PR TITLE
Fix missing route description in apidoc

### DIFF
--- a/resources/views/vendor/apidoc/partials/route.blade.php
+++ b/resources/views/vendor/apidoc/partials/route.blade.php
@@ -1,5 +1,5 @@
 <?php
-    $descriptions = explode("\n---\n", $route['description'] ?? '');
+    $descriptions = explode("\n---\n", $route['metadata']['description'] ?? '');
 
     $topDescription = $descriptions[0];
     $bottomDescription = $descriptions[1] ?? '';


### PR DESCRIPTION
Didn't notice this when upgrading the docs generator library. Good job, me '_')b