### PR TITLE
Use JSON datatype for news page

### DIFF
--- a/database/migrations/2020_01_20_031913_json_news_post_page.php
+++ b/database/migrations/2020_01_20_031913_json_news_post_page.php
@@ -1,0 +1,30 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+
+class JsonNewsPostPage extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        // DBAL (2.10.0) can't migrate to JSON datatype.
+        // It only creates TEXT with DC2Type:json as comment.
+        DB::statement('ALTER TABLE news_posts MODIFY page JSON');
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        // DBAL (2.10.0) can't migrate from JSON datatype.
+        // It explodes at unrecognized JSON datatype.
+        DB::statement('ALTER TABLE news_posts MODIFY page TEXT');
+    }
+}


### PR DESCRIPTION
TEXT is sometimes barely enough. It's not enough for the latest post (spotlight 2019 autumn) when the camo hostname is a bit long (22 characters in my case).

And dbal can't handle JSON datatype.