### PR TITLE
Fix duration not being translated in supporter email

### DIFF
--- a/app/Mail/DonationThanks.php
+++ b/app/Mail/DonationThanks.php
@@ -20,7 +20,6 @@
 
 namespace App\Mail;
 
-use App\Models\SupporterTag;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
 use Illuminate\Mail\Mailable;
@@ -39,16 +38,10 @@ class DonationThanks extends Mailable implements ShouldQueue
      *
      * @return void
      */
-    public function __construct($donor, $length, $amount, $isGift, $continued)
+    public function __construct($donor, $duration, $amount, $isGift, $continued)
     {
-        $this->params = [
-            'continued' => $continued,
-            'donor' => $donor,
-            'duration' => SupporterTag::getDurationText($length),
-            'amount' => $amount,
-            'isGift' => $isGift,
-            'minutes' => round($amount / config('payments.running_cost') * 525949, 1), // 365.2425 days
-        ];
+        $this->params = compact('continued', 'donor', 'duration', 'amount', 'isGift');
+        $this->params['minutes'] = round($amount / config('payments.running_cost') * 525949, 1); // 365.2425 days
     }
 
     /**

--- a/app/Models/SupporterTag.php
+++ b/app/Models/SupporterTag.php
@@ -96,7 +96,7 @@ class SupporterTag
         throw new \Exception('not a valid duration.');
     }
 
-    public static function getDurationText($length)
+    public static function getDurationText($length, ?string $locale = null)
     {
         // don't forget to update StoreSupporterTagPrice.durationText in coffee
         $years = (int) ($length / 12);
@@ -104,11 +104,11 @@ class SupporterTag
         $texts = [];
 
         if ($years > 0) {
-            $texts[] = trans_choice('common.count.years', $years);
+            $texts[] = trans_choice('common.count.years', $years, [], $locale);
         }
 
         if ($months > 0) {
-            $texts[] = trans_choice('common.count.months', $months);
+            $texts[] = trans_choice('common.count.months', $months, [], $locale);
         }
 
         return implode(', ', $texts);

--- a/resources/views/emails/store/donation_thanks.blade.php
+++ b/resources/views/emails/store/donation_thanks.blade.php
@@ -22,7 +22,7 @@
 ]) !!}
 {!! trans('mail.donation_thanks.keep_free') !!}
 {!! trans('mail.donation_thanks.benefit.'.($isGift ? 'gift' : 'self'), [
-    'duration' => $duration,
+    'duration' => \App\Models\SupporterTag::getDurationText($duration),
 ]) !!}
 {!! trans('mail.donation_thanks.benefit_more') !!}
 


### PR DESCRIPTION
Mailer's locale hasn't been set when the object is constructed