### PR TITLE
Fix wiki panel size

### DIFF
--- a/resources/assets/less/bem/wiki-main-page.less
+++ b/resources/assets/less/bem/wiki-main-page.less
@@ -33,7 +33,7 @@
     grid-gap: 7px;
 
     @media @desktop {
-      grid-template-columns: 50% 50%;
+      grid-template-columns: 1fr 1fr;
     }
 
     padding-top: 45px;


### PR DESCRIPTION
50% in grid ignores the gap size so it overflows by 7px (the gap).