### PR TITLE
Fix missing game mode when linking from modding profile

### DIFF
--- a/resources/assets/coffee/react/modding-profile/header.coffee
+++ b/resources/assets/coffee/react/modding-profile/header.coffee
@@ -42,7 +42,7 @@ export class Header extends React.Component
       div className: 'osu-page osu-page--users',
         div className: 'profile-header',
           div className: 'profile-header__top',
-            el HeaderInfo, user: @props.user, currentMode: @props.currentMode, coverUrl: @props.user.cover_url
+            el HeaderInfo, user: @props.user, currentMode: @props.user.playmode, coverUrl: @props.user.cover_url
 
             if !@props.user.is_bot
               el Stats, user: @props.user


### PR DESCRIPTION
closes #5579

modding profile page doesn't have `currentMode`