### PR TITLE
Fix wiki redirecting to empty page

### DIFF
--- a/app/Models/Wiki/Page.php
+++ b/app/Models/Wiki/Page.php
@@ -144,6 +144,7 @@ class Page implements WikiObject
 
         $query = (new BoolQuery())
             ->must(['match' => ['path_clean' => es_query_and_words($searchPath)]])
+            ->must(['exists' => ['field' => 'page']])
             ->should($localeQuery)
             ->shouldMatch(1);
 


### PR DESCRIPTION
If a request to wiki page with the wrong casing is made before the actual page is indexed, the redirect lookup may end up getting the wrong document as the closest match

closes #5512