### PR TITLE
Fix travis settings

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,9 +12,6 @@ language: php
 php:
   - 7.2
 
-matrix:
-  fast_finish: true
-
 services:
   - mysql
   - redis
@@ -61,6 +58,7 @@ install:
   - php artisan es:index-documents --yes
 
 jobs:
+  fast_finish: true
   include:
     - name: phpunit
       addons: skip


### PR DESCRIPTION
`fast_finish` option has been moved[1] to `jobs` and recent update caused it to override `jobs` hash and delete `jobs.include` in the process.

[1]: https://github.com/travis-ci/docs-travis-ci-com/pull/2562