### PR TITLE
Don't catch errors on news sync

### DIFF
--- a/app/Models/NewsPost.php
+++ b/app/Models/NewsPost.php
@@ -102,13 +102,7 @@ class NewsPost extends Model implements Commentable, Wiki\WikiObject
 
     public static function syncAll()
     {
-        try {
-            $entries = OsuWiki::fetch('news');
-        } catch (Exception $e) {
-            log_error($e);
-
-            return;
-        }
+        $entries = OsuWiki::fetch('news');
 
         $latestSlugs = [];
 


### PR DESCRIPTION
It doesn't generate error on normal operation. Any errors will need to be fixed right way.