### PR TITLE
Fix user best performance returning empty

### DIFF
--- a/app/Libraries/Elasticsearch/SearchParams.php
+++ b/app/Libraries/Elasticsearch/SearchParams.php
@@ -66,7 +66,7 @@ abstract class SearchParams
 
     public function isLoginRequired(): bool
     {
-        return true;
+        return false;
     }
 
     public function shouldReturnEmptyResponse(): bool

--- a/app/Libraries/Search/BeatmapsetSearchRequestParams.php
+++ b/app/Libraries/Search/BeatmapsetSearchRequestParams.php
@@ -47,6 +47,8 @@ class BeatmapsetSearchRequestParams extends BeatmapsetSearchParams
         '8' => 'loved',
     ];
 
+    private $requestQuery;
+
     public function __construct(array $request, ?User $user = null)
     {
         parent::__construct();
@@ -56,10 +58,10 @@ class BeatmapsetSearchRequestParams extends BeatmapsetSearchParams
 
         $this->user = $user;
         $this->from = $this->pageAsFrom(get_int($request['page'] ?? null));
+        $this->requestQuery = $request['q'] ?? $request['query'] ?? null;
 
         if ($this->user !== null) {
-            $this->queryString = es_query_escape_with_caveats($request['q'] ?? $request['query'] ?? null);
-
+            $this->queryString = es_query_escape_with_caveats($this->requestQuery);
             $status = presence($request['s'] ?? null);
             $this->status = static::LEGACY_STATUS_MAP[$status] ?? $status;
 
@@ -132,6 +134,11 @@ class BeatmapsetSearchRequestParams extends BeatmapsetSearchParams
         }
 
         return compact('extras', 'general', 'genres', 'languages', 'modes', 'played', 'ranks', 'statuses');
+    }
+
+    public function isLoginRequired(): bool
+    {
+        return present($this->requestQuery);
     }
 
     private function getDefaultSort(string $order): array

--- a/app/Libraries/Search/ForumSearchRequestParams.php
+++ b/app/Libraries/Search/ForumSearchRequestParams.php
@@ -33,4 +33,9 @@ class ForumSearchRequestParams extends ForumSearchParams
         $this->forumId = get_int($request['forum_id'] ?? null);
         $this->topicId = get_int($request['topic_id'] ?? null);
     }
+
+    public function isLoginRequired(): bool
+    {
+        return true;
+    }
 }

--- a/app/Libraries/Search/PostSearchRequestParams.php
+++ b/app/Libraries/Search/PostSearchRequestParams.php
@@ -34,4 +34,9 @@ class PostSearchRequestParams extends PostSearchParams
         $this->forumId = get_int($request['forum_id'] ?? null);
         $this->includeSubforums = get_bool($request['forum_children'] ?? null);
     }
+
+    public function isLoginRequired(): bool
+    {
+        return true;
+    }
 }

--- a/app/Libraries/Search/UserSearchRequestParams.php
+++ b/app/Libraries/Search/UserSearchRequestParams.php
@@ -30,4 +30,9 @@ class UserSearchRequestParams extends UserSearchParams
         $this->from = $this->pageAsFrom(get_int($request['page'] ?? null));
         $this->recentOnly = get_bool($request['recent_only'] ?? null);
     }
+
+    public function isLoginRequired(): bool
+    {
+        return true;
+    }
 }

--- a/app/Libraries/Search/WikiSearchParams.php
+++ b/app/Libraries/Search/WikiSearchParams.php
@@ -50,9 +50,4 @@ class WikiSearchParams extends SearchParams
     {
         return false;
     }
-
-    public function isLoginRequired(): bool
-    {
-        return false;
-    }
 }

--- a/app/Libraries/Search/WikiSuggestionsParams.php
+++ b/app/Libraries/Search/WikiSuggestionsParams.php
@@ -48,11 +48,6 @@ class WikiSuggestionsParams extends SearchParams
         return false;
     }
 
-    public function isLoginRequired(): bool
-    {
-        return false;
-    }
-
     /**
      * {@inheritdoc}
      */


### PR DESCRIPTION
broken by #5541

Fixes best performance showing empty when cache gets refreshed after being viewed by a guest .
Also moving the overrides to the params classes for requests since non-request params should be useable without any authentication (e.g. in when console)

defaulting `isLoginRequired` to `true` was not the best idea (・_・ヾ