### PR TITLE
Update comment API documentation

### DIFF
--- a/app/Http/Controllers/CommentsController.php
+++ b/app/Http/Controllers/CommentsController.php
@@ -91,6 +91,7 @@ class CommentsController extends Controller
      *
      * @queryParam commentable_type The type of resource to get comments for.
      * @queryParam commentable_id The id of the resource to get comments for.
+     * @queryParam cursor Pagination option. See [CommentSort](#commentsort) for detail. The format follows [Cursor](#cursor) except it's not currently included in the response.
      * @queryParam parent_id Limit to comments which are reply to the specified id. Specify 0 to get top level comments.
      * @queryParam sort Sort option as defined in [CommentSort](#commentsort). Defaults to `new` for guests and user-specified default when authenticated.
      */

--- a/app/Http/Controllers/CommentsController.php
+++ b/app/Http/Controllers/CommentsController.php
@@ -89,6 +89,7 @@ class CommentsController extends Controller
      *
      * @queryParam commentable_type The type of resource to get comments for.
      * @queryParam commentable_id The id of the resource to get comments for.
+     * @queryParam parent_id Limit to comments which are reply to the specified id. Specify 0 to get top level comments.
      */
     public function index()
     {

--- a/app/Http/Controllers/CommentsController.php
+++ b/app/Http/Controllers/CommentsController.php
@@ -77,7 +77,7 @@ class CommentsController extends Controller
     /**
      * Get Comments
      *
-     * Returns a list comments and their replies up to 2 levels deep.
+     * Returns a list comments and their replies up to 2 levels deep. `pinned_comments` is only included when `commentable_type` and `commentable_id` are specified.
      *
      * ---
      *

--- a/app/Http/Controllers/CommentsController.php
+++ b/app/Http/Controllers/CommentsController.php
@@ -92,7 +92,7 @@ class CommentsController extends Controller
      * @queryParam commentable_type The type of resource to get comments for.
      * @queryParam commentable_id The id of the resource to get comments for.
      * @queryParam parent_id Limit to comments which are reply to the specified id. Specify 0 to get top level comments.
-     * @queryParam sort Sort option as defined in [CommentSort](#commentsort).
+     * @queryParam sort Sort option as defined in [CommentSort](#commentsort). Defaults to `new` for guests and user-specified default when authenticated.
      */
     public function index()
     {

--- a/app/Http/Controllers/CommentsController.php
+++ b/app/Http/Controllers/CommentsController.php
@@ -77,13 +77,15 @@ class CommentsController extends Controller
     /**
      * Get Comments
      *
-     * Returns a list comments and their replies up to 2 levels deep. `pinned_comments` is only included when `commentable_type` and `commentable_id` are specified.
+     * Returns a list comments and their replies up to 2 levels deep.
      *
      * ---
      *
      * ### Response Format
      *
-     * Returns [CommentBundle](#commentbundle)
+     * Returns [CommentBundle](#commentbundle).
+     *
+     * `pinned_comments` is only included when `commentable_type` and `commentable_id` are specified.
      *
      * @authenticated
      *

--- a/app/Http/Controllers/CommentsController.php
+++ b/app/Http/Controllers/CommentsController.php
@@ -90,6 +90,7 @@ class CommentsController extends Controller
      * @queryParam commentable_type The type of resource to get comments for.
      * @queryParam commentable_id The id of the resource to get comments for.
      * @queryParam parent_id Limit to comments which are reply to the specified id. Specify 0 to get top level comments.
+     * @queryParam sort Sort option as defined in [CommentSort](#commentsort).
      */
     public function index()
     {

--- a/resources/docs/source/includes/_structures.md
+++ b/resources/docs/source/includes/_structures.md
@@ -20,6 +20,7 @@ Represents a beatmapset.
   "message": "yes",
   "message_html": "<div class='osu-md-default'><p class=\"osu-md-default__paragraph\">yes</p>\n</div>",
   "parent_id": null,
+  "pinned": true,
   "replies_count": 0,
   "updated_at": "2019-09-05T06:31:20+00:00",
   "user_id": 1,
@@ -42,6 +43,7 @@ legacy_name      | string?    | username displayed on legacy comments
 message          | string?    | markdown of the comment's content
 message_html     | string?    | html version of the comment's content
 parent_id        | number?    | ID of the comment's parent
+pinned           | boolean    | Pin status of the comment
 replies_count    | number     | number of replies to the comment
 updated_at       | string     | ISO 8601 date
 user_id          | number     | user ID of the poster
@@ -118,6 +120,7 @@ url              | string     | url of the object
   "has_more": true,
   "has_more_id": 276,
   "included_comments": [],
+  "pinned_comments": [],
   "sort": "new",
   "user_follow": false,
   "user_votes": [277],
@@ -163,6 +166,7 @@ comments          | [Comment](#comment)[]                 | Array of comments or
 has_more          | boolean                               | If there are more comments or replies available
 has_more_id       | number?                               |
 included_comments | [Comment](#comment)[]                 | Related comments; e.g. parent comments and nested replies
+pinned_comments   | [Comment](#comment)[]?                | Pinned comments
 sort              | string                                | one of the [CommentSort](#commentsort) types
 top_level_count   | number?                               | Number of comments at the top level. Not returned for replies.
 total             | number?                               | Total number of comments. Not retuned for replies.

--- a/resources/docs/source/includes/_structures.md
+++ b/resources/docs/source/includes/_structures.md
@@ -179,6 +179,17 @@ users             | [UserCompact](#usercompact)[]         | array of users relat
 
 Available sort types are `new`, `old`, `top`.
 
+Type  | Sort Fields
+----- | ------------------------------------------------------------------------
+new   | `created_at` (descending), `id` (descending)
+old   | `created_at` (ascending), `id` (ascending)
+top   | `votes_count` (descending), `created_at` (descending), `id` (descending)
+
+### Building cursor for comments listing
+
+The returned response will be for comments after the specified sort fields.
+
+For example, use last loaded comment for the fields value to load more comments. Also make sure to use same `sort` and `parent_id` values.
 
 ## ChatChannel
 ```json


### PR DESCRIPTION
Type for `pinned` field is a lie until #5648 is merged.