### PR TITLE
Fix event handler for mobile menu hiding too many blackouts

### DIFF
--- a/resources/assets/coffee/_classes/nav2.coffee
+++ b/resources/assets/coffee/_classes/nav2.coffee
@@ -54,14 +54,15 @@ class @Nav2
     currentPopup.querySelector('.js-nav2--autofocus')?.focus()
 
 
-  autoMobileNav: (e, {target, tree}) =>
+  autoMobileNav: (e, {previousTree, target, tree}) =>
     if target == 'mobile-menu'
       @clickMenu.show('mobile-nav')
       Timeout.set 0, => $(@clickMenu.menu('mobile-menu')).finish().slideDown(150)
 
     if tree.indexOf('mobile-menu') == -1
-      Blackout.hide()
-      Timeout.set 0, => $(@clickMenu.menu('mobile-menu')).finish().slideUp(150)
+      if previousTree.indexOf('mobile-menu') != -1
+        Blackout.hide()
+        Timeout.set 0, => $(@clickMenu.menu('mobile-menu')).finish().slideUp(150)
     else
       Blackout.show()
 

--- a/resources/assets/lib/click-menu.ts
+++ b/resources/assets/lib/click-menu.ts
@@ -69,6 +69,8 @@ export default class ClickMenu {
   }
 
   show = (target?: string | null | undefined) => {
+    const previousTree = this.tree();
+
     this.current = target;
 
     const tree = this.tree();
@@ -103,7 +105,7 @@ export default class ClickMenu {
       this.current = null;
     }
 
-    $.publish('click-menu:current', { target: this.current, tree });
+    $.publish('click-menu:current', { previousTree, target: this.current, tree });
 
     const toFocus = shownMenu?.querySelector('.js-click-menu--autofocus');
 


### PR DESCRIPTION
Only hide blackout if the menu was previously shown.

Should fix #5656.