### PR TITLE
Change how the Markdown within beatmap discussion reviews are rendered

### DIFF
--- a/resources/assets/lib/beatmap-discussions/disable-tokenizers-plugin.ts
+++ b/resources/assets/lib/beatmap-discussions/disable-tokenizers-plugin.ts
@@ -17,14 +17,18 @@
  */
 
 export function disableTokenizersPlugin({allowedBlocks = [] as string[], allowedInlines = [] as string[]} = {}) {
+  // Ensure core required tokenizers are always allowed (otherwise infinite loops and other bad things happen...)
+  allowedBlocks.push('root', 'newline');
+  allowedInlines.push('text');
+
   this.Parser.prototype.blockMethods
-    .filter((key: string) => key !== 'root' && !allowedBlocks.includes(key))
+    .filter((key: string) => !allowedBlocks.includes(key))
     .forEach((key: string) => {
-      this.Parser.prototype.blockMethods[key] = () => true;
+      this.Parser.prototype.blockTokenizers[key] = () => true;
     });
 
   this.Parser.prototype.inlineMethods
-    .filter((key: string) => key !== 'text' && !allowedInlines.includes(key))
+    .filter((key: string) => !allowedInlines.includes(key))
     .forEach((key: string) => {
       this.Parser.prototype.inlineTokenizers[key] = () => true;
       this.Parser.prototype.inlineTokenizers[key].locator = () => -1;

--- a/resources/assets/lib/beatmap-discussions/disable-tokenizers-plugin.ts
+++ b/resources/assets/lib/beatmap-discussions/disable-tokenizers-plugin.ts
@@ -1,0 +1,32 @@
+/**
+ *    Copyright (c) ppy Pty Ltd <contact@ppy.sh>.
+ *
+ *    This file is part of osu!web. osu!web is distributed with the hope of
+ *    attracting more community contributions to the core ecosystem of osu!.
+ *
+ *    osu!web is free software: you can redistribute it and/or modify
+ *    it under the terms of the Affero GNU General Public License version 3
+ *    as published by the Free Software Foundation.
+ *
+ *    osu!web is distributed WITHOUT ANY WARRANTY; without even the implied
+ *    warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *    See the GNU Affero General Public License for more details.
+ *
+ *    You should have received a copy of the GNU Affero General Public License
+ *    along with osu!web.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+export function disableTokenizersPlugin({allowedBlocks = [] as string[], allowedInlines = [] as string[]} = {}) {
+  this.Parser.prototype.blockMethods
+    .filter((key: string) => key !== 'root' && !allowedBlocks.includes(key))
+    .forEach((key: string) => {
+      this.Parser.prototype.blockMethods[key] = () => true;
+    });
+
+  this.Parser.prototype.inlineMethods
+    .filter((key: string) => key !== 'text' && !allowedInlines.includes(key))
+    .forEach((key: string) => {
+      this.Parser.prototype.inlineTokenizers[key] = () => true;
+      this.Parser.prototype.inlineTokenizers[key].locator = () => -1;
+    });
+}

--- a/resources/assets/lib/beatmap-discussions/review-post.tsx
+++ b/resources/assets/lib/beatmap-discussions/review-post.tsx
@@ -19,6 +19,7 @@
 import { BeatmapDiscussionReview } from 'interfaces/beatmap-discussion-review';
 import * as React from 'react';
 import * as ReactMarkdown from 'react-markdown';
+import { disableTokenizersPlugin } from './disable-tokenizers-plugin';
 import { ReviewPostEmbed } from './review-post-embed';
 import { timestampPlugin } from './timestamp-plugin';
 
@@ -38,14 +39,14 @@ export class ReviewPost extends React.Component<Props> {
   paragraph(source: string) {
     return (
         <ReactMarkdown
-          allowedTypes={[
-            'emphasis',
-            'link',
-            'paragraph',
-            'strong',
-            'text',
-          ]}
           plugins={[
+            [
+              disableTokenizersPlugin,
+              {
+                allowedBlocks: ['paragraph'],
+                allowedInlines: ['emphasis', 'strong'],
+              },
+            ],
             timestampPlugin,
           ]}
           key={osu.uuid()}


### PR DESCRIPTION
The previous parser settings would cull nodes that used disabled markdown features instead of just rendering the source/unformatted text.

This change will just leave the Markdown raw unless it's one of the enabled features.

Feels kinda silly that I have to implement this as a plugin that overrides the core tokenizers... 🤷‍♂