### PR TITLE
Change handling of urls within beatmap discussion reviews

### DIFF
--- a/resources/assets/lib/beatmap-discussions/autolink-plugin.ts
+++ b/resources/assets/lib/beatmap-discussions/autolink-plugin.ts
@@ -1,0 +1,60 @@
+/**
+ *    Copyright (c) ppy Pty Ltd <contact@ppy.sh>.
+ *
+ *    This file is part of osu!web. osu!web is distributed with the hope of
+ *    attracting more community contributions to the core ecosystem of osu!.
+ *
+ *    osu!web is free software: you can redistribute it and/or modify
+ *    it under the terms of the Affero GNU General Public License version 3
+ *    as published by the Free Software Foundation.
+ *
+ *    osu!web is distributed WITHOUT ANY WARRANTY; without even the implied
+ *    warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *    See the GNU Affero General Public License for more details.
+ *
+ *    You should have received a copy of the GNU Affero General Public License
+ *    along with osu!web.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+import { Eat } from 'remark-parse';
+import { Node } from 'unist';
+
+export function autolinkPlugin() {
+  function locator(value: string, fromIndex: number) {
+    return value.indexOf('http', fromIndex);
+  }
+
+  function inlineTokenizer(eat: Eat, value: string, silent?: true): Node | boolean | void {
+    const regex = new RegExp(osu.urlRegex);
+    const result = regex.exec(value);
+
+    if (!result || result.index !== 0) {
+      return;
+    }
+
+    if (silent) {
+      return true;
+    }
+
+    const [matched, , url] = result;
+
+    return eat(matched)({
+      children: [
+        {type: 'text', value: url},
+      ],
+      href: matched,
+      type: 'link',
+    });
+  }
+
+  // Ideally 'Parser' here should be typed like Parser from 'remark-parse', but the provided types appear wonky --
+  // they causes issues with the inlineTokenizer definition below, so we're gonna leave it as an implicit 'any' for now.
+  const Parser = this.Parser;
+  const inlineTokenizers = Parser.prototype.inlineTokenizers;
+  const inlineMethods = Parser.prototype.inlineMethods;
+
+  // Inject inlineTokenizer
+  inlineTokenizer.locator = locator;
+  inlineTokenizers.link = inlineTokenizer;
+  inlineMethods.unshift('link');
+}

--- a/resources/assets/lib/beatmap-discussions/review-post.tsx
+++ b/resources/assets/lib/beatmap-discussions/review-post.tsx
@@ -19,6 +19,7 @@
 import { BeatmapDiscussionReview } from 'interfaces/beatmap-discussion-review';
 import * as React from 'react';
 import * as ReactMarkdown from 'react-markdown';
+import { autolinkPlugin } from './autolink-plugin';
 import { disableTokenizersPlugin } from './disable-tokenizers-plugin';
 import { ReviewPostEmbed } from './review-post-embed';
 import { timestampPlugin } from './timestamp-plugin';
@@ -47,6 +48,7 @@ export class ReviewPost extends React.Component<Props> {
                 allowedInlines: ['emphasis', 'strong'],
               },
             ],
+            autolinkPlugin,
             timestampPlugin,
           ]}
           key={osu.uuid()}

--- a/resources/assets/lib/globals.d.ts
+++ b/resources/assets/lib/globals.d.ts
@@ -73,6 +73,7 @@ interface OsuCommon {
   transChoice: (key: string, count: number, replacements?: any, locale?: string) => string;
   transExists: (key: string, locale?: string) => boolean;
   urlPresence: (url?: string | null) => string;
+  urlRegex: RegExp;
   uuid: () => string;
   formatNumber(num: number, precision?: number, options?: Intl.NumberFormatOptions, locale?: string): string;
   formatNumber(num: null, precision?: number, options?: Intl.NumberFormatOptions, locale?: string): null;


### PR DESCRIPTION
Changed to ignore markdown-formatted links and instead autolinks urls that appear instead.

- [x] depends on #5688