### PR TITLE
Fixed the issue with time of loved not showing in the Germanic translation

### DIFF
--- a/resources/lang/de/beatmapsets.php
+++ b/resources/lang/de/beatmapsets.php
@@ -36,7 +36,7 @@ return [
         'details' => [
             'favourite' => 'Dieses Beatmapset zu deinen Favoriten hinzufügen',
             'logged-out' => 'Zum Herunterladen von Beatmaps muss man eingeloggt sein!',
-            'loved' => 'loved am ',
+            'loved' => 'loved am :timeago',
             'mapped_by' => 'erstellt von :mapper',
             'unfavourite' => 'Dieses Beatmapset von deinen Favoriten entfernen',
             'updated_timeago' => 'zuletzt aktualisiert :timeago',


### PR DESCRIPTION
As said on https://osu.ppy.sh/community/forums/topics/1028649 the time when the map was loved isn't showing due to the missing ':timeago', any German speaking user could check if the line makes sense? Thank you :)