### PR TITLE
Fix missing translation on landing page footer

### DIFF
--- a/resources/lang/en/layout.php
+++ b/resources/lang/en/layout.php
@@ -283,7 +283,6 @@ return [
             'changelog-index' => 'Changelog',
             'beatmaps' => 'Beatmap Listing',
             'download' => 'Download osu!',
-            'wiki' => 'Wiki',
         ],
         'help' => [
             '_' => 'Help & Community',
@@ -291,6 +290,7 @@ return [
             'forum' => 'Community Forums',
             'livestreams' => 'Live Streams',
             'report' => 'Report an Issue',
+            'wiki' => 'Wiki',
         ],
         'legal' => [
             '_' => 'Legal & Status',


### PR DESCRIPTION
Recent change to footer link missed translation update.