### PR TITLE
Fix error when submitting score in multiplayer rooms

### DIFF
--- a/database/migrations/2020_03_09_100459_remove_multiplayer_rooms_high_accuracy_precision.php
+++ b/database/migrations/2020_03_09_100459_remove_multiplayer_rooms_high_accuracy_precision.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class RemoveMultiplayerRoomsHighAccuracyPrecision extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('multiplayer_rooms_high', function (Blueprint $table) {
+            $table->float('accuracy')->default(0)->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        // This won't actually do anything; change() won't add precision,
+        Schema::table('multiplayer_rooms_high', function (Blueprint $table) {
+            $table->float('accuracy', 5, 4)->default(0)->change();
+        });
+    }
+}

--- a/database/migrations/2020_03_09_100459_remove_multiplayer_rooms_high_accuracy_precision.php
+++ b/database/migrations/2020_03_09_100459_remove_multiplayer_rooms_high_accuracy_precision.php
@@ -25,9 +25,7 @@ class RemoveMultiplayerRoomsHighAccuracyPrecision extends Migration
      */
     public function down()
     {
-        // This won't actually do anything; change() won't add precision,
-        Schema::table('multiplayer_rooms_high', function (Blueprint $table) {
-            $table->float('accuracy', 5, 4)->default(0)->change();
-        });
+        // raw because change() won't add precision.
+        DB::statement('ALTER TABLE multiplayer_rooms_high MODIFY COLUMN accuracy double(5, 4) NOT NULL DEFAULT 0');
     }
 }


### PR DESCRIPTION
It died if the aggregate accuracy of plays went over 9.9999 because of the precision set on the column; this is already fixed on production
ref: ppy/osu#8062

- [x] add `2020_03_09_100459_remove_multiplayer_rooms_high_accuracy_precision` to production