### PR TITLE
Fix translated dates not showing on beatmap info 

### DIFF
--- a/resources/assets/coffee/react/_components/beatmapset-mapping.coffee
+++ b/resources/assets/coffee/react/_components/beatmapset-mapping.coffee
@@ -56,9 +56,11 @@ export class BeatmapsetMapping extends React.PureComponent
 
 
   renderDate: (key, attribute) =>
-    div dangerouslySetInnerHTML: __html:
-      osu.trans "beatmapsets.show.details_date.#{key}",
-        timeago: osu.timeago(@props.beatmapset[attribute])
+    div
+      className: "#{bn}__date"
+      dangerouslySetInnerHTML: __html:
+        osu.trans "beatmapsets.show.details_date.#{key}",
+          timeago: osu.timeago(@props.beatmapset[attribute])
 
 
   userLink: (user) ->

--- a/resources/assets/coffee/react/_components/beatmapset-mapping.coffee
+++ b/resources/assets/coffee/react/_components/beatmapset-mapping.coffee
@@ -57,7 +57,7 @@ export class BeatmapsetMapping extends React.PureComponent
 
   renderDate: (key, attribute) =>
     div dangerouslySetInnerHTML: __html:
-      osu.trans "beatmapsets.show.details.#{key}",
+      osu.trans "beatmapsets.show.details_date.#{key}",
         timeago: osu.timeago(@props.beatmapset[attribute])
 
 

--- a/resources/assets/less/bem/beatmapset-mapping.less
+++ b/resources/assets/less/bem/beatmapset-mapping.less
@@ -30,7 +30,9 @@
   }
 
   &__date {
-    font-weight: 700;
+    .timeago {
+      font-weight: 700;
+    }
   }
 
   &__mapper {

--- a/resources/lang/en/beatmapsets.php
+++ b/resources/lang/en/beatmapsets.php
@@ -34,16 +34,10 @@ return [
         'discussion' => 'Discussion',
 
         'details' => [
-            'approved' => 'approved :timeago',
             'favourite' => 'Favourite this beatmapset',
             'logged-out' => 'You need to sign in before downloading any beatmaps!',
-            'loved' => 'loved :timeago',
             'mapped_by' => 'mapped by :mapper',
-            'qualified' => 'qualified :timeago',
-            'ranked' => 'ranked :timeago',
-            'submitted' => 'submitted :timeago',
             'unfavourite' => 'Unfavourite this beatmapset',
-            'updated' => 'last updated :timeago',
             'updated_timeago' => 'last updated :timeago',
 
             'download' => [
@@ -57,6 +51,15 @@ return [
                 'bottom' => 'to access more features',
                 'top' => 'Sign In',
             ],
+        ],
+
+        'details_date' => [
+            'approved' => 'approved :timeago',
+            'loved' => 'loved :timeago',
+            'qualified' => 'qualified :timeago',
+            'ranked' => 'ranked :timeago',
+            'submitted' => 'submitted :timeago',
+            'updated' => 'last updated :timeago',
         ],
 
         'favourites' => [


### PR DESCRIPTION
Change beatmap mapping details translation keys to force them to stop using the old translations without variables.