### PR TITLE
Add missing title for multiplayer match page

### DIFF
--- a/resources/lang/en/page_title.php
+++ b/resources/lang/en/page_title.php
@@ -106,6 +106,9 @@ return [
         'livestreams_controller' => [
             '_' => 'live streams',
         ],
+        'matches_controller' => [
+            '_' => 'matches',
+        ],
         'news_controller' => [
             '_' => 'news',
         ],


### PR DESCRIPTION
Resolves #5745. I'm not sure if it's the correct title.