### PR TITLE
Licence cleanup part 1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -67,7 +67,7 @@ jobs:
     - name: browser tests
       script: ./bin/run_dusk.sh
 
-    - name: tslint
+    - name: lint
       env:
         - OSU_SKIP_ASSET_BUILD=1
       addons: skip
@@ -76,6 +76,7 @@ jobs:
       script:
         - yarn
         - yarn lint
+        - ./bin/update-licence -nf
 
     - name: karma
       env:

--- a/app/Console/Commands/EsCreateSearchBlacklist.php
+++ b/app/Console/Commands/EsCreateSearchBlacklist.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 namespace App\Console\Commands;
 
 use App\Libraries\Elasticsearch\Es;

--- a/app/Console/Commands/EsIndexWiki.php
+++ b/app/Console/Commands/EsIndexWiki.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 namespace App\Console\Commands;
 
 use App\Libraries\Elasticsearch\Es;

--- a/app/Exceptions/GitHubNotFoundException.php
+++ b/app/Exceptions/GitHubNotFoundException.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 namespace App\Exceptions;
 
 use Exception;

--- a/app/Exceptions/GitHubTooLargeException.php
+++ b/app/Exceptions/GitHubTooLargeException.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 namespace App\Exceptions;
 
 use Exception;

--- a/app/Http/Controllers/Admin/Store/AddressesController.php
+++ b/app/Http/Controllers/Admin/Store/AddressesController.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 namespace App\Http\Controllers\Admin\Store;
 
 use App\Http\Controllers\Admin\Controller;

--- a/app/Http/Controllers/Admin/Store/OrderItemsController.php
+++ b/app/Http/Controllers/Admin/Store/OrderItemsController.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 namespace App\Http\Controllers\Admin\Store;
 
 use App\Http\Controllers\Admin\Controller;

--- a/app/Http/Controllers/Admin/Store/OrdersController.php
+++ b/app/Http/Controllers/Admin/Store/OrdersController.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 namespace App\Http\Controllers\Admin\Store;
 
 use App\Http\Controllers\Admin\Controller;

--- a/app/Http/Middleware/AutologinFromLegacyCookie.php
+++ b/app/Http/Middleware/AutologinFromLegacyCookie.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 namespace App\Http\Middleware;
 
 use App\Models\LegacySession;

--- a/app/Jobs/UpdateWiki.php
+++ b/app/Jobs/UpdateWiki.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 namespace App\Jobs;
 
 use App\Libraries\OsuWiki;

--- a/app/Models/BeatmapsetUserRating.php
+++ b/app/Models/BeatmapsetUserRating.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 namespace App\Models;
 
 /**

--- a/app/Models/Store/NotificationRequest.php
+++ b/app/Models/Store/NotificationRequest.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 namespace App\Models\Store;
 
 /**

--- a/app/Models/UserRelation.php
+++ b/app/Models/UserRelation.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 namespace App\Models;
 
 use DB;

--- a/app/Providers/AdditionalDuskServiceProvider.php
+++ b/app/Providers/AdditionalDuskServiceProvider.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 namespace App\Providers;
 
 use App\Libraries\UserVerification;

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 namespace App\Providers;
 
 use App\Http\Controllers\Passport\AuthorizationController;

--- a/app/Providers/BroadcastServiceProvider.php
+++ b/app/Providers/BroadcastServiceProvider.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 namespace App\Providers;
 
 use Illuminate\Support\Facades\Broadcast;

--- a/app/Providers/TransactionStateServiceProvider.php
+++ b/app/Providers/TransactionStateServiceProvider.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 namespace App\Providers;
 
 use App\Libraries\TransactionStateManager;

--- a/app/Transformers/Multiplayer/PlaylistItemTransformer.php
+++ b/app/Transformers/Multiplayer/PlaylistItemTransformer.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  *    Copyright (c) ppy Pty Ltd <contact@ppy.sh>.
  *

--- a/app/framework_helper_overrides.php
+++ b/app/framework_helper_overrides.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 // Fixes laravel/framework#12065.
 function e($value)
 {

--- a/bin/update-licence
+++ b/bin/update-licence
@@ -1,0 +1,202 @@
+#!/bin/sh
+
+# Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+# See the LICENCE file in the repository root for full licence text.
+
+set -e
+set -u
+
+_echo() {
+    printf "%s\n" "$@"
+}
+
+DEBUG=0
+NO_UPDATE=0
+QUICK_FAIL=0
+while getopts "dfn" opt
+do
+    case "$opt" in
+        d) DEBUG=1;;
+        f) QUICK_FAIL=1;;
+        n) NO_UPDATE=1;;
+    esac
+done
+
+if [ "$DEBUG" = 1 ]; then
+    _debug() {
+        _echo "$@"
+    }
+else
+    _debug() {
+        true
+    }
+fi
+
+_fix() {
+    old_header="$1"
+    shift
+    new_header="$1"
+    shift
+    pattern="$1"
+    shift
+
+    old_header_lines=$(_echo "$old_header" | wc -l)
+    new_header_lines=$(_echo "$new_header" | wc -l)
+
+    # please don't have files which name contains newline
+    find "$@" -name "$pattern" | while read file; do
+        case "$file" in
+            database/migrations/2016_03_18_170000_create_oauth_scopes_table.php|\
+            database/migrations/2016_03_18_170001_create_oauth_grants_table.php|\
+            database/migrations/2016_03_18_170002_create_oauth_grant_scopes_table.php|\
+            database/migrations/2016_03_18_170003_create_oauth_clients_table.php|\
+            database/migrations/2016_03_18_170004_create_oauth_client_endpoints_table.php|\
+            database/migrations/2016_03_18_170005_create_oauth_client_scopes_table.php|\
+            database/migrations/2016_03_18_170006_create_oauth_client_grants_table.php|\
+            database/migrations/2016_03_18_170007_create_oauth_sessions_table.php|\
+            database/migrations/2016_03_18_170008_create_oauth_session_scopes_table.php|\
+            database/migrations/2016_03_18_170009_create_oauth_auth_codes_table.php|\
+            database/migrations/2016_03_18_170010_create_oauth_auth_code_scopes_table.php|\
+            database/migrations/2016_03_18_170011_create_oauth_access_tokens_table.php|\
+            database/migrations/2016_03_18_170012_create_oauth_access_token_scopes_table.php|\
+            database/migrations/2016_03_18_170013_create_oauth_refresh_tokens_table.php|\
+            resources/assets/build/*|\
+            resources/assets/js/ziggy.js|\
+            resources/assets/less/jquery-ui/slider.less|\
+            resources/assets/less/jquery-ui/theme.less|\
+            resources/assets/less/spinner.less|\
+            resources/assets/less/torus.less)
+                _debug "S $file"
+                continue
+            ;;
+        esac
+
+        new_current_header=$(head -n "$new_header_lines" "$file")
+        if [ "$new_current_header" = "$new_header" ]; then
+            continue
+        fi
+
+        old_current_header=$(head -n "$old_header_lines" "$file")
+        if [ "$old_current_header" != "$old_header" ]; then
+            echo "? $file"
+            # As the whole process is inside pipe, there's no way to modify global variable.
+            # This is needed to tell travis the correct return code.
+            if [ "$QUICK_FAIL" = 1 ]; then
+                echo "Found file with invalid licence header."
+                echo "QUICK_FAIL (-f) option enabled, stopping check."
+                echo "Run without -f for full check."
+                exit 1
+            fi
+            continue
+        fi
+
+        test "$NO_UPDATE" = 1 && continue
+
+        lines=$(cat "$file" | wc -l)
+        content=$(tail -n $(($lines - $old_header_lines)) "$file")
+        (
+            _echo "$new_header"
+            _echo "$content"
+        ) > "$file"
+        _debug "U $file"
+    done
+}
+
+licence_old_blade=$(cat <<EOF
+{{--
+    Copyright (c) ppy Pty Ltd <contact@ppy.sh>.
+
+    This file is part of osu!web. osu!web is distributed with the hope of
+    attracting more community contributions to the core ecosystem of osu!.
+
+    osu!web is free software: you can redistribute it and/or modify
+    it under the terms of the Affero GNU General Public License version 3
+    as published by the Free Software Foundation.
+
+    osu!web is distributed WITHOUT ANY WARRANTY; without even the implied
+    warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+    See the GNU Affero General Public License for more details.
+
+    You should have received a copy of the GNU Affero General Public License
+    along with osu!web.  If not, see <http://www.gnu.org/licenses/>.
+--}}
+EOF
+)
+
+licence_old_c=$(cat <<EOF
+/**
+ *    Copyright (c) ppy Pty Ltd <contact@ppy.sh>.
+ *
+ *    This file is part of osu!web. osu!web is distributed with the hope of
+ *    attracting more community contributions to the core ecosystem of osu!.
+ *
+ *    osu!web is free software: you can redistribute it and/or modify
+ *    it under the terms of the Affero GNU General Public License version 3
+ *    as published by the Free Software Foundation.
+ *
+ *    osu!web is distributed WITHOUT ANY WARRANTY; without even the implied
+ *    warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *    See the GNU Affero General Public License for more details.
+ *
+ *    You should have received a copy of the GNU Affero General Public License
+ *    along with osu!web.  If not, see <http://www.gnu.org/licenses/>.
+ */
+EOF
+)
+
+licence_old_coffee=$(cat <<EOF
+###
+#    Copyright (c) ppy Pty Ltd <contact@ppy.sh>.
+#
+#    This file is part of osu!web. osu!web is distributed with the hope of
+#    attracting more community contributions to the core ecosystem of osu!.
+#
+#    osu!web is free software: you can redistribute it and/or modify
+#    it under the terms of the Affero GNU General Public License version 3
+#    as published by the Free Software Foundation.
+#
+#    osu!web is distributed WITHOUT ANY WARRANTY; without even the implied
+#    warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+#    See the GNU Affero General Public License for more details.
+#
+#    You should have received a copy of the GNU Affero General Public License
+#    along with osu!web.  If not, see <http://www.gnu.org/licenses/>.
+###
+EOF
+)
+
+licence_old_php=$(printf "<?php\n\n%s" "$licence_old_c")
+
+licence_new_blade=$(cat <<EOF
+{{--
+    Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+    See the LICENCE file in the repository root for full licence text.
+--}}
+EOF
+)
+
+licence_new_c=$(cat <<EOF
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+EOF
+)
+
+licence_new_coffee=$(cat <<EOF
+# Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+# See the LICENCE file in the repository root for full licence text.
+EOF
+)
+
+licence_new_php=$(printf "<?php\n\n%s" "$licence_new_c")
+
+_fix "${licence_old_php}" "${licence_new_php}" '*.php' app/ database/ resources/lang/en/ routes/ tests/
+_fix "${licence_old_blade}" "${licence_new_blade}" '*.blade.php' resources/views/
+
+_fix "${licence_old_c}" "${licence_new_c}" '*.less' resources/assets/
+
+_fix "${licence_old_c}" "${licence_new_c}" '*.ts' resources/assets/
+_fix "${licence_old_c}" "${licence_new_c}" '*.tsx' resources/assets/
+_fix "${licence_old_c}" "${licence_new_c}" '*.js' resources/assets/
+_fix "${licence_old_c}" "${licence_new_c}" '*.js' *.js
+
+_fix "${licence_old_coffee}" "${licence_new_coffee}" '*.coffee' resources/assets/

--- a/bin/update-licence
+++ b/bin/update-licence
@@ -7,7 +7,7 @@ set -e
 set -u
 
 _echo() {
-    printf "%s\n" "$@"
+    printf "%s\n" "$*"
 }
 
 DEBUG=0

--- a/database/factories/AchievementFactory.php
+++ b/database/factories/AchievementFactory.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 /*
 |--------------------------------------------------------------------------
 | Model Factories

--- a/database/factories/ArtistFactory.php
+++ b/database/factories/ArtistFactory.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 $factory->define(App\Models\Artist::class, function (Faker\Generator $faker) {
     return  [
         'name' => function () use ($faker) {

--- a/database/factories/BanchoStatsFactory.php
+++ b/database/factories/BanchoStatsFactory.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 /*
 |--------------------------------------------------------------------------
 | Model Factories

--- a/database/factories/BeatmapDiscussionFactory.php
+++ b/database/factories/BeatmapDiscussionFactory.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 /*
 |--------------------------------------------------------------------------
 | Model Factories

--- a/database/factories/BeatmapDiscussionPostFactory.php
+++ b/database/factories/BeatmapDiscussionPostFactory.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 /*
 |--------------------------------------------------------------------------
 | Model Factories

--- a/database/factories/BeatmapFactory.php
+++ b/database/factories/BeatmapFactory.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 /*
 |--------------------------------------------------------------------------
 | Model Factories

--- a/database/factories/BeatmapMirrorFactory.php
+++ b/database/factories/BeatmapMirrorFactory.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 use App\Models\BeatmapMirror;
 
 $factory->define(BeatmapMirror::class, function (Faker\Generator $faker) {

--- a/database/factories/BeatmapPackFactory.php
+++ b/database/factories/BeatmapPackFactory.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 $factory->define(App\Models\BeatmapPack::class, function (Faker\Generator $faker) {
     return  [
         'url' => function () use ($faker) {

--- a/database/factories/BeatmapsetFactory.php
+++ b/database/factories/BeatmapsetFactory.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 /*
 |--------------------------------------------------------------------------
 | Model Factories

--- a/database/factories/BuildFactory.php
+++ b/database/factories/BuildFactory.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 use Carbon\Carbon;
 
 $factory->define(App\Models\Build::class, function (Faker\Generator $faker) {

--- a/database/factories/ChangelogFactory.php
+++ b/database/factories/ChangelogFactory.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 /*
 |--------------------------------------------------------------------------
 | Model Factories

--- a/database/factories/Chat/ChannelFactory.php
+++ b/database/factories/Chat/ChannelFactory.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  *    Copyright (c) ppy Pty Ltd <contact@ppy.sh>.
  *

--- a/database/factories/Chat/MessageFactory.php
+++ b/database/factories/Chat/MessageFactory.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  *    Copyright (c) ppy Pty Ltd <contact@ppy.sh>.
  *

--- a/database/factories/Chat/UserChannelFactory.php
+++ b/database/factories/Chat/UserChannelFactory.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  *    Copyright (c) ppy Pty Ltd <contact@ppy.sh>.
  *

--- a/database/factories/CommentFactory.php
+++ b/database/factories/CommentFactory.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 $factory->define(App\Models\Comment::class, function (Faker\Generator $faker) {
     return [
         'user_id' => function () {

--- a/database/factories/ContestEntryFactory.php
+++ b/database/factories/ContestEntryFactory.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 $factory->define(App\Models\ContestEntry::class, function (Faker\Generator $faker) {
     return [
         'user_id' => function () {

--- a/database/factories/ContestFactory.php
+++ b/database/factories/ContestFactory.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 $factory->define(App\Models\Contest::class, function (Faker\Generator $faker) {
     return  [
         'name' => function () use ($faker) {

--- a/database/factories/CountryFactory.php
+++ b/database/factories/CountryFactory.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 /*
 |--------------------------------------------------------------------------
 | Model Factories

--- a/database/factories/ForumFactory.php
+++ b/database/factories/ForumFactory.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 use App\Models\Forum\AuthOption;
 use App\Models\User;
 

--- a/database/factories/GenreFactory.php
+++ b/database/factories/GenreFactory.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 $factory->define(App\Models\Genre::class, function (Faker\Generator $faker) {
     return  [
         'name' => function () use ($faker) {

--- a/database/factories/GroupFactory.php
+++ b/database/factories/GroupFactory.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 $factory->define(App\Models\Group::class, function (Faker\Generator $faker) {
     return [
         'group_name' => function () use ($faker) {

--- a/database/factories/LanguageFactory.php
+++ b/database/factories/LanguageFactory.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 $factory->define(App\Models\Language::class, function (Faker\Generator $faker) {
     return  [
         'name' => function () use ($faker) {

--- a/database/factories/Multiplayer/EventFactory.php
+++ b/database/factories/Multiplayer/EventFactory.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 $factory->define(App\Models\Multiplayer\Event::class, function (Faker\Generator $faker) {
     return [
         'match_id' => function () {

--- a/database/factories/Multiplayer/GameFactory.php
+++ b/database/factories/Multiplayer/GameFactory.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 use Carbon\Carbon;
 
 $factory->define(App\Models\Multiplayer\Game::class, function (Faker\Generator $faker) {

--- a/database/factories/Multiplayer/MatchFactory.php
+++ b/database/factories/Multiplayer/MatchFactory.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 $factory->define(App\Models\Multiplayer\Match::class, function (Faker\Generator $faker) {
     return [
         'name' => function () use ($faker) {

--- a/database/factories/OAuth/ClientFactory.php
+++ b/database/factories/OAuth/ClientFactory.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 $factory->define(App\Models\OAuth\Client::class, function (Faker\Generator $faker) {
     return  [
         'user_id' => function () {

--- a/database/factories/OrderFactory.php
+++ b/database/factories/OrderFactory.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 $factory->define(App\Models\Store\Order::class, function (Faker\Generator $faker) {
     return  [
         'user_id' => function () {

--- a/database/factories/OrderItemFactory.php
+++ b/database/factories/OrderItemFactory.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 $factory->define(App\Models\Store\OrderItem::class, function (Faker\Generator $faker) {
     return  [
         'order_id' => function () {

--- a/database/factories/PlaylistItemFactory.php
+++ b/database/factories/PlaylistItemFactory.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 $factory->define(App\Models\Multiplayer\PlaylistItem::class, function (Faker\Generator $faker) {
     return  [
         'beatmap_id' => function () {

--- a/database/factories/ProductFactory.php
+++ b/database/factories/ProductFactory.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 /*
 |--------------------------------------------------------------------------
 | Model Factories

--- a/database/factories/RoomFactory.php
+++ b/database/factories/RoomFactory.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 $factory->define(App\Models\Multiplayer\Room::class, function (Faker\Generator $faker) {
     return  [
         'user_id' => function (array $self) {

--- a/database/factories/RoomScoreFactory.php
+++ b/database/factories/RoomScoreFactory.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 $factory->define(App\Models\Multiplayer\RoomScore::class, function (Faker\Generator $faker) {
     return  [
         'playlist_item_id' => function () {

--- a/database/factories/ScoreBestFactory.php
+++ b/database/factories/ScoreBestFactory.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 use App\Models\Score\Best\Osu;
 
 $factory->define(App\Models\Score\Best\Osu::class, function (Faker\Generator $faker) {

--- a/database/factories/SpotlightFactory.php
+++ b/database/factories/SpotlightFactory.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 $factory->define(App\Models\Spotlight::class, function (Faker\Generator $faker) {
     $startDate = $faker->dateTimeBetween('-6 years', 'now');
     $endDate = Carbon\Carbon::instance($startDate)->addMonths(1);

--- a/database/factories/StatsFactory.php
+++ b/database/factories/StatsFactory.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 if (!function_exists('generateStats')) {
     function generateStats()
     {

--- a/database/factories/TournamentFactory.php
+++ b/database/factories/TournamentFactory.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 $factory->define(App\Models\Tournament::class, function (Faker\Generator $faker) {
     return  [
         'name' => "Such {$faker->word}",

--- a/database/factories/UpdateStreamFactory.php
+++ b/database/factories/UpdateStreamFactory.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 $factory->define(App\Models\UpdateStream::class, function (Faker\Generator $faker) {
     return  [
         'name' => function () use ($faker) {

--- a/database/factories/UserAccountHistoryFactory.php
+++ b/database/factories/UserAccountHistoryFactory.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 use App\Models\UserAccountHistory;
 
 $factory->define(UserAccountHistory::class, function (Faker\Generator $faker) {

--- a/database/factories/UserDonationFactory.php
+++ b/database/factories/UserDonationFactory.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 $factory->define(App\Models\UserDonation::class, function (Faker\Generator $faker) {
     return  [
         'user_id' => function () {

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 $factory->define(App\Models\User::class, function (Faker\Generator $faker) {
     $existing_users = DB::table('phpbb_users')->get();
     $countries = DB::table('osu_countries')->get()->toArray();

--- a/database/factories/UserGroupFactory.php
+++ b/database/factories/UserGroupFactory.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  *    Copyright (c) ppy Pty Ltd <contact@ppy.sh>.
  *

--- a/database/factories/UserGroupFactory.php
+++ b/database/factories/UserGroupFactory.php
@@ -16,9 +16,9 @@
  *    You should have received a copy of the GNU Affero General Public License
  *    along with osu!web.  If not, see <http://www.gnu.org/licenses/>.
  */
- $factory->define(App\Models\UserGroup::class, function (Faker\Generator $faker) {
-     return [
-         'group_leader' => 0,
-         'user_pending' => 0,
-     ];
- });
+$factory->define(App\Models\UserGroup::class, function (Faker\Generator $faker) {
+    return [
+        'group_leader' => 0,
+        'user_pending' => 0,
+    ];
+});

--- a/database/factories/UserMonthlyPlaycountFactory.php
+++ b/database/factories/UserMonthlyPlaycountFactory.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 $factory->define(App\Models\UserMonthlyPlaycount::class, function (Faker\Generator $faker) {
     return [
         'year_month' => function () use ($faker) {

--- a/database/factories/UserRelationFactory.php
+++ b/database/factories/UserRelationFactory.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  *    Copyright (c) ppy Pty Ltd <contact@ppy.sh>.
  *

--- a/database/migrations/2015_01_01_133337_multiplayer_base_tables.php
+++ b/database/migrations/2015_01_01_133337_multiplayer_base_tables.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 

--- a/database/migrations/2015_01_01_133337_updates_base_tables.php
+++ b/database/migrations/2015_01_01_133337_updates_base_tables.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 use Illuminate\Database\Migrations\Migration;
 
 class UpdatesBaseTables extends Migration

--- a/database/migrations/2015_12_07_061307_create_forum_covers_table.php
+++ b/database/migrations/2015_12_07_061307_create_forum_covers_table.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 

--- a/database/migrations/2016_01_12_074035_unique_user_customization_user_id.php
+++ b/database/migrations/2016_01_12_074035_unique_user_customization_user_id.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 use Illuminate\Database\Migrations\Migration;
 
 class UniqueUserCustomizationUserId extends Migration

--- a/database/migrations/2016_01_29_090810_add_description_to_achievements.php
+++ b/database/migrations/2016_01_29_090810_add_description_to_achievements.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 use Illuminate\Database\Migrations\Migration;
 
 class AddDescriptionToAchievements extends Migration

--- a/database/migrations/2016_02_23_094326_create_jobs_table.php
+++ b/database/migrations/2016_02_23_094326_create_jobs_table.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 

--- a/database/migrations/2016_02_25_072543_add_cover_updated_at_to_beatmapsets.php
+++ b/database/migrations/2016_02_25_072543_add_cover_updated_at_to_beatmapsets.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 

--- a/database/migrations/2016_02_25_080550_create_failed_jobs_table.php
+++ b/database/migrations/2016_02_25_080550_create_failed_jobs_table.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 

--- a/database/migrations/2016_02_27_103851_create_osu_slack_users_table.php
+++ b/database/migrations/2016_02_27_103851_create_osu_slack_users_table.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 

--- a/database/migrations/2016_02_29_052133_create_beatmapset_discussions.php
+++ b/database/migrations/2016_02_29_052133_create_beatmapset_discussions.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 

--- a/database/migrations/2016_02_29_060025_create_beatmap_discussions.php
+++ b/database/migrations/2016_02_29_060025_create_beatmap_discussions.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 

--- a/database/migrations/2016_02_29_081309_create_beatmap_discussion_posts.php
+++ b/database/migrations/2016_02_29_081309_create_beatmap_discussion_posts.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 

--- a/database/migrations/2016_03_02_214730_change_primary_key_on_slack_users.php
+++ b/database/migrations/2016_03_02_214730_change_primary_key_on_slack_users.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 use Illuminate\Database\Migrations\Migration;
 
 class ChangePrimaryKeyOnSlackUsers extends Migration

--- a/database/migrations/2016_03_03_223651_osu_slack_user_make_slack_id_nullable.php
+++ b/database/migrations/2016_03_03_223651_osu_slack_user_make_slack_id_nullable.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 use Illuminate\Database\Migrations\Migration;
 
 class OsuSlackUserMakeSlackIdNullable extends Migration

--- a/database/migrations/2016_03_09_083112_add_index_on_slack_id.php
+++ b/database/migrations/2016_03_09_083112_add_index_on_slack_id.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 use Illuminate\Database\Migrations\Migration;
 
 class AddIndexOnSlackId extends Migration

--- a/database/migrations/2016_03_22_054843_create_beatmap_discussion_votes.php
+++ b/database/migrations/2016_03_22_054843_create_beatmap_discussion_votes.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 

--- a/database/migrations/2016_04_12_111756_add_last_editor_id_to_beatmap_discussion_posts.php
+++ b/database/migrations/2016_04_12_111756_add_last_editor_id_to_beatmap_discussion_posts.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 use Illuminate\Database\Migrations\Migration;
 
 class AddLastEditorIdToBeatmapDiscussionPosts extends Migration

--- a/database/migrations/2016_04_13_054710_add_system_to_beatmap_discussion_posts.php
+++ b/database/migrations/2016_04_13_054710_add_system_to_beatmap_discussion_posts.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 use Illuminate\Database\Migrations\Migration;
 
 class AddSystemToBeatmapDiscussionPosts extends Migration

--- a/database/migrations/2016_04_14_061643_create_user_zebras_table.php
+++ b/database/migrations/2016_04_14_061643_create_user_zebras_table.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 

--- a/database/migrations/2016_04_19_112407_create_store_notification_requests_table.php
+++ b/database/migrations/2016_04_19_112407_create_store_notification_requests_table.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 

--- a/database/migrations/2016_05_10_080557_update_achievements_table.php
+++ b/database/migrations/2016_05_10_080557_update_achievements_table.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 use Illuminate\Database\Migrations\Migration;
 
 class UpdateAchievementsTable extends Migration

--- a/database/migrations/2016_06_17_081023_create_beatmapset_events.php
+++ b/database/migrations/2016_06_17_081023_create_beatmapset_events.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 

--- a/database/migrations/2016_06_21_054206_create_poll_votes_table.php
+++ b/database/migrations/2016_06_21_054206_create_poll_votes_table.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 use Illuminate\Database\Migrations\Migration;
 
 class CreatePollVotesTable extends Migration

--- a/database/migrations/2016_06_21_055139_create_poll_options_table.php
+++ b/database/migrations/2016_06_21_055139_create_poll_options_table.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 use Illuminate\Database\Migrations\Migration;
 
 class CreatePollOptionsTable extends Migration

--- a/database/migrations/2016_06_21_134532_create_banchostats_table.php
+++ b/database/migrations/2016_06_21_134532_create_banchostats_table.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 

--- a/database/migrations/2016_07_21_072328_create_artist_tables.php
+++ b/database/migrations/2016_07_21_072328_create_artist_tables.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 

--- a/database/migrations/2016_07_29_024320_create_contest_tables.php
+++ b/database/migrations/2016_07_29_024320_create_contest_tables.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 

--- a/database/migrations/2016_08_04_100929_add_length_to_artist_tracks.php
+++ b/database/migrations/2016_08_04_100929_add_length_to_artist_tracks.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 

--- a/database/migrations/2016_08_16_101048_create_sessions_table.php
+++ b/database/migrations/2016_08_16_101048_create_sessions_table.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 use Illuminate\Database\Migrations\Migration;
 
 class CreateSessionsTable extends Migration

--- a/database/migrations/2016_08_25_031518_add_show_votes_to_contests.php
+++ b/database/migrations/2016_08_25_031518_add_show_votes_to_contests.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 

--- a/database/migrations/2016_08_25_055700_create_contest_vote_aggregates_view.php
+++ b/database/migrations/2016_08_25_055700_create_contest_vote_aggregates_view.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 use Illuminate\Database\Migrations\Migration;
 
 class CreateContestVoteAggregatesView extends Migration

--- a/database/migrations/2016_08_31_062640_add_visible_to_artists_table.php
+++ b/database/migrations/2016_08_31_062640_add_visible_to_artists_table.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 

--- a/database/migrations/2016_08_31_103716_add_exclusive_to_artist_tracks.php
+++ b/database/migrations/2016_08_31_103716_add_exclusive_to_artist_tracks.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 

--- a/database/migrations/2016_09_06_124728_add_soft_deletes_to_posts_topics_tables.php
+++ b/database/migrations/2016_09_06_124728_add_soft_deletes_to_posts_topics_tables.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 

--- a/database/migrations/2016_09_07_105853_add_visible_to_contests.php
+++ b/database/migrations/2016_09_07_105853_add_visible_to_contests.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 

--- a/database/migrations/2016_09_20_203638_contest_submissions.php
+++ b/database/migrations/2016_09_20_203638_contest_submissions.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 

--- a/database/migrations/2016_09_30_064049_create_user_contest_entries_table.php
+++ b/database/migrations/2016_09_30_064049_create_user_contest_entries_table.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 

--- a/database/migrations/2016_10_05_061323_add_max_entries_to_contests.php
+++ b/database/migrations/2016_10_05_061323_add_max_entries_to_contests.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 

--- a/database/migrations/2016_10_24_062803_update_jobs_table.php
+++ b/database/migrations/2016_10_24_062803_update_jobs_table.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2016_10_28_000000_update_oauth_tables.php
+++ b/database/migrations/2016_10_28_000000_update_oauth_tables.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 use Illuminate\Database\Migrations\Migration;
 
 class UpdateOauthTables extends Migration

--- a/database/migrations/2016_10_28_000001_create_passport_oauth_auth_codes_table.php
+++ b/database/migrations/2016_10_28_000001_create_passport_oauth_auth_codes_table.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2016_10_28_000002_create_passport_oauth_access_tokens_table.php
+++ b/database/migrations/2016_10_28_000002_create_passport_oauth_access_tokens_table.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2016_10_28_000003_create_passport_oauth_refresh_tokens_table.php
+++ b/database/migrations/2016_10_28_000003_create_passport_oauth_refresh_tokens_table.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2016_10_28_000004_create_passport_oauth_clients_table.php
+++ b/database/migrations/2016_10_28_000004_create_passport_oauth_clients_table.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2016_10_28_000005_create_passport_oauth_personal_access_clients_table.php
+++ b/database/migrations/2016_10_28_000005_create_passport_oauth_personal_access_clients_table.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2016_11_02_063649_add_user_id_to_contest_entries.php
+++ b/database/migrations/2016_11_02_063649_add_user_id_to_contest_entries.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2016_11_04_022225_add_extra_options_to_contests.php
+++ b/database/migrations/2016_11_04_022225_add_extra_options_to_contests.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2016_12_01_090638_add_soft_delete_to_beatmap_discussion_posts.php
+++ b/database/migrations/2016_12_01_090638_add_soft_delete_to_beatmap_discussion_posts.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Support\Facades\Schema;
 

--- a/database/migrations/2016_12_01_114033_add_additional_links_to_artists.php
+++ b/database/migrations/2016_12_01_114033_add_additional_links_to_artists.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2016_12_02_092104_add_soft_delete_to_beatmap_discussions.php
+++ b/database/migrations/2016_12_02_092104_add_soft_delete_to_beatmap_discussions.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Support\Facades\Schema;
 

--- a/database/migrations/2016_12_07_063316_create_artist_albums_table.php
+++ b/database/migrations/2016_12_07_063316_create_artist_albums_table.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2016_12_07_065315_add_album_id_to_artist_tracks.php
+++ b/database/migrations/2016_12_07_065315_add_album_id_to_artist_tracks.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2016_12_09_052957_add_more_fields_to_artist_tracks.php
+++ b/database/migrations/2016_12_09_052957_add_more_fields_to_artist_tracks.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2016_12_16_080558_update_kudos_exchange.php
+++ b/database/migrations/2016_12_16_080558_update_kudos_exchange.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 use Illuminate\Database\Migrations\Migration;
 
 class UpdateKudosExchange extends Migration

--- a/database/migrations/2016_12_19_124550_add_kudosu_block_to_beatmap_discussions.php
+++ b/database/migrations/2016_12_19_124550_add_kudosu_block_to_beatmap_discussions.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Support\Facades\Schema;
 

--- a/database/migrations/2016_12_19_132350_add_kudosu_refresh_votes_to_beatmap_discussions.php
+++ b/database/migrations/2016_12_19_132350_add_kudosu_refresh_votes_to_beatmap_discussions.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Support\Facades\Schema;
 

--- a/database/migrations/2017_01_13_062704_nullable_entry_url_on_contest_entries.php
+++ b/database/migrations/2017_01_13_062704_nullable_entry_url_on_contest_entries.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2017_02_01_105338_drop_slack_users.php
+++ b/database/migrations/2017_02_01_105338_drop_slack_users.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Support\Facades\Schema;
 

--- a/database/migrations/2017_02_06_083745_nullable_cover_json_on_user_profile_customizations.php
+++ b/database/migrations/2017_02_06_083745_nullable_cover_json_on_user_profile_customizations.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Support\Facades\Schema;
 

--- a/database/migrations/2017_02_10_030227_contest_votes_change_weighting_to_float.php
+++ b/database/migrations/2017_02_10_030227_contest_votes_change_weighting_to_float.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2017_02_13_013536_delete_contest_vote_aggregates_view.php
+++ b/database/migrations/2017_02_13_013536_delete_contest_vote_aggregates_view.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 use Illuminate\Database\Migrations\Migration;
 
 class DeleteContestVoteAggregatesView extends Migration

--- a/database/migrations/2017_02_20_141012_allow_nulls_on_user_contest_entries.php
+++ b/database/migrations/2017_02_20_141012_allow_nulls_on_user_contest_entries.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Support\Facades\Schema;
 

--- a/database/migrations/2017_02_21_084403_mb4_forum_last_topic.php
+++ b/database/migrations/2017_02_21_084403_mb4_forum_last_topic.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 use Illuminate\Database\Migrations\Migration;
 
 class Mb4ForumLastTopic extends Migration

--- a/database/migrations/2017_02_22_061910_nullables_on_forum_covers.php
+++ b/database/migrations/2017_02_22_061910_nullables_on_forum_covers.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Support\Facades\Schema;
 

--- a/database/migrations/2017_03_10_080135_add_index_to_user_donations.php
+++ b/database/migrations/2017_03_10_080135_add_index_to_user_donations.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Support\Facades\Schema;
 

--- a/database/migrations/2017_05_04_070936_add_index_on_osu_builds.php
+++ b/database/migrations/2017_05_04_070936_add_index_on_osu_builds.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Support\Facades\Schema;
 

--- a/database/migrations/2017_05_12_111922_add_build_propagation_history_table.php
+++ b/database/migrations/2017_05_12_111922_add_build_propagation_history_table.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Support\Facades\Schema;
 

--- a/database/migrations/2017_05_22_061803_add_allow_multiple_to_products.php
+++ b/database/migrations/2017_05_22_061803_add_allow_multiple_to_products.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2017_05_22_073156_drop_order_id_product_id_from_order_items.php
+++ b/database/migrations/2017_05_22_073156_drop_order_id_product_id_from_order_items.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2017_05_26_101854_add_extra_data_to_order_items_table.php
+++ b/database/migrations/2017_05_26_101854_add_extra_data_to_order_items_table.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2017_05_31_042932_add_supporter_tag_to_products.php
+++ b/database/migrations/2017_05_31_042932_add_supporter_tag_to_products.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 use App\Models\Store;
 use Illuminate\Database\Migrations\Migration;
 

--- a/database/migrations/2017_06_02_040908_CreateCountryStatisticsTables.php
+++ b/database/migrations/2017_06_02_040908_CreateCountryStatisticsTables.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2017_07_14_040809_add_action_field_to_chat_tables.php
+++ b/database/migrations/2017_07_14_040809_add_action_field_to_chat_tables.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Support\Facades\Schema;
 

--- a/database/migrations/2017_07_20_013337_create_osu_beatmappacks_table.php
+++ b/database/migrations/2017_07_20_013337_create_osu_beatmappacks_table.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2017_07_20_013338_create_osu_beatmappacks_items_table.php
+++ b/database/migrations/2017_07_20_013338_create_osu_beatmappacks_items_table.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2017_07_20_094844_add_playmode_to_osu_beatmappacks.php
+++ b/database/migrations/2017_07_20_094844_add_playmode_to_osu_beatmappacks.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2017_07_26_093948_add_more_type_to_beatmapset_events.php
+++ b/database/migrations/2017_07_26_093948_add_more_type_to_beatmapset_events.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 use Illuminate\Database\Migrations\Migration;
 
 class AddMoreTypeToBeatmapsetEvents extends Migration

--- a/database/migrations/2017_08_03_064207_unresolve_non_issue_beatmap_discussions.php
+++ b/database/migrations/2017_08_03_064207_unresolve_non_issue_beatmap_discussions.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 use Illuminate\Database\Migrations\Migration;
 
 class UnresolveNonIssueBeatmapDiscussions extends Migration

--- a/database/migrations/2017_08_04_104549_make_all_beatmap_discussion_general_as_suggestion.php
+++ b/database/migrations/2017_08_04_104549_make_all_beatmap_discussion_general_as_suggestion.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 use Illuminate\Database\Migrations\Migration;
 
 class MakeAllBeatmapDiscussionGeneralAsSuggestion extends Migration

--- a/database/migrations/2017_08_28_075817_add_discussion_enabled_to_beatmapsets.php
+++ b/database/migrations/2017_08_28_075817_add_discussion_enabled_to_beatmapsets.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Support\Facades\Schema;
 

--- a/database/migrations/2017_08_28_080125_add_deleted_at_to_beatmapsets.php
+++ b/database/migrations/2017_08_28_080125_add_deleted_at_to_beatmapsets.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Support\Facades\Schema;
 

--- a/database/migrations/2017_08_28_090801_directly_use_beatmapset_id_for_beatmap_discussions.php
+++ b/database/migrations/2017_08_28_090801_directly_use_beatmapset_id_for_beatmap_discussions.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Support\Facades\Schema;
 

--- a/database/migrations/2017_08_28_110634_drop_beatmapset_discussions.php
+++ b/database/migrations/2017_08_28_110634_drop_beatmapset_discussions.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 use Illuminate\Database\Migrations\Migration;
 
 class DropBeatmapsetDiscussions extends Migration

--- a/database/migrations/2017_09_01_101541_create_osu_profile_banners.php
+++ b/database/migrations/2017_09_01_101541_create_osu_profile_banners.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2017_09_04_064001_add_deleted_at_to_beatmaps.php
+++ b/database/migrations/2017_09_04_064001_add_deleted_at_to_beatmaps.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Support\Facades\Schema;
 

--- a/database/migrations/2017_09_06_050956_add_youtube_to_artists.php
+++ b/database/migrations/2017_09_06_050956_add_youtube_to_artists.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2017_09_07_084729_better_forum_posts_index.php
+++ b/database/migrations/2017_09_07_084729_better_forum_posts_index.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Support\Facades\Schema;
 

--- a/database/migrations/2017_09_08_110651_simplify_forum_posts_index.php
+++ b/database/migrations/2017_09_08_110651_simplify_forum_posts_index.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Support\Facades\Schema;
 

--- a/database/migrations/2017_09_12_065003_fix_logs_table_encoding.php
+++ b/database/migrations/2017_09_12_065003_fix_logs_table_encoding.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 use Illuminate\Database\Migrations\Migration;
 
 class FixLogsTableEncoding extends Migration

--- a/database/migrations/2017_09_13_102556_create_user_channels_table.php
+++ b/database/migrations/2017_09_13_102556_create_user_channels_table.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2017_09_20_055045_create_payments_table.php
+++ b/database/migrations/2017_09_20_055045_create_payments_table.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2017_10_10_082642_add_ip_bans.php
+++ b/database/migrations/2017_10_10_082642_add_ip_bans.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Support\Facades\Schema;
 

--- a/database/migrations/2017_10_20_133251_add_beatmapset_watches.php
+++ b/database/migrations/2017_10_20_133251_add_beatmapset_watches.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Support\Facades\Schema;
 

--- a/database/migrations/2017_10_25_054504_add_banner_to_tournaments.php
+++ b/database/migrations/2017_10_25_054504_add_banner_to_tournaments.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2017_11_17_074755_add_index_to_payments_transaction_id.php
+++ b/database/migrations/2017_11_17_074755_add_index_to_payments_transaction_id.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Support\Facades\Schema;
 

--- a/database/migrations/2017_11_22_070257_update_discussion_type_by_mapper.php
+++ b/database/migrations/2017_11_22_070257_update_discussion_type_by_mapper.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 use Illuminate\Database\Migrations\Migration;
 
 class UpdateDiscussionTypeByMapper extends Migration

--- a/database/migrations/2017_11_22_081837_remove_kudosu_refresh_votes_from_beatmap_discussions.php
+++ b/database/migrations/2017_11_22_081837_remove_kudosu_refresh_votes_from_beatmap_discussions.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 use Illuminate\Database\Migrations\Migration;
 
 class RemoveKudosuRefreshVotesFromBeatmapDiscussions extends Migration

--- a/database/migrations/2017_11_22_114135_add_even_more_type_to_beatmapset_events.php
+++ b/database/migrations/2017_11_22_114135_add_even_more_type_to_beatmapset_events.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 use Illuminate\Database\Migrations\Migration;
 
 class AddEvenMoreTypeToBeatmapsetEvents extends Migration

--- a/database/migrations/2017_11_23_102444_add_index_to_kudosu_histories_kudosuable.php
+++ b/database/migrations/2017_11_23_102444_add_index_to_kudosu_histories_kudosuable.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Support\Facades\Schema;
 

--- a/database/migrations/2017_11_27_064736_fix_user_sig_encoding.php
+++ b/database/migrations/2017_11_27_064736_fix_user_sig_encoding.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 use Illuminate\Database\Migrations\Migration;
 
 class FixUserSigEncoding extends Migration

--- a/database/migrations/2017_11_29_033957_add_nomination_reset_type_to_beatmapset_events.php
+++ b/database/migrations/2017_11_29_033957_add_nomination_reset_type_to_beatmapset_events.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 use Illuminate\Database\Migrations\Migration;
 
 class AddNominationResetTypeToBeatmapsetEvents extends Migration

--- a/database/migrations/2017_12_13_083252_change_costs_to_decimal.php
+++ b/database/migrations/2017_12_13_083252_change_costs_to_decimal.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 use Illuminate\Database\Migrations\Migration;
 
 class ChangeCostsToDecimal extends Migration

--- a/database/migrations/2017_12_20_090905_add_new_rank_cache_columns.php
+++ b/database/migrations/2017_12_20_090905_add_new_rank_cache_columns.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 use Illuminate\Database\Migrations\Migration;
 
 class AddNewRankCacheColumns extends Migration

--- a/database/migrations/2018_01_03_082931_add_hype_to_beatmapsets.php
+++ b/database/migrations/2018_01_03_082931_add_hype_to_beatmapsets.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Support\Facades\Schema;
 

--- a/database/migrations/2018_01_09_063809_add_processing_type_to_order_status.php
+++ b/database/migrations/2018_01_09_063809_add_processing_type_to_order_status.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 use Illuminate\Database\Migrations\Migration;
 
 class AddProcessingTypeToOrderStatus extends Migration

--- a/database/migrations/2018_01_11_060632_add_nominations_to_beatmapsets.php
+++ b/database/migrations/2018_01_11_060632_add_nominations_to_beatmapsets.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Support\Facades\Schema;
 

--- a/database/migrations/2018_04_06_081112_unique_beatmapset_discussion_votes.php
+++ b/database/migrations/2018_04_06_081112_unique_beatmapset_discussion_votes.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Support\Facades\Schema;
 

--- a/database/migrations/2018_04_12_080404_add_index_to_achievements_name.php
+++ b/database/migrations/2018_04_12_080404_add_index_to_achievements_name.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Support\Facades\Schema;
 

--- a/database/migrations/2018_04_12_085114_add_spotify_and_osu_profile_to_artists.php
+++ b/database/migrations/2018_04_12_085114_add_spotify_and_osu_profile_to_artists.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Support\Facades\Schema;
 

--- a/database/migrations/2018_04_20_100654_add_queue_time_to_beatmapsets.php
+++ b/database/migrations/2018_04_20_100654_add_queue_time_to_beatmapsets.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Support\Facades\Schema;
 

--- a/database/migrations/2018_05_09_083801_add_wiki_and_store_link_to_tournaments.php
+++ b/database/migrations/2018_05_09_083801_add_wiki_and_store_link_to_tournaments.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Support\Facades\Schema;
 

--- a/database/migrations/2018_05_22_024629_create_changelogs.php
+++ b/database/migrations/2018_05_22_024629_create_changelogs.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2018_06_06_091751_link_streams_to_changelog_entries.php
+++ b/database/migrations/2018_06_06_091751_link_streams_to_changelog_entries.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Support\Facades\Schema;
 

--- a/database/migrations/2018_06_22_132317_link_streams_to_repositories.php
+++ b/database/migrations/2018_06_22_132317_link_streams_to_repositories.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Support\Facades\Schema;
 

--- a/database/migrations/2018_06_25_072709_update_beatmapset_datetimes_datatype.php
+++ b/database/migrations/2018_06_25_072709_update_beatmapset_datetimes_datatype.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 use Illuminate\Database\Migrations\Migration;
 
 class UpdateBeatmapsetDatetimesDatatype extends Migration

--- a/database/migrations/2018_07_03_101029_add_default_category_to_repositories.php
+++ b/database/migrations/2018_07_03_101029_add_default_category_to_repositories.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Support\Facades\Schema;
 

--- a/database/migrations/2018_07_03_103002_update_repositories_nullable_stream_id.php
+++ b/database/migrations/2018_07_03_103002_update_repositories_nullable_stream_id.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Support\Facades\Schema;
 

--- a/database/migrations/2018_07_03_114909_link_changelog_entries_to_repositories.php
+++ b/database/migrations/2018_07_03_114909_link_changelog_entries_to_repositories.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Support\Facades\Schema;
 

--- a/database/migrations/2018_07_03_115128_set_changelog_entries_repository_id.php
+++ b/database/migrations/2018_07_03_115128_set_changelog_entries_repository_id.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 use Illuminate\Database\Migrations\Migration;
 
 class SetChangelogEntriesRepositoryId extends Migration

--- a/database/migrations/2018_07_03_115621_drop_repository_from_changelog_entries.php
+++ b/database/migrations/2018_07_03_115621_drop_repository_from_changelog_entries.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Support\Facades\Schema;
 

--- a/database/migrations/2018_07_12_110501_add_build_on_tag_to_repositories.php
+++ b/database/migrations/2018_07_12_110501_add_build_on_tag_to_repositories.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Support\Facades\Schema;
 

--- a/database/migrations/2018_07_13_073008_add_chat_channel_types.php
+++ b/database/migrations/2018_07_13_073008_add_chat_channel_types.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 use Illuminate\Database\Migrations\Migration;
 
 class AddChatChannelTypes extends Migration

--- a/database/migrations/2018_07_26_110501_add_love_type_to_beatmapset_events.php
+++ b/database/migrations/2018_07_26_110501_add_love_type_to_beatmapset_events.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 use Illuminate\Database\Migrations\Migration;
 
 class AddLoveTypeToBeatmapsetEvents extends Migration

--- a/database/migrations/2018_07_26_211352_add_moderating_groups_to_forums.php
+++ b/database/migrations/2018_07_26_211352_add_moderating_groups_to_forums.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2018_07_31_073629_create_comments.php
+++ b/database/migrations/2018_07_31_073629_create_comments.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2018_07_31_101323_create_news_posts.php
+++ b/database/migrations/2018_07_31_101323_create_news_posts.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2018_08_02_073727_drop_comments_from_builds.php
+++ b/database/migrations/2018_08_02_073727_drop_comments_from_builds.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2018_08_03_102238_add_reserved_to_order_items.php
+++ b/database/migrations/2018_08_03_102238_add_reserved_to_order_items.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Support\Facades\Schema;
 

--- a/database/migrations/2018_08_27_053717_add_country_code_to_payments.php
+++ b/database/migrations/2018_08_27_053717_add_country_code_to_payments.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2018_09_26_082418_add_soft_delete_to_user_contest_entries.php
+++ b/database/migrations/2018_09_26_082418_add_soft_delete_to_user_contest_entries.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2018_10_12_045503_add_index_to_orders_updated_at.php
+++ b/database/migrations/2018_10_12_045503_add_index_to_orders_updated_at.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2018_10_15_102603_create_comment_votes.php
+++ b/database/migrations/2018_10_15_102603_create_comment_votes.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2018_10_16_012859_add_votes_count_to_comments.php
+++ b/database/migrations/2018_10_16_012859_add_votes_count_to_comments.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2018_11_29_050923_create_rooms.php
+++ b/database/migrations/2018_11_29_050923_create_rooms.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2018_11_29_081727_create_playlist_items.php
+++ b/database/migrations/2018_11_29_081727_create_playlist_items.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2018_12_06_094847_add_ruleset_id_to_multiplayer_playlist_items.php
+++ b/database/migrations/2018_12_06_094847_add_ruleset_id_to_multiplayer_playlist_items.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2018_12_13_072418_create_multiplayer_scores.php
+++ b/database/migrations/2018_12_13_072418_create_multiplayer_scores.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2018_12_13_121903_add_reportable_type_to_user_reports.php
+++ b/database/migrations/2018_12_13_121903_add_reportable_type_to_user_reports.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2018_12_14_100020_add_chat_channel_id_to_multiplayer_room.php
+++ b/database/migrations/2018_12_14_100020_add_chat_channel_id_to_multiplayer_room.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2018_12_21_101924_create_multiplayer_scores_high.php
+++ b/database/migrations/2018_12_21_101924_create_multiplayer_scores_high.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2018_12_21_101935_create_multiplayer_rooms_high.php
+++ b/database/migrations/2018_12_21_101935_create_multiplayer_rooms_high.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2018_12_25_090628_add_participation_index_to_multiplayer_scores.php
+++ b/database/migrations/2018_12_25_090628_add_participation_index_to_multiplayer_scores.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2018_12_26_114102_add_participation_count_to_multiplayer_rooms.php
+++ b/database/migrations/2018_12_26_114102_add_participation_count_to_multiplayer_rooms.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2018_12_26_120639_change_multiplayer_scores_rank_to_enum.php
+++ b/database/migrations/2018_12_26_120639_change_multiplayer_scores_rank_to_enum.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 use Illuminate\Database\Migrations\Migration;
 
 class ChangeMultiplayerScoresRankToEnum extends Migration

--- a/database/migrations/2019_01_17_051612_add_available_until_to_products.php
+++ b/database/migrations/2019_01_17_051612_add_available_until_to_products.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2019_01_17_065444_add_notifications.php
+++ b/database/migrations/2019_01_17_065444_add_notifications.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2019_01_23_031727_add_user_notifications.php
+++ b/database/migrations/2019_01_23_031727_add_user_notifications.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2019_02_15_062607_add_shopify_id_to_products.php
+++ b/database/migrations/2019_02_15_062607_add_shopify_id_to_products.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2019_04_01_202237_add_poll_hide_results_to_topics.php
+++ b/database/migrations/2019_04_01_202237_add_poll_hide_results_to_topics.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2019_04_09_053403_add_allow_topic_covers_to_forums.php
+++ b/database/migrations/2019_04_09_053403_add_allow_topic_covers_to_forums.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2019_04_17_103403_add_discussion_locked_to_beatmapsets.php
+++ b/database/migrations/2019_04_17_103403_add_discussion_locked_to_beatmapsets.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2019_04_23_051152_add_discussion_locked_to_beatmapset_events.php
+++ b/database/migrations/2019_04_23_051152_add_discussion_locked_to_beatmapset_events.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 use Illuminate\Database\Migrations\Migration;
 
 class AddDiscussionLockedToBeatmapsetEvents extends Migration

--- a/database/migrations/2019_05_22_041713_add_hidden_to_user_channels.php
+++ b/database/migrations/2019_05_22_041713_add_hidden_to_user_channels.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Support\Facades\Schema;
 

--- a/database/migrations/2019_05_28_024814_create_follows.php
+++ b/database/migrations/2019_05_28_024814_create_follows.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2019_06_25_083703_add_options_to_user_profile_customizations.php
+++ b/database/migrations/2019_06_25_083703_add_options_to_user_profile_customizations.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2019_07_23_034016_add_score_process_queue.php
+++ b/database/migrations/2019_07_23_034016_add_score_process_queue.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2019_07_25_082550_add_url_to_badges.php
+++ b/database/migrations/2019_07_25_082550_add_url_to_badges.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2019_08_07_070216_add_last_post_at_to_beatmap_discussions.php
+++ b/database/migrations/2019_08_07_070216_add_last_post_at_to_beatmap_discussions.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2019_08_07_103120_add_index_to_beatmap_discussion.php
+++ b/database/migrations/2019_08_07_103120_add_index_to_beatmap_discussion.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2019_08_21_104727_add_index_to_beatmapset_events.php
+++ b/database/migrations/2019_08_21_104727_add_index_to_beatmapset_events.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2019_08_26_053354_add_expires_at_index_to_oauth_tables.php
+++ b/database/migrations/2019_08_26_053354_add_expires_at_index_to_oauth_tables.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2019_08_27_094035_add_client_id_index_to_oauth_access_tokens.php
+++ b/database/migrations/2019_08_27_094035_add_client_id_index_to_oauth_access_tokens.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2019_09_11_135102_add_beatmap_discussion_post_to_report_types.php
+++ b/database/migrations/2019_09_11_135102_add_beatmap_discussion_post_to_report_types.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 use Illuminate\Database\Migrations\Migration;
 
 class AddBeatmapDiscussionPostToReportTypes extends Migration

--- a/database/migrations/2019_09_18_074659_update_beatmapset_discussion_polymorphic_name.php
+++ b/database/migrations/2019_09_18_074659_update_beatmapset_discussion_polymorphic_name.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 use Illuminate\Database\Migrations\Migration;
 
 class UpdateBeatmapsetDiscussionPolymorphicName extends Migration

--- a/database/migrations/2019_10_21_075612_add_pinned_field_to_comments.php
+++ b/database/migrations/2019_10_21_075612_add_pinned_field_to_comments.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2019_10_23_023102_add_hidden_to_beatmapset_packs.php
+++ b/database/migrations/2019_10_23_023102_add_hidden_to_beatmapset_packs.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2019_10_23_100514_create_user_notification_options.php
+++ b/database/migrations/2019_10_23_100514_create_user_notification_options.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2019_11_07_095402_add_parent_id_to_beatmap_discussions.php
+++ b/database/migrations/2019_11_07_095402_add_parent_id_to_beatmap_discussions.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2019_11_14_032004_add_new_index_to_scores_high.php
+++ b/database/migrations/2019_11_14_032004_add_new_index_to_scores_high.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2019_11_27_084154_add_bpm_to_beatmaps.php
+++ b/database/migrations/2019_11_27_084154_add_bpm_to_beatmaps.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2019_12_04_015903_add_extra_columns_to_groups.php
+++ b/database/migrations/2019_12_04_015903_add_extra_columns_to_groups.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2019_12_11_045755_add_show_in_client_to_user_contest_entries.php
+++ b/database/migrations/2019_12_11_045755_add_show_in_client_to_user_contest_entries.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2020_01_17_080543_update_multiplayer_mods.php
+++ b/database/migrations/2020_01_17_080543_update_multiplayer_mods.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 use Illuminate\Database\Migrations\Migration;
 
 class UpdateMultiplayerMods extends Migration

--- a/database/migrations/2020_01_20_031913_json_news_post_page.php
+++ b/database/migrations/2020_01_20_031913_json_news_post_page.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 use Illuminate\Database\Migrations\Migration;
 
 class JsonNewsPostPage extends Migration

--- a/database/migrations/2020_01_23_083342_nullable_groups_display_order.php
+++ b/database/migrations/2020_01_23_083342_nullable_groups_display_order.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2020_02_13_080406_add_country_acronym_to_scores_high.php
+++ b/database/migrations/2020_02_13_080406_add_country_acronym_to_scores_high.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2020_03_09_095216_add_channel_type_index_to_channels.php
+++ b/database/migrations/2020_03_09_095216_add_channel_type_index_to_channels.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2020_03_09_100459_remove_multiplayer_rooms_high_accuracy_precision.php
+++ b/database/migrations/2020_03_09_100459_remove_multiplayer_rooms_high_accuracy_precision.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/seeds/DatabaseSeeder.php
+++ b/database/seeds/DatabaseSeeder.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 use Illuminate\Database\Seeder;
 
 class DatabaseSeeder extends Seeder

--- a/database/seeds/ModelSeeders/BanchoStatsSeeder.php
+++ b/database/seeds/ModelSeeders/BanchoStatsSeeder.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 use Carbon\Carbon;
 use Illuminate\Database\Seeder;
 

--- a/database/seeds/ModelSeeders/BeatmapSeeder.php
+++ b/database/seeds/ModelSeeders/BeatmapSeeder.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 use App\Models\Beatmap;
 use App\Models\BeatmapDifficulty;
 use App\Models\BeatmapFailtimes;

--- a/database/seeds/ModelSeeders/ChangelogSeeder.php
+++ b/database/seeds/ModelSeeders/ChangelogSeeder.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 use App\Models\Build;
 use App\Models\BuildPropagationHistory;
 use App\Models\Changelog;

--- a/database/seeds/ModelSeeders/CountrySeeder.php
+++ b/database/seeds/ModelSeeders/CountrySeeder.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 use Illuminate\Database\Seeder;
 
 class CountrySeeder extends Seeder

--- a/database/seeds/ModelSeeders/EventSeeder.php
+++ b/database/seeds/ModelSeeders/EventSeeder.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 use Faker\Factory as Faker;
 use Illuminate\Database\Seeder;
 

--- a/database/seeds/ModelSeeders/ForumSeeder.php
+++ b/database/seeds/ModelSeeders/ForumSeeder.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 use Faker\Factory;
 use Illuminate\Database\Seeder;
 

--- a/database/seeds/ModelSeeders/MiscSeeder.php
+++ b/database/seeds/ModelSeeders/MiscSeeder.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 use Illuminate\Database\Seeder;
 
 class MiscSeeder extends Seeder

--- a/database/seeds/ModelSeeders/MultiplayerSeeder.php
+++ b/database/seeds/ModelSeeders/MultiplayerSeeder.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 use App\Models\Beatmap;
 use App\Models\Multiplayer\PlaylistItem;
 use App\Models\Multiplayer\Room;

--- a/database/seeds/ModelSeeders/ProductSeeder.php
+++ b/database/seeds/ModelSeeders/ProductSeeder.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 use Illuminate\Database\Seeder;
 
 class ProductSeeder extends Seeder

--- a/database/seeds/ModelSeeders/ScoreSeeder.php
+++ b/database/seeds/ModelSeeders/ScoreSeeder.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 use Faker\Factory as Faker;
 use Illuminate\Database\Seeder;
 

--- a/database/seeds/ModelSeeders/SpotlightSeeder.php
+++ b/database/seeds/ModelSeeders/SpotlightSeeder.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 use App\Models\Beatmap;
 use App\Models\Score\Best\Model as ScoresBestModel;
 use App\Models\Spotlight;

--- a/database/seeds/ModelSeeders/UserProfileSeeder.php
+++ b/database/seeds/ModelSeeders/UserProfileSeeder.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 use Illuminate\Database\Seeder;
 
 class UserProfileSeeder extends Seeder

--- a/database/seeds/ModelSeeders/UserSeeder.php
+++ b/database/seeds/ModelSeeders/UserSeeder.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 use Faker\Factory as Faker;
 use Illuminate\Database\Seeder;
 

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -1,3 +1,6 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 // karma-webpack doesn't exit on compile error.
 // This plugin makes it exit on compile error.
 class ExitOnErrorWebpackPlugin {

--- a/resources/assets/app.js
+++ b/resources/assets/app.js
@@ -1,3 +1,6 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 import 'jquery-prefilter.coffee';
 
 // import-glob-loader doesn't seem to work with resolve: {}?

--- a/resources/assets/js/bootstrap-lang.js
+++ b/resources/assets/js/bootstrap-lang.js
@@ -1,3 +1,6 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 (function() {
   'use strict'
   if (typeof(Lang) === 'function') {

--- a/resources/assets/lib/coffee-modules.d.ts
+++ b/resources/assets/lib/coffee-modules.d.ts
@@ -1,3 +1,6 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 /* tslint:disable:max-classes-per-file */
 
 // importable coffeescript modules

--- a/resources/assets/lib/globals.d.ts
+++ b/resources/assets/lib/globals.d.ts
@@ -1,3 +1,6 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 // interfaces for using process.env
 interface Process {
   env: ProcessEnv;

--- a/resources/assets/lib/lang-overrides.ts
+++ b/resources/assets/lib/lang-overrides.ts
@@ -1,3 +1,6 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 Lang._origGetPluralForm = Lang._getPluralForm;
 
 // pt-br isn't in original getPluralForm so the locale needs to be

--- a/resources/assets/lib/register-components.coffee
+++ b/resources/assets/lib/register-components.coffee
@@ -1,3 +1,6 @@
+# Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+# See the LICENCE file in the repository root for full licence text.
+
 import { ReactTurbolinks } from 'react-turbolinks'
 import { BeatmapsetPanel } from 'beatmapset-panel'
 import { BlockButton } from 'block-button'

--- a/resources/assets/lib/shopify-buy.d.ts
+++ b/resources/assets/lib/shopify-buy.d.ts
@@ -1,3 +1,6 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 declare module 'shopify-buy' {
   export default class Shopify {
     static buildClient(args: any): any;

--- a/resources/views/accounts/_edit_sessions.blade.php
+++ b/resources/views/accounts/_edit_sessions.blade.php
@@ -1,3 +1,7 @@
+{{--
+    Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+    See the LICENCE file in the repository root for full licence text.
+--}}
 <div class="account-edit">
     <div class="account-edit__section">
         <h2 class="account-edit__section-title">

--- a/resources/views/contests/_countdown.blade.php
+++ b/resources/views/contests/_countdown.blade.php
@@ -1,3 +1,7 @@
+{{--
+    Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+    See the LICENCE file in the repository root for full licence text.
+--}}
 @if($deadline)
   <div class='contest__countdown-timer'>
     <div class='js-react--countdownTimer' data-deadline='{{json_time($deadline)}}'></div>

--- a/resources/views/contests/_voting-entrylist.blade.php
+++ b/resources/views/contests/_voting-entrylist.blade.php
@@ -1,3 +1,7 @@
+{{--
+    Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+    See the LICENCE file in the repository root for full licence text.
+--}}
 @if ($contest->type == 'art')
     <div class="js-react--contestArtList" data-src="contest-{{$contest->id}}"></div>
 @else

--- a/resources/views/emails/beatmapset/update_notice.blade.php
+++ b/resources/views/emails/beatmapset/update_notice.blade.php
@@ -1,3 +1,7 @@
+{{--
+    Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+    See the LICENCE file in the repository root for full licence text.
+--}}
 {!! trans('mail.common.hello', ['user' => $user->username]) !!}
 
 {!! trans('mail.beatmapset_update_notice.new', ['title' => $beatmapset->title]) !!}

--- a/resources/views/emails/forum/new_reply.blade.php
+++ b/resources/views/emails/forum/new_reply.blade.php
@@ -1,3 +1,7 @@
+{{--
+    Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+    See the LICENCE file in the repository root for full licence text.
+--}}
 {!! trans('mail.common.hello', ['user' => $user->username]) !!}
 
 {!! trans('mail.forum_new_reply.new', ['title' => $topic->topic_title]) !!}

--- a/resources/views/layout/popup-container.blade.php
+++ b/resources/views/layout/popup-container.blade.php
@@ -1,3 +1,7 @@
+{{--
+    Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+    See the LICENCE file in the repository root for full licence text.
+--}}
 <div id="popup-container">
     <div class="alert alert-dismissable popup-clone col-md-6 col-md-offset-3 text-center" style="display: none">
         <button type="button" data-dismiss="alert" class="close"><i class="fas fa-times"></i></button>

--- a/resources/views/vendor/apidoc/documentarian.blade.php
+++ b/resources/views/vendor/apidoc/documentarian.blade.php
@@ -1,3 +1,7 @@
+{{--
+    Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+    See the LICENCE file in the repository root for full licence text.
+--}}
 ---
 {!! $frontmatter !!}
 ---

--- a/resources/views/vendor/apidoc/partials/example-requests/bash.blade.php
+++ b/resources/views/vendor/apidoc/partials/example-requests/bash.blade.php
@@ -1,3 +1,7 @@
+{{--
+    Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+    See the LICENCE file in the repository root for full licence text.
+--}}
 <?php
     $authorization = '';
 

--- a/resources/views/vendor/apidoc/partials/example-requests/javascript.blade.php
+++ b/resources/views/vendor/apidoc/partials/example-requests/javascript.blade.php
@@ -1,3 +1,7 @@
+{{--
+    Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+    See the LICENCE file in the repository root for full licence text.
+--}}
 ```javascript
 const url = new URL("{{ rtrim(config('app.docs_url') ?: config('app.url'), '/') }}/{{ ltrim($route['boundUri'], '/') }}");
 @if(count($route['queryParameters']))

--- a/resources/views/vendor/apidoc/partials/example-requests/php.blade.php
+++ b/resources/views/vendor/apidoc/partials/example-requests/php.blade.php
@@ -1,3 +1,7 @@
+{{--
+    Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+    See the LICENCE file in the repository root for full licence text.
+--}}
 ```php
 
 $client = new \GuzzleHttp\Client();

--- a/resources/views/vendor/apidoc/partials/frontmatter.blade.php
+++ b/resources/views/vendor/apidoc/partials/frontmatter.blade.php
@@ -1,3 +1,7 @@
+{{--
+    Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+    See the LICENCE file in the repository root for full licence text.
+--}}
 title: API Reference
 
 language_tabs:

--- a/resources/views/vendor/apidoc/partials/info.blade.php
+++ b/resources/views/vendor/apidoc/partials/info.blade.php
@@ -1,3 +1,7 @@
+{{--
+    Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+    See the LICENCE file in the repository root for full licence text.
+--}}
 # Introduction
 
 Welcome to the documentation for osu!api v2. You can use this API to get information on various circles and those who click them.

--- a/resources/views/vendor/apidoc/partials/route.blade.php
+++ b/resources/views/vendor/apidoc/partials/route.blade.php
@@ -1,3 +1,7 @@
+{{--
+    Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+    See the LICENCE file in the repository root for full licence text.
+--}}
 <?php
     $descriptions = explode("\n---\n", $route['metadata']['description'] ?? '');
 

--- a/routes/console.php
+++ b/routes/console.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 /*
 |--------------------------------------------------------------------------
 | Console Routes

--- a/tests/Browser.php
+++ b/tests/Browser.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 namespace Tests;
 
 use Laravel\Dusk\Browser as DuskBrowser;

--- a/tests/Browser/BeatmapDiscussionPostsTest.php
+++ b/tests/Browser/BeatmapDiscussionPostsTest.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 namespace Tests\Browser;
 
 use App\Models\Beatmap;

--- a/tests/Browser/LoginTest.php
+++ b/tests/Browser/LoginTest.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 namespace Tests\Browser;
 
 use App\Models\User;

--- a/tests/Browser/SanityTest.php
+++ b/tests/Browser/SanityTest.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 namespace Tests\Browser;
 
 use App\Models\Country;

--- a/tests/Browser/ScaffoldDummy.php
+++ b/tests/Browser/ScaffoldDummy.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 namespace Tests\Browser;
 
 class ScaffoldDummy

--- a/tests/Controllers/AccountControllerTest.php
+++ b/tests/Controllers/AccountControllerTest.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 namespace Tests\Controllers;
 
 use App\Models\User;

--- a/tests/Controllers/BeatmapDiscussionPostsControllerTest.php
+++ b/tests/Controllers/BeatmapDiscussionPostsControllerTest.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 namespace Tests\Controllers;
 
 use App\Events\NewNotificationEvent;

--- a/tests/Controllers/BeatmapDiscussionsControllerTest.php
+++ b/tests/Controllers/BeatmapDiscussionsControllerTest.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 namespace Tests\Controllers;
 
 use App\Models\Beatmap;

--- a/tests/Controllers/Chat/Channels/MessagesControllerTest.php
+++ b/tests/Controllers/Chat/Channels/MessagesControllerTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  *    Copyright (c) ppy Pty Ltd <contact@ppy.sh>.
  *

--- a/tests/Controllers/Chat/ChannelsControllerTest.php
+++ b/tests/Controllers/Chat/ChannelsControllerTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  *    Copyright (c) ppy Pty Ltd <contact@ppy.sh>.
  *

--- a/tests/Controllers/Chat/ChatControllerTest.php
+++ b/tests/Controllers/Chat/ChatControllerTest.php
@@ -1,4 +1,5 @@
 <?php
+
 /**
  *    Copyright (c) ppy Pty Ltd <contact@ppy.sh>.
  *

--- a/tests/Controllers/ClientVerificationsControllerTest.php
+++ b/tests/Controllers/ClientVerificationsControllerTest.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 namespace Tests\Controllers;
 
 use App\Models\User;

--- a/tests/Controllers/CommentsControllerTest.php
+++ b/tests/Controllers/CommentsControllerTest.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 namespace Tests\Controllers;
 
 use App\Models\Beatmapset;

--- a/tests/Controllers/ForumForumsControllerTest.php
+++ b/tests/Controllers/ForumForumsControllerTest.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 namespace Tests\Controllers;
 
 use App\Models\Forum;

--- a/tests/Controllers/ForumTopicsControllerTest.php
+++ b/tests/Controllers/ForumTopicsControllerTest.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 namespace Tests\Controllers;
 
 use App\Models\Forum;

--- a/tests/Controllers/HomeControllerTest.php
+++ b/tests/Controllers/HomeControllerTest.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 namespace Tests\Controllers;
 
 use Tests\TestCase;

--- a/tests/Controllers/LegacyInterOpControllerTest.php
+++ b/tests/Controllers/LegacyInterOpControllerTest.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 namespace Tests\Controllers;
 
 use App\Models\Achievement;

--- a/tests/Controllers/UsersControllerTest.php
+++ b/tests/Controllers/UsersControllerTest.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 namespace Tests\Controllers;
 
 use App\Models\Country;

--- a/tests/CreatesApplication.php
+++ b/tests/CreatesApplication.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 namespace Tests;
 
 use Illuminate\Contracts\Console\Kernel;

--- a/tests/DuskTestCase.php
+++ b/tests/DuskTestCase.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 namespace Tests;
 
 use Facebook\WebDriver\Chrome\ChromeOptions;

--- a/tests/Hashing/OsuHasherTest.php
+++ b/tests/Hashing/OsuHasherTest.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 namespace Tests\Hashing;
 
 use App\Hashing\OsuHasher;

--- a/tests/Libraries/BeatmapsetDiscussionReviewTest.php
+++ b/tests/Libraries/BeatmapsetDiscussionReviewTest.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 namespace Tests;
 
 use App\Exceptions\InvariantException;

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,3 +1,5 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
 
 /**
  * As our first step, we'll pull in the user's webpack.mix.js


### PR DESCRIPTION
- adds licences to the files without one,
- adds missing newlines so they are uniform,
- and adds travis test for correct file header.

Also fix indentation in one of the files. And remove an unused file.

The check/update script currently allows old header. This will be updated later.

Actual licence update will be done once this one is merged as otherwise the automated changes (30k+ lines) will be mixed with the manual changes here.

Looking at the script, I wonder if I should rewrite it in something like javascript :neutral_face: 