### PR TITLE
Check discussion lock status on hype validation

### DIFF
--- a/app/Models/Beatmapset.php
+++ b/app/Models/Beatmapset.php
@@ -835,17 +835,21 @@ class Beatmapset extends Model implements AfterCommit, Commentable
             if ($this->user_id === $user->getKey()) {
                 $message = 'owner';
             } else {
-                $hyped = $this
-                    ->beatmapDiscussions()
-                    ->withoutTrashed()
-                    ->ofType('hype')
-                    ->where('user_id', '=', $user->getKey())
-                    ->exists();
+                if ($this->discussion_locked) {
+                    $message = 'discussion_locked';
+                } else {
+                    $hyped = $this
+                        ->beatmapDiscussions()
+                        ->withoutTrashed()
+                        ->ofType('hype')
+                        ->where('user_id', '=', $user->getKey())
+                        ->exists();
 
-                if ($hyped) {
-                    $message = 'hyped';
-                } elseif ($user->remainingHype() <= 0) {
-                    $message = 'limit_exceeded';
+                    if ($hyped) {
+                        $message = 'hyped';
+                    } elseif ($user->remainingHype() <= 0) {
+                        $message = 'limit_exceeded';
+                    }
                 }
             }
         }

--- a/resources/assets/coffee/react/beatmap-discussions/nominations.coffee
+++ b/resources/assets/coffee/react/beatmap-discussions/nominations.coffee
@@ -125,7 +125,8 @@ export class Nominations extends React.PureComponent
                   text: if userAlreadyHyped then osu.trans('beatmaps.hype.button_done') else osu.trans('beatmaps.hype.button')
                   icon: 'fas fa-bullhorn'
                   props:
-                    disabled: userAlreadyHyped
+                    disabled: !@props.beatmapset.current_user_attributes.can_hype
+                    title: @props.beatmapset.current_user_attributes?.can_hype_reason
                     onClick: @focusHypeInput
 
           if mapCanBeNominated || mapIsQualified

--- a/resources/lang/en/model_validation.php
+++ b/resources/lang/en/model_validation.php
@@ -32,6 +32,7 @@ return [
         ],
 
         'hype' => [
+            'discussion_locked' => "This beatmap is currently locked for discussion and can't be hyped",
             'guest' => 'Must be signed in to hype.',
             'hyped' => 'You have already hyped this beatmap.',
             'limit_exceeded' => 'You have used all your hype.',


### PR DESCRIPTION
Validation magic convenience. Except it's not used in the other place.

Resolves #5696.