### PR TITLE
Fix IME input on beatmap listing

### DIFF
--- a/resources/assets/coffee/react/beatmaps/search-panel.coffee
+++ b/resources/assets/coffee/react/beatmaps/search-panel.coffee
@@ -112,8 +112,11 @@ export class SearchPanel extends React.Component
 
   onChange: (event) =>
     query = event.target.value
-    @pinnedInputRef.current.value = query
-    @inputRef.current.value = query
+    if @pinnedInputRef.current.value != query
+      @pinnedInputRef.current.value = query
+
+    if @inputRef.current.value != query
+      @inputRef.current.value = query
 
     controller.updateFilters { query }
 


### PR DESCRIPTION
Fixes input composition events firing too often on safari.

closes #5766