### PR TITLE
Fix duplicated client verification submission error

### DIFF
--- a/app/Http/Controllers/ClientVerificationsController.php
+++ b/app/Http/Controllers/ClientVerificationsController.php
@@ -29,10 +29,6 @@ class ClientVerificationsController extends Controller
         $hash = request('ch');
         $client = UserClient::lookupOrNew(auth()->user()->getKey(), $hash);
 
-        if ($client === null) {
-            abort(422); // TODO: add page mentioning invalid hash
-        }
-
         if ($client->verified) {
             return ext_view('client_verifications.completed');
         }
@@ -43,13 +39,7 @@ class ClientVerificationsController extends Controller
     public function store()
     {
         $hash = request('ch');
-        $client = UserClient::lookupOrNew(auth()->user()->getKey(), $hash);
-
-        if ($client === null) {
-            abort(422); // TODO: add page mentioning invalid hash
-        }
-
-        $client->fill(['verified' => true])->save();
+        UserClient::markVerified(auth()->user()->getKey(), $hash);
 
         return ext_view('client_verifications.completed');
     }

--- a/app/Http/Controllers/ClientVerificationsController.php
+++ b/app/Http/Controllers/ClientVerificationsController.php
@@ -41,6 +41,6 @@ class ClientVerificationsController extends Controller
         $hash = request('ch');
         UserClient::markVerified(auth()->user()->getKey(), $hash);
 
-        return ext_view('client_verifications.completed');
+        return ujs_redirect(route('client-verifications.create', ['ch' => $hash]));
     }
 }

--- a/resources/assets/less/bem/dialog-form.less
+++ b/resources/assets/less/bem/dialog-form.less
@@ -10,6 +10,7 @@
   padding: 10px;
   color: #fff;
 
+  // FIXME: this should be migrated to btn-osu-big
   &__button {
     .reset-input();
     .default-text-shadow();
@@ -21,18 +22,22 @@
     margin: 5px 5px;
     min-width: 160px;
     border-radius: 10000px;
-    background-color: @osu-colour-blue-3;
+    background-color: var(--bg);
+    --bg: @osu-colour-blue-3;
+    --bg-hover: @osu-colour-blue-2;
 
     .link-hover({
-      background-color: @osu-colour-blue-2;
+      background-color: var(--bg-hover);
     });
 
     &--cancel {
-      background-color: @osu-colour-red-3;
+      --bg: @osu-colour-red-3;
+      --bg-hover: @osu-colour-red-2;
+    }
 
-      .link-hover({
-        background-color: @osu-colour-red-2;
-      });
+    &[disabled] {
+      opacity: 0.9;
+      --bg-hover: var(--bg);
     }
   }
 

--- a/resources/lang/en/common.php
+++ b/resources/lang/en/common.php
@@ -21,6 +21,7 @@ return [
     'buttons' => [
         'admin' => 'Admin',
         'authorise' => 'Authorise',
+        'authorising' => 'Authorising...',
         'back_to_previous' => 'Return to previous position',
         'back_to_top' => 'Back to top',
         'cancel' => 'Cancel',

--- a/resources/lang/en/layout.php
+++ b/resources/lang/en/layout.php
@@ -145,6 +145,10 @@ return [
             'error' => 'Page Missing',
             'description' => "Sorry, but the page you requested isn't here!",
         ],
+        '422' => [
+            'error' => 'Invalid request parameter',
+            'description' => '',
+        ],
         '500' => [
             'error' => 'Oh no! Something broke! ;_;',
             'description' => "We're automatically notified of every error.",

--- a/resources/lang/en/page_title.php
+++ b/resources/lang/en/page_title.php
@@ -19,6 +19,7 @@ return [
             '403' => 'forbidden',
             '401' => 'unauthorized',
             '405' => 'missing',
+            '422' => 'invalid request',
             '500' => 'something broke',
             '503' => 'maintenance',
         ],

--- a/resources/views/client_verifications/create.blade.php
+++ b/resources/views/client_verifications/create.blade.php
@@ -66,10 +66,11 @@
                 {!! Form::open([
                     'url' => route('client-verifications.store'),
                     'method' => 'POST',
+                    'data-remote' => 'true',
                 ]) !!}
                     <input type="hidden" name="ch" value="{{ $hash }}" />
 
-                    <button class="dialog-form__button">
+                    <button class="dialog-form__button" data-disable-with="{{ trans('common.buttons.authorising') }}">
                         {{ trans('common.buttons.authorise') }}
                     </button>
                 {!! Form::close() !!}

--- a/tests/Controllers/ClientVerificationsControllerTest.php
+++ b/tests/Controllers/ClientVerificationsControllerTest.php
@@ -78,9 +78,14 @@ class ClientVerificationsControllerTest extends TestCase
         $this->assertSame($initialCount, UserClient::count());
         $this->assertFalse(UserClient::lookupOrNew($user->getKey(), $hash)->exists);
 
+        $returnUrl = route('client-verifications.create', ['ch' => $hash]);
+
         $this->actingAsVerified($user)
             ->post($url)
-            ->assertSuccessful()
+            ->assertRedirect($returnUrl);
+
+        $this->actingAsVerified($user)
+            ->get($returnUrl)
             ->assertViewIs('client_verifications.completed');
 
         $this->assertSame($initialCount + 1, UserClient::count());
@@ -88,7 +93,10 @@ class ClientVerificationsControllerTest extends TestCase
 
         $this->actingAsVerified($user)
             ->post($url)
-            ->assertSuccessful()
+            ->assertRedirect($returnUrl);
+
+        $this->actingAsVerified($user)
+            ->get($returnUrl)
             ->assertViewIs('client_verifications.completed');
 
         $this->assertSame($initialCount + 1, UserClient::count());


### PR DESCRIPTION
There's timing issue when multiple verifications of same client sent at the same time. And the button should be disabled on submit.

Moved exceptions around to skip manually handling errors.