### PR TITLE
Add API scope for reading beatmaps

### DIFF
--- a/app/Http/Controllers/API/BeatmapsController.php
+++ b/app/Http/Controllers/API/BeatmapsController.php
@@ -10,6 +10,11 @@ use Request;
 
 class BeatmapsController extends Controller
 {
+    public function __construct()
+    {
+        $this->middleware('require-scopes:beatmaps.read');
+    }
+
     public function show($id)
     {
         $beatmap = Beatmap::findOrFail($id);

--- a/app/Http/Controllers/API/BeatmapsetsController.php
+++ b/app/Http/Controllers/API/BeatmapsetsController.php
@@ -10,6 +10,12 @@ use Request;
 
 class BeatmapsetsController extends Controller
 {
+    public function __construct()
+    {
+        $this->middleware('require-scopes:beatmaps.read');
+    }
+
+
     public function lookup()
     {
         $beatmapId = Request::input('beatmap_id');

--- a/app/Http/Controllers/API/BeatmapsetsController.php
+++ b/app/Http/Controllers/API/BeatmapsetsController.php
@@ -15,7 +15,6 @@ class BeatmapsetsController extends Controller
         $this->middleware('require-scopes:beatmaps.read');
     }
 
-
     public function lookup()
     {
         $beatmapId = Request::input('beatmap_id');

--- a/app/Http/Controllers/BeatmapsController.php
+++ b/app/Http/Controllers/BeatmapsController.php
@@ -13,6 +13,15 @@ use Request;
 
 class BeatmapsController extends Controller
 {
+    public function __construct()
+    {
+        parent::__construct();
+
+        if (is_api_request()) {
+            $this->middleware('require-scopes:beatmaps.read');
+        }
+    }
+
     public function show($id)
     {
         $beatmap = Beatmap::findOrFail($id);

--- a/app/Http/Controllers/BeatmapsetsController.php
+++ b/app/Http/Controllers/BeatmapsetsController.php
@@ -23,6 +23,15 @@ use Request;
 
 class BeatmapsetsController extends Controller
 {
+    public function __construct()
+    {
+        parent::__construct();
+
+        if (is_api_request()) {
+            $this->middleware('require-scopes:beatmaps.read', ['only' => ['search', 'show']]);
+        }
+    }
+
     public function destroy($id)
     {
         $beatmapset = Beatmapset::findOrFail($id);

--- a/app/Http/Middleware/AuthApi.php
+++ b/app/Http/Middleware/AuthApi.php
@@ -11,18 +11,18 @@ use Illuminate\Http\Request;
 
 class AuthApi
 {
+    const SKIP_GET = [
+        'api/v2/changelog/',
+        'api/v2/comments/',
+        'api/v2/seasonal-backgrounds/',
+    ];
+
     // TODO: this should be definable per-controller or action.
     public static function skipAuth($request)
     {
-        static $skipGet = [
-            'api/v2/changelog/',
-            'api/v2/comments/',
-            'api/v2/seasonal-backgrounds/',
-        ];
-
         $path = "{$request->decodedPath()}/";
 
-        return $request->isMethod('GET') && starts_with($path, $skipGet);
+        return $request->isMethod('GET') && starts_with($path, static::SKIP_GET);
     }
 
     public function handle(Request $request, Closure $next)

--- a/app/Libraries/RouteScopesHelper.php
+++ b/app/Libraries/RouteScopesHelper.php
@@ -1,22 +1,7 @@
 <?php
 
-/**
- *    Copyright (c) ppy Pty Ltd <contact@ppy.sh>.
- *
- *    This file is part of osu!web. osu!web is distributed with the hope of
- *    attracting more community contributions to the core ecosystem of osu!.
- *
- *    osu!web is free software: you can redistribute it and/or modify
- *    it under the terms of the Affero GNU General Public License version 3
- *    as published by the Free Software Foundation.
- *
- *    osu!web is distributed WITHOUT ANY WARRANTY; without even the implied
- *    warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
- *    See the GNU Affero General Public License for more details.
- *
- *    You should have received a copy of the GNU Affero General Public License
- *    along with osu!web.  If not, see <http://www.gnu.org/licenses/>.
- */
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
 
 namespace App\Libraries;
 

--- a/app/Libraries/RouteScopesHelper.php
+++ b/app/Libraries/RouteScopesHelper.php
@@ -41,20 +41,23 @@ class RouteScopesHelper
 
             // add missing middleware if necessary; exact order might be wrong.
             $newString = "require-scopes:{$scopesString}";
-            if (!in_array('require-scopes', $middlewares, true)) {
+            $index = array_search('require-scopes', $middlewares, true);
+            if ($index === false) {
                 $middlewares[] = 'require-scopes';
             }
 
             $exists = false;
             foreach ($middlewares as &$middleware) {
+                // replace existing value if it exists
                 if (starts_with($middleware, 'require-scopes:')) {
                     $middleware = $newString;
                     $exists = true;
                 }
             }
 
+            // otherwise insert new value after require-scopes if possible.
             if (!$exists) {
-                $middlewares[] = $newString;
+                array_splice($middlewares, $index ? $index + 1 : count($middlewares), 0, $newString);
             }
 
             $route['middlewares'] = $middlewares;

--- a/app/Libraries/RouteScopesHelper.php
+++ b/app/Libraries/RouteScopesHelper.php
@@ -149,6 +149,6 @@ class RouteScopesHelper
 
     public function toJson(string $filename)
     {
-        file_put_contents($filename, str_replace('\/', '/', json_encode($this->toArray(), JSON_PRETTY_PRINT)));
+        file_put_contents($filename, str_replace('\/', '/', json_encode($this->toArray(), JSON_PRETTY_PRINT)."\n"));
     }
 }

--- a/app/Libraries/RouteScopesHelper.php
+++ b/app/Libraries/RouteScopesHelper.php
@@ -1,0 +1,112 @@
+<?php
+
+/**
+ *    Copyright (c) ppy Pty Ltd <contact@ppy.sh>.
+ *
+ *    This file is part of osu!web. osu!web is distributed with the hope of
+ *    attracting more community contributions to the core ecosystem of osu!.
+ *
+ *    osu!web is free software: you can redistribute it and/or modify
+ *    it under the terms of the Affero GNU General Public License version 3
+ *    as published by the Free Software Foundation.
+ *
+ *    osu!web is distributed WITHOUT ANY WARRANTY; without even the implied
+ *    warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
+ *    See the GNU Affero General Public License for more details.
+ *
+ *    You should have received a copy of the GNU Affero General Public License
+ *    along with osu!web.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+namespace App\Libraries;
+
+use Route;
+
+class RouteScopesHelper
+{
+    public $routes;
+
+    public static function importCsv(string $filename)
+    {
+        $csv = array_map('str_getcsv', file($filename));
+
+        $routes = array_map(function ($line) use ($csv) {
+            $a = array_combine($csv[0], $line);
+            $a['middlewares'] = explode(',', $a['middlewares']);
+            $a['scopes'] = array_filter(explode(',', $a['scopes']));
+
+            return $a;
+        }, $csv);
+
+        array_shift($routes); // remove column header
+
+        $obj = new static;
+        $obj->routes = $routes;
+
+        return $obj;
+    }
+
+    public function toArray()
+    {
+        $array = [];
+
+        foreach (Route::getRoutes() as $route) {
+            if (!starts_with($route->uri, 'api/')) {
+                continue;
+            }
+
+            // uri will still have the placeholders and wrong verbs, but we don't need them.
+            $request = request()->create($route->uri, 'GET');
+            app()->instance('request', $request); // set current request so is_api_request can work.
+
+            $uri = $route->uri;
+            $middlewares = array_filter($route->gatherMiddleware(), function ($middleware) {
+                // only consider the named middleware.
+                return is_string($middleware);
+            });
+            $controller = $route->action['controller'] ?? null;
+            $scopes = [];
+
+            foreach ($middlewares as $middleware) {
+                if (is_string($middleware) && starts_with($middleware, 'require-scopes:')) {
+                    $scopes = array_merge($scopes, explode(',', substr($middleware, strlen('require-scopes:'))));
+                }
+            }
+
+            sort($scopes);
+
+            foreach ($route->methods as $method) {
+                $array[] = compact('uri', 'method', 'controller', 'middlewares', 'scopes');
+            }
+        }
+
+        return $array;
+    }
+
+    public function toJson(string $filename)
+    {
+        file_put_contents($filename, str_replace('\/', '/', json_encode($this->toArray(), JSON_PRETTY_PRINT)));
+    }
+
+    public function toCsv(string $filename)
+    {
+        $array = $this->toArray();
+
+        $file = fopen($filename, 'w');
+        fputcsv($file, ['uri', 'method', 'controller', 'middlewares', 'scopes']);
+
+        foreach ($array as $obj) {
+            $fields = [
+                $obj['uri'],
+                $obj['method'],
+                $obj['controller'],
+                implode(',', $obj['middlewares']),
+                implode(',', $obj['scopes']),
+            ];
+
+            fputcsv($file, $fields);
+        }
+
+        fclose($file);
+    }
+}

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -52,6 +52,7 @@ class AuthServiceProvider extends ServiceProvider
         });
 
         Passport::tokensCan([
+            'beatmaps.read' => trans('api.scopes.beatmaps.read'),
             'friends.read' => trans('api.scopes.friends.read'),
             'identify' => trans('api.scopes.identify'),
             'users.read' => trans('api.scopes.users.read'),

--- a/database/factories/BuildFactory.php
+++ b/database/factories/BuildFactory.php
@@ -19,6 +19,6 @@ $factory->define(App\Models\Build::class, function (Faker\Generator $faker) {
         'users' => rand(100, 10000),
         'stream_id' => function () use ($streams, $streamCount) {
             return $streams[rand(0, $streamCount - 1)];
-        }
+        },
     ];
 });

--- a/database/factories/BuildFactory.php
+++ b/database/factories/BuildFactory.php
@@ -9,12 +9,16 @@ $factory->define(App\Models\Build::class, function (Faker\Generator $faker) {
     $date = $faker->dateTimeBetween('-5 years');
 
     $streams = config('osu.changelog.update_streams');
-    $stream_count = count($streams);
+    $streamCount = count($streams);
 
     return [
-        'version' => Carbon::instance($date)->format('Ymd'),
+        'version' => function () use ($date) {
+            return Carbon::instance($date)->format('Ymd');
+        },
         'date' => $date,
         'users' => rand(100, 10000),
-        'stream_id' => $streams[rand(0, $stream_count - 1)],
+        'stream_id' => function () use ($streams, $streamCount) {
+            return $streams[rand(0, $streamCount - 1)];
+        }
     ];
 });

--- a/database/factories/ChangelogFactory.php
+++ b/database/factories/ChangelogFactory.php
@@ -17,14 +17,16 @@
 use App\Models\User;
 
 $factory->define(App\Models\Changelog::class, function (Faker\Generator $faker) {
-    $u = User::orderByRaw('RAND()')->first();
-
     return [
-        'user_id' => $u->user_id,
+        'user_id' => function () {
+            $u = User::orderByRaw('RAND()')->first() ?? factory(User::class)->create();
+
+            return $u->getKey();
+        },
         'prefix' => $faker->randomElement(['*', '+', '?']),
         'category' => $faker->randomElement(['Web', 'Audio', 'Code', 'Editor', 'Gameplay', 'Graphics']),
         'message' => $faker->catchPhrase,
         'checksum' => $faker->md5,
-        'date' => $faker->dateTimeBetween($startDate = '-6 weeks', $endDate = 'now'),
+        'date' => $faker->dateTimeBetween('-6 weeks', 'now'),
     ];
 });

--- a/database/factories/CommentFactory.php
+++ b/database/factories/CommentFactory.php
@@ -11,7 +11,9 @@ $factory->define(App\Models\Comment::class, function (Faker\Generator $faker) {
         'message' => function () use ($faker) {
             return $faker->paragraph();
         },
-        'commentable_type' => 'build', // TODO: add support for more types
+        'commentable_type' => function () {
+            return 'build'; // TODO: add support for more types
+        },
         'commentable_id' => function () {
             return factory(App\Models\Build::class)->create()->build_id;
         },

--- a/resources/lang/en/api.php
+++ b/resources/lang/en/api.php
@@ -15,6 +15,10 @@ return [
     'scopes' => [
         'identify' => 'Identify you and read your public profile.',
 
+        'beatmaps' => [
+            'read' => 'View beatmaps and your activity on them on your behalf.'
+        ],
+
         'friends' => [
             'read' => 'See who you are following.',
         ],

--- a/resources/lang/en/api.php
+++ b/resources/lang/en/api.php
@@ -16,7 +16,7 @@ return [
         'identify' => 'Identify you and read your public profile.',
 
         'beatmaps' => [
-            'read' => 'View beatmaps and your activity on them on your behalf.'
+            'read' => 'View beatmaps and your activity on them on your behalf.',
         ],
 
         'friends' => [

--- a/tests/RouteScopesTest.php
+++ b/tests/RouteScopesTest.php
@@ -54,7 +54,10 @@ class RouteScopesTest extends TestCase
     private function importExpectations()
     {
         $this->expectations = [];
-        $routes = RouteScopesHelper::importCsv('expected.csv')->routes;
+
+        $helper = new RouteScopesHelper;
+        $helper->fromJson('tests/api_routes.json');
+        $routes = $helper->routes;
         foreach ($routes as $route) {
             $key = "{$route['method']}@{$route['controller']}";
             $this->expectations[$key] = $route;

--- a/tests/RouteScopesTest.php
+++ b/tests/RouteScopesTest.php
@@ -55,7 +55,7 @@ class RouteScopesTest extends TestCase
 
         $failures = [];
         foreach (Route::getRoutes() as $route) {
-             /** @var \Illuminate\Routing\Route $route */
+            /** @var \Illuminate\Routing\Route $route */
             if (!starts_with($route->uri, 'api/')) {
                 continue;
             }
@@ -76,7 +76,7 @@ class RouteScopesTest extends TestCase
                 try {
                     if ($method === 'GET' && starts_with(ltrim($url, '/').'/', AuthApi::SKIP_GET)) {
                         $this->assertTrue(in_array($status, [200, 302], true), $key);
-                    } else if (in_array('require-scopes', $middlewares)) {
+                    } elseif (in_array('require-scopes', $middlewares, true)) {
                         $this->assertSame(401, $status, $key);
                     } else {
                         $this->assertNotSame(401, $status, $key);
@@ -100,7 +100,7 @@ class RouteScopesTest extends TestCase
                     function ($failure) {
                         return [
                             'message' => $failure->getMessage(),
-                            'diff' => optional($failure->getComparisonFailure())->toString()
+                            'diff' => optional($failure->getComparisonFailure())->toString(),
                         ];
                     },
                     $failures

--- a/tests/api_routes.json
+++ b/tests/api_routes.json
@@ -1,0 +1,937 @@
+[
+    {
+        "uri": "api/v2/beatmapsets/{beatmapset}/favourites",
+        "method": "POST",
+        "controller": "App\\Http\\Controllers\\Beatmapsets\\FavouritesController@store",
+        "middlewares": [
+            "auth-custom-api",
+            "require-scopes",
+            "auth"
+        ],
+        "scopes": []
+    },
+    {
+        "uri": "api/v2/beatmapsets/discussions/review",
+        "method": "POST",
+        "controller": "App\\Http\\Controllers\\BeatmapDiscussionsController@review",
+        "middlewares": [
+            "auth-custom-api",
+            "require-scopes",
+            "auth"
+        ],
+        "scopes": []
+    },
+    {
+        "uri": "api/v2/comments",
+        "method": "GET",
+        "controller": "App\\Http\\Controllers\\CommentsController@index",
+        "middlewares": [
+            "auth-custom-api",
+            "require-scopes"
+        ],
+        "scopes": []
+    },
+    {
+        "uri": "api/v2/comments",
+        "method": "HEAD",
+        "controller": "App\\Http\\Controllers\\CommentsController@index",
+        "middlewares": [
+            "auth-custom-api",
+            "require-scopes"
+        ],
+        "scopes": []
+    },
+    {
+        "uri": "api/v2/comments",
+        "method": "POST",
+        "controller": "App\\Http\\Controllers\\CommentsController@store",
+        "middlewares": [
+            "auth-custom-api",
+            "require-scopes",
+            "auth"
+        ],
+        "scopes": []
+    },
+    {
+        "uri": "api/v2/comments/{comment}",
+        "method": "GET",
+        "controller": "App\\Http\\Controllers\\CommentsController@show",
+        "middlewares": [
+            "auth-custom-api",
+            "require-scopes"
+        ],
+        "scopes": []
+    },
+    {
+        "uri": "api/v2/comments/{comment}",
+        "method": "HEAD",
+        "controller": "App\\Http\\Controllers\\CommentsController@show",
+        "middlewares": [
+            "auth-custom-api",
+            "require-scopes"
+        ],
+        "scopes": []
+    },
+    {
+        "uri": "api/v2/comments/{comment}",
+        "method": "PUT",
+        "controller": "App\\Http\\Controllers\\CommentsController@update",
+        "middlewares": [
+            "auth-custom-api",
+            "require-scopes",
+            "auth"
+        ],
+        "scopes": []
+    },
+    {
+        "uri": "api/v2/comments/{comment}",
+        "method": "PATCH",
+        "controller": "App\\Http\\Controllers\\CommentsController@update",
+        "middlewares": [
+            "auth-custom-api",
+            "require-scopes",
+            "auth"
+        ],
+        "scopes": []
+    },
+    {
+        "uri": "api/v2/comments/{comment}",
+        "method": "DELETE",
+        "controller": "App\\Http\\Controllers\\CommentsController@destroy",
+        "middlewares": [
+            "auth-custom-api",
+            "require-scopes",
+            "auth"
+        ],
+        "scopes": []
+    },
+    {
+        "uri": "api/v2/comments/{comment}/vote",
+        "method": "POST",
+        "controller": "App\\Http\\Controllers\\CommentsController@voteStore",
+        "middlewares": [
+            "auth-custom-api",
+            "require-scopes",
+            "auth"
+        ],
+        "scopes": []
+    },
+    {
+        "uri": "api/v2/comments/{comment}/vote",
+        "method": "DELETE",
+        "controller": "App\\Http\\Controllers\\CommentsController@voteDestroy",
+        "middlewares": [
+            "auth-custom-api",
+            "require-scopes",
+            "auth"
+        ],
+        "scopes": []
+    },
+    {
+        "uri": "api/v2/chat/new",
+        "method": "POST",
+        "controller": "App\\Http\\Controllers\\Chat\\ChatController@newConversation",
+        "middlewares": [
+            "auth-custom-api",
+            "require-scopes",
+            "auth"
+        ],
+        "scopes": []
+    },
+    {
+        "uri": "api/v2/chat/updates",
+        "method": "GET",
+        "controller": "App\\Http\\Controllers\\Chat\\ChatController@updates",
+        "middlewares": [
+            "auth-custom-api",
+            "require-scopes",
+            "auth"
+        ],
+        "scopes": []
+    },
+    {
+        "uri": "api/v2/chat/updates",
+        "method": "HEAD",
+        "controller": "App\\Http\\Controllers\\Chat\\ChatController@updates",
+        "middlewares": [
+            "auth-custom-api",
+            "require-scopes",
+            "auth"
+        ],
+        "scopes": []
+    },
+    {
+        "uri": "api/v2/chat/presence",
+        "method": "GET",
+        "controller": "App\\Http\\Controllers\\Chat\\ChatController@presence",
+        "middlewares": [
+            "auth-custom-api",
+            "require-scopes",
+            "auth"
+        ],
+        "scopes": []
+    },
+    {
+        "uri": "api/v2/chat/presence",
+        "method": "HEAD",
+        "controller": "App\\Http\\Controllers\\Chat\\ChatController@presence",
+        "middlewares": [
+            "auth-custom-api",
+            "require-scopes",
+            "auth"
+        ],
+        "scopes": []
+    },
+    {
+        "uri": "api/v2/chat/channels/{channel}/messages",
+        "method": "GET",
+        "controller": "App\\Http\\Controllers\\Chat\\Channels\\MessagesController@index",
+        "middlewares": [
+            "auth-custom-api",
+            "require-scopes",
+            "auth"
+        ],
+        "scopes": []
+    },
+    {
+        "uri": "api/v2/chat/channels/{channel}/messages",
+        "method": "HEAD",
+        "controller": "App\\Http\\Controllers\\Chat\\Channels\\MessagesController@index",
+        "middlewares": [
+            "auth-custom-api",
+            "require-scopes",
+            "auth"
+        ],
+        "scopes": []
+    },
+    {
+        "uri": "api/v2/chat/channels/{channel}/messages",
+        "method": "POST",
+        "controller": "App\\Http\\Controllers\\Chat\\Channels\\MessagesController@store",
+        "middlewares": [
+            "auth-custom-api",
+            "require-scopes",
+            "auth"
+        ],
+        "scopes": []
+    },
+    {
+        "uri": "api/v2/chat/channels/{channel}/users/{user}",
+        "method": "PUT",
+        "controller": "App\\Http\\Controllers\\Chat\\ChannelsController@join",
+        "middlewares": [
+            "auth-custom-api",
+            "require-scopes",
+            "auth"
+        ],
+        "scopes": []
+    },
+    {
+        "uri": "api/v2/chat/channels/{channel}/users/{user}",
+        "method": "DELETE",
+        "controller": "App\\Http\\Controllers\\Chat\\ChannelsController@part",
+        "middlewares": [
+            "auth-custom-api",
+            "require-scopes",
+            "auth"
+        ],
+        "scopes": []
+    },
+    {
+        "uri": "api/v2/chat/channels/{channel}/mark-as-read/{message}",
+        "method": "PUT",
+        "controller": "App\\Http\\Controllers\\Chat\\ChannelsController@markAsRead",
+        "middlewares": [
+            "auth-custom-api",
+            "require-scopes",
+            "auth"
+        ],
+        "scopes": []
+    },
+    {
+        "uri": "api/v2/chat/channels",
+        "method": "GET",
+        "controller": "App\\Http\\Controllers\\Chat\\ChannelsController@index",
+        "middlewares": [
+            "auth-custom-api",
+            "require-scopes",
+            "auth"
+        ],
+        "scopes": []
+    },
+    {
+        "uri": "api/v2/chat/channels",
+        "method": "HEAD",
+        "controller": "App\\Http\\Controllers\\Chat\\ChannelsController@index",
+        "middlewares": [
+            "auth-custom-api",
+            "require-scopes",
+            "auth"
+        ],
+        "scopes": []
+    },
+    {
+        "uri": "api/v2/changelog/{stream}/{build}",
+        "method": "GET",
+        "controller": "App\\Http\\Controllers\\ChangelogController@build",
+        "middlewares": [
+            "auth-custom-api",
+            "require-scopes"
+        ],
+        "scopes": []
+    },
+    {
+        "uri": "api/v2/changelog/{stream}/{build}",
+        "method": "HEAD",
+        "controller": "App\\Http\\Controllers\\ChangelogController@build",
+        "middlewares": [
+            "auth-custom-api",
+            "require-scopes"
+        ],
+        "scopes": []
+    },
+    {
+        "uri": "api/v2/changelog",
+        "method": "GET",
+        "controller": "App\\Http\\Controllers\\ChangelogController@index",
+        "middlewares": [
+            "auth-custom-api",
+            "require-scopes"
+        ],
+        "scopes": []
+    },
+    {
+        "uri": "api/v2/changelog",
+        "method": "HEAD",
+        "controller": "App\\Http\\Controllers\\ChangelogController@index",
+        "middlewares": [
+            "auth-custom-api",
+            "require-scopes"
+        ],
+        "scopes": []
+    },
+    {
+        "uri": "api/v2/changelog/{changelog}",
+        "method": "GET",
+        "controller": "App\\Http\\Controllers\\ChangelogController@show",
+        "middlewares": [
+            "auth-custom-api",
+            "require-scopes"
+        ],
+        "scopes": []
+    },
+    {
+        "uri": "api/v2/changelog/{changelog}",
+        "method": "HEAD",
+        "controller": "App\\Http\\Controllers\\ChangelogController@show",
+        "middlewares": [
+            "auth-custom-api",
+            "require-scopes"
+        ],
+        "scopes": []
+    },
+    {
+        "uri": "api/v2/rooms/{mode?}",
+        "method": "GET",
+        "controller": "App\\Http\\Controllers\\Multiplayer\\RoomsController@index",
+        "middlewares": [
+            "auth-custom-api",
+            "require-scopes",
+            "auth"
+        ],
+        "scopes": []
+    },
+    {
+        "uri": "api/v2/rooms/{mode?}",
+        "method": "HEAD",
+        "controller": "App\\Http\\Controllers\\Multiplayer\\RoomsController@index",
+        "middlewares": [
+            "auth-custom-api",
+            "require-scopes",
+            "auth"
+        ],
+        "scopes": []
+    },
+    {
+        "uri": "api/v2/rooms/{room}/users/{user}",
+        "method": "PUT",
+        "controller": "App\\Http\\Controllers\\Multiplayer\\RoomsController@join",
+        "middlewares": [
+            "auth-custom-api",
+            "require-scopes",
+            "auth"
+        ],
+        "scopes": []
+    },
+    {
+        "uri": "api/v2/rooms/{room}/users/{user}",
+        "method": "DELETE",
+        "controller": "App\\Http\\Controllers\\Multiplayer\\RoomsController@part",
+        "middlewares": [
+            "auth-custom-api",
+            "require-scopes",
+            "auth"
+        ],
+        "scopes": []
+    },
+    {
+        "uri": "api/v2/rooms/{room}/leaderboard",
+        "method": "GET",
+        "controller": "App\\Http\\Controllers\\Multiplayer\\RoomsController@leaderboard",
+        "middlewares": [
+            "auth-custom-api",
+            "require-scopes",
+            "auth"
+        ],
+        "scopes": []
+    },
+    {
+        "uri": "api/v2/rooms/{room}/leaderboard",
+        "method": "HEAD",
+        "controller": "App\\Http\\Controllers\\Multiplayer\\RoomsController@leaderboard",
+        "middlewares": [
+            "auth-custom-api",
+            "require-scopes",
+            "auth"
+        ],
+        "scopes": []
+    },
+    {
+        "uri": "api/v2/rooms/{room}/playlist/{playlist}/scores",
+        "method": "POST",
+        "controller": "App\\Http\\Controllers\\Multiplayer\\Rooms\\Playlist\\ScoresController@store",
+        "middlewares": [
+            "auth-custom-api",
+            "require-scopes",
+            "auth"
+        ],
+        "scopes": []
+    },
+    {
+        "uri": "api/v2/rooms/{room}/playlist/{playlist}/scores/{score}",
+        "method": "PUT",
+        "controller": "App\\Http\\Controllers\\Multiplayer\\Rooms\\Playlist\\ScoresController@update",
+        "middlewares": [
+            "auth-custom-api",
+            "require-scopes",
+            "auth"
+        ],
+        "scopes": []
+    },
+    {
+        "uri": "api/v2/rooms/{room}/playlist/{playlist}/scores/{score}",
+        "method": "PATCH",
+        "controller": "App\\Http\\Controllers\\Multiplayer\\Rooms\\Playlist\\ScoresController@update",
+        "middlewares": [
+            "auth-custom-api",
+            "require-scopes",
+            "auth"
+        ],
+        "scopes": []
+    },
+    {
+        "uri": "api/v2/reports",
+        "method": "POST",
+        "controller": "App\\Http\\Controllers\\ReportsController@store",
+        "middlewares": [
+            "auth-custom-api",
+            "require-scopes",
+            "auth"
+        ],
+        "scopes": []
+    },
+    {
+        "uri": "api/v2/rooms",
+        "method": "POST",
+        "controller": "App\\Http\\Controllers\\Multiplayer\\RoomsController@store",
+        "middlewares": [
+            "auth-custom-api",
+            "require-scopes",
+            "auth"
+        ],
+        "scopes": []
+    },
+    {
+        "uri": "api/v2/rooms/{room}",
+        "method": "GET",
+        "controller": "App\\Http\\Controllers\\Multiplayer\\RoomsController@show",
+        "middlewares": [
+            "auth-custom-api",
+            "require-scopes",
+            "auth"
+        ],
+        "scopes": []
+    },
+    {
+        "uri": "api/v2/rooms/{room}",
+        "method": "HEAD",
+        "controller": "App\\Http\\Controllers\\Multiplayer\\RoomsController@show",
+        "middlewares": [
+            "auth-custom-api",
+            "require-scopes",
+            "auth"
+        ],
+        "scopes": []
+    },
+    {
+        "uri": "api/v2/seasonal-backgrounds",
+        "method": "GET",
+        "controller": "App\\Http\\Controllers\\SeasonalBackgroundsController@index",
+        "middlewares": [
+            "auth-custom-api",
+            "require-scopes"
+        ],
+        "scopes": []
+    },
+    {
+        "uri": "api/v2/seasonal-backgrounds",
+        "method": "HEAD",
+        "controller": "App\\Http\\Controllers\\SeasonalBackgroundsController@index",
+        "middlewares": [
+            "auth-custom-api",
+            "require-scopes"
+        ],
+        "scopes": []
+    },
+    {
+        "uri": "api/v2/scores/{mode}/{score}/download",
+        "method": "GET",
+        "controller": "App\\Http\\Controllers\\ScoresController@download",
+        "middlewares": [
+            "auth-custom-api",
+            "require-scopes",
+            "auth"
+        ],
+        "scopes": []
+    },
+    {
+        "uri": "api/v2/scores/{mode}/{score}/download",
+        "method": "HEAD",
+        "controller": "App\\Http\\Controllers\\ScoresController@download",
+        "middlewares": [
+            "auth-custom-api",
+            "require-scopes",
+            "auth"
+        ],
+        "scopes": []
+    },
+    {
+        "uri": "api/v2/beatmaps/{id}/scores",
+        "method": "GET",
+        "controller": "App\\Http\\Controllers\\BeatmapsController@scores",
+        "middlewares": [
+            "auth-custom-api",
+            "require-scopes"
+        ],
+        "scopes": []
+    },
+    {
+        "uri": "api/v2/beatmaps/{id}/scores",
+        "method": "HEAD",
+        "controller": "App\\Http\\Controllers\\BeatmapsController@scores",
+        "middlewares": [
+            "auth-custom-api",
+            "require-scopes"
+        ],
+        "scopes": []
+    },
+    {
+        "uri": "api/v2/beatmaps/lookup",
+        "method": "GET",
+        "controller": "App\\Http\\Controllers\\API\\BeatmapsController@lookup",
+        "middlewares": [
+            "auth-custom-api",
+            "require-scopes"
+        ],
+        "scopes": []
+    },
+    {
+        "uri": "api/v2/beatmaps/lookup",
+        "method": "HEAD",
+        "controller": "App\\Http\\Controllers\\API\\BeatmapsController@lookup",
+        "middlewares": [
+            "auth-custom-api",
+            "require-scopes"
+        ],
+        "scopes": []
+    },
+    {
+        "uri": "api/v2/beatmaps/{beatmap}",
+        "method": "GET",
+        "controller": "App\\Http\\Controllers\\API\\BeatmapsController@show",
+        "middlewares": [
+            "auth-custom-api",
+            "require-scopes"
+        ],
+        "scopes": []
+    },
+    {
+        "uri": "api/v2/beatmaps/{beatmap}",
+        "method": "HEAD",
+        "controller": "App\\Http\\Controllers\\API\\BeatmapsController@show",
+        "middlewares": [
+            "auth-custom-api",
+            "require-scopes"
+        ],
+        "scopes": []
+    },
+    {
+        "uri": "api/v2/beatmapsets/search/{filters?}",
+        "method": "GET",
+        "controller": "App\\Http\\Controllers\\BeatmapsetsController@search",
+        "middlewares": [
+            "auth-custom-api",
+            "require-scopes"
+        ],
+        "scopes": []
+    },
+    {
+        "uri": "api/v2/beatmapsets/search/{filters?}",
+        "method": "HEAD",
+        "controller": "App\\Http\\Controllers\\BeatmapsetsController@search",
+        "middlewares": [
+            "auth-custom-api",
+            "require-scopes"
+        ],
+        "scopes": []
+    },
+    {
+        "uri": "api/v2/beatmapsets/lookup",
+        "method": "GET",
+        "controller": "App\\Http\\Controllers\\API\\BeatmapsetsController@lookup",
+        "middlewares": [
+            "auth-custom-api",
+            "require-scopes"
+        ],
+        "scopes": []
+    },
+    {
+        "uri": "api/v2/beatmapsets/lookup",
+        "method": "HEAD",
+        "controller": "App\\Http\\Controllers\\API\\BeatmapsetsController@lookup",
+        "middlewares": [
+            "auth-custom-api",
+            "require-scopes"
+        ],
+        "scopes": []
+    },
+    {
+        "uri": "api/v2/beatmapsets/{beatmapset}/download",
+        "method": "GET",
+        "controller": "App\\Http\\Controllers\\BeatmapsetsController@download",
+        "middlewares": [
+            "auth-custom-api",
+            "require-scopes"
+        ],
+        "scopes": []
+    },
+    {
+        "uri": "api/v2/beatmapsets/{beatmapset}/download",
+        "method": "HEAD",
+        "controller": "App\\Http\\Controllers\\BeatmapsetsController@download",
+        "middlewares": [
+            "auth-custom-api",
+            "require-scopes"
+        ],
+        "scopes": []
+    },
+    {
+        "uri": "api/v2/beatmapsets/{beatmapset}",
+        "method": "GET",
+        "controller": "App\\Http\\Controllers\\BeatmapsetsController@show",
+        "middlewares": [
+            "auth-custom-api",
+            "require-scopes"
+        ],
+        "scopes": []
+    },
+    {
+        "uri": "api/v2/beatmapsets/{beatmapset}",
+        "method": "HEAD",
+        "controller": "App\\Http\\Controllers\\BeatmapsetsController@show",
+        "middlewares": [
+            "auth-custom-api",
+            "require-scopes"
+        ],
+        "scopes": []
+    },
+    {
+        "uri": "api/v2/friends",
+        "method": "GET",
+        "controller": "App\\Http\\Controllers\\FriendsController@index",
+        "middlewares": [
+            "auth-custom-api",
+            "require-scopes",
+            "auth",
+            "require-scopes:friends.read"
+        ],
+        "scopes": [
+            "friends.read"
+        ]
+    },
+    {
+        "uri": "api/v2/friends",
+        "method": "HEAD",
+        "controller": "App\\Http\\Controllers\\FriendsController@index",
+        "middlewares": [
+            "auth-custom-api",
+            "require-scopes",
+            "auth",
+            "require-scopes:friends.read"
+        ],
+        "scopes": [
+            "friends.read"
+        ]
+    },
+    {
+        "uri": "api/v2/me/{mode?}",
+        "method": "GET",
+        "controller": "App\\Http\\Controllers\\UsersController@me",
+        "middlewares": [
+            "auth-custom-api",
+            "require-scopes",
+            "require-scopes:identify"
+        ],
+        "scopes": [
+            "identify"
+        ]
+    },
+    {
+        "uri": "api/v2/me/{mode?}",
+        "method": "HEAD",
+        "controller": "App\\Http\\Controllers\\UsersController@me",
+        "middlewares": [
+            "auth-custom-api",
+            "require-scopes",
+            "require-scopes:identify"
+        ],
+        "scopes": [
+            "identify"
+        ]
+    },
+    {
+        "uri": "api/v2/me/download-quota-check",
+        "method": "GET",
+        "controller": "App\\Http\\Controllers\\HomeController@downloadQuotaCheck",
+        "middlewares": [
+            "auth-custom-api",
+            "require-scopes",
+            "auth"
+        ],
+        "scopes": []
+    },
+    {
+        "uri": "api/v2/me/download-quota-check",
+        "method": "HEAD",
+        "controller": "App\\Http\\Controllers\\HomeController@downloadQuotaCheck",
+        "middlewares": [
+            "auth-custom-api",
+            "require-scopes",
+            "auth"
+        ],
+        "scopes": []
+    },
+    {
+        "uri": "api/v2/notifications",
+        "method": "GET",
+        "controller": "App\\Http\\Controllers\\NotificationsController@index",
+        "middlewares": [
+            "auth-custom-api",
+            "require-scopes",
+            "auth"
+        ],
+        "scopes": []
+    },
+    {
+        "uri": "api/v2/notifications",
+        "method": "HEAD",
+        "controller": "App\\Http\\Controllers\\NotificationsController@index",
+        "middlewares": [
+            "auth-custom-api",
+            "require-scopes",
+            "auth"
+        ],
+        "scopes": []
+    },
+    {
+        "uri": "api/v2/notifications/mark-read",
+        "method": "POST",
+        "controller": "App\\Http\\Controllers\\NotificationsController@markRead",
+        "middlewares": [
+            "auth-custom-api",
+            "require-scopes",
+            "auth"
+        ],
+        "scopes": []
+    },
+    {
+        "uri": "api/v2/rankings/{mode}/{type}",
+        "method": "GET",
+        "controller": "App\\Http\\Controllers\\RankingController@index",
+        "middlewares": [
+            "auth-custom-api",
+            "require-scopes"
+        ],
+        "scopes": []
+    },
+    {
+        "uri": "api/v2/rankings/{mode}/{type}",
+        "method": "HEAD",
+        "controller": "App\\Http\\Controllers\\RankingController@index",
+        "middlewares": [
+            "auth-custom-api",
+            "require-scopes"
+        ],
+        "scopes": []
+    },
+    {
+        "uri": "api/v2/spotlights",
+        "method": "GET",
+        "controller": "App\\Http\\Controllers\\SpotlightsController@index",
+        "middlewares": [
+            "auth-custom-api",
+            "require-scopes"
+        ],
+        "scopes": []
+    },
+    {
+        "uri": "api/v2/spotlights",
+        "method": "HEAD",
+        "controller": "App\\Http\\Controllers\\SpotlightsController@index",
+        "middlewares": [
+            "auth-custom-api",
+            "require-scopes"
+        ],
+        "scopes": []
+    },
+    {
+        "uri": "api/v2/users/{user}/kudosu",
+        "method": "GET",
+        "controller": "App\\Http\\Controllers\\UsersController@kudosu",
+        "middlewares": [
+            "auth-custom-api",
+            "require-scopes",
+            "require-scopes:users.read"
+        ],
+        "scopes": [
+            "users.read"
+        ]
+    },
+    {
+        "uri": "api/v2/users/{user}/kudosu",
+        "method": "HEAD",
+        "controller": "App\\Http\\Controllers\\UsersController@kudosu",
+        "middlewares": [
+            "auth-custom-api",
+            "require-scopes",
+            "require-scopes:users.read"
+        ],
+        "scopes": [
+            "users.read"
+        ]
+    },
+    {
+        "uri": "api/v2/users/{user}/scores/{type}",
+        "method": "GET",
+        "controller": "App\\Http\\Controllers\\UsersController@scores",
+        "middlewares": [
+            "auth-custom-api",
+            "require-scopes",
+            "require-scopes:users.read"
+        ],
+        "scopes": [
+            "users.read"
+        ]
+    },
+    {
+        "uri": "api/v2/users/{user}/scores/{type}",
+        "method": "HEAD",
+        "controller": "App\\Http\\Controllers\\UsersController@scores",
+        "middlewares": [
+            "auth-custom-api",
+            "require-scopes",
+            "require-scopes:users.read"
+        ],
+        "scopes": [
+            "users.read"
+        ]
+    },
+    {
+        "uri": "api/v2/users/{user}/beatmapsets/{type}",
+        "method": "GET",
+        "controller": "App\\Http\\Controllers\\UsersController@beatmapsets",
+        "middlewares": [
+            "auth-custom-api",
+            "require-scopes",
+            "require-scopes:users.read"
+        ],
+        "scopes": [
+            "users.read"
+        ]
+    },
+    {
+        "uri": "api/v2/users/{user}/beatmapsets/{type}",
+        "method": "HEAD",
+        "controller": "App\\Http\\Controllers\\UsersController@beatmapsets",
+        "middlewares": [
+            "auth-custom-api",
+            "require-scopes",
+            "require-scopes:users.read"
+        ],
+        "scopes": [
+            "users.read"
+        ]
+    },
+    {
+        "uri": "api/v2/users/{user}/recent_activity",
+        "method": "GET",
+        "controller": "App\\Http\\Controllers\\UsersController@recentActivity",
+        "middlewares": [
+            "auth-custom-api",
+            "require-scopes",
+            "require-scopes:users.read"
+        ],
+        "scopes": [
+            "users.read"
+        ]
+    },
+    {
+        "uri": "api/v2/users/{user}/recent_activity",
+        "method": "HEAD",
+        "controller": "App\\Http\\Controllers\\UsersController@recentActivity",
+        "middlewares": [
+            "auth-custom-api",
+            "require-scopes",
+            "require-scopes:users.read"
+        ],
+        "scopes": [
+            "users.read"
+        ]
+    },
+    {
+        "uri": "api/v2/users/{user}/{mode?}",
+        "method": "GET",
+        "controller": "App\\Http\\Controllers\\UsersController@show",
+        "middlewares": [
+            "auth-custom-api",
+            "require-scopes",
+            "require-scopes:users.read"
+        ],
+        "scopes": [
+            "users.read"
+        ]
+    },
+    {
+        "uri": "api/v2/users/{user}/{mode?}",
+        "method": "HEAD",
+        "controller": "App\\Http\\Controllers\\UsersController@show",
+        "middlewares": [
+            "auth-custom-api",
+            "require-scopes",
+            "require-scopes:users.read"
+        ],
+        "scopes": [
+            "users.read"
+        ]
+    }
+]

--- a/tests/api_routes.json
+++ b/tests/api_routes.json
@@ -521,9 +521,12 @@
         "controller": "App\\Http\\Controllers\\BeatmapsController@scores",
         "middlewares": [
             "auth-custom-api",
-            "require-scopes"
+            "require-scopes",
+            "require-scopes:beatmaps.read"
         ],
-        "scopes": []
+        "scopes": [
+            "beatmaps.read"
+        ]
     },
     {
         "uri": "api/v2/beatmaps/{id}/scores",
@@ -531,9 +534,12 @@
         "controller": "App\\Http\\Controllers\\BeatmapsController@scores",
         "middlewares": [
             "auth-custom-api",
-            "require-scopes"
+            "require-scopes",
+            "require-scopes:beatmaps.read"
         ],
-        "scopes": []
+        "scopes": [
+            "beatmaps.read"
+        ]
     },
     {
         "uri": "api/v2/beatmaps/lookup",
@@ -541,9 +547,12 @@
         "controller": "App\\Http\\Controllers\\API\\BeatmapsController@lookup",
         "middlewares": [
             "auth-custom-api",
-            "require-scopes"
+            "require-scopes",
+            "require-scopes:beatmaps.read"
         ],
-        "scopes": []
+        "scopes": [
+            "beatmaps.read"
+        ]
     },
     {
         "uri": "api/v2/beatmaps/lookup",
@@ -551,9 +560,12 @@
         "controller": "App\\Http\\Controllers\\API\\BeatmapsController@lookup",
         "middlewares": [
             "auth-custom-api",
-            "require-scopes"
+            "require-scopes",
+            "require-scopes:beatmaps.read"
         ],
-        "scopes": []
+        "scopes": [
+            "beatmaps.read"
+        ]
     },
     {
         "uri": "api/v2/beatmaps/{beatmap}",
@@ -561,9 +573,12 @@
         "controller": "App\\Http\\Controllers\\API\\BeatmapsController@show",
         "middlewares": [
             "auth-custom-api",
-            "require-scopes"
+            "require-scopes",
+            "require-scopes:beatmaps.read"
         ],
-        "scopes": []
+        "scopes": [
+            "beatmaps.read"
+        ]
     },
     {
         "uri": "api/v2/beatmaps/{beatmap}",
@@ -571,9 +586,12 @@
         "controller": "App\\Http\\Controllers\\API\\BeatmapsController@show",
         "middlewares": [
             "auth-custom-api",
-            "require-scopes"
+            "require-scopes",
+            "require-scopes:beatmaps.read"
         ],
-        "scopes": []
+        "scopes": [
+            "beatmaps.read"
+        ]
     },
     {
         "uri": "api/v2/beatmapsets/search/{filters?}",
@@ -581,9 +599,12 @@
         "controller": "App\\Http\\Controllers\\BeatmapsetsController@search",
         "middlewares": [
             "auth-custom-api",
-            "require-scopes"
+            "require-scopes",
+            "require-scopes:beatmaps.read"
         ],
-        "scopes": []
+        "scopes": [
+            "beatmaps.read"
+        ]
     },
     {
         "uri": "api/v2/beatmapsets/search/{filters?}",
@@ -591,9 +612,12 @@
         "controller": "App\\Http\\Controllers\\BeatmapsetsController@search",
         "middlewares": [
             "auth-custom-api",
-            "require-scopes"
+            "require-scopes",
+            "require-scopes:beatmaps.read"
         ],
-        "scopes": []
+        "scopes": [
+            "beatmaps.read"
+        ]
     },
     {
         "uri": "api/v2/beatmapsets/lookup",
@@ -601,9 +625,12 @@
         "controller": "App\\Http\\Controllers\\API\\BeatmapsetsController@lookup",
         "middlewares": [
             "auth-custom-api",
-            "require-scopes"
+            "require-scopes",
+            "require-scopes:beatmaps.read"
         ],
-        "scopes": []
+        "scopes": [
+            "beatmaps.read"
+        ]
     },
     {
         "uri": "api/v2/beatmapsets/lookup",
@@ -611,9 +638,12 @@
         "controller": "App\\Http\\Controllers\\API\\BeatmapsetsController@lookup",
         "middlewares": [
             "auth-custom-api",
-            "require-scopes"
+            "require-scopes",
+            "require-scopes:beatmaps.read"
         ],
-        "scopes": []
+        "scopes": [
+            "beatmaps.read"
+        ]
     },
     {
         "uri": "api/v2/beatmapsets/{beatmapset}/download",
@@ -641,9 +671,12 @@
         "controller": "App\\Http\\Controllers\\BeatmapsetsController@show",
         "middlewares": [
             "auth-custom-api",
-            "require-scopes"
+            "require-scopes",
+            "require-scopes:beatmaps.read"
         ],
-        "scopes": []
+        "scopes": [
+            "beatmaps.read"
+        ]
     },
     {
         "uri": "api/v2/beatmapsets/{beatmapset}",
@@ -651,9 +684,12 @@
         "controller": "App\\Http\\Controllers\\BeatmapsetsController@show",
         "middlewares": [
             "auth-custom-api",
-            "require-scopes"
+            "require-scopes",
+            "require-scopes:beatmaps.read"
         ],
-        "scopes": []
+        "scopes": [
+            "beatmaps.read"
+        ]
     },
     {
         "uri": "api/v2/friends",


### PR DESCRIPTION
- adds `beatmaps.read` scope
- helper to export and import list of declared middleware on api routes
- more specific scope tester