### PR TITLE
Show correct wiki parent page title

### DIFF
--- a/app/Http/Controllers/WikiController.php
+++ b/app/Http/Controllers/WikiController.php
@@ -25,8 +25,7 @@ class WikiController extends Controller
             return $this->showImage($path);
         }
 
-        $locale = $this->locale();
-        $page = Wiki\Page::lookupForController($path, $locale);
+        $page = Wiki\Page::lookupForController($path, $this->locale());
 
         if (!$page->isVisible()) {
             $redirectTarget = (new WikiRedirect)->sync()->resolve($path);
@@ -42,7 +41,7 @@ class WikiController extends Controller
             $status = 404;
         }
 
-        return ext_view($page->template(), compact('page', 'locale'), null, $status ?? null);
+        return ext_view($page->template(), compact('page'), null, $status ?? null);
     }
 
     public function sitemap()

--- a/app/Models/Wiki/Page.php
+++ b/app/Models/Wiki/Page.php
@@ -37,11 +37,13 @@ class Page implements WikiObject
 
     public $locale;
     public $path;
+    public $requestedLocale;
 
     private $defaultSubtitle;
     private $defaultTitle;
     private $source;
     private $page;
+    private $parent = false;
 
     public static function cleanupPath($path)
     {
@@ -75,9 +77,9 @@ class Page implements WikiObject
         return $page;
     }
 
-    public static function lookup($path, $locale)
+    public static function lookup($path, $locale, $requestedLocale = null)
     {
-        $page = new static($path, $locale);
+        $page = new static($path, $locale, $requestedLocale);
         $page->esFetch();
 
         return $page;
@@ -88,7 +90,7 @@ class Page implements WikiObject
         $page = static::lookup($path, $locale)->sync();
 
         if (!$page->isVisible() && $page->isTranslation()) {
-            $page = static::lookup($path, config('app.fallback_locale'))->sync();
+            $page = static::lookup($path, config('app.fallback_locale'), $locale)->sync();
         }
 
         return $page;
@@ -152,10 +154,11 @@ class Page implements WikiObject
         }
     }
 
-    public function __construct($path, $locale)
+    public function __construct($path, $locale, $requestedLocale = null)
     {
         $this->path = OsuWiki::cleanPath($path);
         $this->locale = $locale;
+        $this->requestedLocale = $requestedLocale ?? $locale;
 
         $defaultTitles = explode('/', str_replace('_', ' ', $this->path));
         $this->defaultTitle = array_pop($defaultTitles);
@@ -216,13 +219,33 @@ class Page implements WikiObject
 
     public function hasParent()
     {
-        return $this->parentPath() !== null
-            && static::lookup($this->parentPath(), $this->locale)->isVisible();
+        return $this->parent() !== null;
     }
 
     public function needsCleanup(): bool
     {
         return $this->page['header']['needs_cleanup'] ?? false;
+    }
+
+    public function parent()
+    {
+        if ($this->parent === false) {
+            $parentPath = $this->parentPath();
+
+            if ($parentPath === null) {
+                $parent = null;
+            } else {
+                $parent = static::lookup($this->parentPath(), $this->requestedLocale);
+
+                if (!$parent->isVisible()) {
+                    $parent = null;
+                }
+            }
+
+            $this->parent = $parent;
+        }
+
+        return $this->parent;
     }
 
     public function isLegalTranslation(): bool
@@ -294,6 +317,10 @@ class Page implements WikiObject
     {
         if ($this->page === null) {
             return;
+        }
+
+        if ($this->parent() !== null) {
+            return $this->parent()->title();
         }
 
         return presence($this->page['header']['subtitle'] ?? null) ?? $this->defaultSubtitle;

--- a/resources/views/wiki/_notice.blade.php
+++ b/resources/views/wiki/_notice.blade.php
@@ -2,9 +2,9 @@
     Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
     See the LICENCE file in the repository root for full licence text.
 --}}
-@if ($page->isVisible() && $page->locale !== $locale)
+@if ($page->isVisible() && $page->locale !== $page->requestedLocale)
     <div class="wiki-notice">
-        {{ trans('wiki.show.fallback_translation', ['language' => locale_name($locale)]) }}
+        {{ trans('wiki.show.fallback_translation', ['language' => locale_name($page->requestedLocale)]) }}
     </div>
 @endif
 

--- a/resources/views/wiki/show.blade.php
+++ b/resources/views/wiki/show.blade.php
@@ -3,7 +3,7 @@
     See the LICENCE file in the repository root for full licence text.
 --}}
 @php
-    $url = wiki_url($page->path, $locale);
+    $url = wiki_url($page->path, $page->requestedLocale);
     $title = $page->title();
 
     $links = [
@@ -17,7 +17,7 @@
     if ($parentTitle !== null) {
         $link = ['title' => $parentTitle];
         if ($page->hasParent()) {
-            $link['url'] = wiki_url($page->parentPath(), $locale);
+            $link['url'] = wiki_url($page->parentPath(), $page->requestedLocale);
         }
         $links[] = $link;
     }


### PR DESCRIPTION
As it turned out we're already fetching the parent page on every requests so I just save that somewhere and use it for subtitle (parent title).

Resolves #5511.