### PR TITLE
Fix script used by docker

### DIFF
--- a/bin/db_setup.sh
+++ b/bin/db_setup.sh
@@ -1,11 +1,5 @@
 #!/bin/sh
 
-set -e
-set -u
-
-# goes to top directory.
-cd "$(dirname "${0}")/.."
-
 for db in osu osu_store osu_mp osu_chat osu_charts osu_updates; do
   echo "CREATE DATABASE ${db} DEFAULT CHARSET utf8mb4" | mysql -u root
 done


### PR DESCRIPTION
The script is run in weird way (presumably to skip exporting variables?) and result in the main shell having nounset and errexit set, breaking the init script.

The script is simple enough already so the options aren't really needed.

Should resolve #5809.