### PR TITLE
Fix country mismatch in inactive user test

### DIFF
--- a/tests/Controllers/SessionsControllerTest.php
+++ b/tests/Controllers/SessionsControllerTest.php
@@ -5,6 +5,7 @@
 
 namespace Tests\Controllers;
 
+use App\Models\Country;
 use App\Models\LoginAttempt;
 use App\Models\User;
 use Tests\TestCase;
@@ -27,12 +28,15 @@ class SessionsControllerTest extends TestCase
     public function testLoginInactiveUser()
     {
         $password = 'password1';
-        $user = factory(User::class)->create(compact('password'));
+        $countryAcronym = (Country::first() ?? factory(Country::class)->create())->getKey();
+        $user = factory(User::class)->create(['password' => $password, 'country_acronym' => $countryAcronym]);
         $user->update(['user_lastvisit' => now()->subDays(config('osu.user.inactive_days_verification') + 1)]);
 
         $this->post(route('login'), [
             'username' => $user->username,
             'password' => $password,
+        ], [
+            'CF_IPCOUNTRY' => $countryAcronym,
         ])->assertSuccessful();
 
         $this->assertAuthenticated();


### PR DESCRIPTION
In `SessionsControllerTest::testLoginInactiveUser` the created user has random country but ForceReactivation class detects the request country as `null`. Null obviously doesn't match with the user's country and it redirects to password reset page so the test fails.

If you need to test if the created user has the same country as the request, there should be a new testcase for that.

How on earth does this test pass on your setups?

_I run tests from inside of the container with `bin/phpunit -d memory_limit=-1`_