### PR TITLE
Prevent language/genre Any from being set

### DIFF
--- a/app/Models/Beatmapset.php
+++ b/app/Models/Beatmapset.php
@@ -1172,12 +1172,12 @@ class Beatmapset extends Model implements AfterCommit, Commentable
     {
         $this->validationErrors()->reset();
 
-        if ($this->isDirty('language_id') && $this->language === null) {
-            $this->validationErrors()->add('language_id', '.invalid');
+        if ($this->isDirty('language_id') && ($this->language === null || $this->language_id === 0)) {
+            $this->validationErrors()->add('language_id', 'invalid');
         }
 
-        if ($this->isDirty('genre_id') && $this->genre === null) {
-            $this->validationErrors()->add('genre_id', '.invalid');
+        if ($this->isDirty('genre_id') && ($this->genre === null || $this->genre_id === 0)) {
+            $this->validationErrors()->add('genre_id', 'invalid');
         }
 
         return $this->validationErrors()->isEmpty();

--- a/resources/assets/lib/beatmapsets-show/metadata-editor.tsx
+++ b/resources/assets/lib/beatmapsets-show/metadata-editor.tsx
@@ -48,12 +48,10 @@ export default class MetadataEditor extends React.PureComponent<Props, State> {
               onChange={this.setLanguageId}
             >
               {this.languages.map((language) => (
-                <option
-                  key={language.id ?? 0}
-                  value={language.id ?? 0}
-                >
-                  {language.name}
-                </option>
+                language.id === null ? null :
+                  <option key={language.id} value={language.id}>
+                    {language.name}
+                  </option>
               ))}
             </select>
           </div>
@@ -72,12 +70,10 @@ export default class MetadataEditor extends React.PureComponent<Props, State> {
               onChange={this.setGenreId}
             >
               {this.genres.map((genre) => (
-                <option
-                  key={genre.id ?? 0}
-                  value={genre.id ?? 0}
-                >
-                  {genre.name}
-                </option>
+                genre.id === null ? null :
+                  <option key={genre.id} value={genre.id}>
+                    {genre.name}
+                  </option>
               ))}
             </select>
           </div>

--- a/resources/lang/en/model_validation.php
+++ b/resources/lang/en/model_validation.php
@@ -4,6 +4,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 return [
+    'invalid' => 'Invalid :attribute specified.',
     'not_negative' => ':attribute cannot be negative.',
     'required' => ':attribute is required.',
     'too_long' => ':attribute exceeded maximum length - can only be up to :limit characters.',


### PR DESCRIPTION
Resolves #5850.

I was thinking adding column like `settable` to indicate whether it can be used for beatmapset but I couldn't find a good name so it's id-based for now. Id 0 is kind of special already so it should be fine...? 🤷‍♂ 

Also fixed validation message.