### PR TITLE
Add _lio endpoint for indexing beatmapsets

### DIFF
--- a/app/Http/Controllers/LegacyInterOpController.php
+++ b/app/Http/Controllers/LegacyInterOpController.php
@@ -32,20 +32,6 @@ class LegacyInterOpController extends Controller
 {
     use DispatchesJobs;
 
-    public function indexBeatmapset($id)
-    {
-        $beatmapset = Beatmapset::withTrashed()->findOrFail($id);
-
-        if (!$beatmapset->trashed()) {
-            $job = (new RegenerateBeatmapsetCover($beatmapset))->onQueue('beatmap_default');
-            $this->dispatch($job);
-        }
-
-        dispatch(new EsIndexDocument($beatmapset));
-
-        return response(null, 204);
-    }
-
     public function generateNotification()
     {
         $params = request()->all();
@@ -66,6 +52,20 @@ class LegacyInterOpController extends Controller
 
             return response(null, 204);
         }
+    }
+
+    public function indexBeatmapset($id)
+    {
+        $beatmapset = Beatmapset::withTrashed()->findOrFail($id);
+
+        if (!$beatmapset->trashed()) {
+            $job = (new RegenerateBeatmapsetCover($beatmapset))->onQueue('beatmap_default');
+            $this->dispatch($job);
+        }
+
+        dispatch(new EsIndexDocument($beatmapset));
+
+        return response(null, 204);
     }
 
     public function news()

--- a/app/Http/Controllers/LegacyInterOpController.php
+++ b/app/Http/Controllers/LegacyInterOpController.php
@@ -43,7 +43,7 @@ class LegacyInterOpController extends Controller
 
         dispatch(new EsIndexDocument($beatmapset));
 
-        return ['success' => true];
+        return response(null, 204);
     }
 
     public function generateNotification()

--- a/app/Http/Controllers/LegacyInterOpController.php
+++ b/app/Http/Controllers/LegacyInterOpController.php
@@ -32,12 +32,16 @@ class LegacyInterOpController extends Controller
 {
     use DispatchesJobs;
 
-    public function regenerateBeatmapsetCovers($id)
+    public function indexBeatmapset($id)
     {
-        $beatmapset = Beatmapset::findOrFail($id);
+        $beatmapset = Beatmapset::withTrashed()->findOrFail($id);
 
-        $job = (new RegenerateBeatmapsetCover($beatmapset))->onQueue('beatmap_default');
-        $this->dispatch($job);
+        if (!$beatmapset->trashed()) {
+            $job = (new RegenerateBeatmapsetCover($beatmapset))->onQueue('beatmap_default');
+            $this->dispatch($job);
+        }
+
+        dispatch(new EsIndexDocument($beatmapset));
 
         return ['success' => true];
     }

--- a/routes/web.php
+++ b/routes/web.php
@@ -414,8 +414,8 @@ Route::group(['as' => 'api.', 'prefix' => 'api', 'middleware' => ['auth-custom-a
 // Callbacks for legacy systems to interact with
 Route::group(['prefix' => '_lio', 'middleware' => 'lio'], function () {
     Route::post('generate-notification', 'LegacyInterOpController@generateNotification');
+    Route::post('index-beatmapset/{beatmapset}', 'LegacyInterOpController@indexBeatmapset');
     Route::post('/refresh-beatmapset-cache/{beatmapset}', 'LegacyInterOpController@refreshBeatmapsetCache');
-    Route::post('/regenerate-beatmapset-covers/{beatmapset}', 'LegacyInterOpController@regenerateBeatmapsetCovers');
     Route::post('user-achievement/{user}/{achievement}/{beatmap?}', 'LegacyInterOpController@userAchievement')->name('lio.user-achievement');
     Route::post('/user-best-scores-check/{user}', 'LegacyInterOpController@userBestScoresCheck');
     Route::post('user-send-message', 'LegacyInterOpController@userSendMessage');


### PR DESCRIPTION
- regenerating covers now also indexes, `regenerate-beatmapset-covers/{beatmapset}` renamed to `index-beatmapset/{beatmapset}`
- deletes from index if soft-deleted
- [x] calls to `regenerate-beatmapset-covers` should be updated to call `index-beatmapset` instead