### PR TITLE
Fix wrong profile customisation being used in transformer

### DIFF
--- a/app/Transformers/UserCompactTransformer.php
+++ b/app/Transformers/UserCompactTransformer.php
@@ -63,7 +63,7 @@ class UserCompactTransformer extends TransformerAbstract
         'is_restricted' => 'IsNotOAuth',
     ];
 
-    protected $userProfileCustomization;
+    protected $userProfileCustomization = [];
 
     public function transform(User $user)
     {
@@ -326,10 +326,10 @@ class UserCompactTransformer extends TransformerAbstract
 
     protected function userProfileCustomization(User $user): UserProfileCustomization
     {
-        if (!isset($this->userProfileCustomization)) {
-            $this->userProfileCustomization = $user->userProfileCustomization ?? $user->userProfileCustomization()->make();
+        if (!isset($this->userProfileCustomization[$user->getKey()])) {
+            $this->userProfileCustomization[$user->getKey()] = $user->userProfileCustomization ?? $user->userProfileCustomization()->make();
         }
 
-        return $this->userProfileCustomization;
+        return $this->userProfileCustomization[$user->getKey()];
     }
 }


### PR DESCRIPTION
I felt like I forgotten a case when looking at storing that instance variable. And it's this one.

Resolves #5866.