### PR TITLE
Clarify docs for oauth/token parameters

### DIFF
--- a/resources/views/vendor/apidoc/partials/info.blade.php
+++ b/resources/views/vendor/apidoc/partials/info.blade.php
@@ -124,7 +124,7 @@ fetch("{!! route('oauth.passport.token') !!}", {
 
 `POST {!! route('oauth.passport.token') !!}`
 
-Parameters
+Form-data parameters passed in the request body:
 
 Name          | Type   | Description
 --------------|--------|-------------------------------


### PR DESCRIPTION
Clarify that required parameters should be passed in request body not as params in url
Resolves #5872