### PR TITLE
Add per-route throttling

### DIFF
--- a/app/Http/Controllers/PasswordResetController.php
+++ b/app/Http/Controllers/PasswordResetController.php
@@ -21,6 +21,7 @@ class PasswordResetController extends Controller
 
         $this->middleware('guest');
         $this->middleware('throttle:60,10');
+        $this->middleware('throttle-route:20,1440', ['only' => 'create']);
     }
 
     public function destroy()

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -53,6 +53,7 @@ class Kernel extends HttpKernel
         'guest' => Middleware\RedirectIfAuthenticated::class,
         'require-scopes' => Middleware\RequireScopes::class,
         'throttle' => \Illuminate\Routing\Middleware\ThrottleRequests::class,
+        'throttle-route' => \App\Libraries\ThrottleRouteRequests::class,
         'verify-user' => Middleware\VerifyUser::class,
     ];
 }

--- a/app/Libraries/ThrottleRouteRequests.php
+++ b/app/Libraries/ThrottleRouteRequests.php
@@ -1,0 +1,35 @@
+<?php
+
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
+namespace App\Libraries;
+
+use Illuminate\Routing\Middleware\ThrottleRequests;
+use RuntimeException;
+use Symfony\Component\HttpFoundation\Response;
+
+class ThrottleRouteRequests extends ThrottleRequests
+{
+    /**
+     * Overriden to skip adding the headers for now.
+     */
+    protected function addHeaders(Response $response, $maxAttempts, $remainingAttempts, $retryAfter = null)
+    {
+        return $response;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function resolveRequestSignature($request)
+    {
+        $userId = optional($request->user())->getAuthIdentifier() ?? $request->ip();
+
+        if ($route = $request->route()) {
+            return sha1($userId.'|'.$route->getDomain().'|'.$request->path());
+        }
+
+        throw new RuntimeException('Unable to generate the request signature. Route unavailable.');
+    }
+}

--- a/app/Libraries/ThrottleRouteRequests.php
+++ b/app/Libraries/ThrottleRouteRequests.php
@@ -27,7 +27,7 @@ class ThrottleRouteRequests extends ThrottleRequests
         $userId = optional($request->user())->getAuthIdentifier() ?? $request->ip();
 
         if ($route = $request->route()) {
-            return sha1($userId.'|'.$route->getDomain().'|'.$request->path());
+            return sha1($userId.'|'.$route->getDomain().'|'.$request->method().'|'.$request->path());
         }
 
         throw new RuntimeException('Unable to generate the request signature. Route unavailable.');


### PR DESCRIPTION
Just simple per-path for now, actual ~~per-group~~ and multi-level decay can come later since that involves overriding more things.

The decay time can't be changed until the previous timer expires.

per-group configuration throttling doesn't actually seem possible in a rational manner with the way middleware and routing works in laravel...