### PR TITLE
Include beatmap favourite count in search scoring

### DIFF
--- a/app/Libraries/Elasticsearch/FunctionScore.php
+++ b/app/Libraries/Elasticsearch/FunctionScore.php
@@ -1,0 +1,49 @@
+<?php
+
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
+namespace App\Libraries\Elasticsearch;
+
+class FunctionScore implements Queryable
+{
+    private $boostMode = 'multiply';
+    private $functions = [];
+    private $query;
+
+    /**
+     * @param array|Queryable $query
+     */
+    public function __construct($query)
+    {
+        $this->query = $query;
+    }
+
+    public function applyFunction(array $function): self
+    {
+        $this->functions[] = $function;
+
+        return $this;
+    }
+
+    public function boostMode(string $boostMode): self
+    {
+        $this->boostMode = $boostMode;
+
+        return $this;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function toArray(): array
+    {
+        return [
+            'function_score' => [
+                'boost_mode' => $this->boostMode,
+                'functions' => $this->functions,
+                'query' => QueryHelper::clauseToArray($this->query),
+            ],
+        ];
+    }
+}

--- a/app/Libraries/Search/BeatmapsetSearch.php
+++ b/app/Libraries/Search/BeatmapsetSearch.php
@@ -78,10 +78,10 @@ class BeatmapsetSearch extends RecordSearch
                 ->applyFunction([
                     'field_value_factor' => [
                         'field' => 'favourite_count',
+                        'missing' => 0,
                         'modifier' => 'ln1p',
                     ],
-                ])
-                ->boostMode('avg');
+                ]);
         }
 
         return $query;

--- a/app/Libraries/Search/BeatmapsetSearch.php
+++ b/app/Libraries/Search/BeatmapsetSearch.php
@@ -6,6 +6,7 @@
 namespace App\Libraries\Search;
 
 use App\Libraries\Elasticsearch\BoolQuery;
+use App\Libraries\Elasticsearch\FunctionScore;
 use App\Libraries\Elasticsearch\QueryHelper;
 use App\Libraries\Elasticsearch\RecordSearch;
 use App\Models\Beatmap;
@@ -71,6 +72,17 @@ class BeatmapsetSearch extends RecordSearch
                 'query' => $nested->toArray(),
             ],
         ]);
+
+        if (present($this->params->queryString)) {
+            $query = (new FunctionScore($query))
+                ->applyFunction([
+                    'field_value_factor' => [
+                        'field' => 'favourite_count',
+                        'modifier' => 'ln1p',
+                    ],
+                ])
+                ->boostMode('avg');
+        }
 
         return $query;
     }


### PR DESCRIPTION
closes #5681

I was going to include `play_count` into the scoring as well, but that doesn't get updated in the index since we stopped doing a full reindex

There looks like a more suitable `rank_feature` type in elasticsearch 7 for handling this, but other changes need to be done before we can move to it.