### PR TITLE
Add cutoff for showing relative time in beatmap info

### DIFF
--- a/app/helpers.php
+++ b/app/helpers.php
@@ -756,7 +756,7 @@ function timeago($date)
     $display_date = i18n_time($date);
     $attribute_date = json_time($date);
 
-    return "<time class='js-timeago timeago' datetime='{$attribute_date}'>{$display_date}</time>";
+    return "<time class='js-timeago' datetime='{$attribute_date}'>{$display_date}</time>";
 }
 
 function link_to_user($id, $username = null, $color = null, $classNames = null)

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -756,7 +756,7 @@ function timeago($date)
     $display_date = i18n_time($date);
     $attribute_date = json_time($date);
 
-    return "<time class='timeago' datetime='{$attribute_date}'>{$display_date}</time>";
+    return "<time class='js-timeago timeago' datetime='{$attribute_date}'>{$display_date}</time>";
 }
 
 function link_to_user($id, $username = null, $color = null, $classNames = null)

--- a/resources/assets/coffee/_classes/timeago.coffee
+++ b/resources/assets/coffee/_classes/timeago.coffee
@@ -9,9 +9,9 @@ class @Timeago
 
       mutations.forEach (mutation) ->
         $nodes = $(mutation.addedNodes)
-        $nodes.find('.timeago').add($nodes.filter('.timeago')).timeago()
+        $nodes.find('.js-timeago').add($nodes.filter('.js-timeago')).timeago()
 
 
     $(document).on 'turbolinks:load', =>
-      $('.timeago').timeago()
+      $('.js-timeago').timeago()
       @observer.observe document.body, childList: true, subtree: true

--- a/resources/assets/coffee/_classes/tooltip-default.coffee
+++ b/resources/assets/coffee/_classes/tooltip-default.coffee
@@ -16,7 +16,7 @@ class @TooltipDefault
 
     return if _.size(title) == 0
 
-    isTime = el.classList.contains('timeago') || el.classList.contains('js-tooltip-time')
+    isTime = el.classList.contains('js-timeago') || el.classList.contains('js-tooltip-time')
 
     $content =
       if isTime

--- a/resources/assets/coffee/osu_common.coffee
+++ b/resources/assets/coffee/osu_common.coffee
@@ -174,7 +174,7 @@
 
   timeago: (time) ->
     el = document.createElement('time')
-    el.classList.add 'timeago'
+    el.classList.add 'js-timeago', 'timeago'
     el.setAttribute 'datetime', time
     el.textContent = time
     el.outerHTML

--- a/resources/assets/coffee/osu_common.coffee
+++ b/resources/assets/coffee/osu_common.coffee
@@ -174,7 +174,7 @@
 
   timeago: (time) ->
     el = document.createElement('time')
-    el.classList.add 'js-timeago', 'timeago'
+    el.classList.add 'js-timeago'
     el.setAttribute 'datetime', time
     el.textContent = time
     el.outerHTML

--- a/resources/assets/coffee/react/_components/beatmapset-mapping.coffee
+++ b/resources/assets/coffee/react/_components/beatmapset-mapping.coffee
@@ -3,6 +3,8 @@
 
 import * as React from 'react'
 import { div, span, a, time } from 'react-dom-factories'
+import { StringWithComponent } from 'string-with-component'
+import TimeWithTooltip from 'time-with-tooltip'
 el = React.createElement
 
 bn = 'beatmapset-mapping'
@@ -43,9 +45,14 @@ export class BeatmapsetMapping extends React.PureComponent
   renderDate: (key, attribute) =>
     div
       className: "#{bn}__date"
-      dangerouslySetInnerHTML: __html:
-        osu.trans "beatmapsets.show.details_date.#{key}",
-          timeago: osu.timeago(@props.beatmapset[attribute])
+      el StringWithComponent,
+        pattern: osu.trans "beatmapsets.show.details_date.#{key}"
+        mappings:
+          ':timeago':
+            TimeWithTooltip
+              dateTime: @props.beatmapset[attribute]
+              key: 'timeago'
+              relative: true
 
 
   userLink: (user) ->

--- a/resources/assets/coffee/react/_components/beatmapset-mapping.coffee
+++ b/resources/assets/coffee/react/_components/beatmapset-mapping.coffee
@@ -2,7 +2,7 @@
 # See the LICENCE file in the repository root for full licence text.
 
 import * as React from 'react'
-import { div, span, a, time } from 'react-dom-factories'
+import { a, div, span, strong, time } from 'react-dom-factories'
 import { StringWithComponent } from 'string-with-component'
 import TimeWithTooltip from 'time-with-tooltip'
 el = React.createElement
@@ -43,16 +43,16 @@ export class BeatmapsetMapping extends React.PureComponent
 
 
   renderDate: (key, attribute) =>
-    div
-      className: "#{bn}__date"
+    div null,
       el StringWithComponent,
         pattern: osu.trans "beatmapsets.show.details_date.#{key}"
         mappings:
           ':timeago':
-            TimeWithTooltip
-              dateTime: @props.beatmapset[attribute]
-              key: 'timeago'
-              relative: Math.abs(moment().diff(moment(@props.beatmapset[attribute]), 'weeks')) < 4
+            strong null,
+              el TimeWithTooltip,
+                dateTime: @props.beatmapset[attribute]
+                key: 'timeago'
+                relative: Math.abs(moment().diff(moment(@props.beatmapset[attribute]), 'weeks')) < 4
 
 
   userLink: (user) ->

--- a/resources/assets/coffee/react/_components/beatmapset-mapping.coffee
+++ b/resources/assets/coffee/react/_components/beatmapset-mapping.coffee
@@ -52,7 +52,7 @@ export class BeatmapsetMapping extends React.PureComponent
             TimeWithTooltip
               dateTime: @props.beatmapset[attribute]
               key: 'timeago'
-              relative: true
+              relative: Math.abs(moment().diff(moment(@props.beatmapset[attribute]), 'weeks')) < 4
 
 
   userLink: (user) ->

--- a/resources/assets/less/bem/beatmapset-mapping.less
+++ b/resources/assets/less/bem/beatmapset-mapping.less
@@ -14,12 +14,6 @@
     justify-content: center;
   }
 
-  &__date {
-    .timeago {
-      font-weight: 700;
-    }
-  }
-
   &__mapper {
     margin-bottom: 5px;
   }

--- a/resources/assets/lib/time-with-tooltip.tsx
+++ b/resources/assets/lib/time-with-tooltip.tsx
@@ -4,9 +4,21 @@
 import * as moment from 'moment';
 import * as React from 'react';
 
-export default function TimeWithTooltip({ dateTime, format }: { dateTime: string, format?: string }) {
-  if (format == null) {
-    format = 'll';
+interface Props {
+  dateTime: string;
+  format: string;
+  relative: boolean;
+}
+
+export default function TimeWithTooltip(props: Props) {
+  const { dateTime, format = 'll', relative = false } = props;
+
+  if (relative) {
+    return (
+      <time className='timeago' dateTime={dateTime}>
+        {dateTime}
+      </time>
+    );
   }
 
   return (

--- a/resources/assets/lib/time-with-tooltip.tsx
+++ b/resources/assets/lib/time-with-tooltip.tsx
@@ -12,17 +12,10 @@ interface Props {
 
 export default function TimeWithTooltip(props: Props) {
   const { dateTime, format = 'll', relative = false } = props;
-
-  if (relative) {
-    return (
-      <time className='js-timeago timeago' dateTime={dateTime}>
-        {dateTime}
-      </time>
-    );
-  }
+  const className = relative ? 'js-timeago' : 'js-tooltip-time';
 
   return (
-    <time className='js-tooltip-time timeago' dateTime={dateTime} title={dateTime}>
+    <time className={`${className} timeago`} dateTime={dateTime} title={dateTime}>
       {moment(dateTime).format(format)}
     </time>
   );

--- a/resources/assets/lib/time-with-tooltip.tsx
+++ b/resources/assets/lib/time-with-tooltip.tsx
@@ -16,7 +16,7 @@ export default function TimeWithTooltip(props: Props) {
   const className = relative ? 'js-timeago' : 'js-tooltip-time';
 
   return (
-    <time className={`${className} timeago`} title={props.dateTime} {...otherProps}>
+    <time className={className} title={props.dateTime} {...otherProps}>
       {moment(props.dateTime).format(format)}
     </time>
   );

--- a/resources/assets/lib/time-with-tooltip.tsx
+++ b/resources/assets/lib/time-with-tooltip.tsx
@@ -7,16 +7,17 @@ import * as React from 'react';
 interface Props {
   dateTime: string;
   format: string;
+  key?: string;
   relative: boolean;
 }
 
 export default function TimeWithTooltip(props: Props) {
-  const { dateTime, format = 'll', relative = false } = props;
+  const { format = 'll', relative = false, ...otherProps } = props;
   const className = relative ? 'js-timeago' : 'js-tooltip-time';
 
   return (
-    <time className={`${className} timeago`} dateTime={dateTime} title={dateTime}>
-      {moment(dateTime).format(format)}
+    <time className={`${className} timeago`} title={props.dateTime} {...otherProps}>
+      {moment(props.dateTime).format(format)}
     </time>
   );
 }

--- a/resources/assets/lib/time-with-tooltip.tsx
+++ b/resources/assets/lib/time-with-tooltip.tsx
@@ -15,14 +15,14 @@ export default function TimeWithTooltip(props: Props) {
 
   if (relative) {
     return (
-      <time className='timeago' dateTime={dateTime}>
+      <time className='js-timeago timeago' dateTime={dateTime}>
         {dateTime}
       </time>
     );
   }
 
   return (
-    <time className='js-tooltip-time' dateTime={dateTime} title={dateTime}>
+    <time className='js-tooltip-time timeago' dateTime={dateTime} title={dateTime}>
       {moment(dateTime).format(format)}
     </time>
   );


### PR DESCRIPTION
- cuts off at 4 weeks
- add `timeago` support to `TimeWithTooltip`
- switch to react component for rendering

closes #5682