### PR TITLE
Don't send global notification for new problem on qualified map if it also disqualifies

### DIFF
--- a/app/Http/Controllers/BeatmapDiscussionPostsController.php
+++ b/app/Http/Controllers/BeatmapDiscussionPostsController.php
@@ -137,7 +137,7 @@ class BeatmapDiscussionPostsController extends Controller
 
         $notifyQualifiedProblem = false;
 
-        if ($discussion->beatmapset->isQualified() && $discussion->message_type === 'problem') {
+        if (!$disqualify && $discussion->beatmapset->isQualified() && $discussion->message_type === 'problem') {
             $openProblems = $discussion
                 ->beatmapset
                 ->beatmapDiscussions()

--- a/tests/Controllers/BeatmapDiscussionPostsControllerTest.php
+++ b/tests/Controllers/BeatmapDiscussionPostsControllerTest.php
@@ -780,8 +780,8 @@ class BeatmapDiscussionPostsControllerTest extends TestCase
         return [
             [
                 'bng',
-                [Notification::BEATMAPSET_DISQUALIFY, Notification::BEATMAPSET_DISCUSSION_POST_NEW, Notification::BEATMAPSET_DISCUSSION_QUALIFIED_PROBLEM],
-                [],
+                [Notification::BEATMAPSET_DISQUALIFY, Notification::BEATMAPSET_DISCUSSION_POST_NEW],
+                [Notification::BEATMAPSET_DISCUSSION_QUALIFIED_PROBLEM],
             ],
             [
                 null,


### PR DESCRIPTION
Resolves #5184.

As mentioned in the issue, there's nothing to check for BNGs if the post also disqualifies the map.