### PR TITLE
Adjust height of profile page detail bar

### DIFF
--- a/resources/assets/less/bem/profile-detail-bar.less
+++ b/resources/assets/less/bem/profile-detail-bar.less
@@ -12,6 +12,7 @@
 
   @media @desktop {
     padding: 10px @gutter-profile-page-desktop;
+    height: 60px;
   }
 
   &__column {
@@ -25,10 +26,7 @@
       margin: -5px;
       padding: 0;
       flex-wrap: nowrap;
-    }
-
-    &--left {
-      align-self: stretch;
+      height: calc(100% + ($margin * -2));
     }
 
     &--right {


### PR DESCRIPTION
Resolves #5713.

...except not really. The original reported bug has been (accidentally) fixed in #5653.

This PR further fixes the height change that occurs when toggling rank detail view due to one of the bar contents being slightly taller than expected. That pushes the entire container height when it's rendered, resulting in the buttons being moved around.


and resolves #5775