### PR TITLE
Change Uploadable to use file streams for uploads

### DIFF
--- a/app/Http/Controllers/ContestEntriesController.php
+++ b/app/Http/Controllers/ContestEntriesController.php
@@ -44,16 +44,16 @@ class ContestEntriesController extends Controller
                 $allowedExtensions[] = 'jpg';
                 $allowedExtensions[] = 'jpeg';
                 $allowedExtensions[] = 'png';
-                $maxFilesize = 4000000;
+                $maxFilesize = 8 * 1024 * 1024;
                 break;
             case 'beatmap':
                 $allowedExtensions[] = 'osu';
                 $allowedExtensions[] = 'osz';
-                $maxFilesize = 20000000;
+                $maxFilesize = 32 * 1024 * 1024;
                 break;
             case 'music':
                 $allowedExtensions[] = 'mp3';
-                $maxFilesize = 15000000;
+                $maxFilesize = 16 * 1024 * 1024;
                 break;
         }
 

--- a/app/Traits/Uploadable.php
+++ b/app/Traits/Uploadable.php
@@ -6,6 +6,7 @@
 namespace App\Traits;
 
 use App\Libraries\StorageWithUrl;
+use Illuminate\Http\File;
 
 trait Uploadable
 {
@@ -117,6 +118,6 @@ trait Uploadable
             'ext' => $fileExtension,
         ]);
 
-        $this->storage()->put($this->filePath(), file_get_contents($filePath));
+        $this->storage()->putFileAs($this->fileDir(), new File($filePath), $this->fileName());
     }
 }

--- a/resources/assets/coffee/react/contest-entry/uploader.coffee
+++ b/resources/assets/coffee/react/contest-entry/uploader.coffee
@@ -19,15 +19,15 @@ export class Uploader extends React.Component
     switch @props.contest.type
       when 'art'
         allowedExtensions = ['.jpg', '.jpeg', '.png']
-        maxSize = 4000000
+        maxSize = 8*1024*1024
 
       when 'beatmap'
         allowedExtensions = ['.osu', '.osz']
-        maxSize = 20000000
+        maxSize = 32*1024*1024
 
       when 'music'
         allowedExtensions = ['.mp3']
-        maxSize = 15000000
+        maxSize = 16*1024*1024
 
 
     $dropzone = $('.js-contest-entry-upload--dropzone')


### PR DESCRIPTION
PHP was running out of memory while checking the mimetype of uploaded files (see: OSU-WEB-7B1 on sentry)

This should fix that (reference: https://laravel.com/docs/6.x/filesystem#storing-files).

One side effect will probably be that mimetypes are detected via file extension instead of file content, but that's probably... acceptable? 🤷‍♂️

(also bumps up the size limits for contest entries)