### PR TITLE
Fix beatmaps search relevancy score weighting

### DIFF
--- a/app/Libraries/Search/BeatmapsetSearch.php
+++ b/app/Libraries/Search/BeatmapsetSearch.php
@@ -79,7 +79,7 @@ class BeatmapsetSearch extends RecordSearch
                     'field_value_factor' => [
                         'field' => 'favourite_count',
                         'missing' => 0,
-                        'modifier' => 'ln1p',
+                        'modifier' => 'ln2p',
                     ],
                 ]);
         }


### PR DESCRIPTION
0 favorites shouldn't cause the relevancy score to be 0.

Found this when checking for #5956 but I'm not sure if this alone will fix the issue.