### PR TITLE
Match the header menu items colours with the sections colours

### DIFF
--- a/app/helpers.php
+++ b/app/helpers.php
@@ -1564,7 +1564,7 @@ function section_to_hue_map($section): int
         'blue' => 200,
         'darkorange' => 20,
         'green' => 115,
-        'orange' => 46,
+        'orange' => 45,
         'pink' => 333,
         'purple' => 255,
         'red' => 0,

--- a/resources/assets/less/colors.less
+++ b/resources/assets/less/colors.less
@@ -132,6 +132,11 @@
 @osu-colour-red-1: hsl(@osu-colour-red-hue, 100%, 70%);
 @osu-colour-red-2: hsl(@osu-colour-red-hue, 80%, 60%);
 @osu-colour-red-3: hsl(@osu-colour-red-hue, 60%, 50%);
+// Darkorange
+@osu-colour-darkorange-hue: 20;
+@osu-colour-darkorange-1: hsl(@osu-colour-darkorange-hue, 100%, 70%);
+@osu-colour-darkorange-2: hsl(@osu-colour-darkorange-hue, 80%, 60%);
+@osu-colour-darkorange-3: hsl(@osu-colour-darkorange-hue, 60%, 50%);
 
 @pink-text: @pink-dark;
 @green-text: @green-darker;

--- a/resources/assets/less/sections.less
+++ b/resources/assets/less/sections.less
@@ -36,15 +36,16 @@
   background-color: @osu-colour-h2;
 }
 
-.menu-colour(beatmaps, blue);
-.menu-colour(beatmapsets, blue);
-.menu-colour(community, pink);
-.menu-colour(error, pink);
-.menu-colour(help, yellow);
-.menu-colour(home, purple);
-.menu-colour(multiplayer, pink);
-.menu-colour(rankings, green);
-.menu-colour(store, pink);
+.menu-colour(beatmaps, osu-colour-blue-1);
+.menu-colour(beatmapsets, osu-colour-blue-1);
+.menu-colour(community, osu-colour-pink-1);
+.menu-colour(error, osu-colour-pink-1);
+.menu-colour(help, osu-colour-orange-1);
+.menu-colour(home, osu-colour-purple-1);
+.menu-colour(multiplayer, osu-colour-pink-1);
+.menu-colour(rankings, osu-colour-green-1);
+.menu-colour(store, osu-colour-darkorange-1);
+
 
 .menu-colour(@section, @colour) {
   .u-section-@{section}--before-bg-normal {


### PR DESCRIPTION
Maps the menu colours to the same ones as in the `section_to_hue_map` function.

`darkorange` was only defined in the `$colourToHue` array and found no mention of it in the Colour Palette, but I added it in `colors.less` ; was it the right thing to do?

Resolve #5984.