### PR TITLE
Fix slow beatmap events listing

### DIFF
--- a/app/Libraries/ModdingHistoryEventsBundle.php
+++ b/app/Libraries/ModdingHistoryEventsBundle.php
@@ -25,7 +25,7 @@ class ModdingHistoryEventsBundle
     private $params;
     private $total;
     private $user;
-    private $withExtras = false;
+    private $withExtras = false; // TODO: change to includes list instead.
 
     public static function forProfile(User $user, array $searchParams)
     {
@@ -82,11 +82,6 @@ class ModdingHistoryEventsBundle
     {
         return $this->memoize(__FUNCTION__, function () {
             $array = [
-                'discussions' => json_collection(
-                    $this->getDiscussions(),
-                    'BeatmapDiscussion',
-                    ['starting_post', 'beatmap', 'beatmapset', 'current_user_attributes']
-                ),
                 'events' => json_collection(
                     $this->getEvents(),
                     'BeatmapsetEvent',
@@ -100,6 +95,12 @@ class ModdingHistoryEventsBundle
             ];
 
             if ($this->withExtras) {
+                $array['discussions'] = json_collection(
+                    $this->getDiscussions(),
+                    'BeatmapDiscussion',
+                    ['starting_post', 'beatmap', 'beatmapset', 'current_user_attributes']
+                );
+
                 $array['posts'] = json_collection(
                     $this->getPosts(),
                     'BeatmapDiscussionPost',
@@ -169,6 +170,10 @@ class ModdingHistoryEventsBundle
                 'beatmapset',
                 'startingPost',
             ];
+
+            if (!$this->withExtras) {
+                return collect();
+            }
 
             $parents = BeatmapDiscussion::search($this->searchParams);
             $parents['query']->with($includes);

--- a/app/Libraries/ModdingHistoryEventsBundle.php
+++ b/app/Libraries/ModdingHistoryEventsBundle.php
@@ -92,11 +92,6 @@ class ModdingHistoryEventsBundle
                     'BeatmapsetEvent',
                     ['discussion.starting_post', 'beatmapset.user']
                 ),
-                'posts' => json_collection(
-                    $this->getPosts(),
-                    'BeatmapDiscussionPost',
-                    ['beatmap_discussion.beatmapset']
-                ),
                 'users' => json_collection(
                     $this->getUsers(),
                     'UserCompact',
@@ -105,7 +100,14 @@ class ModdingHistoryEventsBundle
             ];
 
             if ($this->withExtras) {
+                $array['posts'] = json_collection(
+                    $this->getPosts(),
+                    'BeatmapDiscussionPost',
+                    ['beatmap_discussion.beatmapset']
+                );
+
                 $array['votes'] = $this->getVotes();
+
                 $kudosu = $this->user
                     ->receivedKudosu()
                     ->with('post', 'post.topic', 'giver')

--- a/app/Libraries/ModdingHistoryEventsBundle.php
+++ b/app/Libraries/ModdingHistoryEventsBundle.php
@@ -244,8 +244,14 @@ class ModdingHistoryEventsBundle
         return $this->memoize(__FUNCTION__, function () {
             $discussions = $this->getDiscussions();
             $events = $this->getEvents();
-            $posts = $this->getPosts();
-            $votes = $this->getVotes();
+
+            if ($this->withExtras) {
+                $posts = $this->getPosts();
+                $votes = $this->getVotes();
+            } else {
+                $posts = collect();
+                $votes = [];
+            }
 
             $userIds = [];
             foreach ($discussions as $discussion) {

--- a/app/Libraries/ModdingHistoryEventsBundle.php
+++ b/app/Libraries/ModdingHistoryEventsBundle.php
@@ -46,6 +46,8 @@ class ModdingHistoryEventsBundle
         $obj->isModerator = priv_check('BeatmapDiscussionModerate')->can();
         $obj->isKudosuModerator = priv_check('BeatmapDiscussionAllowOrDenyKudosu')->can();
 
+        $obj->searchParams['is_moderator'] = $obj->isModerator;
+
         if (!$obj->isModerator) {
             $obj->searchParams['with_deleted'] = false;
         }

--- a/app/Libraries/ModdingHistoryEventsBundle.php
+++ b/app/Libraries/ModdingHistoryEventsBundle.php
@@ -207,11 +207,13 @@ class ModdingHistoryEventsBundle
     {
         return $this->memoize(__FUNCTION__, function () {
             $events = BeatmapsetEvent::search($this->searchParams);
+            // beatmapset has global scopes with deleted_at and active but these are not indexed,
+            // which makes whereHas('beatmapset') unusable.
             $events['query'] = $events['query']->with([
                 'beatmapset.user',
                 'beatmapDiscussion.beatmapset',
                 'beatmapDiscussion.startingPost',
-            ])->whereHas('beatmapset');
+            ]);
 
             if ($this->isModerator) {
                 $events['query']->with(['beatmapset' => function ($query) {

--- a/app/Models/BeatmapsetEvent.php
+++ b/app/Models/BeatmapsetEvent.php
@@ -234,6 +234,7 @@ class BeatmapsetEvent extends Model
 
     public function beatmapset()
     {
+        // FIXME: consistency with BeatmapDiscussion which includes deleted.
         return $this->belongsTo(Beatmapset::class, 'beatmapset_id');
     }
 

--- a/resources/assets/coffee/react/modding-profile/events.coffee
+++ b/resources/assets/coffee/react/modding-profile/events.coffee
@@ -1,7 +1,7 @@
 # Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 # See the LICENCE file in the repository root for full licence text.
 
-import Event from 'beatmap-discussions/event'
+import DiscussionEvents from 'beatmap-discussions/events'
 import * as React from 'react'
 import { div, h2, a, img } from 'react-dom-factories'
 el = React.createElement
@@ -16,15 +16,10 @@ export class Events extends React.Component
         else
           div className: 'beatmapset-events beatmapset-events--profile',
             [
-              for event in @props.events
-                if !event.beatmapset
-                  continue
-
-                div className: 'beatmapset-events__event', key: event.id,
-                  el Event,
-                    event: event
-                    mode: 'profile'
-                    users: @props.users
+              el DiscussionEvents,
+                events: @props.events
+                key: 'events'
+                users: @props.users
 
               a
                 className: 'modding-profile-list__show-more'

--- a/resources/assets/lib/beatmap-discussions/event.tsx
+++ b/resources/assets/lib/beatmap-discussions/event.tsx
@@ -29,6 +29,7 @@ export default class Event extends React.PureComponent<Props> {
     return this.props.event.comment?.beatmap_discussion_id;
   }
 
+  // discussion page doesn't include the discussion as part of the event.
   private get discussion() {
     return this.props.event.discussion ?? this.props.discussions?.[this.discussionId ?? ''];
   }

--- a/resources/assets/lib/beatmap-discussions/event.tsx
+++ b/resources/assets/lib/beatmap-discussions/event.tsx
@@ -65,17 +65,26 @@ export default class Event extends React.PureComponent<Props> {
 
   renderProfileVersion() {
     const cover = this.props.event.beatmapset?.covers?.list;
-    let discussionLink = route('beatmapsets.discussion', { beatmapset: this.beatmapsetId });
-    if (this.discussionId != null) {
-      discussionLink = `${discussionLink}#/${this.discussionId}`;
+
+    let discussionLink: string | undefined;
+    if (this.beatmapsetId != null) {
+      discussionLink = route('beatmapsets.discussion', { beatmapset: this.beatmapsetId });
+      if (this.discussionId != null) {
+        discussionLink = `${discussionLink}#/${this.discussionId}`;
+      }
     }
 
     return (
       <div className='beatmapset-event'>
-        <a href={discussionLink}>
-          <img className='beatmapset-cover' src={cover} />
-        </a>
-
+        {discussionLink != null ? (
+          <a href={discussionLink}>
+            <img className='beatmapset-cover' src={cover} />
+          </a>
+        ) : (
+          // TODO: this text barely fits and should be replaced with an icon
+          // instead of a translation that overflows.
+          <span className='beatmapset-cover'>beatmap deleted</span>
+        )}
         <div className={osu.classWithModifiers('beatmapset-event__icon', [kebabCase(this.props.event.type), 'beatmapset-activities'])} />
 
         <div>

--- a/resources/assets/lib/beatmap-discussions/events.tsx
+++ b/resources/assets/lib/beatmap-discussions/events.tsx
@@ -7,13 +7,12 @@ import * as React from 'react';
 import Event from './event';
 
 interface Props {
-  discussions: Record<string, BeatmapDiscussion>;
   events: BeatmapsetEventJson[];
   users: Record<string, UserJSON>;
 }
 
 export default class Events extends React.PureComponent<Props> {
   render() {
-    return this.props.events.map((event) => <Event discussions={this.props.discussions} event={event} key={event.id} mode='profile' users={this.props.users} />);
+    return this.props.events.map((event) => <Event event={event} key={event.id} mode='profile' users={this.props.users} />);
   }
 }


### PR DESCRIPTION
caused by #5963; the query builder causing the issue didn't change but ended up used in a condition that doesn't work very well.

- `BeatmapDiscussionPost::scopeVisible()` should not be called without filtering by `user_id`, and especially not when the condition has `whereHas('user' ...->default())`. The discussion post listing didn't use `visible()` to filter so it didn't have the same issue.
- posts not actually needed on listing page, so no longer fetched

Turns out the implicit `deleted_at` and `active` global scopes on `Beatmapset` has no index covering them making `whereHas('beatmapset')` not so great to use; if only one condition is included, it's fine, but having both is bad. 
Then there's inconsistency where `BeatmapDiscussion::beatmapset()` includes `withTrashed()` but `BeatmapsetEvent::beatmapset()` does not which is why some other places weren't affected...