### PR TITLE
Fix username change test for user ID 1

### DIFF
--- a/tests/Libraries/ChangeUsernameTest.php
+++ b/tests/Libraries/ChangeUsernameTest.php
@@ -16,7 +16,7 @@ class ChangeUsernameTest extends TestCase
 {
     public function testUserCannotBeRenamed()
     {
-        $user = $this->createUser(['user_id' => 1]);
+        $user = User::find(1) ?? $this->createUser(['user_id' => 1]);
 
         $errors = $user->validateChangeUsername('newusername')->all();
         $this->assertArrayHasKey('user_id', $errors);


### PR DESCRIPTION
always fails for me because I have a user with ID 1

should be safe to pull the existing user because this test is only checking that user_id is *one of* the validation errors