### PR TITLE
Score detail page fixes

### DIFF
--- a/app/Http/Controllers/ScoresController.php
+++ b/app/Http/Controllers/ScoresController.php
@@ -21,7 +21,7 @@ class ScoresController extends Controller
 
     public function download($mode, $id)
     {
-        // allow downloading replays for review purpose
+        // don't limit downloading replays of restricted users for review purpose
         $score = ScoreBest::getClassByString($mode)
             ::where('score_id', $id)
             ->where('replay', true)

--- a/app/Http/Controllers/ScoresController.php
+++ b/app/Http/Controllers/ScoresController.php
@@ -56,6 +56,7 @@ class ScoresController extends Controller
     {
         $score = ScoreBest::getClassByString($mode)
             ::whereHas('beatmap.beatmapset')
+            ->visibleUsers()
             ->findOrFail($id);
 
         return ext_view('scores.show', [

--- a/app/Http/Controllers/ScoresController.php
+++ b/app/Http/Controllers/ScoresController.php
@@ -21,6 +21,7 @@ class ScoresController extends Controller
 
     public function download($mode, $id)
     {
+        // allow downloading replays for review purpose
         $score = ScoreBest::getClassByString($mode)
             ::where('score_id', $id)
             ->where('replay', true)

--- a/app/Models/Score/Best/Model.php
+++ b/app/Models/Score/Best/Model.php
@@ -98,8 +98,6 @@ abstract class Model extends BaseModel
         }
 
         return with_db_fallback('mysql-readonly', function ($connection) use ($options) {
-            $alwaysAccurate = false;
-
             $query = static::on($connection)
                 ->where('beatmap_id', '=', $this->beatmap_id)
                 ->where(function ($query) {
@@ -114,10 +112,6 @@ abstract class Model extends BaseModel
 
             if (isset($options['type'])) {
                 $query->withType($options['type'], ['user' => $this->user]);
-
-                if ($options['type'] === 'country') {
-                    $alwaysAccurate = true;
-                }
             }
 
             if (isset($options['mods'])) {
@@ -126,17 +120,7 @@ abstract class Model extends BaseModel
 
             $countQuery = DB::raw('DISTINCT user_id');
 
-            if ($alwaysAccurate) {
-                return 1 + $query->visibleUsers()->default()->count($countQuery);
-            }
-
-            $rank = 1 + $query->count($countQuery);
-
-            if ($rank < config('osu.beatmaps.max-scores') * 3) {
-                return 1 + $query->visibleUsers()->default()->count($countQuery);
-            } else {
-                return $rank;
-            }
+            return 1 + $query->visibleUsers()->default()->count($countQuery);
         });
     }
 

--- a/resources/assets/less/bem/score-beatmap.less
+++ b/resources/assets/less/bem/score-beatmap.less
@@ -26,6 +26,7 @@
       border-radius: 10000px;
       padding: 2px 8px;
       font-size: @font-size--normal;
+      flex: none;
     }
   }
 

--- a/resources/assets/less/bem/score-dial.less
+++ b/resources/assets/less/bem/score-dial.less
@@ -14,6 +14,7 @@
       font-family: @font-grade;
       font-size: @font-size--large-4;
       text-shadow: 0 0 10px @osu-colour-c1;
+      padding-top: 0.15em; // compensating font baseline being too high
     }
   }
 


### PR DESCRIPTION
- more accurate rank calculation (resolves #6035)
- disable hidden scores
- more centered score grade

The accurate score rank calculation used to be rather slow but it should be fine now after denormalizing `hidden` column and updating index?