### PR TITLE
Update auth failure status code to 403

### DIFF
--- a/app/Http/Controllers/SessionsController.php
+++ b/app/Http/Controllers/SessionsController.php
@@ -60,7 +60,7 @@ class SessionsController extends Controller
                 'user' => Auth::user()->defaultJson(),
             ];
         } else {
-            return error_popup($authError);
+            return error_popup($authError, 403);
         }
     }
 

--- a/tests/Controllers/SessionsControllerTest.php
+++ b/tests/Controllers/SessionsControllerTest.php
@@ -63,6 +63,21 @@ class SessionsControllerTest extends TestCase
         $this->assertSame('', $user->fresh()->user_password);
     }
 
+    public function testLoginMissingParameters()
+    {
+        $password = 'password1';
+        $user = factory(User::class)->create(compact('password'));
+
+        $this->post(route('login'))->assertStatus(422);
+        $this->assertGuest();
+
+        $this->post(route('login'), ['username' => $user->username])->assertStatus(422);
+        $this->assertGuest();
+
+        $this->post(route('login'), compact('password'))->assertStatus(422);
+        $this->assertGuest();
+    }
+
     public function testLoginWrongPassword()
     {
         $password = 'password1';

--- a/tests/Controllers/SessionsControllerTest.php
+++ b/tests/Controllers/SessionsControllerTest.php
@@ -71,7 +71,7 @@ class SessionsControllerTest extends TestCase
         $this->post(route('login'), [
             'username' => $user->username,
             'password' => "{$password}1",
-        ])->assertStatus(422);
+        ])->assertStatus(403);
 
         $this->assertGuest();
 
@@ -90,12 +90,12 @@ class SessionsControllerTest extends TestCase
         $this->post(route('login'), [
             'username' => $user->username,
             'password' => 'password2',
-        ])->assertStatus(422);
+        ])->assertStatus(403);
 
         $this->post(route('login'), [
             'username' => $user->username,
             'password' => 'password3',
-        ])->assertStatus(422);
+        ])->assertStatus(403);
 
         $this->assertGuest();
 
@@ -115,12 +115,12 @@ class SessionsControllerTest extends TestCase
         $this->post(route('login'), [
             'username' => $user->username,
             'password' => $wrongPassword,
-        ])->assertStatus(422);
+        ])->assertStatus(403);
 
         $this->post(route('login'), [
             'username' => $user->username,
             'password' => $wrongPassword,
-        ])->assertStatus(422);
+        ])->assertStatus(403);
 
         $this->assertGuest();
 
@@ -149,7 +149,7 @@ class SessionsControllerTest extends TestCase
         $this->post(route('login'), [
             'username' => $secondUser->username,
             'password' => "{$password}1",
-        ])->assertStatus(422);
+        ])->assertStatus(403);
 
         $this->assertGuest();
 


### PR DESCRIPTION
To differentiate between missing parameter and actual auth fail requests.