### PR TITLE
Add additional test when sending message to previously closed PM

### DIFF
--- a/app/Models/Chat/UserChannel.php
+++ b/app/Models/Chat/UserChannel.php
@@ -171,13 +171,4 @@ class UserChannel extends Model
         // strip out the empty [] elements (from restricted/blocked users)
         return array_values(array_filter($collection));
     }
-
-    // Allows save/update/delete to work with composite primary keys.
-    protected function setKeysForSaveQuery(Builder $query)
-    {
-        return $query->where([
-            'user_id' => $this->user_id,
-            'channel_id' => $this->channel_id,
-        ]);
-    }
 }

--- a/app/Models/Chat/UserChannel.php
+++ b/app/Models/Chat/UserChannel.php
@@ -9,7 +9,6 @@ use App\Models\User;
 use App\Models\UserNotification;
 use App\Models\UserRelation;
 use DB;
-use Illuminate\Database\Eloquent\Builder;
 
 /**
  * @property Channel $channel

--- a/tests/Controllers/Chat/ChatControllerTest.php
+++ b/tests/Controllers/Chat/ChatControllerTest.php
@@ -62,6 +62,41 @@ class ChatControllerTest extends TestCase
             )->assertStatus(200);
     }
 
+    public function testCreatePMWhenLeftChannel() // success
+    {
+        $this->actAsScopedUser($this->user, ['*']);
+        $request = $this->json(
+            'POST',
+            route('api.chat.new'),
+            [
+                'target_id' => $this->anotherUser->user_id,
+                'message' => self::$faker->sentence(),
+            ]
+        );
+
+        $channelId = $request->json('new_channel_id');
+        $request->assertSuccessful();
+
+        app('OsuAuthorize')->cacheReset();
+        $this->json(
+                'DELETE',
+                route('api.chat.channels.part', [
+                    'channel' => $channelId,
+                    'user' => $this->user->user_id,
+                ])
+            )->assertSuccessful();
+
+        app('OsuAuthorize')->cacheReset();
+        $this->json(
+                'POST',
+                route('api.chat.new'),
+                [
+                    'target_id' => $this->anotherUser->user_id,
+                    'message' => self::$faker->sentence(),
+                ]
+            )->assertSuccessful();
+    }
+
     public function testCreatePMWhenGuest() // fail
     {
         $this->json(

--- a/tests/Controllers/Chat/ChatControllerTest.php
+++ b/tests/Controllers/Chat/ChatControllerTest.php
@@ -51,7 +51,7 @@ class ChatControllerTest extends TestCase
             )->assertStatus(200);
 
         // should return existing conversation and not error
-        $this->actAsScopedUser($this->user, ['*']);
+        app('OsuAuthorize')->cacheReset();
         $this->json(
                 'POST',
                 route('api.chat.new'),
@@ -270,7 +270,7 @@ class ChatControllerTest extends TestCase
         ]);
 
         // ensure conversation with $this->anotherUser isn't visible
-        $this->actAsScopedUser($this->user, ['*']);
+        app('OsuAuthorize')->cacheReset();
         $this->json('GET', route('api.chat.presence'))
             ->assertStatus(200)
             ->assertJsonMissing(['users' => [
@@ -308,7 +308,7 @@ class ChatControllerTest extends TestCase
         $this->anotherUser->update(['user_warnings' => 1]);
 
         // ensure conversation with $this->anotherUser isn't visible
-        $this->actAsScopedUser($this->user, ['*']);
+        app('OsuAuthorize')->cacheReset();
         $this->json('GET', route('api.chat.presence'))
             ->assertStatus(200)
             ->assertJsonMissing(['users' => [
@@ -320,7 +320,7 @@ class ChatControllerTest extends TestCase
         $this->anotherUser->update(['user_warnings' => 0]);
 
         // ensure conversation with $this->anotherUser is visible again
-        $this->actAsScopedUser($this->user, ['*']);
+        app('OsuAuthorize')->cacheReset();
         $this->json('GET', route('api.chat.presence'))
             ->assertStatus(200)
             ->assertJsonFragment(['users' => [
@@ -346,7 +346,7 @@ class ChatControllerTest extends TestCase
         $channelId = $presenceData['new_channel_id'];
 
         // leave PM with $this->anotherUser
-        $this->actAsScopedUser($this->user, ['*']);
+        app('OsuAuthorize')->cacheReset();
         $this->json('DELETE', route('api.chat.channels.part', [
             'channel' => $channelId,
             'user' => $this->user->user_id,
@@ -354,7 +354,7 @@ class ChatControllerTest extends TestCase
             ->assertStatus(204);
 
         // ensure conversation with $this->anotherUser isn't visible
-        $this->actAsScopedUser($this->user, ['*']);
+        app('OsuAuthorize')->cacheReset();
         $this->json('GET', route('api.chat.presence'))
             ->assertStatus(200)
             ->assertJsonMissing(['users' => [
@@ -363,6 +363,7 @@ class ChatControllerTest extends TestCase
             ]]);
 
         // reopen PM with $this->anotherUser
+        app('OsuAuthorize')->cacheReset();
         $this->json(
                 'POST',
                 route('api.chat.new'),
@@ -373,7 +374,7 @@ class ChatControllerTest extends TestCase
             )->assertStatus(200);
 
         // ensure conversation with $this->anotherUser is visible again
-        $this->actAsScopedUser($this->user, ['*']);
+        app('OsuAuthorize')->cacheReset();
         $this->json('GET', route('api.chat.presence'))
             ->assertStatus(200)
             ->assertJsonFragment(['users' => [
@@ -404,7 +405,7 @@ class ChatControllerTest extends TestCase
         ]))
             ->assertStatus(204);
 
-        $this->actAsScopedUser($this->user, ['*']);
+        app('OsuAuthorize')->cacheReset();
         $this->json('GET', route('api.chat.updates'), ['since' => $publicMessage->message_id])
             ->assertStatus(204);
     }
@@ -422,7 +423,7 @@ class ChatControllerTest extends TestCase
         ]))
             ->assertStatus(204);
 
-        $this->actAsScopedUser($this->user, ['*']);
+        app('OsuAuthorize')->cacheReset();
         $this->json('GET', route('api.chat.updates'), ['since' => 0])
             ->assertStatus(200)
             ->assertJsonFragment(['content' => $publicMessage->content]);
@@ -451,7 +452,7 @@ class ChatControllerTest extends TestCase
         ]);
 
         // ensure reply is visible
-        $this->actAsScopedUser($this->user, ['*']);
+        app('OsuAuthorize')->cacheReset();
         $this->json('GET', route('api.chat.updates'), ['since' => 0])
             ->assertStatus(200)
             ->assertJsonFragment(['content' => $publicMessage->content]);
@@ -460,7 +461,7 @@ class ChatControllerTest extends TestCase
         $this->anotherUser->update(['user_warnings' => 1]);
 
         // ensure reply is no longer visible
-        $this->actAsScopedUser($this->user, ['*']);
+        app('OsuAuthorize')->cacheReset();
         $this->json('GET', route('api.chat.updates'), ['since' => 0])
             ->assertStatus(204);
     }


### PR DESCRIPTION
Tests fixes from #6057
Also reset `OsuAuthorize` cache between requests, otherwise it uses the existing result instead of actually checking again.