### PR TITLE
Add endpoint returning playlist item's scores

### DIFF
--- a/app/Http/Controllers/Multiplayer/Rooms/Playlist/ScoresController.php
+++ b/app/Http/Controllers/Multiplayer/Rooms/Playlist/ScoresController.php
@@ -23,11 +23,10 @@ class ScoresController extends BaseController
     {
         $playlist = PlaylistItem::where('room_id', $roomId)->where('id', $playlistId)->firstOrFail();
 
-        return json_collection(
-            $playlist->topScores(),
-            'Multiplayer\RoomScore',
-            ['user.country']
-        );
+        $scores = json_collection($playlist->topScores()->get()->pluck('score'), 'Multiplayer\RoomScore', ['user.country']);
+        $total = $playlist->topScores()->count();
+
+        return compact('scores', 'total');
     }
 
     public function store($roomId, $playlistId)

--- a/app/Models/Multiplayer/PlaylistItem.php
+++ b/app/Models/Multiplayer/PlaylistItem.php
@@ -93,22 +93,10 @@ class PlaylistItem extends Model
 
     public function topScores()
     {
-        $scores = $this->highScores()->get();
-
-        // sort by total_score desc and then date asc if scores are equal
-        // no index on scores or timestamps
-        return $scores->sort(function ($a, $b) {
-            if ($a->total_score === $b->total_score) {
-                if ($a->updated_at->timestamp === $b->updated_at->timestamp) {
-                    // On the rare chance that both were submitted in the same second, default to submission order
-                    return $a->id < $b->id;
-                }
-
-                return $a->updated_at->timestamp < $b->updated_at->timestamp;
-            }
-
-            return $b->total_score - $a->total_score;
-        })->values();
+        return $this->highScores()
+            ->with('score')
+            ->orderBy('total_score', 'desc')
+            ->orderBy('score_id', 'asc');
     }
 
     private function validateRuleset()

--- a/app/Models/Multiplayer/PlaylistItemUserHighScore.php
+++ b/app/Models/Multiplayer/PlaylistItemUserHighScore.php
@@ -16,6 +16,7 @@ use App\Models\Model;
  * @property int $playlist_item_id
  * @property float|null $pp
  * @property int $score_id
+ * @property RoomScore $score
  * @property int $total_score
  * @property \Carbon\Carbon $updated_at
  * @property int $user_id
@@ -23,4 +24,9 @@ use App\Models\Model;
 class PlaylistItemUserHighScore extends Model
 {
     protected $table = 'multiplayer_scores_high';
+
+    public function score()
+    {
+        return $this->belongsTo(RoomScore::class);
+    }
 }

--- a/database/migrations/2020_05_28_072624_add_multiplayer_scores_high_top_scores_index.php
+++ b/database/migrations/2020_05_28_072624_add_multiplayer_scores_high_top_scores_index.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2020_05_28_072624_add_multiplayer_scores_high_top_scores_index.php
+++ b/database/migrations/2020_05_28_072624_add_multiplayer_scores_high_top_scores_index.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddMultiplayerScoresHighTopScoresIndex extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('multiplayer_scores_high', function (Blueprint $table) {
+            $table->index(['playlist_item_id', DB::raw('total_score DESC'), 'score_id'], 'top_scores');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('multiplayer_scores_high', function (Blueprint $table) {
+            $table->dropIndex('top_scores');
+        });
+    }
+}

--- a/routes/web.php
+++ b/routes/web.php
@@ -346,7 +346,7 @@ Route::group(['as' => 'api.', 'prefix' => 'api', 'middleware' => ['auth-custom-a
             Route::delete('{room}/users/{user}', 'Multiplayer\RoomsController@part')->name('part');
             Route::get('{room}/leaderboard', 'Multiplayer\RoomsController@leaderboard');
             Route::group(['as' => 'playlist.', 'prefix' => '{room}/playlist'], function () {
-                Route::apiResource('{playlist}/scores', 'Multiplayer\Rooms\Playlist\ScoresController', ['only' => ['store', 'update']]);
+                Route::apiResource('{playlist}/scores', 'Multiplayer\Rooms\Playlist\ScoresController', ['only' => ['index', 'store', 'update']]);
             });
         });
 

--- a/tests/api_routes.json
+++ b/tests/api_routes.json
@@ -398,6 +398,28 @@
     },
     {
         "uri": "api/v2/rooms/{room}/playlist/{playlist}/scores",
+        "method": "GET",
+        "controller": "App\\Http\\Controllers\\Multiplayer\\Rooms\\Playlist\\ScoresController@index",
+        "middlewares": [
+            "auth-custom-api",
+            "require-scopes",
+            "auth"
+        ],
+        "scopes": []
+    },
+    {
+        "uri": "api/v2/rooms/{room}/playlist/{playlist}/scores",
+        "method": "HEAD",
+        "controller": "App\\Http\\Controllers\\Multiplayer\\Rooms\\Playlist\\ScoresController@index",
+        "middlewares": [
+            "auth-custom-api",
+            "require-scopes",
+            "auth"
+        ],
+        "scopes": []
+    },
+    {
+        "uri": "api/v2/rooms/{room}/playlist/{playlist}/scores",
         "method": "POST",
         "controller": "App\\Http\\Controllers\\Multiplayer\\Rooms\\Playlist\\ScoresController@store",
         "middlewares": [


### PR DESCRIPTION
Scores are returned in `total_score` descending order, with submission order tiebreaker.

No pagination yet.

- <del>add migration `2020_05_28_072624_add_multiplayer_scores_high_top_scores_index` </del> small enough should be fine being done during deploy (-nanaya)
  ```
  alter table `multiplayer_scores_high` add index `top_scores`(`playlist_item_id`, total_score DESC, `score_id`);
  ```