### PR TITLE
Fix comment clipping fadeout in Safari

### DIFF
--- a/resources/assets/less/bem/comment.less
+++ b/resources/assets/less/bem/comment.less
@@ -161,7 +161,7 @@
         left: 0;
         width: 100%;
         height: calc(var(--line-height) * 3);
-        background-image: linear-gradient(to bottom, transparent, var(--comments-bg));
+        background-image: linear-gradient(to bottom, hsla(var(--comments-bg-hsl), 0), hsl(var(--comments-bg-hsl)));
         pointer-events: none;
       }
     }

--- a/resources/assets/less/bem/comments.less
+++ b/resources/assets/less/bem/comments.less
@@ -5,11 +5,11 @@
   @_top: comments;
   @_header-spacing: 20px;
 
-  --comments-bg: @osu-colour-b5;
+  --comments-bg-hsl: var(--hsl-b5);
   --comments-fg: @osu-colour-c1;
   display: flex;
   flex-direction: column;
-  background-color: var(--comments-bg);
+  background-color: hsl(var(--comments-bg-hsl));
   color: var(--comments-fg);
 
   @media @desktop {
@@ -48,8 +48,8 @@
 
     &--pinned {
       margin-top: 20px;
-      --comments-bg: @osu-colour-b4;
-      background-color: var(--comments-bg);
+      --comments-bg-hsl: var(--hsl-b4);
+      background-color: hsl(var(--comments-bg-hsl));
     }
   }
 

--- a/resources/assets/less/bem/osu-page.less
+++ b/resources/assets/less/bem/osu-page.less
@@ -2,7 +2,8 @@
 // See the LICENCE file in the repository root for full licence text.
 
 .osu-page {
-  @_default-bg: @osu-colour-b5;
+  @_default-bg-hsl: var(--hsl-b5);
+  @_default-bg: hsl(@_default-bg-hsl);
   @_default-fg: @osu-colour-c1;
 
   align-self: center;
@@ -124,9 +125,9 @@
 
   &--comment {
     .default();
-    --comments-bg: @_default-bg;
+    --comments-bg-hsl: @_default-bg-hsl;
     --comments-fg: @_default-fg;
-    background-color: var(--comments-bg);
+    background-color: hsl(var(--comments-bg-hsl));
     color: var(--comments-fg);
     padding: 10px 0 0;
     margin-bottom: 0;
@@ -134,9 +135,9 @@
 
   &--comments {
     .default();
-    --comments-bg: @_default-bg;
+    --comments-bg-hsl: @_default-bg-hsl;
     --comments-fg: @_default-fg;
-    background-color: var(--comments-bg);
+    background-color: hsl(var(--comments-bg-hsl));
     color: var(--comments-fg);
     padding: 10px 0;
   }


### PR DESCRIPTION
Fade colour from correct transparent bg colour instead of transparent black (?).

- [x] Depends on #6066

Fixes this:
![](https://s.myconan.net/2020-05/firefox_2020-05-28_18-16-29.png)