### PR TITLE
Don't save new PM channel if message is not sent

### DIFF
--- a/app/Http/Controllers/ChatController.php
+++ b/app/Http/Controllers/ChatController.php
@@ -30,10 +30,7 @@ class ChatController extends Controller
             $json['can_message'] = priv_check('ChatStart', $targetUser)->can();
 
             $channel = Channel::findPM($targetUser, Auth::user());
-
-            if ($channel !== null) {
-                $channel->addUser(Auth::user());
-            }
+            optional($channel)->addUser(Auth::user());
         }
 
         $presence = UserChannel::presenceForUser(Auth::user());

--- a/app/Http/Controllers/ChatController.php
+++ b/app/Http/Controllers/ChatController.php
@@ -31,7 +31,7 @@ class ChatController extends Controller
 
             $channel = Channel::findPM($targetUser, Auth::user());
 
-            if ($channel !== null && !$channel->hasUser(Auth::user())) {
+            if ($channel !== null) {
                 $channel->addUser(Auth::user());
             }
         }

--- a/app/Http/Controllers/ChatController.php
+++ b/app/Http/Controllers/ChatController.php
@@ -29,7 +29,7 @@ class ChatController extends Controller
             $json['target'] = json_item($targetUser, 'UserCompact');
             $json['can_message'] = priv_check('ChatStart', $targetUser)->can();
 
-            $channel = Channel::where('name', Channel::getPMChannelName($targetUser, Auth::user()))->first();
+            $channel = Channel::findPM($targetUser, Auth::user());
 
             if ($channel !== null && !$channel->hasUser(Auth::user())) {
                 $channel->addUser(Auth::user());

--- a/app/Libraries/Chat.php
+++ b/app/Libraries/Chat.php
@@ -9,7 +9,6 @@ use App\Exceptions\API;
 use App\Models\Chat\Channel;
 use App\Models\User;
 use ChaseConey\LaravelDatadogHelper\Datadog;
-use DB;
 
 class Chat
 {
@@ -38,29 +37,32 @@ class Chat
 
         priv_check_user($sender, 'ChatStart', $target)->ensureCan();
 
-        $channelName = Channel::getPMChannelName($target, $sender);
-        $channel = Channel::where('name', $channelName)->first();
+        return (new Channel)->getConnection()->transaction(function () use ($sender, $target, $message, $isAction) {
+            $channel = Channel::findPM($target, $sender);
 
-        if ($channel === null) {
-            $channel = DB::transaction(function () use ($sender, $target, $channelName) {
-                $channel = new Channel();
-                $channel->name = $channelName;
-                $channel->type = Channel::TYPES['pm'];
-                $channel->description = ''; // description is not nullable
-                $channel->save();
+            $newChannel = $channel === null;
+
+            if ($newChannel) {
+                $channel = Channel::create([
+                    'name' => Channel::getPMChannelName($target, $sender),
+                    'type' => Channel::TYPES['pm'],
+                    'description' => '', // description is not nullable
+                ]);
 
                 $channel->addUser($sender);
                 $channel->addUser($target);
+            } else {
+                $channel->addUser($sender);
+            }
 
-                return $channel;
-            });
+            $ret = static::sendMessage($sender, $channel, $message, $isAction);
 
-            Datadog::increment('chat.channel.create', 1, ['type' => $channel->type]);
-        } else {
-            $channel->addUser($sender);
-        }
+            if ($newChannel) {
+                Datadog::increment('chat.channel.create', 1, ['type' => $channel->type]);
+            }
 
-        return static::sendMessage($sender, $channel, $message, $isAction);
+            return $ret;
+        });
     }
 
     public static function sendMessage($sender, $channel, $message, $isAction)

--- a/app/Models/Chat/Channel.php
+++ b/app/Models/Chat/Channel.php
@@ -41,6 +41,13 @@ class Channel extends Model
         'group' => 'GROUP',
     ];
 
+    public static function findPM($user1, $user2)
+    {
+        $channelName = static::getPMChannelName($user1, $user2);
+
+        return static::where('name', $channelName)->first();
+    }
+
     /**
      * @param User $user1
      * @param User $user2

--- a/tests/Libraries/ChatTest.php
+++ b/tests/Libraries/ChatTest.php
@@ -1,0 +1,100 @@
+<?php
+
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
+namespace Tests\Libraries;
+
+use App\Libraries\Chat;
+use App\Models\Chat\Channel;
+use App\Models\Chat\Message;
+use App\Models\User;
+use Exception;
+use Tests\TestCase;
+
+class ChatTest extends TestCase
+{
+    public function testSendPM()
+    {
+        $sender = factory(User::class)->create();
+        $sender->markSessionVerified();
+        $target = factory(User::class)->create(['pm_friends_only' => false]);
+
+        $initialChannelsCount = Channel::count();
+        $initialMessagesCount = Message::count();
+
+        Chat::sendPrivateMessage($sender, $target, 'test message', false);
+
+        $channel = Channel::findPM($sender, $target);
+
+        $this->assertInstanceOf(Channel::class, $channel);
+        $this->assertSame($initialChannelsCount + 1, Channel::count());
+        $this->assertSame($initialMessagesCount + 1, Message::count());
+    }
+
+    public function testSendPMFriendsOnlyFailed()
+    {
+        $sender = factory(User::class)->create();
+        $sender->markSessionVerified();
+        $target = factory(User::class)->create(['pm_friends_only' => true]);
+
+        $initialChannelsCount = Channel::count();
+        $initialMessagesCount = Message::count();
+
+        try {
+            Chat::sendPrivateMessage($sender, $target, 'test message', false);
+        } catch (Exception $e) {
+            $savedException = $e;
+        }
+
+        $this->assertNull(Channel::findPM($sender, $target));
+        $this->assertSame($initialChannelsCount, Channel::count());
+        $this->assertSame($initialMessagesCount, Message::count());
+        $this->assertSame(
+            'User is blocking messages from people not on their friends list.',
+            $savedException->getMessage()
+        );
+    }
+
+    public function testSendPMTooLongNotCreatingNewChannel()
+    {
+        $sender = factory(User::class)->create();
+        $sender->markSessionVerified();
+        $target = factory(User::class)->create(['pm_friends_only' => false]);
+
+        $initialChannelsCount = Channel::count();
+        $initialMessagesCount = Message::count();
+        $longMessage = str_repeat('a', config('osu.chat.message_length_limit') + 1);
+
+        try {
+            Chat::sendPrivateMessage($sender, $target, $longMessage, false);
+        } catch (Exception $e) {
+            $savedException = $e;
+        }
+
+        $this->assertNull(Channel::findPM($sender, $target));
+        $this->assertSame($initialChannelsCount, Channel::count());
+        $this->assertSame($initialMessagesCount, Message::count());
+        $this->assertSame(
+            'The message you are trying to send is too long.',
+            $savedException->getMessage()
+        );
+    }
+
+    public function testSendPMSecondTime()
+    {
+        $sender = factory(User::class)->create();
+        $sender->markSessionVerified();
+        $target = factory(User::class)->create(['pm_friends_only' => false]);
+
+        Chat::sendPrivateMessage($sender, $target, 'test message', false);
+
+        $initialChannelsCount = Channel::count();
+        $initialMessagesCount = Message::count();
+
+        Chat::sendPrivateMessage($sender, $target, 'test message again', false);
+
+        $this->assertSame($initialChannelsCount, Channel::count());
+        $this->assertSame($initialMessagesCount + 1, Message::count());
+    }
+}


### PR DESCRIPTION
Found this when working on a different issue.

Also `DB::transaction` only works for default database which `Channel` model isn't using.