### PR TITLE
Ensure deleted beatmaps aren't selected by default in a review (attempt 2)

### DIFF
--- a/resources/assets/lib/beatmap-discussions/editor-discussion-component.tsx
+++ b/resources/assets/lib/beatmap-discussions/editor-discussion-component.tsx
@@ -32,7 +32,7 @@ export default class EditorDiscussionComponent extends React.Component<Props> {
   componentDidUpdate = () => {
     const path = this.path();
 
-    if (this.props.element.beatmapId && this.props.beatmaps[this.props.element.beatmapId]?.deleted_at === null) {
+    if (this.props.element.beatmapId) {
       const content = this.props.element.children[0].text;
       const matches = content.match(BeatmapDiscussionHelper.TIMESTAMP_REGEX);
       let timestamp = null;
@@ -44,7 +44,7 @@ export default class EditorDiscussionComponent extends React.Component<Props> {
 
       Transforms.setNodes(this.context, {timestamp}, {at: path});
     } else {
-      Transforms.setNodes(this.context, {beatmapId: null, timestamp: null}, {at: path});
+      Transforms.setNodes(this.context, {timestamp: null}, {at: path});
     }
   }
 

--- a/resources/assets/lib/beatmap-discussions/editor.tsx
+++ b/resources/assets/lib/beatmap-discussions/editor.tsx
@@ -423,7 +423,7 @@ export default class Editor extends React.Component<Props, State> {
           }
 
           // clear invalid beatmapId references (for pasted embed content)
-          if (node.beatmapId && !this.props.beatmaps[node.beatmapId]) {
+          if (node.beatmapId && (!this.props.beatmaps[node.beatmapId] || this.props.beatmaps[node.beatmapId].deleted_at)) {
             Transforms.setNodes(editor, {beatmapId: null}, {at: path});
           }
         }


### PR DESCRIPTION
Also now handles the case where references to a deleted beatmap are pasted in

fixes #6110 (regression caused by #6103)