### PR TITLE
Add endpoint to rejoin PM channel

### DIFF
--- a/app/Libraries/Chat.php
+++ b/app/Libraries/Chat.php
@@ -43,14 +43,7 @@ class Chat
             $newChannel = $channel === null;
 
             if ($newChannel) {
-                $channel = Channel::create([
-                    'name' => Channel::getPMChannelName($target, $sender),
-                    'type' => Channel::TYPES['pm'],
-                    'description' => '', // description is not nullable
-                ]);
-
-                $channel->addUser($sender);
-                $channel->addUser($target);
+                $channel = Channel::createPM($target, $sender);
             } else {
                 $channel->addUser($sender);
             }

--- a/app/Models/Chat/Channel.php
+++ b/app/Models/Chat/Channel.php
@@ -41,6 +41,23 @@ class Channel extends Model
         'group' => 'GROUP',
     ];
 
+    public static function createPM($user1, $user2)
+    {
+        $channel = new static([
+            'name' => static::getPMChannelName($user1, $user2),
+            'type' => static::TYPES['pm'],
+            'description' => '', // description is not nullable
+        ]);
+
+        $channel->getConnection()->transaction(function () use ($channel, $user1, $user2) {
+            $channel->save();
+            $channel->addUser($user1);
+            $channel->addUser($user2);
+        });
+
+        return $channel;
+    }
+
     public static function findPM($user1, $user2)
     {
         $channelName = static::getPMChannelName($user1, $user2);

--- a/app/Transformers/Chat/ChannelTransformer.php
+++ b/app/Transformers/Chat/ChannelTransformer.php
@@ -12,6 +12,7 @@ use App\Transformers\UserCompactTransformer;
 class ChannelTransformer extends TransformerAbstract
 {
     protected $availableIncludes = [
+        'recent_messages',
         'users',
     ];
 
@@ -23,6 +24,15 @@ class ChannelTransformer extends TransformerAbstract
             'description' => $channel->description,
             'type' => $channel->type,
         ];
+    }
+
+    public function includeRecentMessages(Channel $channel)
+    {
+        $messages = $channel->exists
+            ? $channel->filteredMessages()->orderBy('message_id', 'desc')->limit(50)->get()
+            : [];
+
+        return $this->collection($messages, new MessageTransformer);
     }
 
     public function includeUsers(Channel $channel)

--- a/resources/docs/source/includes/_structures.md
+++ b/resources/docs/source/includes/_structures.md
@@ -223,6 +223,7 @@ type             | string               | see channel types below
 first_message_id*| number?              | `message_id` of first message (only returned in presence responses)
 last_read_id*    | number?              | `message_id` of last message read (only returned in presence responses)
 last_message_id* | number?              | `message_id` of last known message (only returned in presence responses)
+recent_messages  | ChatMessage[]?       | up to 50 most recent messages
 moderated*       | boolean              | user can't send message when the value is `true` (only returned in presence responses)
 users*           | number[]?            | array of `user_id` that are in the channel (not included for `PUBLIC` channels)
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -333,7 +333,7 @@ Route::group(['as' => 'api.', 'prefix' => 'api', 'middleware' => ['auth-custom-a
                 Route::delete('{channel}/users/{user}', 'ChannelsController@part')->name('part');
                 Route::put('{channel}/mark-as-read/{message}', 'ChannelsController@markAsRead')->name('mark-as-read');
             });
-            Route::apiResource('channels', 'ChannelsController', ['only' => ['index']]);
+            Route::apiResource('channels', 'ChannelsController', ['only' => ['index', 'store']]);
         });
 
         Route::get('changelog/{stream}/{build}', 'ChangelogController@build')->name('changelog.build');

--- a/tests/api_routes.json
+++ b/tests/api_routes.json
@@ -260,6 +260,17 @@
         "scopes": []
     },
     {
+        "uri": "api/v2/chat/channels",
+        "method": "POST",
+        "controller": "App\\Http\\Controllers\\Chat\\ChannelsController@store",
+        "middlewares": [
+            "auth-custom-api",
+            "require-scopes",
+            "auth"
+        ],
+        "scopes": []
+    },
+    {
         "uri": "api/v2/changelog/{stream}/{build}",
         "method": "GET",
         "controller": "App\\Http\\Controllers\\ChangelogController@build",


### PR DESCRIPTION
Resolves #6105.

`join` sounds like a better name but it already exists and there's no way to re-purpose that for this as it requires `channel_id` which not known.

A blank channel data will be returned if there's no existing channel. Not sure if it makes sense but an empty response doesn't sound much better either :thinking: 

The alternative is to include `hidden` channels in presence?

- [x] Depends on #6106