### PR TITLE
Fix review beatmap selector on the modding profile/history pages

### DIFF
--- a/app/Http/Controllers/BeatmapDiscussionsController.php
+++ b/app/Http/Controllers/BeatmapDiscussionsController.php
@@ -7,6 +7,7 @@ namespace App\Http\Controllers;
 
 use App\Exceptions\ModelNotSavedException;
 use App\Libraries\BeatmapsetDiscussionReview;
+use App\Models\Beatmap;
 use App\Models\BeatmapDiscussion;
 use App\Models\Beatmapset;
 use App\Models\User;
@@ -98,6 +99,7 @@ class BeatmapDiscussionsController extends Controller
 
         // TODO: remove this when reviews are released
         $relatedDiscussions = [];
+        $relatedBeatmapsetIds = [];
         if (config('osu.beatmapset.discussion_review_enabled')) {
             $children = BeatmapDiscussion::whereIn('parent_id', $discussions->pluck('id'))
                 ->with([
@@ -120,6 +122,7 @@ class BeatmapDiscussionsController extends Controller
         foreach ($discussions->merge($relatedDiscussions) as $discussion) {
             $userIds[$discussion->user_id] = true;
             $userIds[$discussion->startingPost->last_editor_id] = true;
+            $relatedBeatmapsetIds[$discussion->beatmapset_id] = true;
         }
 
         $users = User::whereIn('user_id', array_keys($userIds))
@@ -127,11 +130,17 @@ class BeatmapDiscussionsController extends Controller
             ->default()
             ->get();
 
+        $relatedBeatmaps = Beatmap::whereIn('beatmapset_id', array_keys($relatedBeatmapsetIds))->get();
+
         $jsonChunks = [
             'discussions' => json_collection(
                 $discussions,
                 'BeatmapDiscussion',
                 ['starting_post', 'beatmap', 'beatmapset', 'current_user_attributes']
+            ),
+            'related-beatmaps' => json_collection(
+                $relatedBeatmaps,
+                'Beatmap'
             ),
             'related-discussions' => json_collection(
                 $relatedDiscussions,

--- a/app/Libraries/ModdingHistoryEventsBundle.php
+++ b/app/Libraries/ModdingHistoryEventsBundle.php
@@ -5,6 +5,7 @@
 
 namespace App\Libraries;
 
+use App\Models\Beatmap;
 use App\Models\BeatmapDiscussion;
 use App\Models\BeatmapDiscussionPost;
 use App\Models\BeatmapDiscussionVote;
@@ -95,6 +96,11 @@ class ModdingHistoryEventsBundle
             ];
 
             if ($this->withExtras) {
+                $array['beatmaps'] = json_collection(
+                    $this->getBeatmaps(),
+                    'Beatmap'
+                );
+
                 $array['discussions'] = json_collection(
                     $this->getDiscussions(),
                     'BeatmapDiscussion',
@@ -159,6 +165,22 @@ class ModdingHistoryEventsBundle
         }
 
         return $this->memoized[$key];
+    }
+
+    private function getBeatmaps()
+    {
+        return $this->memoize(__FUNCTION__, function () {
+            if (!$this->withExtras) {
+                return collect();
+            }
+
+            $beatmapsetId = $this->getDiscussions()
+                ->pluck('beatmapset_id')
+                ->unique()
+                ->toArray();
+
+            return Beatmap::whereIn('beatmapset_id', $beatmapsetId)->get();
+        });
     }
 
     private function getDiscussions()

--- a/resources/assets/coffee/react/beatmap-discussions-history.coffee
+++ b/resources/assets/coffee/react/beatmap-discussions-history.coffee
@@ -6,5 +6,6 @@ import { Main } from './beatmap-discussions-history/main'
 reactTurbolinks.registerPersistent 'beatmap-discussions-history', Main, true, (target) ->
   discussions: osu.parseJson 'json-discussions'
   users: osu.parseJson 'json-users'
+  relatedBeatmaps: osu.parseJson 'json-related-beatmaps'
   relatedDiscussions: osu.parseJson 'json-related-discussions'
   container: target

--- a/resources/assets/coffee/react/beatmap-discussions-history/main.coffee
+++ b/resources/assets/coffee/react/beatmap-discussions-history/main.coffee
@@ -20,6 +20,7 @@ export class Main extends React.PureComponent
       @state =
         discussions: props.discussions
         users: props.users
+        relatedBeatmaps: props.relatedBeatmaps
         relatedDiscussions: props.relatedDiscussions
 
 
@@ -81,10 +82,7 @@ export class Main extends React.PureComponent
   beatmaps: =>
     return @cache.beatmaps if @cache.beatmaps?
 
-    beatmaps = _.map(@discussions(), (d) => d.beatmap)
-                .filter((b) => b != undefined)
-
-    @cache.beatmaps = _.keyBy(beatmaps, 'id')
+    @cache.beatmaps = _.keyBy(this.props.relatedBeatmaps, 'id')
 
 
   saveStateToContainer: =>

--- a/resources/assets/coffee/react/modding-profile.coffee
+++ b/resources/assets/coffee/react/modding-profile.coffee
@@ -4,6 +4,7 @@
 import { Main } from './modding-profile/main'
 
 reactTurbolinks.registerPersistent 'modding-profile', Main, true, (target) ->
+  beatmaps: osu.parseJson('json-beatmaps')
   discussions: osu.parseJson('json-discussions')
   events: osu.parseJson('json-events')
   extras: osu.parseJson('json-extras')

--- a/resources/assets/coffee/react/modding-profile/main.coffee
+++ b/resources/assets/coffee/react/modding-profile/main.coffee
@@ -38,6 +38,7 @@ export class Main extends React.PureComponent
       @initialPage = page if page?
 
       @state =
+        beatmaps: props.beatmaps
         discussions: props.discussions
         events: props.events
         user: props.user
@@ -137,10 +138,7 @@ export class Main extends React.PureComponent
 
 
   beatmaps: =>
-    beatmaps = _.map(@discussions(), (d) => d.beatmap)
-                .filter((b) => b != undefined)
-
-    @cache.beatmaps ?= _.keyBy(beatmaps, 'id')
+    @cache.beatmaps ?= _.keyBy(this.state.beatmaps, 'id')
 
 
   render: =>

--- a/resources/assets/coffee/react/modding-profile/main.coffee
+++ b/resources/assets/coffee/react/modding-profile/main.coffee
@@ -104,9 +104,12 @@ export class Main extends React.PureComponent
         discussion = _.find discussions, id: newDiscussion.id
         discussions = _.reject discussions, id: newDiscussion.id
         newDiscussion = _.merge(discussion, newDiscussion)
-        # The discussion list shows discussions started by the current user, so it can be assumed that the first post is theirs
-        newDiscussion.starting_post = newDiscussion.posts[0]
-        discussions.push(newDiscussion)
+      else
+        # if this is a new discussion, it won't have beatmapset included ('cuz the parent is the beatmapset)
+        newDiscussion.beatmapset = beatmapset
+
+      newDiscussion.starting_post = newDiscussion.posts[0]
+      discussions.push(newDiscussion)
 
       _.each newDiscussion.posts, (newPost) ->
         if postIds.includes(newPost.id)
@@ -120,7 +123,7 @@ export class Main extends React.PureComponent
 
       users.push(newUser)
 
-    @cache.users = @cache.discussions = @cache.beatmaps = null
+    @cache.users = @cache.discussions = @cache.userDiscussions = @cache.beatmaps = null
     @setState
       discussions: _.reverse(_.sortBy(discussions, (d) -> Date.parse(d.starting_post.created_at)))
       posts: _.reverse(_.sortBy(posts, (p) -> Date.parse(p.created_at)))
@@ -226,7 +229,7 @@ export class Main extends React.PureComponent
     switch name
       when 'discussions'
         props:
-          discussions: @state.discussions
+          discussions: @userDiscussions()
           user: @state.user
           users: @users()
         component: Discussions
@@ -371,6 +374,12 @@ export class Main extends React.PureComponent
         username: osu.trans 'users.deleted'
 
     @cache.users
+
+  userDiscussions: =>
+    if !@cache.userDiscussions
+      @cache.userDiscussions = _.filter @state.discussions, (d) => d.user_id == @state.user.id
+
+    @cache.userDiscussions
 
 
   ujsDiscussionUpdate: (_e, data) =>

--- a/resources/assets/lib/beatmap-discussions/editor.tsx
+++ b/resources/assets/lib/beatmap-discussions/editor.tsx
@@ -380,7 +380,9 @@ export default class Editor extends React.Component<Props, State> {
 
   sortedBeatmaps = () => {
     if (this.cache.sortedBeatmaps == null) {
-      this.cache.sortedBeatmaps = sortWithMode(_.values(this.props.beatmaps));
+      // filter to only include beatmaps from the current discussion's beatmapset (for the modding profile page)
+      const beatmaps = _.filter(this.props.beatmaps, {beatmapset_id: this.props.beatmapset.id});
+      this.cache.sortedBeatmaps = sortWithMode(beatmaps);
     }
 
     return this.cache.sortedBeatmaps;


### PR DESCRIPTION
The selector was erroneously showing all beatmaps that were loaded on the modding profile/history page in every editor (i.e. dropdown selectors were not limited to the review's beatmapset)... this also meant that beatmaps that weren't referenced didn't appear in the selectors either.

Both these issues are fixed by this PR.

(Server-side validation would have rejected any invalid reviews that were submitted in the meantime however)

fixes #6086