### PR TITLE
Fix broken bold/italic on slate serialization

### DIFF
--- a/resources/assets/lib/beatmap-discussions/editor-helpers.ts
+++ b/resources/assets/lib/beatmap-discussions/editor-helpers.ts
@@ -46,12 +46,12 @@ export const serializeSlateDocument = (input: SlateNode[]) => {
         node.children.forEach((child: SlateNode) => {
           if (child.text !== '') {
             if (currentMarks.bold !== (child.bold ?? false)) {
-              currentMarks.bold = child.bold;
+              currentMarks.bold = child.bold ?? false;
               childOutput.push('**');
             }
 
             if (currentMarks.italic !== (child.italic ?? false)) {
-              currentMarks.italic = child.italic;
+              currentMarks.italic = child.italic ?? false;
               childOutput.push('*');
             }
           }


### PR DESCRIPTION
`currentMarks` could sometimes end up with `undefined` props, so the next node could incorrectly check `undefined !== false` and add more asterisks.

can be tested in modding review paragraph with 3 words, first italics, second normal, third bold.