### PR TITLE
Include sender in Channel#store recent_messages

### DIFF
--- a/app/Http/Controllers/Chat/ChannelsController.php
+++ b/app/Http/Controllers/Chat/ChannelsController.php
@@ -181,7 +181,7 @@ class ChannelsController extends Controller
         }
 
         if (isset($channel)) {
-            return json_item($channel, 'Chat/Channel', ['recent_messages']);
+            return json_item($channel, 'Chat/Channel', ['recent_messages.sender']);
         } else {
             abort(422, 'unknown or missing type parameter');
         }

--- a/app/Transformers/Chat/ChannelTransformer.php
+++ b/app/Transformers/Chat/ChannelTransformer.php
@@ -28,9 +28,17 @@ class ChannelTransformer extends TransformerAbstract
 
     public function includeRecentMessages(Channel $channel)
     {
-        $messages = $channel->exists
-            ? $channel->filteredMessages()->orderBy('message_id', 'desc')->limit(50)->get()
-            : [];
+        if ($channel->exists) {
+            $messages = $channel
+                ->filteredMessages()
+                // assumes sender will be included by the Message transformer
+                ->with('sender')
+                ->orderBy('message_id', 'desc')
+                ->limit(50)
+                ->get();
+        } else {
+            $messages = [];
+        }
 
         return $this->collection($messages, new MessageTransformer);
     }


### PR DESCRIPTION
So client can just pass it the same way as ChatMessage from other responses.