### PR TITLE
Disable docker elasticsearch index auto creation

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -41,6 +41,7 @@ services:
     volumes:
       - elasticsearch:/usr/share/elasticsearch/data
     environment:
+      action.auto_create_index: "false"
       discovery.type: single-node
   php:
     build:


### PR DESCRIPTION
Prevents accidentally creating unaliased indices with the wrong schema.