### PR TITLE
Hide redundant ranking in mobile

### DIFF
--- a/resources/assets/coffee/react/profile-page/detail-bar.coffee
+++ b/resources/assets/coffee/react/profile-page/detail-bar.coffee
@@ -74,11 +74,13 @@ export class DetailBar extends React.PureComponent
               div className: "bar__text",
                 "#{@props.stats.level.progress}%"
 
-        div className: "#{bn}__entry #{if @props.expanded then 'visible-xs' else ''}",
-          el Rank, type: 'global', stats: @props.stats
+        if !@props.expanded
+          el React.Fragment, null,
+            div className: "#{bn}__entry hidden-xs",
+              el Rank, type: 'global', stats: @props.stats
 
-        div className: "#{bn}__entry #{if @props.expanded then 'visible-xs' else ''}",
-          el Rank, type: 'country', stats: @props.stats
+            div className: "#{bn}__entry hidden-xs",
+              el Rank, type: 'country', stats: @props.stats
 
         div className: "#{bn}__entry #{bn}__entry--level",
           div

--- a/resources/assets/less/bem/profile-detail-bar.less
+++ b/resources/assets/less/bem/profile-detail-bar.less
@@ -17,12 +17,10 @@
 
   &__column {
     display: flex;
-    width: 100%;
     padding: 5px;
     flex-wrap: wrap;
 
     @media @desktop {
-      width: auto;
       margin: -5px;
       padding: 0;
       flex-wrap: nowrap;


### PR DESCRIPTION
Almost forgot about this. Found yesterday when adding that mania variants.