### PR TITLE
Remove blank poll option

### DIFF
--- a/app/Http/Controllers/Forum/TopicsController.php
+++ b/app/Http/Controllers/Forum/TopicsController.php
@@ -428,7 +428,7 @@ class TopicsController extends Controller
 
     private function getPollParams()
     {
-        return get_params(request(), 'forum_topic_poll', [
+        $params = get_params(request(), 'forum_topic_poll', [
             'hide_results:bool',
             'length_days:int',
             'max_options:int',
@@ -436,6 +436,12 @@ class TopicsController extends Controller
             'title',
             'vote_change:bool',
         ]);
+
+        if (isset($params['options'])) {
+            $params['options'] = array_filter($params['options'], 'trim_unicode');
+        }
+
+        return $params;
     }
 
     private function groupFeatureVotes($topic)

--- a/app/Http/Controllers/Forum/TopicsController.php
+++ b/app/Http/Controllers/Forum/TopicsController.php
@@ -428,7 +428,7 @@ class TopicsController extends Controller
 
     private function getPollParams()
     {
-        $params = get_params(request(), 'forum_topic_poll', [
+        return get_params(request(), 'forum_topic_poll', [
             'hide_results:bool',
             'length_days:int',
             'max_options:int',
@@ -436,12 +436,6 @@ class TopicsController extends Controller
             'title',
             'vote_change:bool',
         ]);
-
-        if (isset($params['options'])) {
-            $params['options'] = array_filter($params['options'], 'trim_unicode');
-        }
-
-        return $params;
     }
 
     private function groupFeatureVotes($topic)

--- a/app/Models/Forum/Topic.php
+++ b/app/Models/Forum/Topic.php
@@ -421,7 +421,7 @@ class Topic extends Model implements AfterCommit
 
     public function setTopicTitleAttribute($value)
     {
-        $this->attributes['topic_title'] = preg_replace('/(^\s+|\s+$)/u', '', $value);
+        $this->attributes['topic_title'] = trim_unicode($value);
     }
 
     public function save(array $options = [])

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -1220,6 +1220,13 @@ function get_string($input)
     }
 }
 
+function get_string_split($input)
+{
+    return get_arr(explode("\r\n", get_string($input)), function ($item) {
+        return presence(trim_unicode($item));
+    });
+}
+
 function get_class_basename($className)
 {
     return substr($className, strrpos($className, '\\') + 1);
@@ -1291,7 +1298,7 @@ function get_param_value($input, $type)
         case 'string':
             return get_string($input);
         case 'string_split':
-            return get_arr(explode("\r\n", get_string($input)), 'trim_unicode');
+            return get_string_split($input);
         case 'string[]':
             return get_arr($input, 'get_string');
         case 'int[]':

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -353,6 +353,11 @@ function img2x(array $attributes)
     return tag('img', $attributes);
 }
 
+function trim_unicode(?string $value)
+{
+    return preg_replace('/(^\s+|\s+$)/u', '', $value);
+}
+
 function truncate(string $text, $limit = 100, $ellipsis = '...')
 {
     if (mb_strlen($text) > $limit) {

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -1282,27 +1282,20 @@ function get_param_value($input, $type)
             return $input;
         case 'bool':
             return get_bool($input);
-            break;
         case 'int':
             return get_int($input);
-            break;
         case 'file':
             return get_file($input);
-            break;
         case 'float':
             return get_float($input);
-            break;
         case 'string':
             return get_string($input);
         case 'string_split':
             return array_filter(get_arr(explode("\r\n", $input), 'get_string'), 'trim_unicode');
-            break;
         case 'string[]':
             return get_arr($input, 'get_string');
-            break;
         case 'int[]':
             return get_arr($input, 'get_int');
-            break;
         default:
             return presence((string) $input);
     }

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -1291,7 +1291,7 @@ function get_param_value($input, $type)
         case 'string':
             return get_string($input);
         case 'string_split':
-            return array_filter(get_arr(explode("\r\n", $input), 'get_string'), 'trim_unicode');
+            return get_arr(explode("\r\n", get_string($input)), 'trim_unicode');
         case 'string[]':
             return get_arr($input, 'get_string');
         case 'int[]':

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -1295,7 +1295,7 @@ function get_param_value($input, $type)
         case 'string':
             return get_string($input);
         case 'string_split':
-            return get_arr(explode("\r\n", $input), 'get_string');
+            return array_filter(get_arr(explode("\r\n", $input), 'get_string'), 'trim_unicode');
             break;
         case 'string[]':
             return get_arr($input, 'get_string');


### PR DESCRIPTION
Recycling unicode trim from topic. Probably should update `string_split` to exclude blank items instead? :thinking: 

Resolves #6131.