### PR TITLE
Escape url for use in css

### DIFF
--- a/resources/assets/coffee/osu_common.coffee
+++ b/resources/assets/coffee/osu_common.coffee
@@ -241,7 +241,7 @@
 
 
   urlPresence: (url) ->
-    if osu.present(url) then "url(#{url})" else null
+    if osu.present(url) then "url(#{encodeURI(url)})" else null
 
 
   navigate: (url, keepScroll, {action = 'advance'} = {}) ->


### PR DESCRIPTION
Found this while cleaning up old branches. Thankfully not a problem so far.