### PR TITLE
Fix incorrect translation key

### DIFF
--- a/resources/lang/ar/model_validation.php
+++ b/resources/lang/ar/model_validation.php
@@ -10,7 +10,7 @@ return [
     'too_long' => ':attribute تجاوز الحد المطلوب - يمكن ان يصل حد :limit حروف فقط.',
     'wrong_confirmation' => 'التأكيد لا يتطابق.',
 
-    'beatmap_discussion_post' => [
+    'beatmapset_discussion_post' => [
         'discussion_locked' => 'المناقشة مقفلة.',
         'first_post' => 'لا يمكن حذف منشور البداية.',
 

--- a/resources/lang/be/model_validation.php
+++ b/resources/lang/be/model_validation.php
@@ -10,7 +10,7 @@ return [
     'too_long' => ':attribute максімальная колькасць сімвалаў перавышана - абмежаванне на :limit сімвалаў.',
     'wrong_confirmation' => 'Пацверджання не супадае.',
 
-    'beatmap_discussion_post' => [
+    'beatmapset_discussion_post' => [
         'discussion_locked' => 'Абмеркаванне закрыта.',
         'first_post' => 'Нельга выдаліць пачатковы допіс.',
 

--- a/resources/lang/bg/model_validation.php
+++ b/resources/lang/bg/model_validation.php
@@ -10,7 +10,7 @@ return [
     'too_long' => ':attribute превишена максимална дължина - може да бъде само до :limit символа.',
     'wrong_confirmation' => 'Потвърждението не съвпада.',
 
-    'beatmap_discussion_post' => [
+    'beatmapset_discussion_post' => [
         'discussion_locked' => 'Дискусията е заключена.',
         'first_post' => 'Не можете да изтриете началната публикация.',
 

--- a/resources/lang/cs/model_validation.php
+++ b/resources/lang/cs/model_validation.php
@@ -10,7 +10,7 @@ return [
     'too_long' => ':attribute přesáhl maximální délku - může mít maximálně :limit znaků.',
     'wrong_confirmation' => 'Potvrzení se neshoduje.',
 
-    'beatmap_discussion_post' => [
+    'beatmapset_discussion_post' => [
         'discussion_locked' => 'Diskuze je uzamčená.',
         'first_post' => 'Počáteční příspěvek nelze odstranit.',
 

--- a/resources/lang/da/model_validation.php
+++ b/resources/lang/da/model_validation.php
@@ -10,7 +10,7 @@ return [
     'too_long' => ':attribute overskrider maksimal længde - kan højest være op til :limit karakterer.',
     'wrong_confirmation' => 'Bekræftelseskoden matchede ikke.',
 
-    'beatmap_discussion_post' => [
+    'beatmapset_discussion_post' => [
         'discussion_locked' => 'Diskussion er låst.',
         'first_post' => 'Kan ikke slette det startende opslag.',
 

--- a/resources/lang/de/model_validation.php
+++ b/resources/lang/de/model_validation.php
@@ -10,7 +10,7 @@ return [
     'too_long' => ':attribute hat die maximale Länge überschritten - höchstens :limit Zeichen.',
     'wrong_confirmation' => 'Bestätigung stimmt nicht überein.',
 
-    'beatmap_discussion_post' => [
+    'beatmapset_discussion_post' => [
         'discussion_locked' => 'Diskussion ist gesperrt.',
         'first_post' => 'Der erste Beitrag kann nicht gelöscht werden.',
 

--- a/resources/lang/el/model_validation.php
+++ b/resources/lang/el/model_validation.php
@@ -10,7 +10,7 @@ return [
     'too_long' => 'το :attribute υπερβαίνει το μέγιστο όριο χαρακτήρων - μπορεί να είναι μέχρι :limit χαρακτήρες.',
     'wrong_confirmation' => 'Η βεβαίωση δεν ταιριάζει.',
 
-    'beatmap_discussion_post' => [
+    'beatmapset_discussion_post' => [
         'discussion_locked' => 'Η συζήτηση έχει κλειδωθεί.',
         'first_post' => 'Το αρχικό post δε μπορεί να διαγραφεί.',
 

--- a/resources/lang/en/model_validation.php
+++ b/resources/lang/en/model_validation.php
@@ -10,15 +10,6 @@ return [
     'too_long' => ':attribute exceeded maximum length - can only be up to :limit characters.',
     'wrong_confirmation' => 'Confirmation does not match.',
 
-    'beatmap_discussion_post' => [
-        'discussion_locked' => 'Discussion is locked.',
-        'first_post' => 'Can not delete starting post.',
-
-        'attributes' => [
-            'message' => 'The message',
-        ],
-    ],
-
     'beatmapset_discussion' => [
         'beatmap_missing' => 'Timestamp is specified but beatmap is missing.',
         'beatmapset_no_hype' => "Beatmap can't be hyped.",
@@ -44,6 +35,15 @@ return [
         'timestamp' => [
             'exceeds_beatmapset_length' => 'Specified timestamp is beyond the length of the beatmap.',
             'negative' => "Timestamp can't be negative.",
+        ],
+    ],
+
+    'beatmapset_discussion_post' => [
+        'discussion_locked' => 'Discussion is locked.',
+        'first_post' => 'Can not delete starting post.',
+
+        'attributes' => [
+            'message' => 'The message',
         ],
     ],
 

--- a/resources/lang/es/model_validation.php
+++ b/resources/lang/es/model_validation.php
@@ -10,7 +10,7 @@ return [
     'too_long' => ':attribute ha excedido el límite máximo - sólo puede ser de hasta :limit caracteres.',
     'wrong_confirmation' => 'La confirmación no coincide.',
 
-    'beatmap_discussion_post' => [
+    'beatmapset_discussion_post' => [
         'discussion_locked' => 'La discusión está cerrada.',
         'first_post' => 'No se puede eliminar la publicación inicial.',
 

--- a/resources/lang/fi/model_validation.php
+++ b/resources/lang/fi/model_validation.php
@@ -10,7 +10,7 @@ return [
     'too_long' => ':attribute ylittää maksimipituuden - voi olla enintään :limit merkkiä.',
     'wrong_confirmation' => 'Tarkistus ei täsmää.',
 
-    'beatmap_discussion_post' => [
+    'beatmapset_discussion_post' => [
         'discussion_locked' => 'Keskustelu on lukittu.',
         'first_post' => 'Aloitusviestiä ei voida poistaa.',
 

--- a/resources/lang/fr/model_validation.php
+++ b/resources/lang/fr/model_validation.php
@@ -10,7 +10,7 @@ return [
     'too_long' => ':attribute dépasse la longeur maximale - elle est de :limit caractères.',
     'wrong_confirmation' => 'La confirmation ne correspond pas.',
 
-    'beatmap_discussion_post' => [
+    'beatmapset_discussion_post' => [
         'discussion_locked' => 'La discussion est verrouillée.',
         'first_post' => 'Impossible de supprimer le post de départ.',
 

--- a/resources/lang/hu/model_validation.php
+++ b/resources/lang/hu/model_validation.php
@@ -10,7 +10,7 @@ return [
     'too_long' => ':attribute elérte a maximális hosszt - csak :limit karakter hosszú lehet.',
     'wrong_confirmation' => 'A megerősítés nem egyezik.',
 
-    'beatmap_discussion_post' => [
+    'beatmapset_discussion_post' => [
         'discussion_locked' => 'A megbeszélés zárolva van.',
         'first_post' => 'Nem lehet a kezdő posztot törölni.',
 

--- a/resources/lang/id/model_validation.php
+++ b/resources/lang/id/model_validation.php
@@ -10,7 +10,7 @@ return [
     'too_long' => ':attribute melebihi batas maksimum - hanya bisa hingga :limit karakter.',
     'wrong_confirmation' => 'Konfirmasi tidak cocok.',
 
-    'beatmap_discussion_post' => [
+    'beatmapset_discussion_post' => [
         'discussion_locked' => 'Diskusi terkunci',
         'first_post' => 'Tidak dapat menghapus postingan awal.',
 

--- a/resources/lang/it/model_validation.php
+++ b/resources/lang/it/model_validation.php
@@ -10,7 +10,7 @@ return [
     'too_long' => ':attribute ha superato la lunghezza massima - può essere solo fino a :limit caratteri.',
     'wrong_confirmation' => 'La conferma non corrisponde.',
 
-    'beatmap_discussion_post' => [
+    'beatmapset_discussion_post' => [
         'discussion_locked' => 'La discussione è chiusa.',
         'first_post' => 'Non puoi cancellare il post iniziale.',
 

--- a/resources/lang/ja/model_validation.php
+++ b/resources/lang/ja/model_validation.php
@@ -10,7 +10,7 @@ return [
     'too_long' => ':attributeの使用文字数の制限を超えています。上限は:limit文字です。',
     'wrong_confirmation' => '認証が一致しません。',
 
-    'beatmap_discussion_post' => [
+    'beatmapset_discussion_post' => [
         'discussion_locked' => 'ディスカッションはロックされています。',
         'first_post' => '最初の投稿は削除できません。',
 

--- a/resources/lang/ko/model_validation.php
+++ b/resources/lang/ko/model_validation.php
@@ -10,7 +10,7 @@ return [
     'too_long' => ':attribute의 최대 길이를 초과 했습니다 - :limit자 까지만 쓸 수 있습니다.',
     'wrong_confirmation' => '확인란이 일치하지 않습니다.',
 
-    'beatmap_discussion_post' => [
+    'beatmapset_discussion_post' => [
         'discussion_locked' => '토론이 잠겨있습니다.',
         'first_post' => '시작글은 삭제할 수 없습니다.',
 

--- a/resources/lang/nl/model_validation.php
+++ b/resources/lang/nl/model_validation.php
@@ -10,7 +10,7 @@ return [
     'too_long' => ':attribute heeft de maximum lengte overschreden - kan enkel tot :limit karakters gebruiken.',
     'wrong_confirmation' => 'Bevestiging komt niet overeen.',
 
-    'beatmap_discussion_post' => [
+    'beatmapset_discussion_post' => [
         'discussion_locked' => 'Discussie is vergrendeld.',
         'first_post' => 'Je kan de startpost niet verwijderen.',
 

--- a/resources/lang/no/model_validation.php
+++ b/resources/lang/no/model_validation.php
@@ -10,7 +10,7 @@ return [
     'too_long' => ':attribute overskrider maksimumslengden - kan bare være opp til :limit tegn.',
     'wrong_confirmation' => 'Bekreftelsen stemmer ikke.',
 
-    'beatmap_discussion_post' => [
+    'beatmapset_discussion_post' => [
         'discussion_locked' => 'Diskusjonen er låst.',
         'first_post' => 'Kan ikke slette det første innlegget.',
 

--- a/resources/lang/pl/model_validation.php
+++ b/resources/lang/pl/model_validation.php
@@ -10,7 +10,7 @@ return [
     'too_long' => 'Atrybut „:attribute” przekroczył maksymalną liczbę znaków - możliwe jest użycie tylko :limit znaków.',
     'wrong_confirmation' => 'Potwierdzenie się nie zgadza.',
 
-    'beatmap_discussion_post' => [
+    'beatmapset_discussion_post' => [
         'discussion_locked' => 'Dyskusja została zablokowana.',
         'first_post' => 'Nie możesz usunąć posta rozpoczynającego.',
 

--- a/resources/lang/pt-br/model_validation.php
+++ b/resources/lang/pt-br/model_validation.php
@@ -10,7 +10,7 @@ return [
     'too_long' => ':attribute ultrapassou tamanho máximo - deve ser até :limit caracteres.',
     'wrong_confirmation' => 'Confirmação não confere.',
 
-    'beatmap_discussion_post' => [
+    'beatmapset_discussion_post' => [
         'discussion_locked' => 'Discussão está trancada.',
         'first_post' => 'Não é possível excluir a publicação inicial.',
 

--- a/resources/lang/pt/model_validation.php
+++ b/resources/lang/pt/model_validation.php
@@ -10,7 +10,7 @@ return [
     'too_long' => ':attribute limite máximo excedido - só pode ser até :limit caracteres.',
     'wrong_confirmation' => 'A confirmação não corresponde.',
 
-    'beatmap_discussion_post' => [
+    'beatmapset_discussion_post' => [
         'discussion_locked' => 'A discussão está bloqueada.',
         'first_post' => 'Não é possível eliminar uma publicação inicial.',
 

--- a/resources/lang/ro/model_validation.php
+++ b/resources/lang/ro/model_validation.php
@@ -10,7 +10,7 @@ return [
     'too_long' => ':attribute depășește lungimea maximă - poate fi doar până la :limit de caractere.',
     'wrong_confirmation' => 'Confirmarea nu se potrivește.',
 
-    'beatmap_discussion_post' => [
+    'beatmapset_discussion_post' => [
         'discussion_locked' => 'Discuția este închisă.',
         'first_post' => 'Nu se poate șterge postarea de pornire.',
 

--- a/resources/lang/ru/model_validation.php
+++ b/resources/lang/ru/model_validation.php
@@ -10,7 +10,7 @@ return [
     'too_long' => ':attribute превышает максимальное количество символов - можно использовать только до :limit characters символов.',
     'wrong_confirmation' => 'Повторы не совпадают.',
 
-    'beatmap_discussion_post' => [
+    'beatmapset_discussion_post' => [
         'discussion_locked' => 'Обсуждение закрыто.',
         'first_post' => 'Невозможно удалить первую публикацию.',
 

--- a/resources/lang/sk/model_validation.php
+++ b/resources/lang/sk/model_validation.php
@@ -24,7 +24,7 @@ return [
     'too_long' => ':attribute presiahol maximálnu dĺžku - môže mať maximálne :limit znakov.',
     'wrong_confirmation' => 'Potvrdenie sa nezhoduje.',
 
-    'beatmap_discussion_post' => [
+    'beatmapset_discussion_post' => [
         'discussion_locked' => 'Diskusia je uzamknutá.',
         'first_post' => 'Počiatočný príspevok sa nedá odstrániť.',
     ],

--- a/resources/lang/sv/model_validation.php
+++ b/resources/lang/sv/model_validation.php
@@ -10,7 +10,7 @@ return [
     'too_long' => ':attribute överskred maximal längd - kan endast vara upp till :limit tecken.',
     'wrong_confirmation' => 'Bekräftelse matchar inte.',
 
-    'beatmap_discussion_post' => [
+    'beatmapset_discussion_post' => [
         'discussion_locked' => 'Diskussion är låst.',
         'first_post' => 'Kan inte radera ursprungs inlägg.',
 

--- a/resources/lang/th/model_validation.php
+++ b/resources/lang/th/model_validation.php
@@ -10,7 +10,7 @@ return [
     'too_long' => ':attribute เกินความยาวสูงสุด - สามารถใส่ได้ถึงแค่ :limit ตัวอักษร',
     'wrong_confirmation' => 'การยืนยันไม่ตรงกัน',
 
-    'beatmap_discussion_post' => [
+    'beatmapset_discussion_post' => [
         'discussion_locked' => 'การสนทนาได้ถูกล็อกไว้',
         'first_post' => 'ไม่สามารถลบโพสต์ที่เริ่มต้น',
 

--- a/resources/lang/tr/model_validation.php
+++ b/resources/lang/tr/model_validation.php
@@ -10,7 +10,7 @@ return [
     'too_long' => ':attribute azami uzunluğu aştı - sadece :limit karakter olabilir.',
     'wrong_confirmation' => 'Doğrulama eşleşmiyor.',
 
-    'beatmap_discussion_post' => [
+    'beatmapset_discussion_post' => [
         'discussion_locked' => 'Tartışma kilitli.',
         'first_post' => 'Başlangıç yazısı silinemez.',
 

--- a/resources/lang/uk/model_validation.php
+++ b/resources/lang/uk/model_validation.php
@@ -10,7 +10,7 @@ return [
     'too_long' => ':attribute перевищує максимальну кількість символів - можна використовувати тільки до :limit символів.',
     'wrong_confirmation' => 'Повтори не збігаються.',
 
-    'beatmap_discussion_post' => [
+    'beatmapset_discussion_post' => [
         'discussion_locked' => 'Обговорення закрито.',
         'first_post' => 'Неможливо видалити першу публікацію.',
 

--- a/resources/lang/vi/model_validation.php
+++ b/resources/lang/vi/model_validation.php
@@ -10,7 +10,7 @@ return [
     'too_long' => ':attribute vượt quá độ dài cho phép - chỉ có thể lên đến :limit kí tự.',
     'wrong_confirmation' => 'Xác nhận không phù hợp.',
 
-    'beatmap_discussion_post' => [
+    'beatmapset_discussion_post' => [
         'discussion_locked' => 'Cuộc thảo luận đã bị khóa.',
         'first_post' => 'Không thể xóa bài đăng mở đầu.',
 

--- a/resources/lang/zh-tw/model_validation.php
+++ b/resources/lang/zh-tw/model_validation.php
@@ -10,7 +10,7 @@ return [
     'too_long' => ':attribute 超出最大長度——最多允許 :limit 個字符。',
     'wrong_confirmation' => '確認信息不匹配。',
 
-    'beatmap_discussion_post' => [
+    'beatmapset_discussion_post' => [
         'discussion_locked' => '討論被鎖定。',
         'first_post' => '無法刪除第一個討論。',
 

--- a/resources/lang/zh/model_validation.php
+++ b/resources/lang/zh/model_validation.php
@@ -10,7 +10,7 @@ return [
     'too_long' => ':attribute 超出最大长度——最多允许 :limit 个字符。',
     'wrong_confirmation' => '确认信息不匹配。',
 
-    'beatmap_discussion_post' => [
+    'beatmapset_discussion_post' => [
         'discussion_locked' => '讨论被锁定。',
         'first_post' => '无法删除第一个讨论。',
 


### PR DESCRIPTION
The prefix in model has been changed to the correct one but the translation files haven't :frowning: 

(controller name and route still need fixing)