### PR TITLE
Remove alert display for query detector

### DIFF
--- a/config/querydetector.php
+++ b/config/querydetector.php
@@ -57,7 +57,6 @@ return [
      */
     'output' => [
         \BeyondCode\QueryDetector\Outputs\Log::class,
-        \BeyondCode\QueryDetector\Outputs\Alert::class,
         \BeyondCode\QueryDetector\Outputs\Clockwork::class,
     ],
 ];


### PR DESCRIPTION
A bit hidden in clockwork and log is better than disabling it altogether.