### PR TITLE
FIx spelling of the Ukrainian language

### DIFF
--- a/app/Libraries/LocaleMeta.php
+++ b/app/Libraries/LocaleMeta.php
@@ -121,7 +121,7 @@ class LocaleMeta
             'flag' => 'TR',
         ],
         'uk' => [
-            'name' => 'українська мова',
+            'name' => 'Українська мова',
             'flag' => 'UA',
         ],
         'vi' => [


### PR DESCRIPTION
Now with a capital letter, like other languages