### PR TITLE
Translation key update

### DIFF
--- a/resources/lang/ar/model_validation.php
+++ b/resources/lang/ar/model_validation.php
@@ -39,11 +39,11 @@ return [
     ],
 
     'beatmapset_discussion_post' => [
-        'discussion_locked' => '',
-        'first_post' => '',
+        'discussion_locked' => 'المناقشة مقفلة.',
+        'first_post' => 'لا يمكن حذف منشور البداية.',
 
         'attributes' => [
-            'message' => '',
+            'message' => 'الرسالة',
         ],
     ],
 

--- a/resources/lang/be/model_validation.php
+++ b/resources/lang/be/model_validation.php
@@ -39,11 +39,11 @@ return [
     ],
 
     'beatmapset_discussion_post' => [
-        'discussion_locked' => '',
-        'first_post' => '',
+        'discussion_locked' => 'Абмеркаванне закрыта.',
+        'first_post' => 'Нельга выдаліць пачатковы допіс.',
 
         'attributes' => [
-            'message' => '',
+            'message' => 'Паведамленне',
         ],
     ],
 

--- a/resources/lang/bg/model_validation.php
+++ b/resources/lang/bg/model_validation.php
@@ -39,8 +39,8 @@ return [
     ],
 
     'beatmapset_discussion_post' => [
-        'discussion_locked' => '',
-        'first_post' => '',
+        'discussion_locked' => 'Дискусията е заключена.',
+        'first_post' => 'Не можете да изтриете началната публикация.',
 
         'attributes' => [
             'message' => '',

--- a/resources/lang/cs/model_validation.php
+++ b/resources/lang/cs/model_validation.php
@@ -39,11 +39,11 @@ return [
     ],
 
     'beatmapset_discussion_post' => [
-        'discussion_locked' => '',
-        'first_post' => '',
+        'discussion_locked' => 'Diskuze je uzamčená.',
+        'first_post' => 'Počáteční příspěvek nelze odstranit.',
 
         'attributes' => [
-            'message' => '',
+            'message' => 'Zpráva',
         ],
     ],
 

--- a/resources/lang/da/model_validation.php
+++ b/resources/lang/da/model_validation.php
@@ -39,11 +39,11 @@ return [
     ],
 
     'beatmapset_discussion_post' => [
-        'discussion_locked' => '',
-        'first_post' => '',
+        'discussion_locked' => 'Diskussion er låst.',
+        'first_post' => 'Kan ikke slette det startende opslag.',
 
         'attributes' => [
-            'message' => '',
+            'message' => 'Beskeden',
         ],
     ],
 

--- a/resources/lang/el/model_validation.php
+++ b/resources/lang/el/model_validation.php
@@ -39,8 +39,8 @@ return [
     ],
 
     'beatmapset_discussion_post' => [
-        'discussion_locked' => '',
-        'first_post' => '',
+        'discussion_locked' => 'Η συζήτηση έχει κλειδωθεί.',
+        'first_post' => 'Το αρχικό post δε μπορεί να διαγραφεί.',
 
         'attributes' => [
             'message' => '',

--- a/resources/lang/fi/model_validation.php
+++ b/resources/lang/fi/model_validation.php
@@ -39,8 +39,8 @@ return [
     ],
 
     'beatmapset_discussion_post' => [
-        'discussion_locked' => '',
-        'first_post' => '',
+        'discussion_locked' => 'Keskustelu on lukittu.',
+        'first_post' => 'Aloitusviestiä ei voida poistaa.',
 
         'attributes' => [
             'message' => '',

--- a/resources/lang/hu/model_validation.php
+++ b/resources/lang/hu/model_validation.php
@@ -39,11 +39,11 @@ return [
     ],
 
     'beatmapset_discussion_post' => [
-        'discussion_locked' => '',
-        'first_post' => '',
+        'discussion_locked' => 'A megbeszélés zárolva van.',
+        'first_post' => 'Nem lehet a kezdő posztot törölni.',
 
         'attributes' => [
-            'message' => '',
+            'message' => 'Az üzenet',
         ],
     ],
 

--- a/resources/lang/it/model_validation.php
+++ b/resources/lang/it/model_validation.php
@@ -39,11 +39,11 @@ return [
     ],
 
     'beatmapset_discussion_post' => [
-        'discussion_locked' => '',
-        'first_post' => '',
+        'discussion_locked' => 'La discussione è chiusa.',
+        'first_post' => 'Non puoi cancellare il post iniziale.',
 
         'attributes' => [
-            'message' => '',
+            'message' => 'Il messaggio',
         ],
     ],
 

--- a/resources/lang/ja/model_validation.php
+++ b/resources/lang/ja/model_validation.php
@@ -39,11 +39,11 @@ return [
     ],
 
     'beatmapset_discussion_post' => [
-        'discussion_locked' => '',
-        'first_post' => '',
+        'discussion_locked' => 'ディスカッションはロックされています。',
+        'first_post' => '最初の投稿は削除できません。',
 
         'attributes' => [
-            'message' => '',
+            'message' => 'メッセージ',
         ],
     ],
 

--- a/resources/lang/no/model_validation.php
+++ b/resources/lang/no/model_validation.php
@@ -39,11 +39,11 @@ return [
     ],
 
     'beatmapset_discussion_post' => [
-        'discussion_locked' => '',
-        'first_post' => '',
+        'discussion_locked' => 'Diskusjonen er låst.',
+        'first_post' => 'Kan ikke slette det første innlegget.',
 
         'attributes' => [
-            'message' => '',
+            'message' => 'Meldingen',
         ],
     ],
 

--- a/resources/lang/pl/model_validation.php
+++ b/resources/lang/pl/model_validation.php
@@ -39,11 +39,11 @@ return [
     ],
 
     'beatmapset_discussion_post' => [
-        'discussion_locked' => '',
-        'first_post' => '',
+        'discussion_locked' => 'Dyskusja została zablokowana.',
+        'first_post' => 'Nie możesz usunąć posta rozpoczynającego.',
 
         'attributes' => [
-            'message' => '',
+            'message' => 'Wiadomość',
         ],
     ],
 

--- a/resources/lang/pt/model_validation.php
+++ b/resources/lang/pt/model_validation.php
@@ -39,11 +39,11 @@ return [
     ],
 
     'beatmapset_discussion_post' => [
-        'discussion_locked' => '',
-        'first_post' => '',
+        'discussion_locked' => 'A discussão está bloqueada.',
+        'first_post' => 'Não é possível eliminar uma publicação inicial.',
 
         'attributes' => [
-            'message' => '',
+            'message' => 'A mensagem',
         ],
     ],
 

--- a/resources/lang/ro/model_validation.php
+++ b/resources/lang/ro/model_validation.php
@@ -39,11 +39,11 @@ return [
     ],
 
     'beatmapset_discussion_post' => [
-        'discussion_locked' => '',
-        'first_post' => '',
+        'discussion_locked' => 'Discuția este închisă.',
+        'first_post' => 'Nu se poate șterge postarea de pornire.',
 
         'attributes' => [
-            'message' => '',
+            'message' => 'Mesajul',
         ],
     ],
 

--- a/resources/lang/sk/model_validation.php
+++ b/resources/lang/sk/model_validation.php
@@ -24,11 +24,6 @@ return [
     'too_long' => ':attribute presiahol maximálnu dĺžku - môže mať maximálne :limit znakov.',
     'wrong_confirmation' => 'Potvrdenie sa nezhoduje.',
 
-    'beatmapset_discussion_post' => [
-        'discussion_locked' => 'Diskusia je uzamknutá.',
-        'first_post' => 'Počiatočný príspevok sa nedá odstrániť.',
-    ],
-
     'beatmapset_discussion' => [
         'beatmap_missing' => 'Časová sekvencia je špecifikovaná, ale chýba beatmapa.',
         'beatmapset_no_hype' => "Táto beatmapa nemôže byť nadchnutá.",
@@ -49,6 +44,11 @@ return [
             'exceeds_beatmapset_length' => 'Upresnená sekvencia času presahuje dĺžku beatmapy.',
             'negative' => "Časová sekvencia nemôže byť záporná.",
         ],
+    ],
+
+    'beatmapset_discussion_post' => [
+        'discussion_locked' => 'Diskusia je uzamknutá.',
+        'first_post' => 'Počiatočný príspevok sa nedá odstrániť.',
     ],
 
     'comment' => [

--- a/resources/lang/sk/model_validation.php
+++ b/resources/lang/sk/model_validation.php
@@ -1,22 +1,7 @@
 <?php
 
-/**
- *    Copyright (c) ppy Pty Ltd <contact@ppy.sh>.
- *
- *    This file is part of osu!web. osu!web is distributed with the hope of
- *    attracting more community contributions to the core ecosystem of osu!.
- *
- *    osu!web is free software: you can redistribute it and/or modify
- *    it under the terms of the Affero GNU General Public License version 3
- *    as published by the Free Software Foundation.
- *
- *    osu!web is distributed WITHOUT ANY WARRANTY; without even the implied
- *    warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.
- *    See the GNU Affero General Public License for more details.
- *
- *    You should have received a copy of the GNU Affero General Public License
- *    along with osu!web.  If not, see <http://www.gnu.org/licenses/>.
- */
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
 
 return [
     'not_negative' => ':attribute nemôže byť negatívny.',
@@ -53,6 +38,10 @@ return [
 
     'comment' => [
         'deleted_parent' => 'Odpovedať na odstránený komentár nie je povolené.',
+
+        'attributes' => [
+            'message' => 'Správa',
+        ],
     ],
 
     'forum' => [
@@ -86,6 +75,14 @@ return [
         ],
     ],
 
+    'oauth' => [
+        'client' => [
+            'attributes' => [
+                'name' => 'Názov aplikácie',
+            ],
+        ],
+    ],
+
     'user' => [
         'contains_username' => 'Heslo nemôže obsahovať užívateľské meno.',
         'email_already_used' => 'E-mailová adresa už bola použitá.',
@@ -110,6 +107,12 @@ return [
         'wrong_password_confirmation' => 'Zadané heslá sa nezhodujú.',
         'too_long' => 'Prekročila sa maximálna dĺžka - maximálna dĺžka je :limit znakov.',
 
+        'attributes' => [
+            'username' => 'Meno Uživateľa',
+            'user_email' => 'E-mailová adrEsa',
+            'password' => 'Heslo',
+        ],
+
         'change_username' => [
             'supporter_required' => [
                 '_' => 'Musíš mať :link pre zmenu mena!',
@@ -121,5 +124,13 @@ return [
 
     'user_report' => [
         'self' => "",
+    ],
+
+    'store' => [
+        'order_item' => [
+            'attributes' => [
+                'cost' => 'Cena',
+            ],
+        ],
     ],
 ];

--- a/resources/lang/sv/model_validation.php
+++ b/resources/lang/sv/model_validation.php
@@ -39,8 +39,8 @@ return [
     ],
 
     'beatmapset_discussion_post' => [
-        'discussion_locked' => 'Diskussionen är låst.',
-        'first_post' => 'Kan inte radera startinlägget.',
+        'discussion_locked' => 'Diskussion är låst.',
+        'first_post' => 'Kan inte radera ursprungs inlägg.',
 
         'attributes' => [
             'message' => 'Meddelandet',

--- a/resources/lang/sv/model_validation.php
+++ b/resources/lang/sv/model_validation.php
@@ -39,8 +39,8 @@ return [
     ],
 
     'beatmapset_discussion_post' => [
-        'discussion_locked' => 'Diskussion är låst.',
-        'first_post' => 'Kan inte radera ursprungs inlägg.',
+        'discussion_locked' => 'Diskussionen är låst.',
+        'first_post' => 'Kan inte radera startinlägget.',
 
         'attributes' => [
             'message' => 'Meddelandet',

--- a/resources/lang/tr/model_validation.php
+++ b/resources/lang/tr/model_validation.php
@@ -39,11 +39,11 @@ return [
     ],
 
     'beatmapset_discussion_post' => [
-        'discussion_locked' => '',
-        'first_post' => '',
+        'discussion_locked' => 'Tartışma kilitli.',
+        'first_post' => 'Başlangıç yazısı silinemez.',
 
         'attributes' => [
-            'message' => '',
+            'message' => 'Mesaj',
         ],
     ],
 

--- a/resources/lang/uk/model_validation.php
+++ b/resources/lang/uk/model_validation.php
@@ -39,11 +39,11 @@ return [
     ],
 
     'beatmapset_discussion_post' => [
-        'discussion_locked' => '',
-        'first_post' => '',
+        'discussion_locked' => 'Обговорення закрито.',
+        'first_post' => 'Неможливо видалити першу публікацію.',
 
         'attributes' => [
-            'message' => '',
+            'message' => 'Повідомлення',
         ],
     ],
 

--- a/resources/lang/vi/model_validation.php
+++ b/resources/lang/vi/model_validation.php
@@ -39,11 +39,11 @@ return [
     ],
 
     'beatmapset_discussion_post' => [
-        'discussion_locked' => '',
-        'first_post' => '',
+        'discussion_locked' => 'Cuộc thảo luận đã bị khóa.',
+        'first_post' => 'Không thể xóa bài đăng mở đầu.',
 
         'attributes' => [
-            'message' => '',
+            'message' => 'Tin nhắn',
         ],
     ],
 

--- a/resources/lang/zh-tw/model_validation.php
+++ b/resources/lang/zh-tw/model_validation.php
@@ -39,11 +39,11 @@ return [
     ],
 
     'beatmapset_discussion_post' => [
-        'discussion_locked' => '',
-        'first_post' => '',
+        'discussion_locked' => '討論被鎖定。',
+        'first_post' => '無法刪除第一個討論。',
 
         'attributes' => [
-            'message' => '',
+            'message' => '訊息',
         ],
     ],
 


### PR DESCRIPTION
Put back translations that are gone when updating key from `beatmap_discussion_post` to `beatmapset_discussion_post`. The files will need to be reuploaded to crowdin once merged.

I also noticed `sk` never has its translation updated (not included in @peppy's update script after initial import?). Updated `model_validation.php` file here so the file can be uploaded without nuking other updated translations.