### PR TITLE
Add additional exclusions when indexing Beatmapsets

### DIFF
--- a/app/Models/Elasticsearch/BeatmapsetTrait.php
+++ b/app/Models/Elasticsearch/BeatmapsetTrait.php
@@ -22,11 +22,6 @@ trait BeatmapsetTrait
         );
     }
 
-    public function esShouldIndex()
-    {
-        return !$this->trashed() && !present($this->download_disabled_url);
-    }
-
     public static function esIndexName()
     {
         return config('osu.elasticsearch.prefix').'beatmaps';
@@ -46,6 +41,11 @@ trait BeatmapsetTrait
     public static function esSchemaFile()
     {
         return config_path('schemas/beatmaps.json');
+    }
+
+    public function esShouldIndex()
+    {
+        return !$this->trashed() && !present($this->download_disabled_url);
     }
 
     public static function esType()

--- a/app/Models/Elasticsearch/BeatmapsetTrait.php
+++ b/app/Models/Elasticsearch/BeatmapsetTrait.php
@@ -29,8 +29,7 @@ trait BeatmapsetTrait
 
     public static function esIndexingQuery()
     {
-        return static::on('mysql')
-            ->withoutGlobalScopes()
+        return static::withoutGlobalScopes()
             ->active()
             ->with('beatmaps') // note that the with query will run with the default scopes.
             ->with(['beatmaps.difficulty' => function ($query) {

--- a/app/Models/Elasticsearch/BeatmapsetTrait.php
+++ b/app/Models/Elasticsearch/BeatmapsetTrait.php
@@ -24,7 +24,7 @@ trait BeatmapsetTrait
 
     public function esShouldIndex()
     {
-        return !$this->trashed();
+        return !$this->trashed() && !present($this->download_disabled_url);
     }
 
     public static function esIndexName()

--- a/app/Models/Elasticsearch/BeatmapsetTrait.php
+++ b/app/Models/Elasticsearch/BeatmapsetTrait.php
@@ -13,15 +13,6 @@ trait BeatmapsetTrait
 {
     use EsIndexableModel;
 
-    public function toEsJson()
-    {
-        return array_merge(
-            $this->esBeatmapsetValues(),
-            ['beatmaps' => $this->esBeatmapsValues()],
-            ['difficulties' => $this->esDifficultiesValues()]
-        );
-    }
-
     public static function esIndexName()
     {
         return config('osu.elasticsearch.prefix').'beatmaps';
@@ -50,6 +41,15 @@ trait BeatmapsetTrait
     public static function esType()
     {
         return 'beatmaps';
+    }
+
+    public function toEsJson()
+    {
+        return array_merge(
+            $this->esBeatmapsetValues(),
+            ['beatmaps' => $this->esBeatmapsValues()],
+            ['difficulties' => $this->esDifficultiesValues()]
+        );
     }
 
     private function esBeatmapsetValues()

--- a/app/Models/Elasticsearch/BeatmapsetTrait.php
+++ b/app/Models/Elasticsearch/BeatmapsetTrait.php
@@ -33,14 +33,14 @@ trait BeatmapsetTrait
         return config_path('schemas/beatmaps.json');
     }
 
-    public function esShouldIndex()
-    {
-        return !$this->trashed() && !present($this->download_disabled_url);
-    }
-
     public static function esType()
     {
         return 'beatmaps';
+    }
+
+    public function esShouldIndex()
+    {
+        return !$this->trashed() && !present($this->download_disabled_url);
     }
 
     public function toEsJson()

--- a/app/Models/Elasticsearch/PostTrait.php
+++ b/app/Models/Elasticsearch/PostTrait.php
@@ -13,10 +13,37 @@ trait PostTrait
 {
     use EsIndexableModel;
 
+    public static function esIndexName()
+    {
+        return config('osu.elasticsearch.prefix').'posts';
+    }
+
+    public static function esIndexingQuery()
+    {
+        $forumIds = Forum::where('enable_indexing', 1)->pluck('forum_id');
+
+        return static::withoutGlobalScopes()->whereIn('forum_id', $forumIds)->with('forum');
+    }
+
+    public static function esSchemaFile()
+    {
+        return config_path('schemas/posts.json');
+    }
+
+    public static function esType()
+    {
+        return 'posts';
+    }
+
     public function esRouting()
     {
         // Post and Topic should have the same routing for relationships to work.
         return $this->topic_id;
+    }
+
+    public function esShouldIndex()
+    {
+        return $this->forum->enable_indexing && !$this->trashed();
     }
 
     public function getEsId()
@@ -44,32 +71,5 @@ trait PostTrait
         ];
 
         return $values;
-    }
-
-    public static function esIndexName()
-    {
-        return config('osu.elasticsearch.prefix').'posts';
-    }
-
-    public static function esIndexingQuery()
-    {
-        $forumIds = Forum::where('enable_indexing', 1)->pluck('forum_id');
-
-        return static::withoutGlobalScopes()->whereIn('forum_id', $forumIds)->with('forum');
-    }
-
-    public static function esSchemaFile()
-    {
-        return config_path('schemas/posts.json');
-    }
-
-    public static function esType()
-    {
-        return 'posts';
-    }
-
-    public function esShouldIndex()
-    {
-        return $this->forum->enable_indexing && !$this->trashed();
     }
 }

--- a/app/Models/Elasticsearch/PostTrait.php
+++ b/app/Models/Elasticsearch/PostTrait.php
@@ -55,7 +55,7 @@ trait PostTrait
     {
         $forumIds = Forum::on('mysql')->where('enable_indexing', 1)->pluck('forum_id');
 
-        return static::on('mysql')->withoutGlobalScopes()->whereIn('forum_id', $forumIds);
+        return static::on('mysql')->withoutGlobalScopes()->whereIn('forum_id', $forumIds)->with('forum');
     }
 
     public static function esSchemaFile()

--- a/app/Models/Elasticsearch/PostTrait.php
+++ b/app/Models/Elasticsearch/PostTrait.php
@@ -53,9 +53,9 @@ trait PostTrait
 
     public static function esIndexingQuery()
     {
-        $forumIds = Forum::on('mysql')->where('enable_indexing', 1)->pluck('forum_id');
+        $forumIds = Forum::where('enable_indexing', 1)->pluck('forum_id');
 
-        return static::on('mysql')->withoutGlobalScopes()->whereIn('forum_id', $forumIds)->with('forum');
+        return static::withoutGlobalScopes()->whereIn('forum_id', $forumIds)->with('forum');
     }
 
     public static function esSchemaFile()

--- a/app/Models/Elasticsearch/TopicTrait.php
+++ b/app/Models/Elasticsearch/TopicTrait.php
@@ -13,6 +13,29 @@ trait TopicTrait
 {
     use EsIndexableModel;
 
+    public static function esIndexName()
+    {
+        return Post::esIndexName();
+    }
+
+    public static function esIndexingQuery()
+    {
+        $forumIds = Forum::where('enable_indexing', 1)->pluck('forum_id');
+
+        return static::withoutGlobalScopes()->whereIn('forum_id', $forumIds)->with('forum');
+    }
+
+    public static function esSchemaFile()
+    {
+        return Post::esSchemaFile();
+    }
+
+
+    public static function esType()
+    {
+        return Post::esType();
+    }
+
     public function esRouting()
     {
         // Post and Topic should have the same routing for relationships to work.
@@ -39,32 +62,10 @@ trait TopicTrait
         return $values;
     }
 
-    public static function esIndexName()
-    {
-        return Post::esIndexName();
-    }
-
-    public static function esIndexingQuery()
-    {
-        $forumIds = Forum::where('enable_indexing', 1)->pluck('forum_id');
-
-        return static::withoutGlobalScopes()->whereIn('forum_id', $forumIds)->with('forum');
-    }
-
-    public static function esSchemaFile()
-    {
-        return Post::esSchemaFile();
-    }
-
     public function esShouldIndex()
     {
         return $this->forum->enable_indexing
             && !$this->trashed()
             && $this->topic_moved_id === 0;
-    }
-
-    public static function esType()
-    {
-        return Post::esType();
     }
 }

--- a/app/Models/Elasticsearch/TopicTrait.php
+++ b/app/Models/Elasticsearch/TopicTrait.php
@@ -30,7 +30,6 @@ trait TopicTrait
         return Post::esSchemaFile();
     }
 
-
     public static function esType()
     {
         return Post::esType();
@@ -40,6 +39,13 @@ trait TopicTrait
     {
         // Post and Topic should have the same routing for relationships to work.
         return $this->topic_id;
+    }
+
+    public function esShouldIndex()
+    {
+        return $this->forum->enable_indexing
+            && !$this->trashed()
+            && $this->topic_moved_id === 0;
     }
 
     public function getEsId()
@@ -60,12 +66,5 @@ trait TopicTrait
         ];
 
         return $values;
-    }
-
-    public function esShouldIndex()
-    {
-        return $this->forum->enable_indexing
-            && !$this->trashed()
-            && $this->topic_moved_id === 0;
     }
 }

--- a/app/Models/Elasticsearch/TopicTrait.php
+++ b/app/Models/Elasticsearch/TopicTrait.php
@@ -46,9 +46,9 @@ trait TopicTrait
 
     public static function esIndexingQuery()
     {
-        $forumIds = Forum::on('mysql')->where('enable_indexing', 1)->pluck('forum_id');
+        $forumIds = Forum::where('enable_indexing', 1)->pluck('forum_id');
 
-        return static::on('mysql')->withoutGlobalScopes()->whereIn('forum_id', $forumIds)->with('forum');
+        return static::withoutGlobalScopes()->whereIn('forum_id', $forumIds)->with('forum');
     }
 
     public static function esSchemaFile()

--- a/app/Models/Elasticsearch/TopicTrait.php
+++ b/app/Models/Elasticsearch/TopicTrait.php
@@ -48,7 +48,7 @@ trait TopicTrait
     {
         $forumIds = Forum::on('mysql')->where('enable_indexing', 1)->pluck('forum_id');
 
-        return static::on('mysql')->withoutGlobalScopes()->whereIn('forum_id', $forumIds);
+        return static::on('mysql')->withoutGlobalScopes()->whereIn('forum_id', $forumIds)->with('forum');
     }
 
     public static function esSchemaFile()
@@ -56,15 +56,15 @@ trait TopicTrait
         return Post::esSchemaFile();
     }
 
-    public static function esType()
-    {
-        return Post::esType();
-    }
-
     public function esShouldIndex()
     {
         return $this->forum->enable_indexing
             && !$this->trashed()
             && $this->topic_moved_id === 0;
+    }
+
+    public static function esType()
+    {
+        return Post::esType();
     }
 }

--- a/app/Models/Elasticsearch/UserTrait.php
+++ b/app/Models/Elasticsearch/UserTrait.php
@@ -13,6 +13,31 @@ trait UserTrait
 {
     use EsIndexableModel;
 
+    public static function esIndexName()
+    {
+        return config('osu.elasticsearch.prefix').'users';
+    }
+
+    public static function esIndexingQuery()
+    {
+        $columns = array_keys((new static())->esFilterFields());
+        array_unshift($columns, 'user_id');
+
+        return static::withoutGlobalScopes()
+            ->with('usernameChangeHistoryPublic')
+            ->select($columns);
+    }
+
+    public static function esSchemaFile()
+    {
+        return config_path('schemas/users.json');
+    }
+
+    public static function esType()
+    {
+        return 'users';
+    }
+
     public function toEsJson()
     {
         $mappings = $this->esFilterFields();
@@ -54,30 +79,5 @@ trait UserTrait
         }
 
         return array_intersect_key(static::esMappings(), $columnMap);
-    }
-
-    public static function esIndexName()
-    {
-        return config('osu.elasticsearch.prefix').'users';
-    }
-
-    public static function esIndexingQuery()
-    {
-        $columns = array_keys((new static())->esFilterFields());
-        array_unshift($columns, 'user_id');
-
-        return static::withoutGlobalScopes()
-            ->with('usernameChangeHistoryPublic')
-            ->select($columns);
-    }
-
-    public static function esSchemaFile()
-    {
-        return config_path('schemas/users.json');
-    }
-
-    public static function esType()
-    {
-        return 'users';
     }
 }

--- a/app/Models/Elasticsearch/UserTrait.php
+++ b/app/Models/Elasticsearch/UserTrait.php
@@ -66,8 +66,7 @@ trait UserTrait
         $columns = array_keys((new static())->esFilterFields());
         array_unshift($columns, 'user_id');
 
-        return static::on('mysql')
-            ->withoutGlobalScopes()
+        return static::withoutGlobalScopes()
             ->with('usernameChangeHistoryPublic')
             ->select($columns);
     }

--- a/app/Traits/EsIndexableModel.php
+++ b/app/Traits/EsIndexableModel.php
@@ -78,8 +78,6 @@ trait EsIndexableModel
         Log::info(static::class." Indexed {$count} records in {$duration} s.");
     }
 
-    abstract public function toEsJson();
-
     /**
      * The value for routing.
      * Override to provide a routing value; null by default.
@@ -130,4 +128,6 @@ trait EsIndexableModel
     {
         return $this->getKey();
     }
+
+    abstract public function toEsJson();
 }

--- a/app/Traits/EsIndexableModel.php
+++ b/app/Traits/EsIndexableModel.php
@@ -14,59 +14,6 @@ trait EsIndexableModel
 
     abstract public static function esIndexingQuery();
 
-    abstract public function toEsJson();
-
-    /**
-     * The value for routing.
-     * Override to provide a routing value; null by default.
-     *
-     * @return string|null
-     */
-    public function esRouting()
-    {
-        // null will be omitted when used as routing.
-    }
-
-    public function getEsId()
-    {
-        return $this->getKey();
-    }
-
-    public function esDeleteDocument(array $options = [])
-    {
-        $document = array_merge([
-            'index' => static::esIndexName(),
-            'type' => static::esType(),
-            'routing' => $this->esRouting(),
-            'id' => $this->getEsId(),
-            'client' => ['ignore' => 404],
-        ], $options);
-
-        return Es::getClient()->delete($document);
-    }
-
-    public function esIndexDocument(array $options = [])
-    {
-        if (!$this->esShouldIndex()) {
-            return $this->esDeleteDocument($options);
-        }
-
-        $document = array_merge([
-            'index' => static::esIndexName(),
-            'type' => static::esType(),
-            'routing' => $this->esRouting(),
-            'id' => $this->getEsId(),
-            'body' => $this->toEsJson(),
-        ], $options);
-
-        return Es::getClient()->index($document);
-    }
-
-    public function esShouldIndex()
-    {
-        return true;
-    }
-
     public static function esIndexIntoNew($batchSize = 1000, $name = null, callable $progress = null)
     {
         $newIndex = $name ?? static::esIndexName().'_'.time();
@@ -129,5 +76,58 @@ trait EsIndexableModel
 
         $duration = time() - $startTime;
         Log::info(static::class." Indexed {$count} records in {$duration} s.");
+    }
+
+    abstract public function toEsJson();
+
+    /**
+     * The value for routing.
+     * Override to provide a routing value; null by default.
+     *
+     * @return string|null
+     */
+    public function esRouting()
+    {
+        // null will be omitted when used as routing.
+    }
+
+    public function esDeleteDocument(array $options = [])
+    {
+        $document = array_merge([
+            'index' => static::esIndexName(),
+            'type' => static::esType(),
+            'routing' => $this->esRouting(),
+            'id' => $this->getEsId(),
+            'client' => ['ignore' => 404],
+        ], $options);
+
+        return Es::getClient()->delete($document);
+    }
+
+    public function esIndexDocument(array $options = [])
+    {
+        if (!$this->esShouldIndex()) {
+            return $this->esDeleteDocument($options);
+        }
+
+        $document = array_merge([
+            'index' => static::esIndexName(),
+            'type' => static::esType(),
+            'routing' => $this->esRouting(),
+            'id' => $this->getEsId(),
+            'body' => $this->toEsJson(),
+        ], $options);
+
+        return Es::getClient()->index($document);
+    }
+
+    public function esShouldIndex()
+    {
+        return true;
+    }
+
+    public function getEsId()
+    {
+        return $this->getKey();
     }
 }


### PR DESCRIPTION
Also exclude beatmapsets with `download_disabled_url` set.

The explicit `getDeletedAtColumn` test when reindexing entire table is removed and `esShouldIndex` is now used instead. This means indexing `Topic` and `Post` will need to eager load `forum`, adding additional overhead mostly from laravel.