### PR TITLE
Add meta tag on pages webcrawlers should not be indexing

### DIFF
--- a/app/Http/Controllers/BeatmapsetsController.php
+++ b/app/Http/Controllers/BeatmapsetsController.php
@@ -73,6 +73,8 @@ class BeatmapsetsController extends Controller
                 $languages = [];
             }
 
+            $noindex = !$beatmapset->esShouldIndex();
+
             return ext_view('beatmapsets.show', compact(
                 'beatmapset',
                 'commentBundle',
@@ -80,6 +82,7 @@ class BeatmapsetsController extends Controller
                 'genres',
                 'hasDiscussion',
                 'languages',
+                'noindex',
                 'set'
             ));
         }

--- a/resources/views/layout/metadata.blade.php
+++ b/resources/views/layout/metadata.blade.php
@@ -27,7 +27,7 @@
     @endif
 @endif
 
-@if (isset($noindex))
+@if ($noindex ?? false)
     <meta name="robots" content="noindex">
 @endif
 

--- a/resources/views/layout/metadata.blade.php
+++ b/resources/views/layout/metadata.blade.php
@@ -27,6 +27,10 @@
     @endif
 @endif
 
+@if (isset($noindex))
+    <meta name="robots" content="noindex">
+@endif
+
 <meta name="csrf-param" content="_token">
 <meta name="csrf-token" content="{{ csrf_token() }}">
 


### PR DESCRIPTION
I thought of just adding a generic `$metadata` field to allow adding any number of custom `meta` tags, but then there's these open graph tags that use `property` instead of `name`, and the additional code for allowing arbitrary keys looks dumb ಠ_ಠ