### PR TITLE
Don't fail on missing title

### DIFF
--- a/app/Models/NewsPost.php
+++ b/app/Models/NewsPost.php
@@ -360,7 +360,7 @@ class NewsPost extends Model implements Commentable, Wiki\WikiObject
 
     public function title()
     {
-        return $this->page['header']['title'];
+        return $this->page['header']['title'] ?? 'Title-less news post';
     }
 
     public function url()


### PR DESCRIPTION
Cursory check shows this is the only remaining possible fail case ( ﾟ◡ﾟ)

(probably should have a better title)

The alternative is to not publish the news post if title is missing.