### PR TITLE
Add badge for moderators of forums

### DIFF
--- a/app/Libraries/OsuAuthorize.php
+++ b/app/Libraries/OsuAuthorize.php
@@ -1110,11 +1110,7 @@ class OsuAuthorize
         $this->ensureLoggedIn($user);
         $this->ensureCleanRecord($user);
 
-        if ($user->isModerator()) {
-            return 'ok';
-        }
-
-        if ($forum->moderator_groups !== null && !empty(array_intersect($user->groupIds(), $forum->moderator_groups))) {
+        if ($user->isModerator() || $user->isModeratorForForum($forum)) {
             return 'ok';
         }
 

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -864,6 +864,11 @@ class User extends Model implements AuthenticatableContract, HasLocalePreference
         return in_array($group->getKey(), $this->groupIds(), true) && $this->token() === null;
     }
 
+    public function isModeratorForForum(Forum\Forum $forum): bool
+    {
+        return $forum->moderator_groups !== null && !empty(array_intersect($this->groupIds(), $forum->moderator_groups));
+    }
+
     public function badges()
     {
         return $this->hasMany(UserBadge::class);

--- a/resources/views/forum/topics/_post.blade.php
+++ b/resources/views/forum/topics/_post.blade.php
@@ -19,6 +19,13 @@
     }
 
     $user = $post->userNormalized();
+    $group = isset($topic) && $user->isModeratorForForum($topic->forum)
+        ? (object)[
+            'colour' => 'hsl(200, 60%, 50%)',
+            'group_name' => "{$topic->forum->forum_name} Forum Moderator",
+            'short_name' => 'MOD',
+        ]
+        : ($user->visibleGroups()[0] ?? null);
 ?>
 <div
     class="js-forum-post {{ $post->trashed() ? 'js-forum-post--hidden' : '' }} forum-post"

--- a/resources/views/forum/topics/_post.blade.php
+++ b/resources/views/forum/topics/_post.blade.php
@@ -32,7 +32,7 @@
     data-post-id="{{ $post->getKey() }}"
     data-post-position="{{ $options["postPosition"] }}"
 >
-    @include('forum.topics._post_info', compact('user'))
+    @include('forum.topics._post_info', compact('user', 'group'))
 
     <div class="forum-post__body js-forum-post-edit--container">
         <div class="forum-post__content forum-post__content--header">

--- a/resources/views/forum/topics/_post_info.blade.php
+++ b/resources/views/forum/topics/_post_info.blade.php
@@ -39,9 +39,6 @@
         </span>
     @endif
 
-    @php
-        $group = $user->visibleGroups()[0] ?? null;
-    @endphp
     @if (isset($group))
         <div class="forum-post-info__row forum-post-info__row--group-badge">
             <div


### PR DESCRIPTION
you can't tell who moderators of forums are unless they're in one of the global mod groups, so this adds a fake-group badge to show that. works and looks similar to "Mapper" for beatmap discussions