### PR TITLE
Change "Español" to "español" (correct spelling)

### DIFF
--- a/app/Libraries/LocaleMeta.php
+++ b/app/Libraries/LocaleMeta.php
@@ -41,7 +41,7 @@ class LocaleMeta
             'flag' => 'GB',
         ],
         'es' => [
-            'name' => 'Español',
+            'name' => 'español',
             'flag' => 'ES',
         ],
         'fi' => [


### PR DESCRIPTION
Language names in Spanish are common nouns (_nombres comunes_) and the first letter shouldn't be capitalised.