### PR TITLE
Fix logout incorrectly called on guards without the method

### DIFF
--- a/app/Http/Middleware/CheckUserBanStatus.php
+++ b/app/Http/Middleware/CheckUserBanStatus.php
@@ -44,7 +44,11 @@ class CheckUserBanStatus
         ) {
             logout();
 
-            return ujs_redirect(route('users.disabled'));
+            if (is_api_request()) {
+                abort(403, trans('users.disabled.title'));
+            } else {
+                return ujs_redirect(route('users.disabled'));
+            }
         }
 
         return $next($request);

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -436,7 +436,10 @@ function log_error($exception)
 
 function logout()
 {
-    auth()->logout();
+    $guard = auth()->guard();
+    if ($guard instanceof Illuminate\Contracts\Auth\StatefulGuard) {
+        $guard->logout();
+    }
 
     // FIXME: Temporarily here for cross-site login, nuke after old site is... nuked.
     foreach (['phpbb3_2cjk5_sid', 'phpbb3_2cjk5_sid_check'] as $key) {


### PR DESCRIPTION
`RequestGuard` used by API doesn't have a `logout()` method. This wasn't an issue previously because the `CheckUserBanStatus` middleware didn't apply properly in API requests due to the user not being resolved early enough.