### PR TITLE
Revert "Hide replies of deleted discussion"

### DIFF
--- a/app/Models/BeatmapDiscussionPost.php
+++ b/app/Models/BeatmapDiscussionPost.php
@@ -91,12 +91,7 @@ class BeatmapDiscussionPost extends Model
         $params['with_deleted'] = get_bool($rawParams['with_deleted'] ?? null) ?? false;
 
         if (!$params['with_deleted']) {
-            // using visible() is too slow when combined with orderBy(...)
-            $query
-                ->withoutTrashed()
-                ->whereHas('beatmapDiscussion', function ($discussionQuery) {
-                    $discussionQuery->withoutTrashed();
-                });
+            $query->withoutTrashed();
         }
 
         if (!($rawParams['is_moderator'] ?? false)) {


### PR DESCRIPTION
Reverts ppy/osu-web#6199

It seems in some cases the query will do a lookup on `beatmap_discussions` using temporary tables and filesort first instead of getting `beatmap_discussion_posts` first