### PR TITLE
Use current url to generate url on js side

### DIFF
--- a/resources/assets/lib/laroute.ts
+++ b/resources/assets/lib/laroute.ts
@@ -9,6 +9,12 @@ interface Attributes {
   [key: string]: string | number | null | undefined;
 }
 
+// ensure correct url
+Ziggy.baseUrl = `${document.location.origin}/`;
+Ziggy.baseProtocol = document.location.protocol.slice(0, -1);
+Ziggy.baseDomain = document.location.hostname;
+Ziggy.basePort = +document.location.port || false; // either port number of false if empty (converted to 0)
+
 export function route(name: string, params?: Attributes | null, absolute?: boolean) {
   if (params == null) {
     params = {};

--- a/resources/assets/lib/ziggy.d.ts
+++ b/resources/assets/lib/ziggy.d.ts
@@ -2,7 +2,14 @@
 // See the LICENCE file in the repository root for full licence text.
 
 declare module 'ziggy' {
-  export const Ziggy: {};
+  interface ZiggyClass {
+    baseUrl: string;
+    baseProtocol: string;
+    baseDomain: string;
+    basePort: number | false;
+  }
+
+  export const Ziggy: ZiggyClass;
 }
 
 declare module 'ziggy-route' {

--- a/resources/assets/lib/ziggy.d.ts
+++ b/resources/assets/lib/ziggy.d.ts
@@ -3,10 +3,10 @@
 
 declare module 'ziggy' {
   interface ZiggyClass {
-    baseUrl: string;
-    baseProtocol: string;
     baseDomain: string;
     basePort: number | false;
+    baseProtocol: string;
+    baseUrl: string;
   }
 
   export const Ziggy: ZiggyClass;


### PR DESCRIPTION
Instead of relying on `APP_URL` set during build time, fill them in as they're being accessed. Simplifies dusk testing for docker.