### PR TITLE
Add category and pagination to multiplayer rooms

### DIFF
--- a/app/Http/Controllers/Multiplayer/RoomsController.php
+++ b/app/Http/Controllers/Multiplayer/RoomsController.php
@@ -19,31 +19,11 @@ class RoomsController extends BaseController
 
     public function index()
     {
-        $rooms = Room::query();
-        $limit = clamp(get_int(request('limit')) ?? 250, 1, 250);
+        $params = request()->all();
+        $params['user'] = auth()->user();
 
-        $mode = request('mode');
-        if ($mode === 'ended') {
-            $rooms->ended()->orderBy('ends_at', 'desc');
-        } else {
-            if ($mode === 'participated') {
-                // TODO: should probably do some kind of caching on this.
-                $rooms->hasParticipated(auth()->user());
-            } elseif ($mode === 'owned') {
-                $rooms->startedBy(auth()->user());
-            } else {
-                $rooms->active();
-            }
-
-            $rooms->orderBy('id', 'desc');
-        }
-
-        return json_collection(
-            $rooms
-                ->with('host.country')
-                ->with('playlist.beatmap.beatmapset')
-                ->paginate($limit),
-            'Multiplayer\Room',
+        return Room::search($params,
+            ['host.country', 'playlist.beatmap.beatmapset'],
             [
                 'host.country',
                 'playlist.beatmap.beatmapset',

--- a/app/Models/Multiplayer/Room.php
+++ b/app/Models/Multiplayer/Room.php
@@ -60,7 +60,7 @@ class Room extends Model
 
         switch ($mode) {
             case 'ended':
-                $query->ended()->orderBy('ends_at', 'desc');
+                $query->ended();
                 $sort = 'ended';
                 break;
             case 'participated':

--- a/app/Models/Multiplayer/Room.php
+++ b/app/Models/Multiplayer/Room.php
@@ -6,6 +6,7 @@
 namespace App\Models\Multiplayer;
 
 use App\Exceptions\InvariantException;
+use App\Libraries\DbCursorHelper;
 use App\Models\Chat\Channel;
 use App\Models\Model;
 use App\Models\User;
@@ -33,11 +34,65 @@ class Room extends Model
 {
     use SoftDeletes;
 
+    const SORTS = [
+        'ended' => [
+            ['column' => 'ends_at', 'order' => 'desc', 'type' => 'time'],
+            ['column' => 'id', 'order' => 'desc', 'type' => 'int'],
+        ],
+        'created' => [
+            ['column' => 'id', 'order' => 'desc', 'type' => 'int'],
+        ],
+    ];
+
     protected $table = 'multiplayer_rooms';
     protected $dates = ['starts_at', 'ends_at'];
     protected $attributes = [
         'participant_count' => 0,
     ];
+
+    public static function search($params, $preloads = null, $includes = null)
+    {
+        $query = static::query();
+
+        $mode = presence(get_string($params['mode'] ?? null));
+        $user = $params['user'];
+        $sort = 'created';
+
+        switch ($mode) {
+            case 'ended':
+                $query->ended()->orderBy('ends_at', 'desc');
+                $sort = 'ended';
+                break;
+            case 'participated':
+                $query->hasParticipated($user);
+                break;
+            case 'owned':
+                $query->startedBy($user);
+                break;
+            default:
+                $query->active();
+        }
+
+        $category = presence(get_string($params['category'] ?? null));
+
+        if ($category !== null) {
+            $query->where('category', $category);
+        }
+
+        $cursorHelper = new DbCursorHelper(static::SORTS, $sort);
+        $cursor = $cursorHelper->prepare($params['cursor'] ?? null);
+
+        $query->cursorSort($cursorHelper->getSort(), $cursor);
+
+        foreach ($preloads ?? [] as $preload) {
+            $query->with($preload);
+        }
+
+        $limit = clamp(get_int($params['limit'] ?? 250), 1, 250);
+        $query->limit($limit);
+
+        return json_collection($query->get(), 'Multiplayer\Room', $includes ?? []);
+    }
 
     public function channel()
     {

--- a/app/Models/Multiplayer/Room.php
+++ b/app/Models/Multiplayer/Room.php
@@ -73,8 +73,10 @@ class Room extends Model
                 $query->active();
         }
 
-        $category = presence(get_string($params['category'] ?? null)) ?? 'normal';
-        $query->where('category', $category);
+        $category = presence(get_string($params['category'] ?? null)) ?? 'any';
+        if ($category !== 'any') {
+            $query->where('category', $category);
+        }
 
         $cursorHelper = new DbCursorHelper(static::SORTS, $sort);
         $cursor = $cursorHelper->prepare($params['cursor'] ?? null);

--- a/app/Models/Multiplayer/Room.php
+++ b/app/Models/Multiplayer/Room.php
@@ -73,11 +73,8 @@ class Room extends Model
                 $query->active();
         }
 
-        $category = presence(get_string($params['category'] ?? null));
-
-        if ($category !== null) {
-            $query->where('category', $category);
-        }
+        $category = presence(get_string($params['category'] ?? null)) ?? 'normal';
+        $query->where('category', $category);
 
         $cursorHelper = new DbCursorHelper(static::SORTS, $sort);
         $cursor = $cursorHelper->prepare($params['cursor'] ?? null);

--- a/app/Transformers/Multiplayer/RoomTransformer.php
+++ b/app/Transformers/Multiplayer/RoomTransformer.php
@@ -24,6 +24,7 @@ class RoomTransformer extends TransformerAbstract
         return [
             'id' => $room->id,
             'name' => $room->name,
+            'category' => $room->category,
             'user_id' => $room->user_id,
             'starts_at' => json_time($room->starts_at),
             'ends_at' => json_time($room->ends_at),

--- a/database/migrations/2020_07_08_042634_add_category_to_multiplayer_rooms.php
+++ b/database/migrations/2020_07_08_042634_add_category_to_multiplayer_rooms.php
@@ -1,0 +1,39 @@
+<?php
+
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddCategoryToMultiplayerRooms extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('multiplayer_rooms', function (Blueprint $table) {
+            $table->enum('category', ['normal', 'spotlight'])->default('normal');
+            $table->index(['category', 'ends_at']);
+            $table->index(['category', 'user_id']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('multiplayer_rooms', function (Blueprint $table) {
+            $table->dropIndex(['category', 'ends_at']);
+            $table->dropIndex(['category', 'user_id']);
+            $table->dropColumn('category');
+        });
+    }
+}

--- a/database/migrations/2020_07_10_105258_add_ends_at_index_to_multiplayer_rooms.php
+++ b/database/migrations/2020_07_10_105258_add_ends_at_index_to_multiplayer_rooms.php
@@ -1,0 +1,35 @@
+<?php
+
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddEndsAtIndexToMultiplayerRooms extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('multiplayer_rooms', function (Blueprint $table) {
+            $table->index('ends_at');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('multiplayer_rooms', function (Blueprint $table) {
+            $table->dropIndex('ends_at');
+        });
+    }
+}

--- a/database/migrations/2020_07_10_105258_add_ends_at_index_to_multiplayer_rooms.php
+++ b/database/migrations/2020_07_10_105258_add_ends_at_index_to_multiplayer_rooms.php
@@ -29,7 +29,7 @@ class AddEndsAtIndexToMultiplayerRooms extends Migration
     public function down()
     {
         Schema::table('multiplayer_rooms', function (Blueprint $table) {
-            $table->dropIndex('ends_at');
+            $table->dropIndex(['ends_at']);
         });
     }
 }


### PR DESCRIPTION
- nowhere to set it apart of manually editing database
- use parameter `category` in rooms listing endpoint to filter by category (normal or spotlight)
- add support for cursor based pagination. Sort option is implied by existing parameter `type`
- cursor for more results will need to be built manually
  - for type `ended`, following are required:
    - `cursor[ends_at]`
    - `cursor[id]`
  - for other types:
    - `cursor[id]`
- I can't add those cursor hint in the response without breaking current api ( ﾟ ヮﾟ)

Resolves #6226.