### PR TITLE
Improve chat UI performance with many channels

### DIFF
--- a/resources/assets/less/bem/chat-conversation-list-item.less
+++ b/resources/assets/less/bem/chat-conversation-list-item.less
@@ -3,6 +3,7 @@
 
 .chat-conversation-list-item {
   @edge-margin: 10px; // margin between elements and side of list container.
+  @indicator-width: 2px;
   @tile-margin: 10px; // gap for the indicator and close button.
   @top: chat-conversation-list-item;
 
@@ -71,12 +72,16 @@
     align-self: stretch;
     flex: 1;
     margin-left: @tile-margin;
+
+    @media @mobile {
+      margin-left: @indicator-width * 2;
+    }
   }
 
   &__unread-indicator {
     position: absolute;
     background: @green;
-    width: 2px;
+    width: @indicator-width;
     height: 10px;
     border-radius: 1px;
     pointer-events: none;
@@ -99,7 +104,7 @@
     }
 
     @media @mobile {
-      margin-left: 5px;
+      margin-left: @indicator-width;
     }
   }
 

--- a/resources/assets/less/bem/chat-conversation-list-item.less
+++ b/resources/assets/less/bem/chat-conversation-list-item.less
@@ -13,19 +13,19 @@
 
   @media @desktop {
     &:hover {
-      background: linear-gradient(to right, @osu-colour-b5 5%, @osu-colour-b3 33%, @osu-colour-b3 100%);
+      background: linear-gradient(to right, @osu-colour-b5 20px, @osu-colour-b3 33%, @osu-colour-b3 100%);
     }
   }
 
   @media @mobile {
-    margin-left: 0px;
-    padding-left: 0px;
+    margin-left: 0;
+    padding-left: 0;
     flex-shrink: 0;
   }
 
   &--selected {
     color: white;
-    background: linear-gradient(to right, @osu-colour-b5 5%, @osu-colour-b4 33%, @osu-colour-b4 100%);
+    background: linear-gradient(to right, @osu-colour-b5 20px, @osu-colour-b4 33%, @osu-colour-b4 100%);
     @media @mobile {
       background: @osu-colour-b4;
     }
@@ -41,8 +41,11 @@
     }
 
     @media @desktop {
+      position: absolute;
       opacity: 0;
-      margin-left: -10px;
+      background-color: @osu-colour-b5;
+      height: 100%;
+      margin-left: -11px;
       .@{top}:hover & {
         opacity: 1;
       }
@@ -63,41 +66,32 @@
     align-items: center;
     align-self: stretch;
     flex: 1;
+    margin-left: 11px;
   }
 
   &__unread-indicator {
+    position: absolute;
     background: @green;
     width: 2px;
     height: 10px;
     border-radius: 1px;
     pointer-events: none;
 
-    opacity: 0;
-    .@{top}--unread & {
-      opacity: 1;
-      &::after {
-        opacity: 0.5;
-        .full-size();
-        border-radius: 1px;
-        content: '';
-        box-shadow: 0 0 5px lighten(@green, 10%);
-        animation: glow-pulse 2s infinite;
-      }
+    &::after {
+      opacity: 0.5;
+      .full-size();
+      border-radius: 1px;
+      content: '';
+      box-shadow: 0 0 5px lighten(@green, 10%);
+      animation: glow-pulse 2s infinite;
     }
 
     @media @desktop {
-      margin-left: -10px;
-      margin-right: 10px;
-      .@{top}:hover & {
-        opacity: 0;
-      }
+      margin-left: -1px; // offset is width of unread-indicator - 1px for some reason?
     }
 
     @media @mobile {
-      .@{top}--unread & {
-        margin-left: 5px;
-        margin-right: 0px;
-      }
+      margin-left: 5px;
     }
   }
 
@@ -136,7 +130,7 @@
     flex-shrink: 0;
 
     @media @mobile {
-      margin: 0px 5px;
+      margin: 0 5px;
     }
   }
 }

--- a/resources/assets/less/bem/chat-conversation-list-item.less
+++ b/resources/assets/less/bem/chat-conversation-list-item.less
@@ -1,19 +1,22 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
- .chat-conversation-list-item {
+.chat-conversation-list-item {
+  @edge-margin: 10px; // margin between elements and side of list container.
+  @tile-margin: 10px; // gap for the indicator and close button.
   @top: chat-conversation-list-item;
+
   height: 40px;
   color: white;
   display: flex;
   align-items: center;
-  margin-left: 10px;
-  padding-left: 10px;
+  margin-left: @edge-margin;
+  padding-left: @tile-margin;
   font-size: @font-size--title-small;
 
   @media @desktop {
     &:hover {
-      background: linear-gradient(to right, @osu-colour-b5 20px, @osu-colour-b3 33%, @osu-colour-b3 100%);
+      background: linear-gradient(to right, @osu-colour-b5 @tile-margin, @osu-colour-b3 33%, @osu-colour-b3 100%);
     }
   }
 
@@ -25,7 +28,7 @@
 
   &--selected {
     color: white;
-    background: linear-gradient(to right, @osu-colour-b5 20px, @osu-colour-b4 33%, @osu-colour-b4 100%);
+    background: linear-gradient(to right, @osu-colour-b5 @tile-margin, @osu-colour-b4 33%, @osu-colour-b4 100%);
     @media @mobile {
       background: @osu-colour-b4;
     }
@@ -45,7 +48,7 @@
       opacity: 0;
       background-color: @osu-colour-b5;
       height: 100%;
-      margin-left: -11px;
+      margin-left: -@tile-margin;
       .@{top}:hover & {
         opacity: 1;
       }
@@ -66,7 +69,7 @@
     align-items: center;
     align-self: stretch;
     flex: 1;
-    margin-left: 11px;
+    margin-left: @tile-margin;
   }
 
   &__unread-indicator {
@@ -87,7 +90,7 @@
     }
 
     @media @desktop {
-      margin-left: -1px; // offset is width of unread-indicator - 1px for some reason?
+      margin-left: -$width;
     }
 
     @media @mobile {
@@ -103,13 +106,13 @@
       display: none;
       .@{top}--selected & {
         display: block;
-        padding-right: 10px;
+        padding-right: @tile-margin;
       }
     }
   }
 
   &__chevron {
-    margin-right: 10px;
+    margin-right: @edge-margin;
     color: white;
     opacity: 0;
 

--- a/resources/assets/less/bem/chat-conversation-list-item.less
+++ b/resources/assets/less/bem/chat-conversation-list-item.less
@@ -46,9 +46,9 @@
     @media @desktop {
       position: absolute;
       opacity: 0;
-      background-color: @osu-colour-b5;
       height: 100%;
       margin-left: -@tile-margin;
+
       .@{top}:hover & {
         opacity: 1;
       }
@@ -56,6 +56,7 @@
 
     @media @mobile {
       display: none;
+
       .@{top}--selected & {
         display: block;
         margin-left: 5px;
@@ -91,6 +92,10 @@
 
     @media @desktop {
       margin-left: -$width;
+
+      .@{top}:hover & {
+        opacity: 0;
+      }
     }
 
     @media @mobile {
@@ -104,6 +109,7 @@
 
     @media @mobile {
       display: none;
+
       .@{top}--selected & {
         display: block;
         padding-right: @tile-margin;

--- a/resources/assets/lib/chat/conversation-list-item.tsx
+++ b/resources/assets/lib/chat/conversation-list-item.tsx
@@ -35,10 +35,14 @@ export default class ConversationListItem extends React.Component<any, {}> {
 
     return (
       <div className={className}>
+        {conversation.isUnread
+          ? <div className={`${baseClassName}__unread-indicator`} />
+          : null}
+
         <button className={`${baseClassName}__close-button`} onClick={this.part}>
           <i className='fas fa-times' />
         </button>
-        <div className={`${baseClassName}__unread-indicator`} />
+
         <button className={`${baseClassName}__tile`} onClick={this.switch}>
           <img className={`${baseClassName}__avatar`} src={conversation.icon} />
           <div className={`${baseClassName}__name`}>{conversation.name}</div>


### PR DESCRIPTION
Appears to be mostly an issue with Chrome's handling of layout when the conversation list has a scrollbar.
Making the close button and unread indicator `position: absolute` makes Chrome stop trying to relayout nearly everything on screen.
Safari and Firefox do not appear to have the same relayout issue.

The position of some elements get moved slightly as preserving them ended up having too many confusing calculations

closes #6200