### PR TITLE
Faster initial render when there are many beatmap discussion posts

### DIFF
--- a/resources/assets/coffee/_classes/sticky-header.coffee
+++ b/resources/assets/coffee/_classes/sticky-header.coffee
@@ -36,7 +36,6 @@ class @StickyHeader
 
 
   onScroll: =>
-    console.log('scroll')
     @pin()
     @stickOrUnstick()
 

--- a/resources/assets/coffee/_classes/sticky-header.coffee
+++ b/resources/assets/coffee/_classes/sticky-header.coffee
@@ -7,7 +7,7 @@
 # 2. Add 'js-sticky-header' class to a marker element that should cause the sticky to show.
 class @StickyHeader
   constructor: ->
-    @debouncedOnScroll = _.debounce @onScroll, 100
+    @debouncedOnScroll = _.debounce @onScroll, 20
     @header = document.getElementsByClassName('js-pinned-header')
     @marker = document.getElementsByClassName('js-sticky-header')
     @pinnedSticky = document.getElementsByClassName('js-pinned-header-sticky')
@@ -36,6 +36,7 @@ class @StickyHeader
 
 
   onScroll: =>
+    console.log('scroll')
     @pin()
     @stickOrUnstick()
 

--- a/resources/assets/coffee/_classes/sticky-header.coffee
+++ b/resources/assets/coffee/_classes/sticky-header.coffee
@@ -7,6 +7,7 @@
 # 2. Add 'js-sticky-header' class to a marker element that should cause the sticky to show.
 class @StickyHeader
   constructor: ->
+    @debouncedOnScroll = _.debounce @onScroll, 100
     @header = document.getElementsByClassName('js-pinned-header')
     @marker = document.getElementsByClassName('js-sticky-header')
     @pinnedSticky = document.getElementsByClassName('js-pinned-header-sticky')
@@ -14,7 +15,7 @@ class @StickyHeader
     @stickyContent = document.getElementsByClassName('js-sticky-header-content')
 
     $(window).on 'throttled-scroll', @onScroll
-    $(document).on 'turbolinks:load osu:page:change', => Timeout.set 0, @onScroll
+    $(document).on 'turbolinks:load osu:page:change', @debouncedOnScroll
     $(window).on 'throttled-resize', @stickOrUnstick
 
 


### PR DESCRIPTION
Every discussion post triggers an `osu:page:change` event when mounted; this ends up not working so well when there're hundreds of them continually triggering the handler that needs to do a layout, before the page has even finished rendering all the components.

Would be useful if there was a way to tell if the page finished rendering 🤔 

related #6285; I'm pretty sure the lag with typing is a different issue
(also not sure if `throttled-scroll` should just use the debounced handler as well)