### PR TITLE
Include database defaults when returning new room data

### DIFF
--- a/app/Models/Multiplayer/Room.php
+++ b/app/Models/Multiplayer/Room.php
@@ -250,7 +250,8 @@ class Room extends Model
             }
         });
 
-        return $this;
+        // to load db-level default attributes
+        return $this->fresh();
     }
 
     public function startPlay(User $user, PlaylistItem $playlistItem)


### PR DESCRIPTION
Why `startGame` an instance function though :thinking: 