### PR TITLE
Use older syntax for array merge

### DIFF
--- a/app/Http/Controllers/Multiplayer/Rooms/Playlist/ScoresController.php
+++ b/app/Http/Controllers/Multiplayer/Rooms/Playlist/ScoresController.php
@@ -123,7 +123,7 @@ class ScoresController extends BaseController
         return json_item(
             $score,
             'Multiplayer\Score',
-            ['position', 'scores_around', ...ScoreTransformer::BASE_INCLUDES]
+            array_merge(['position', 'scores_around'], ScoreTransformer::BASE_INCLUDES)
         );
     }
 
@@ -162,7 +162,7 @@ class ScoresController extends BaseController
             return json_item(
                 $score,
                 'Multiplayer\Score',
-                ['position', 'scores_around', ...ScoreTransformer::BASE_INCLUDES]
+                array_merge(['position', 'scores_around'], ScoreTransformer::BASE_INCLUDES)
             );
         } catch (InvariantException $e) {
             return error_popup($e->getMessage(), $e->getStatusCode());


### PR DESCRIPTION
I saw the syntax and thought was neat but forgot to check which version it's added.