### PR TITLE
Fix notification and chat icon don't load

### DIFF
--- a/resources/assets/lib/notifications/worker.ts
+++ b/resources/assets/lib/notifications/worker.ts
@@ -118,6 +118,7 @@ export default class Worker {
   }
 
   @action destroy = () => {
+    this.userId = null;
     this.active = false;
     this.hasData = false;
     this.store.flushStore();


### PR DESCRIPTION
fix #6300 

The problem is when logout, `this.userId` is still saved. After login again, it returns in this condition

https://github.com/ppy/osu-web/blob/b72dd938498c18b758596ac90a4d43666ac287bb/resources/assets/lib/notifications/worker.ts#L211-L213

and doesn't call `this.boot()`, so `this.active` is not changed to `true`.

Alternative solution: call `this.boot()` inside condition above. But I'm not sure which one is better.