### PR TITLE
Change view ranking filter header

### DIFF
--- a/resources/assets/less/bem/ranking-filter.less
+++ b/resources/assets/less/bem/ranking-filter.less
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 .ranking-filter {
+  @top: ranking-filter;
   --gutter: 10px;
   display: flex;
   flex-direction: column;
@@ -13,22 +14,37 @@
   }
 
   &__item {
-    padding: var(--gutter);
+    padding: 5px var(--gutter);
     flex: 1;
+    display: flex;
+    align-items: center;
 
     @media @desktop {
       flex: none;
+      display: block;
     }
 
     &--title {
-      padding: 10px;
       font-weight: bold;
       text-transform: uppercase;
+      font-size: @font-size--normal-2;
+
+      @media @desktop {
+        margin-bottom: 10px;
+        padding: 0 10px;
+      }
     }
 
     &--full {
+      display: block;
+
       @media @desktop {
         flex: 1;
+      }
+
+      .@{top}__item--title {
+        padding: 0;
+        margin-bottom: 10px;
       }
     }
   }

--- a/resources/assets/less/bem/ranking-filter.less
+++ b/resources/assets/less/bem/ranking-filter.less
@@ -20,6 +20,12 @@
       flex: none;
     }
 
+    &--title {
+      padding: 10px;
+      font-weight: bold;
+      text-transform: uppercase;
+    }
+
     &--full {
       @media @desktop {
         flex: 1;

--- a/resources/assets/less/bem/ranking-filter.less
+++ b/resources/assets/less/bem/ranking-filter.less
@@ -6,7 +6,7 @@
   --gutter: 10px;
   display: flex;
   flex-direction: column;
-  margin: calc(var(--gutter) * -1);
+  margin: calc(var(--gutter) / 2 * -1) calc(var(--gutter) * -1);
 
   @media @desktop {
     flex-direction: row;
@@ -14,7 +14,7 @@
   }
 
   &__item {
-    padding: 5px var(--gutter);
+    padding: calc(var(--gutter) / 2) var(--gutter);
     flex: 1;
     display: flex;
     align-items: center;
@@ -27,11 +27,15 @@
     &--title {
       font-weight: bold;
       text-transform: uppercase;
-      font-size: @font-size--normal-2;
+      font-size: @font-size--normal;
+      margin-right: 15px;
 
       @media @desktop {
         margin-bottom: 10px;
-        padding: 0 10px;
+      }
+
+      .@{top}__item--full & {
+        margin-bottom: 10px;
       }
     }
 
@@ -40,11 +44,6 @@
 
       @media @desktop {
         flex: 1;
-      }
-
-      .@{top}__item--title {
-        padding: 0;
-        margin-bottom: 10px;
       }
     }
   }

--- a/resources/assets/less/bem/ranking-filter.less
+++ b/resources/assets/less/bem/ranking-filter.less
@@ -28,14 +28,13 @@
       font-weight: bold;
       text-transform: uppercase;
       font-size: @font-size--normal;
+      margin-bottom: 10px;
       margin-right: 15px;
 
-      @media @desktop {
-        margin-bottom: 10px;
-      }
-
-      .@{top}__item--full & {
-        margin-bottom: 10px;
+      .@{top}__item:not(.@{top}__item--full) & {
+        @media @mobile {
+          margin-bottom: 0;
+        }
       }
     }
 

--- a/resources/assets/lib/ranking-filter.tsx
+++ b/resources/assets/lib/ranking-filter.tsx
@@ -110,7 +110,7 @@ export default class RankingFilter extends React.PureComponent<Props> {
             <Sort
               currentValue={this.filterMode ?? 'all'}
               onChange={this.handleFilterChange}
-              title=''
+              showTitle={false}
               values={['all', 'friends']}
             />
           </div>
@@ -161,7 +161,7 @@ export default class RankingFilter extends React.PureComponent<Props> {
       <Sort
         currentValue={this.currentVariant ?? 'all'}
         onChange={this.handleVariantChange}
-        title=''
+        showTitle={false}
         transPrefix={`beatmaps.variant.${this.props.gameMode}.`}
         values={this.props.variants}
       />

--- a/resources/assets/lib/ranking-filter.tsx
+++ b/resources/assets/lib/ranking-filter.tsx
@@ -96,9 +96,6 @@ export default class RankingFilter extends React.PureComponent<Props> {
     return (
       <div className='ranking-filter'>
         <div className='ranking-filter__item ranking-filter__item--full'>
-          <div className='ranking-filter__item--title'>
-            {osu.trans('rankings.countries.title')}
-          </div>
           {this.renderCountries()}
         </div>
 
@@ -132,13 +129,18 @@ export default class RankingFilter extends React.PureComponent<Props> {
     if (this.props.type !== 'performance') return null;
 
     return (
-      <SelectOptions
-        bn='ranking-select-options'
-        onChange={this.handleCountryChange}
-        options={[...this.options.values()]} // TODO: change to iterable
-        renderOption={this.renderOption}
-        selected={this.selectedOption}
-      />
+      <>
+        <div className='ranking-filter__item--title'>
+          {osu.trans('rankings.countries.title')}
+        </div>
+        <SelectOptions
+          bn='ranking-select-options'
+          onChange={this.handleCountryChange}
+          options={[...this.options.values()]} // TODO: change to iterable
+          renderOption={this.renderOption}
+          selected={this.selectedOption}
+        />
+      </>
     );
   }
 

--- a/resources/assets/lib/ranking-filter.tsx
+++ b/resources/assets/lib/ranking-filter.tsx
@@ -96,15 +96,21 @@ export default class RankingFilter extends React.PureComponent<Props> {
     return (
       <div className='ranking-filter'>
         <div className='ranking-filter__item ranking-filter__item--full'>
+          <div className='ranking-filter__item--title'>
+            {osu.trans('rankings.countries.title')}
+          </div>
           {this.renderCountries()}
         </div>
 
         {currentUser.id != null && (
           <div className='ranking-filter__item'>
+            <div className='ranking-filter__item--title'>
+              {osu.trans('rankings.filter.title')}
+            </div>
             <Sort
               currentValue={this.filterMode ?? 'all'}
               onChange={this.handleFilterChange}
-              title={osu.trans('rankings.filter.title')}
+              title=''
               values={['all', 'friends']}
             />
           </div>
@@ -112,6 +118,9 @@ export default class RankingFilter extends React.PureComponent<Props> {
 
         {this.props.variants != null && (
           <div className='ranking-filter__item'>
+            <div className='ranking-filter__item--title'>
+              {osu.trans('rankings.filter.variant.title')}
+            </div>
             {this.renderVariants()}
           </div>
         )}
@@ -152,7 +161,7 @@ export default class RankingFilter extends React.PureComponent<Props> {
       <Sort
         currentValue={this.currentVariant ?? 'all'}
         onChange={this.handleVariantChange}
-        title={osu.trans('rankings.filter.variant.title')}
+        title=''
         transPrefix={`beatmaps.variant.${this.props.gameMode}.`}
         values={this.props.variants}
       />

--- a/resources/assets/lib/sort.tsx
+++ b/resources/assets/lib/sort.tsx
@@ -1,13 +1,13 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
-import * as React from "react";
+import * as React from 'react';
 
 interface Props {
   currentValue: string;
   modifiers?: string[];
-  title?: string;
   showTitle?: boolean;
+  title?: string;
   transPrefix: string;
   values: string[];
   onChange(event: React.MouseEvent<HTMLButtonElement>): void;
@@ -16,7 +16,7 @@ interface Props {
 export class Sort extends React.PureComponent<Props> {
   static readonly defaultProps = {
     showTitle: true,
-    transPrefix: "sort."
+    transPrefix: 'sort.',
   };
 
   render() {
@@ -45,10 +45,10 @@ export class Sort extends React.PureComponent<Props> {
     });
 
     return (
-      <div className={osu.classWithModifiers("sort", this.props.modifiers)}>
-        <div className="sort__items">
+      <div className={osu.classWithModifiers('sort', this.props.modifiers)}>
+        <div className='sort__items'>
           {this.props.showTitle && (
-            <span className="sort__item sort__item--title">{this.props.title ?? osu.trans("sort._")}</span>
+            <span className='sort__item sort__item--title'>{this.props.title ?? osu.trans('sort._')}</span>
           )}
           {items}
         </div>

--- a/resources/assets/lib/sort.tsx
+++ b/resources/assets/lib/sort.tsx
@@ -7,7 +7,7 @@ interface Props {
   currentValue: string;
   modifiers?: string[];
   title?: string;
-  showTitle: boolean;
+  showTitle?: boolean;
   transPrefix: string;
   values: string[];
   onChange(event: React.MouseEvent<HTMLButtonElement>): void;

--- a/resources/assets/lib/sort.tsx
+++ b/resources/assets/lib/sort.tsx
@@ -1,12 +1,13 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
-import * as React from 'react';
+import * as React from "react";
 
 interface Props {
   currentValue: string;
   modifiers?: string[];
   title?: string;
+  showTitle: boolean;
   transPrefix: string;
   values: string[];
   onChange(event: React.MouseEvent<HTMLButtonElement>): void;
@@ -14,7 +15,8 @@ interface Props {
 
 export class Sort extends React.PureComponent<Props> {
   static readonly defaultProps = {
-    transPrefix: 'sort.',
+    showTitle: true,
+    transPrefix: "sort."
   };
 
   render() {
@@ -43,9 +45,11 @@ export class Sort extends React.PureComponent<Props> {
     });
 
     return (
-      <div className={osu.classWithModifiers('sort', this.props.modifiers)}>
-        <div className='sort__items'>
-          <span className='sort__item sort__item--title'>{this.props.title ?? osu.trans('sort._')}</span>
+      <div className={osu.classWithModifiers("sort", this.props.modifiers)}>
+        <div className="sort__items">
+          {this.props.showTitle && (
+            <span className="sort__item sort__item--title">{this.props.title ?? osu.trans("sort._")}</span>
+          )}
           {items}
         </div>
       </div>

--- a/resources/lang/en/rankings.php
+++ b/resources/lang/en/rankings.php
@@ -6,6 +6,7 @@
 return [
     'countries' => [
         'all' => 'All',
+        'title' => 'Country',
     ],
 
     'filter' => [

--- a/resources/views/rankings/index.blade.php
+++ b/resources/views/rankings/index.blade.php
@@ -73,6 +73,9 @@
                 <div class="ranking-filter">
                     <div class="ranking-filter__item ranking-filter__item--full">
                         @if ($type === 'performance')
+                            <div class="ranking-filter__item--title">
+                                {{ trans('rankings.countries.title') }}
+                            </div>
                             <div class="ranking-select-options">
                                 <div class="ranking-select-options__select">
                                     <div class="ranking-select-options__option">{{ optional($country)->name ?? trans('rankings.countries.all') }}</div>
@@ -82,9 +85,11 @@
                     </div>
                     @if (auth()->check())
                         <div class="ranking-filter__item">
+                            <div class="ranking-filter__item--title">
+                                {{ trans('rankings.filter.title') }}
+                            </div>
                             <div class="sort">
                                 <div class="sort__items">
-                                    <span class="sort__item sort__item--title">{{ trans('rankings.filter.title') }}</span>
                                     <button class="sort__item sort__item--button">{{ trans('sort.all') }}</button>
                                     <button class="sort__item sort__item--button">{{ trans('sort.friends')}}</button>
                                 </div>
@@ -93,9 +98,11 @@
                     @endif
                     @if (isset($variants))
                         <div class="ranking-filter__item">
+                            <div class="ranking-filter__item--title">
+                                {{ trans('rankings.filter.variant.title') }}
+                            </div>
                             <div class="sort">
                                 <div class="sort__items">
-                                    <span class="sort__item sort__item--title">{{ trans('rankings.filter.variant.title') }}</span>
                                     @foreach ($variants as $v)
                                         <button class="sort__item sort__item--button">
                                             {{ trans("beatmaps.variant.{$mode}.{$v}") }}


### PR DESCRIPTION
Closed #6201 

I only change based on the design and don't modify `Sort` component to prevent changes in other page.

**Desktop**

![image](https://user-images.githubusercontent.com/4964985/87417411-54988900-c5fa-11ea-8520-3e119d141f33.png)

**Mobile**

![image](https://user-images.githubusercontent.com/4964985/87417494-7560de80-c5fa-11ea-9700-63de236e839b.png)

The mobile view is cover up half of the screen. Should I make it horizontal?