### PR TITLE
Fix quick search bug when using space keyword only

### DIFF
--- a/resources/assets/lib/quick-search/main.tsx
+++ b/resources/assets/lib/quick-search/main.tsx
@@ -77,7 +77,7 @@ const otherModes: ResultMode[] = ['forum_post', 'wiki_page'];
   }
 
   private count(mode: ResultMode) {
-    if (this.props.worker.searchResult === null) {
+    if (this.props.worker.searchResult === null || this.props.worker.searchResult[mode] === undefined) {
       return 0;
     }
 
@@ -107,7 +107,7 @@ const otherModes: ResultMode[] = ['forum_post', 'wiki_page'];
   }
 
   private renderBeatmapsets() {
-    if (this.props.worker.searchResult == null) {
+    if (this.props.worker.searchResult === null || this.props.worker.searchResult.beatmapset === undefined) {
       return null;
     }
 

--- a/resources/assets/lib/quick-search/main.tsx
+++ b/resources/assets/lib/quick-search/main.tsx
@@ -77,7 +77,7 @@ const otherModes: ResultMode[] = ['forum_post', 'wiki_page'];
   }
 
   private count(mode: ResultMode) {
-    if (this.props.worker.searchResult === null || this.props.worker.searchResult[mode] === undefined) {
+    if (this.props.worker.searchResult === null) {
       return 0;
     }
 
@@ -107,7 +107,7 @@ const otherModes: ResultMode[] = ['forum_post', 'wiki_page'];
   }
 
   private renderBeatmapsets() {
-    if (this.props.worker.searchResult === null || this.props.worker.searchResult.beatmapset === undefined) {
+    if (this.props.worker.searchResult === null) {
       return null;
     }
 

--- a/resources/assets/lib/quick-search/worker.ts
+++ b/resources/assets/lib/quick-search/worker.ts
@@ -121,7 +121,8 @@ export default class Worker {
   }
 
   @action search() {
-    if (this.query.length === 0) {
+    const query = this.query.trim();
+    if (query.length === 0) {
       this.reset();
 
       return;
@@ -129,7 +130,7 @@ export default class Worker {
 
     this.searching = true;
 
-    this.xhr = $.get(route('quick-search'), { query: this.query })
+    this.xhr = $.get(route('quick-search'), { query })
     .done(action((searchResult: SearchResult) => {
       this.searchResult = searchResult;
       this.selected = null;


### PR DESCRIPTION
fix #6308 

Should I change this

https://github.com/ppy/osu-web/blob/eeaecc44c06a4a657765a5eb4a0180a74a93e2ce/resources/assets/lib/quick-search/worker.ts#L25-L30

to this

```ts
interface SearchResult {
  beatmapset?: SearchResultBeatmapset;
  forum_post?: SearchResultSummary;
  user?: SearchResultUser;
  wiki_page?: SearchResultSummary;
}
```

to check another potential undefined?