### PR TITLE
Allow beatmapset search when authenticated using oauth

### DIFF
--- a/app/Libraries/OsuAuthorize.php
+++ b/app/Libraries/OsuAuthorize.php
@@ -502,7 +502,7 @@ class OsuAuthorize
      */
     public function checkBeatmapsetAdvancedSearch(?User $user): string
     {
-        if (!config('osu.beatmapset.guest_advanced_search')) {
+        if (oauth_token() === null && !config('osu.beatmapset.guest_advanced_search')) {
             $this->ensureLoggedIn($user);
         }
 


### PR DESCRIPTION
The user is still guest so some things like personal difficulty rating search won't work.

Resolves #6314.