### PR TITLE
Add support for play mode variant to tournament

### DIFF
--- a/app/Models/Tournament.php
+++ b/app/Models/Tournament.php
@@ -99,8 +99,7 @@ class Tournament extends Model
 
         $userRank = UserStatistics\Model
             ::getClass($this->playModeStr(), $this->play_mode_variant)
-            ::where('user_id', $user->getKey())
-            ->firstOrNew([])
+            ::firstOrNew(['user_id' => $user->getKey()])
             ->globalRank();
 
         if ($this->rank_min !== null && ($userRank === null || $this->rank_min > $userRank)) {

--- a/app/Models/Tournament.php
+++ b/app/Models/Tournament.php
@@ -97,13 +97,18 @@ class Tournament extends Model
             return false;
         }
 
-        $stats = $user->statistics($this->playModeStr(), true)->firstOrNew([]);
+        $stats = UserStatistics\Model
+            ::getClass($this->playModeStr(), $this->play_mode_variant)
+            ::where('user_id', $user->getKey())
+            ->firstOrNew([]);
 
-        if ($this->rank_min !== null && $this->rank_min > $stats->rank_score_index) {
+        $userRank = $stats->globalRank();
+
+        if ($this->rank_min !== null && ($userRank === null || $this->rank_min > $stats->rank_score_index)) {
             return false;
         }
 
-        if ($this->rank_max !== null && $this->rank_max < $stats->rank_score_index) {
+        if ($this->rank_max !== null && ($userRank === null || $this->rank_max < $stats->rank_score_index)) {
             return false;
         }
 

--- a/app/Models/Tournament.php
+++ b/app/Models/Tournament.php
@@ -97,18 +97,17 @@ class Tournament extends Model
             return false;
         }
 
-        $stats = UserStatistics\Model
+        $userRank = UserStatistics\Model
             ::getClass($this->playModeStr(), $this->play_mode_variant)
             ::where('user_id', $user->getKey())
-            ->firstOrNew([]);
+            ->firstOrNew([])
+            ->globalRank();
 
-        $userRank = $stats->globalRank();
-
-        if ($this->rank_min !== null && ($userRank === null || $this->rank_min > $stats->rank_score_index)) {
+        if ($this->rank_min !== null && ($userRank === null || $this->rank_min > $userRank)) {
             return false;
         }
 
-        if ($this->rank_max !== null && ($userRank === null || $this->rank_max < $stats->rank_score_index)) {
+        if ($this->rank_max !== null && ($userRank === null || $this->rank_max < $userRank)) {
             return false;
         }
 

--- a/app/Models/UserStatistics/Model.php
+++ b/app/Models/UserStatistics/Model.php
@@ -20,6 +20,7 @@ abstract class Model extends BaseModel
     protected $primaryKey = 'user_id';
 
     public $timestamps = false;
+    public $incrementing = false;
 
     const UPDATED_AT = 'last_update';
 

--- a/database/migrations/2020_07_17_021430_add_play_mode_variant_to_tournaments.php
+++ b/database/migrations/2020_07_17_021430_add_play_mode_variant_to_tournaments.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2020_07_17_021430_add_play_mode_variant_to_tournaments.php
+++ b/database/migrations/2020_07_17_021430_add_play_mode_variant_to_tournaments.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddPlayModeVariantToTournaments extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('tournaments', function (Blueprint $table) {
+            $table->string('play_mode_variant')->nullable()->after('play_mode');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('tournaments', function (Blueprint $table) {
+            $table->dropColumn('play_mode_variant');
+        });
+    }
+}

--- a/tests/Models/TournamentTest.php
+++ b/tests/Models/TournamentTest.php
@@ -23,7 +23,7 @@ class TournamentTest extends TestCase
             'rank_max' => 100,
         ]);
 
-        $stats = $user->statisticsOsu()->firstOrCreate([
+        $stats = $user->statisticsOsu()->create([
             'rank_score_index' => $tournament->rank_max + 1,
             'rank_score' => 1,
         ]);
@@ -47,7 +47,7 @@ class TournamentTest extends TestCase
             'rank_max' => 100,
         ]);
 
-        $user->statisticsMania()->firstOrCreate([
+        $user->statisticsMania()->create([
             'rank_score_index' => $tournament->rank_max,
             'rank_score' => 1,
         ]);
@@ -56,7 +56,8 @@ class TournamentTest extends TestCase
 
         $stats = UserStatistics\Model
             ::getClass('mania', $playModeVariant)
-            ::firstOrCreate(['user_id' => $user->getKey()], [
+            ::create([
+                'user_id' => $user->getKey(),
                 'rank_score_index' => $tournament->rank_max + 1,
                 'rank_score' => 1,
             ]);


### PR DESCRIPTION
Should be pretty straightforward: set `play_mode_variant` column (`4k` or `7k` for mania) as needed. Empty string isn't a valid variant. Null (value, not "null" string) is.