### PR TITLE
Chat controller cleanup

### DIFF
--- a/app/Http/Controllers/Chat/ChatController.php
+++ b/app/Http/Controllers/Chat/ChatController.php
@@ -121,7 +121,7 @@ class ChatController extends Controller
             abort(422);
         }
 
-        $presence = self::presence();
+        $presence = $this->presence();
 
         $since = $params['since'];
         $limit = clamp(get_int($params['limit'] ?? null) ?? 50, 1, 50);

--- a/app/Http/Controllers/Chat/ChatController.php
+++ b/app/Http/Controllers/Chat/ChatController.php
@@ -143,7 +143,7 @@ class ChatController extends Controller
 
         $messages = $messages->get()->reverse();
 
-        if ($messages->isEmpty() || $since >= $messages->last()->message_id) {
+        if ($messages->isEmpty()) {
             return response([], 204);
         }
 

--- a/app/Http/Controllers/Chat/ChatController.php
+++ b/app/Http/Controllers/Chat/ChatController.php
@@ -11,7 +11,6 @@ use App\Models\Chat\Message;
 use App\Models\Chat\UserChannel;
 use App\Models\User;
 use Auth;
-use Request;
 
 /**
  * @group Chat
@@ -116,14 +115,16 @@ class ChatController extends Controller
      */
     public function updates()
     {
-        if (!present(Request::input('since'))) {
+        $params = request()->all();
+
+        if (!present($params['since'] ?? null)) {
             abort(422);
         }
 
         $presence = self::presence();
 
-        $since = Request::input('since');
-        $limit = clamp(get_int(Request::input('limit')) ?? 50, 1, 50);
+        $since = $params['since'];
+        $limit = clamp(get_int($params['limit'] ?? null) ?? 50, 1, 50);
 
         // this is used to filter out messages from restricted users/etc
         $channelIds = array_map(function ($e) {
@@ -136,8 +137,8 @@ class ChatController extends Controller
             ->since($since)
             ->limit($limit);
 
-        if (present(Request::input('channel_id'))) {
-            $messages->where('channel_id', get_int(Request::input('channel_id')));
+        if (present($params['channel_id'] ?? null)) {
+            $messages->where('channel_id', get_int($params['channel_id']));
         }
 
         $messages = $messages->get()->reverse();

--- a/app/Http/Controllers/Chat/ChatController.php
+++ b/app/Http/Controllers/Chat/ChatController.php
@@ -147,7 +147,7 @@ class ChatController extends Controller
             return response([], 204);
         }
 
-        $response = [
+        return [
             'presence' => $presence,
             'messages' => json_collection(
                 $messages,
@@ -155,8 +155,6 @@ class ChatController extends Controller
                 ['sender']
             ),
         ];
-
-        return $response;
     }
 
     /**


### PR DESCRIPTION
One time `request()` call and remove redundant check `$since >= messages.last.id` after a `messages.id > $since` query.