### PR TITLE
Allow public access of news API endpoint

### DIFF
--- a/app/Http/Middleware/RequireScopes.php
+++ b/app/Http/Middleware/RequireScopes.php
@@ -15,6 +15,7 @@ class RequireScopes
     const NO_TOKEN_REQUIRED = [
         'api/v2/changelog/',
         'api/v2/comments/',
+        'api/v2/news/',
         'api/v2/seasonal-backgrounds/',
         'api/v2/wiki/',
     ];


### PR DESCRIPTION
Resolves #6361.

The alternative is for client to request client grant token and use that instead :thinking: 