### PR TITLE
Fix redis prefix for password reset throttling namespace

### DIFF
--- a/app/Http/Controllers/PasswordResetController.php
+++ b/app/Http/Controllers/PasswordResetController.php
@@ -21,7 +21,7 @@ class PasswordResetController extends Controller
 
         $this->middleware('guest');
         $this->middleware('throttle:60,10');
-        $this->middleware('throttle:20,1440,password-reset-');
+        $this->middleware('throttle:20,1440,password-reset:');
     }
 
     public function destroy()


### PR DESCRIPTION
Current prefix ending with `-` makes it difficult to gather stats of.