### PR TITLE
Increase length of Beatmapset title prefix matching

### DIFF
--- a/config/schemas/beatmaps.json
+++ b/config/schemas/beatmaps.json
@@ -217,8 +217,8 @@
         "tokenizer": {
           "prefix": {
             "type": "edge_ngram",
-            "min_gram": "3",
-            "max_gram": "8",
+            "min_gram": "2",
+            "max_gram": "20",
             "token_chars": [
               "letter",
               "digit"


### PR DESCRIPTION
requires reindex `php artisan es:index-documents --types=beatmapsets --yes --cleanup`

closes #6284