### PR TITLE
Persistent "Hide Deleted Posts" setting

### DIFF
--- a/app/Http/Controllers/AccountController.php
+++ b/app/Http/Controllers/AccountController.php
@@ -206,6 +206,7 @@ class AccountController extends Controller
             'beatmapset_title_show_original:bool',
             'comments_sort:string',
             'extras_order:string[]',
+            'forum_posts_show_deleted:bool',
             'ranking_expanded:bool',
             'user_list_filter:string',
             'user_list_sort:string',

--- a/app/Http/Controllers/Forum/TopicsController.php
+++ b/app/Http/Controllers/Forum/TopicsController.php
@@ -195,11 +195,19 @@ class TopicsController extends Controller
 
     public function show($id)
     {
-        $postStartId = Request::input('start');
-        $postEndId = get_int(Request::input('end'));
-        $nthPost = get_int(Request::input('n'));
-        $skipLayout = get_bool(Request::input('skip_layout')) ?? false;
-        $showDeleted = get_bool(Request::input('with_deleted')) ?? true;
+        $params = get_params(request()->all(), null, [
+            'start',
+            'end:int',
+            'n:int',
+            'skip_layout:bool',
+            'with_deleted:bool',
+        ]);
+
+        $postStartId = $params['start'] ?? null;
+        $postEndId = $params['end'] ?? null;
+        $nthPost = $params['n'] ?? null;
+        $skipLayout = $params['skip_layout'] ?? false;
+        $showDeleted = $params['with_deleted'] ?? true;
         $jumpTo = null;
 
         $topic = Topic

--- a/app/Http/Controllers/Forum/TopicsController.php
+++ b/app/Http/Controllers/Forum/TopicsController.php
@@ -207,7 +207,7 @@ class TopicsController extends Controller
         $postEndId = $params['end'] ?? null;
         $nthPost = $params['n'] ?? null;
         $skipLayout = $params['skip_layout'] ?? false;
-        $showDeleted = $params['with_deleted'] ?? true;
+        $showDeleted = $params['with_deleted'] ?? null;
         $jumpTo = null;
 
         $topic = Topic
@@ -228,9 +228,15 @@ class TopicsController extends Controller
             abort(404);
         }
 
+        if ($userCanModerate) {
+            $showDeleted = $showDeleted ?? auth()->user()->profileCustomization()->forum_posts_show_deleted;
+        } else {
+            $showDeleted = false;
+        }
+
         priv_check('ForumView', $topic->forum)->ensureCan();
 
-        $posts = $topic->posts()->showDeleted($showDeleted && $userCanModerate);
+        $posts = $topic->posts()->showDeleted($showDeleted);
 
         if ($postStartId === 'unread') {
             $postStartId = Post::lastUnreadByUser($topic, Auth::user());

--- a/app/Models/UserProfileCustomization.php
+++ b/app/Models/UserProfileCustomization.php
@@ -162,6 +162,16 @@ class UserProfileCustomization extends Model
         $this->setOption('comments_sort', $value);
     }
 
+    public function getForumPostsShowDeletedAttribute()
+    {
+        return $this->options['forum_posts_show_deleted'] ?? true;
+    }
+
+    public function setForumPostsShowDeletedAttribute($value)
+    {
+        $this->setOption('forum_posts_show_deleted', $value);
+    }
+
     public function getUserListFilterAttribute()
     {
         return $this->options['user_list_filter'] ?? static::USER_LIST['filters']['default'];

--- a/app/Transformers/UserCompactTransformer.php
+++ b/app/Transformers/UserCompactTransformer.php
@@ -325,6 +325,7 @@ class UserCompactTransformer extends TransformerAbstract
             'audio_volume',
             'beatmapset_download',
             'beatmapset_title_show_original',
+            'forum_posts_show_deleted',
             'ranking_expanded',
             'user_list_filter',
             'user_list_sort',

--- a/resources/assets/coffee/_classes/forum.coffee
+++ b/resources/assets/coffee/_classes/forum.coffee
@@ -202,7 +202,7 @@ class @Forum
           forum_posts_show_deleted: +!@showDeleted()
     .done (user) =>
       $.publish 'user:update', user
-      Turbolinks.visit osu.updateQueryString @postUrlN(@currentPostPosition)
+      Turbolinks.visit @postUrlN(@currentPostPosition)
 
 
   initialScrollTo: =>

--- a/resources/assets/coffee/_classes/forum.coffee
+++ b/resources/assets/coffee/_classes/forum.coffee
@@ -199,7 +199,7 @@ class @Forum
       method: 'PUT'
       data:
         user_profile_customization:
-          forum_posts_show_deleted: +!@showDeleted()
+          forum_posts_show_deleted: !@showDeleted()
     .done (user) =>
       $.publish 'user:update', user
       Turbolinks.visit @postUrlN(@currentPostPosition)

--- a/resources/assets/coffee/_classes/forum.coffee
+++ b/resources/assets/coffee/_classes/forum.coffee
@@ -193,8 +193,17 @@ class @Forum
 
 
   toggleDeleted: =>
-    Turbolinks.visit osu.updateQueryString @postUrlN(@currentPostPosition),
-      with_deleted: +!@showDeleted()
+    return if !@showDeleted()? # you don't see this option unless you're a moderator, anyway
+
+    $.ajax laroute.route('account.options'),
+      method: 'PUT'
+      data:
+        user_profile_customization:
+          forum_posts_show_deleted: +!@showDeleted()
+    .done (user) =>
+      $.publish 'user:update', user
+      Turbolinks.visit osu.updateQueryString @postUrlN(@currentPostPosition)
+
 
   initialScrollTo: =>
     return if location.hash != '' ||
@@ -206,19 +215,14 @@ class @Forum
 
 
   postUrlClick: (e) =>
-      e.preventDefault()
+    e.preventDefault()
 
-      id = $(e.target).closest('.js-forum-post').attr('data-post-id')
-      @scrollTo id
+    id = $(e.target).closest('.js-forum-post').attr('data-post-id')
+    @scrollTo id
 
 
   postUrlN: (postN) ->
-    url = "#{document.location.pathname}?n=#{postN}"
-
-    if @showDeleted() == false
-      url += "&with_deleted=0"
-
-    url
+    "#{document.location.pathname}?n=#{postN}"
 
 
   showMore: (e) =>


### PR DESCRIPTION
`with_deleted` query string will still override the saved setting, but won't change it, unless the option is toggled.

I was looking at streamlining some of the `with_deleted` handling but it turned out to be quite messy keeping the url param, blade and js state in sync, so I ended up skipping it.

closes #6218 