### PR TITLE
Shorten duration of guest sessions

### DIFF
--- a/app/Libraries/Session/CacheBasedSessionHandler.php
+++ b/app/Libraries/Session/CacheBasedSessionHandler.php
@@ -1,0 +1,16 @@
+<?php
+
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
+namespace App\Libraries\Session;
+
+use Illuminate\Session\CacheBasedSessionHandler as SessionHandlerBase;
+
+class CacheBasedSessionHandler extends SessionHandlerBase
+{
+    public function setMinutes($minutes)
+    {
+        $this->minutes = $minutes;
+    }
+}

--- a/app/Libraries/Session/SessionManager.php
+++ b/app/Libraries/Session/SessionManager.php
@@ -17,4 +17,15 @@ class SessionManager extends \Illuminate\Session\SessionManager
     {
         return new Store($this->app['config']['session.cookie'], $handler);
     }
+
+    // copied from upstream but with custom CacheBasedSessionHandler
+    protected function createCacheHandler($driver)
+    {
+        $store = $this->config->get('session.store') ?: $driver;
+
+        return new CacheBasedSessionHandler(
+            clone $this->container->make('cache')->store($store),
+            $this->config->get('session.lifetime')
+        );
+    }
 }

--- a/app/Libraries/Session/Store.php
+++ b/app/Libraries/Session/Store.php
@@ -244,9 +244,8 @@ class Store extends \Illuminate\Session\Store
     public function save()
     {
         $isGuest = $this->isGuestSession();
-        $isRedis = static::isUsingRedis();
 
-        if ($isGuest && $isRedis) {
+        if ($isGuest && $this->handler instanceof CacheBasedSessionHandler) {
             $this->handler->setMinutes(120);
         }
 

--- a/app/Libraries/Session/Store.php
+++ b/app/Libraries/Session/Store.php
@@ -243,10 +243,17 @@ class Store extends \Illuminate\Session\Store
      */
     public function save()
     {
+        $isGuest = $this->isGuestSession();
+        $isRedis = static::isUsingRedis();
+
+        if ($isGuest && $isRedis) {
+            $this->handler->setMinutes(120);
+        }
+
         // Overriden to track user sessions in Redis
         parent::save();
 
-        if (!$this->isGuestSession()) {
+        if (!$isGuest) {
             Redis::sadd(config('cache.prefix').':'.$this->getCurrentKeyPrefix(), $this->getKey());
         }
     }


### PR DESCRIPTION
Resolves #6386. Guests still need session at least for csrf so shorten the duration instead. 2 hours should be enough :thinking: 