### PR TITLE
Remove old cache loader

### DIFF
--- a/bootstrap/autoload.php
+++ b/bootstrap/autoload.php
@@ -18,20 +18,3 @@ require_once __DIR__.'/../app/framework_helper_overrides.php';
 */
 
 require __DIR__.'/../vendor/autoload.php';
-
-/*
-|--------------------------------------------------------------------------
-| Include The Compiled Class File
-|--------------------------------------------------------------------------
-|
-| To dramatically increase your application's performance, you may use a
-| compiled class file which contains all of the classes commonly used
-| by a request. The Artisan "optimize" is used to create this file.
-|
-*/
-
-$compiledPath = __DIR__.'/cache/compiled.php';
-
-if (file_exists($compiledPath)) {
-    require $compiledPath;
-}


### PR DESCRIPTION
Precompiling is now done by composer and this check hasn't been useful for a while now. The file itself has been removed in laravel since 5.x but we still need it to preload helper overrides.