### PR TITLE
Fix User hasProfile check

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -1399,7 +1399,7 @@ class User extends Model implements AuthenticatableContract, HasLocalePreference
         return
             $this->user_id !== null
             && !$this->isRestricted()
-            && !$this->isBot();
+            && $this->group_id !== app('groups')->byIdentifier('no_profile')->getKey();
     }
 
     public function updatePage($text)


### PR DESCRIPTION
`isBot()` is actually for chat bots (with group identifier `bot`) which is different from the from the "bot" group that is supposed to be excluded here.

caused by #6419