### PR TITLE
Add temporary exception for timeshift submission from unsupported clients

### DIFF
--- a/app/Http/Controllers/Multiplayer/Rooms/Playlist/ScoresController.php
+++ b/app/Http/Controllers/Multiplayer/Rooms/Playlist/ScoresController.php
@@ -169,7 +169,7 @@ class ScoresController extends BaseController
         abort_if($clientHash === null, 422, 'missing client version');
 
         // temporary measure to allow android builds to submit without access to the underlying dll to hash
-        if (strlen($clientHash) != 32) {
+        if (strlen($clientHash) !== 32) {
             $clientHash = md5($clientHash);
         }
 

--- a/app/Http/Controllers/Multiplayer/Rooms/Playlist/ScoresController.php
+++ b/app/Http/Controllers/Multiplayer/Rooms/Playlist/ScoresController.php
@@ -167,6 +167,11 @@ class ScoresController extends BaseController
 
         $clientHash = presence(request('version_hash'));
         abort_if($clientHash === null, 422, 'missing client version');
+
+        // temporary measure to allow android builds to submit without access to the underlying dll to hash
+        if (strlen($clientHash) != 32)
+            $clientHash = md5($clientHash);
+
         Build::where([
             'hash' => hex2bin($clientHash),
             'allow_ranking' => true,

--- a/app/Http/Controllers/Multiplayer/Rooms/Playlist/ScoresController.php
+++ b/app/Http/Controllers/Multiplayer/Rooms/Playlist/ScoresController.php
@@ -169,8 +169,9 @@ class ScoresController extends BaseController
         abort_if($clientHash === null, 422, 'missing client version');
 
         // temporary measure to allow android builds to submit without access to the underlying dll to hash
-        if (strlen($clientHash) != 32)
+        if (strlen($clientHash) != 32) {
             $clientHash = md5($clientHash);
+        }
 
         Build::where([
             'hash' => hex2bin($clientHash),


### PR DESCRIPTION
Android version is having an issue where it can't access files inside apk to provide the expected hash. For the time being we are allowing an exception for this build, but it won't send an md5sum in this case, rather a string which needs to be md5'd locally to correctly match database.

I wasn't expecting to have to do this, but the database field is a binary and doesn't allow storing a string for direct matching.