### PR TITLE
Fix bookmark forum button not working

### DIFF
--- a/resources/assets/less/bem/forum-topic-nav.less
+++ b/resources/assets/less/bem/forum-topic-nav.less
@@ -25,7 +25,13 @@
     position: absolute;
     bottom: 0;
     left: 0;
-    overflow-x: auto;
+
+    @media @mobile {
+      overflow-x: auto;
+      height: auto;
+      padding-top: 150px;
+      padding-bottom: 10px;
+    }
   }
 
   &__counter {


### PR DESCRIPTION
Fix #6461

Pretty hacky solution.

Move the `overflow: auto` to mobile only, so desktop not affected.

I've checked w3 spec for overflow, looks like if `overflow-x` is set to other than `visible`, `overflow-y` will automatically change to `auto`. So we can't use something like `overflow-x: auto; overflow-y: visible`.

Another possible solution is change the `forum-topic-nav` to `overflow: visible` when bookmark button is clicked.