### PR TITLE
Undo scrollable forum navigation bar

### DIFF
--- a/resources/assets/less/bem/forum-topic-nav.less
+++ b/resources/assets/less/bem/forum-topic-nav.less
@@ -25,7 +25,6 @@
     position: absolute;
     bottom: 0;
     left: 0;
-    overflow-x: auto;
   }
 
   &__counter {


### PR DESCRIPTION
Proper fix will probably take a bit long so just undo the change for now.