### PR TITLE
Fix encoding of obscure email function

### DIFF
--- a/app/helpers.php
+++ b/app/helpers.php
@@ -656,7 +656,7 @@ function obscure_email($email)
         return '<unknown>';
     }
 
-    return $email[0][0].'***'.'@'.$email[1];
+    return mb_substr($email[0], 0, 1).'***'.'@'.$email[1];
 }
 
 function countries_array_for_select()


### PR DESCRIPTION
Apparently email with non-ascii local part is valid email (mail server support varies) ( ﾟ ヮﾟ)

Resolves #6468.