### PR TITLE
Add missing preload for forum topic page

### DIFF
--- a/app/Http/Controllers/Forum/TopicsController.php
+++ b/app/Http/Controllers/Forum/TopicsController.php
@@ -286,6 +286,7 @@ class TopicsController extends Controller
             ->with('user.rank')
             ->with('user.country')
             ->with('user.supporterTagPurchases')
+            ->with('user.userGroups')
             ->get()
             ->sortBy('post_id');
 

--- a/app/Http/Controllers/Forum/TopicsController.php
+++ b/app/Http/Controllers/Forum/TopicsController.php
@@ -282,6 +282,7 @@ class TopicsController extends Controller
         $posts = $posts
             ->take(20)
             ->with('forum')
+            ->with('lastEditor')
             ->with('topic')
             ->with('user.rank')
             ->with('user.country')

--- a/app/Models/Forum/Post.php
+++ b/app/Models/Forum/Post.php
@@ -106,6 +106,13 @@ class Post extends Model implements AfterCommit
         $this->attributes['bbcode_bitfield'] = $bbcode->bitfield;
     }
 
+    public function getPostEditUserAttribute($value)
+    {
+        if ($value !== 0) {
+            return $value;
+        }
+    }
+
     public function setPostTimeAttribute($value)
     {
         $this->attributes['post_time'] = get_timestamp_or_zero($value);


### PR DESCRIPTION
Found when checking other stuff.

There's still at least one more but it's rare case (one extra query for displaying polls) and I'm not yet sure how to properly cache it.