### PR TITLE
Add missing relative position for changelog graph

### DIFF
--- a/resources/assets/less/bem/changelog-chart.less
+++ b/resources/assets/less/bem/changelog-chart.less
@@ -17,6 +17,7 @@
   }
 
   height: 100px;
+  position: relative;
 
   &__area {
     .color(@modifier, @color) {


### PR DESCRIPTION
My data was missing recent changelog usage chart so it wasn't shown and then I forgot to actually check it :pensive: 