### PR TITLE
Fix forum topic bookmark menu and search form

### DIFF
--- a/resources/assets/less/bem/search-forum-options.less
+++ b/resources/assets/less/bem/search-forum-options.less
@@ -18,6 +18,7 @@
 
     @media @desktop {
       width: 300px;
+      position: relative;
     }
 
     &--buttons {

--- a/resources/assets/less/bem/search-forum-options.less
+++ b/resources/assets/less/bem/search-forum-options.less
@@ -11,6 +11,7 @@
     display: block;
     margin: 10px auto;
     width: 100%;
+    padding: 0 10px;
 
     // reset global label style
     text-transform: initial;
@@ -23,6 +24,8 @@
 
     &--buttons {
       display: flex;
+      padding-left: 5px; // remaining 5px is provided by the buttons themselves
+      padding-right: $padding-left;
 
       @media @desktop {
         padding-left: 40px;

--- a/resources/views/forum/topics/_watch.blade.php
+++ b/resources/views/forum/topics/_watch.blade.php
@@ -12,7 +12,7 @@
     ];
 @endphp
 <div
-    class="js-forum-topic-watch"
+    class="js-forum-topic-watch u-relative"
     data-topic-id="{{ $topic->topic_id }}"
 >
     <button


### PR DESCRIPTION
That was weird.

![](https://s.myconan.net/2020-08/firefox_2020-08-17_19-28-51.png)

(the gap between button and menu is too far)

![](https://s.myconan.net/2020-08/firefox_2020-08-17_19-29-17.png)

(labels flew off somewhere)

![](https://s.myconan.net/2020-08/firefox_2020-08-17_19-29-39.png)

(some stuff shouldn't stick to the edge)
