### PR TITLE
Fix skipping saving session on invalid csrf token

### DIFF
--- a/app/Http/Middleware/StartSession.php
+++ b/app/Http/Middleware/StartSession.php
@@ -9,12 +9,20 @@ use Illuminate\Session\Middleware\StartSession as BaseStartSession;
 
 class StartSession extends BaseStartSession
 {
-    protected function sessionConfigured()
+    protected function saveSession($request)
     {
-        if (request()->attributes->get('skip_session')) {
-            return false;
+        if ($this->shouldSaveSession()) {
+            return parent::saveSession($request);
         }
+    }
 
-        return parent::sessionConfigured();
+    protected function sessionIsPersistent(array $config = null)
+    {
+        return $this->shouldSaveSession() && parent::sessionIsPersistent($config);
+    }
+
+    private function shouldSaveSession()
+    {
+        return !request()->attributes->get('skip_session');
     }
 }


### PR DESCRIPTION
This has been broken for a while due to internal change on upstream library. Should be testing this but not quite sure how :thinking: 