### PR TITLE
Wrap long username instead of truncating

### DIFF
--- a/resources/assets/less/bem/forum-post-info.less
+++ b/resources/assets/less/bem/forum-post-info.less
@@ -75,7 +75,6 @@
     }
 
     &--username {
-      overflow-wrap: anywhere;
       word-break: break-word;
 
       font-size: @font-size--title-small-3;

--- a/resources/assets/less/bem/forum-post-info.less
+++ b/resources/assets/less/bem/forum-post-info.less
@@ -75,8 +75,9 @@
     }
 
     &--username {
-      width: 100%;
-      
+      overflow-wrap: anywhere;
+      word-break: break-word;
+
       font-size: @font-size--title-small-3;
       color: @osu-colour-c1;
 

--- a/resources/views/forum/topics/_post_info.blade.php
+++ b/resources/views/forum/topics/_post_info.blade.php
@@ -23,7 +23,7 @@
         @endif
 
         <a
-            class="forum-post-info__row forum-post-info__row--username u-ellipsis-overflow js-usercard"
+            class="forum-post-info__row forum-post-info__row--username js-usercard"
             data-user-id="{{$user->user_id}}"
             href="{{ route("users.show", $user) }}"
         >{{ $user->username }}</a>
@@ -34,7 +34,7 @@
             </div>
         @endif
     @else
-        <span class="forum-post-info__row forum-post-info__row--username u-ellipsis-overflow">
+        <span class="forum-post-info__row forum-post-info__row--username">
             {{ $user->username }}
         </span>
     @endif


### PR DESCRIPTION
Having multiple qtips on the same element where one of them involves disabling all the tooltip interaction on the element turns out to be not a very good idea. 🤔 

Also fixes the usercard position since 100% width ends up always pushing it too far to the side.

`word-break: break-word` actually overrides `overflow-wrap`, but Safari
doesn't support `overflow-wrap: anywhere` yet.

closes #6516