### PR TITLE
Fix menu sometimes overlapped by other object

### DIFF
--- a/resources/assets/less/bem/simple-menu.less
+++ b/resources/assets/less/bem/simple-menu.less
@@ -21,6 +21,7 @@
   font-size: @font-size--title-small;
   overflow: hidden;
   z-index: @z-index--simple-menu;
+  position: relative;
 
   &--beatmapset-watch {
     position: absolute;


### PR DESCRIPTION
Z-index isn't applied correctly without relative positioning. Mainly noticeable on discussion review editor's embed beatmap type/map selector menu being overlap by insertion bar. Also the menu is completely invisible when it's pinned.

It's fine for some reason in Firefox.