### PR TITLE
Add missing dot in datadog login attempts name

### DIFF
--- a/app/Libraries/User/DatadogLoginAttempt.php
+++ b/app/Libraries/User/DatadogLoginAttempt.php
@@ -13,7 +13,7 @@ class DatadogLoginAttempt
     {
         $success = $failReasonOrNull === null;
 
-        Datadog::increment(config('datadog-helper.prefix_web').'login_attempts', 1, [
+        Datadog::increment(config('datadog-helper.prefix_web').'.login_attempts', 1, [
             'success' => (int) $success,
             'reason' => $failReasonOrNull,
         ]);


### PR DESCRIPTION
Missing a dot whoops ( ﾟ ヮﾟ)