### PR TITLE
Fix chart sizing on window resize

### DIFF
--- a/resources/assets/coffee/react/profile-page/historical.coffee
+++ b/resources/assets/coffee/react/profile-page/historical.coffee
@@ -48,9 +48,8 @@ export class Historical extends React.PureComponent
             className: 'title title--page-extra-small'
             osu.trans('users.show.extra.historical.monthly_playcounts.title')
 
-          div
-            className: 'page-extra__chart'
-            ref: @monthlyPlaycountsChartArea
+          div className: 'page-extra__chart',
+            div ref: @monthlyPlaycountsChartArea
 
 
       h3
@@ -111,9 +110,8 @@ export class Historical extends React.PureComponent
             className: 'title title--page-extra-small'
             osu.trans('users.show.extra.historical.replays_watched_counts.title')
 
-          div
-            className: 'page-extra__chart'
-            ref: @replaysWatchedCountsChartArea
+          div className: 'page-extra__chart',
+            div ref: @replaysWatchedCountsChartArea
 
 
   chartUpdate: (attribute, area) =>

--- a/resources/assets/coffee/react/profile-page/rank-chart.coffee
+++ b/resources/assets/coffee/react/profile-page/rank-chart.coffee
@@ -37,9 +37,7 @@ export class RankChart extends React.Component
 
 
   render: =>
-    div
-      className: 'u-full-size'
-      ref: @rankChartArea
+    div ref: @rankChartArea
 
 
   rankChartUpdate: =>

--- a/resources/assets/less/bem/line-chart.less
+++ b/resources/assets/less/bem/line-chart.less
@@ -7,7 +7,7 @@
   @_marker-radius-profile-page: 10px;
   @_line-width: 3px;
   @_line-width-profile-page: 2px;
-  position: relative;
+  .full-size();
 
   &__axis {
     font-family: inherit;

--- a/resources/assets/less/bem/page-extra.less
+++ b/resources/assets/less/bem/page-extra.less
@@ -72,6 +72,7 @@
   &__chart {
     height: 250px;
     width: 100%;
+    position: relative;
   }
 
   &__content-overflow-wrapper-inner {

--- a/resources/assets/less/bem/profile-detail-mobile.less
+++ b/resources/assets/less/bem/profile-detail-mobile.less
@@ -17,6 +17,7 @@
     &--rank-chart {
       grid-column-end: span 4;
       height: 100px;
+      position: relative;
     }
 
     &--half {


### PR DESCRIPTION
Resizing down from desktop to mobile is currently broken. Even just resizing around will incorrectly increase height of personal ranking chart.