### PR TITLE
Fix guest middleware for login endpoint

### DIFF
--- a/app/Http/Controllers/SessionsController.php
+++ b/app/Http/Controllers/SessionsController.php
@@ -17,7 +17,7 @@ class SessionsController extends Controller
     public function __construct()
     {
         $this->middleware('guest', ['only' => [
-            'login',
+            'store',
         ]]);
 
         return parent::__construct();


### PR DESCRIPTION
The action has been renamed. It won't work by default because it would fail csrf check but this is for when someone doing weird thing.