### PR TITLE
Fix user parameter not set properly on beatmap events listing page pagination links

### DIFF
--- a/app/Http/Controllers/Users/ModdingHistoryController.php
+++ b/app/Http/Controllers/Users/ModdingHistoryController.php
@@ -70,6 +70,7 @@ class ModdingHistoryController extends Controller
         $user = $this->user;
 
         $bundle = ModdingHistoryEventsBundle::forListing($user, $this->searchParams);
+        $bundle->paginationIncludeUserParam = false;
         $jsonChunks = $bundle->toArray();
         $paginator = $bundle->getPaginator();
         $params = $bundle->getParams();

--- a/app/Libraries/ModdingHistoryEventsBundle.php
+++ b/app/Libraries/ModdingHistoryEventsBundle.php
@@ -18,6 +18,8 @@ class ModdingHistoryEventsBundle
 {
     const KUDOSU_PER_PAGE = 5;
 
+    public $paginationIncludeUserParam = true;
+
     protected $isModerator;
     protected $isKudosuModerator;
     protected $memoized = [];
@@ -60,7 +62,9 @@ class ModdingHistoryEventsBundle
     {
         $events = $this->getEvents();
         $params = $this->params;
-        unset($params['user']);
+        if (!$this->paginationIncludeUserParam) {
+            unset($params['user']);
+        }
 
         return new LengthAwarePaginator(
             $events,


### PR DESCRIPTION
Resolves #6409.

Although I have a feeling we should just remove the page (and some other user-specific listing pages) entirely and direct the link from modding profile to normal events listing page instead. Not sure why it's not done yet. Should I? :thinking: 

Now I think about it there's blocking problem for user forum post listing which requires keyword for normal search but it's not the case for beatmap modding related stuff.

- [x] decide this or the other one