### PR TITLE
Fix documentation formatting for multiplayer

### DIFF
--- a/app/Http/Controllers/Multiplayer/Rooms/Playlist/ScoresController.php
+++ b/app/Http/Controllers/Multiplayer/Rooms/Playlist/ScoresController.php
@@ -25,9 +25,9 @@ class ScoresController extends BaseController
     }
 
     /**
-     * @group Multiplayer
-     *
      * Get Scores
+     *
+     * @group Multiplayer
      *
      * Returns a list of scores for specified playlist item.
      *
@@ -97,9 +97,9 @@ class ScoresController extends BaseController
     }
 
     /**
-     * @group Multiplayer
-     *
      * Get a Score
+     *
+     * @group Multiplayer
      *
      * Returns detail of specified score and the surrounding scores.
      *
@@ -129,9 +129,9 @@ class ScoresController extends BaseController
     }
 
     /**
-     * @group Multiplayer
-     *
      * Get User High Score
+     *
+     * @group Multiplayer
      *
      * Returns detail of highest score of specified user and the surrounding scores.
      *


### PR DESCRIPTION
Title must come before anything. Even the group declaration.

Reference: https://github.com/mpociot/laravel-apidoc-generator/blob/8be084e39e4373197aa734e6ef6da7deed3655af/src/Extracting/Strategies/Metadata/GetFromDocBlocks.php#L64