### PR TITLE
Include user score in multiplayer room leaderboard

### DIFF
--- a/app/Http/Controllers/Multiplayer/RoomsController.php
+++ b/app/Http/Controllers/Multiplayer/RoomsController.php
@@ -48,13 +48,15 @@ class RoomsController extends BaseController
     {
         $limit = clamp(get_int(request('limit')) ?? 50, 1, 50);
 
-        return json_collection(
+        $leaderboard = json_collection(
             Room::findOrFail($roomId)
                 ->topScores()
                 ->paginate($limit),
             'Multiplayer\UserScoreAggregate',
             ['user.country']
         );
+
+        return compact('leaderboard');
     }
 
     public function part($roomId, $userId)

--- a/app/Http/Controllers/Multiplayer/RoomsController.php
+++ b/app/Http/Controllers/Multiplayer/RoomsController.php
@@ -61,7 +61,7 @@ class RoomsController extends BaseController
             'own_score' => $ownScore !== null ? json_item(
                 $ownScore,
                 'Multiplayer\UserScoreAggregate',
-                ['user.country']
+                ['position', 'user.country']
             ) : null,
         ];
     }

--- a/app/Models/Multiplayer/UserScoreAggregate.php
+++ b/app/Models/Multiplayer/UserScoreAggregate.php
@@ -133,6 +133,21 @@ class UserScoreAggregate extends RoomUserHighScore
         $this->increment('attempts');
     }
 
+    public function userRank()
+    {
+        if ($this->total_score === null || $this->last_score_id === null) {
+            return;
+        }
+
+        $query = $this->room->topScores()
+            ->cursorWhere([
+                ['column' => 'total_score', 'order' => 'ASC', 'value' => $this->total_score],
+                ['column' => 'last_score_id', 'order' => 'DESC', 'value' => $this->last_score_id],
+            ]);
+
+        return 1 + $query->count();
+    }
+
     private function updateUserTotal(Score $current, PlaylistItemUserHighScore $prev)
     {
         if ($current->passed) {

--- a/app/Transformers/Multiplayer/UserScoreAggregateTransformer.php
+++ b/app/Transformers/Multiplayer/UserScoreAggregateTransformer.php
@@ -12,6 +12,7 @@ use App\Transformers\UserCompactTransformer;
 class UserScoreAggregateTransformer extends TransformerAbstract
 {
     protected $availableIncludes = [
+        'position',
         'user',
     ];
 
@@ -26,6 +27,11 @@ class UserScoreAggregateTransformer extends TransformerAbstract
             'total_score' => $score->total_score,
             'user_id' => $score->user_id,
         ];
+    }
+
+    public function includePosition(UserScoreAggregate $score)
+    {
+        return $this->primitive($score->userRank());
     }
 
     public function includeUser(UserScoreAggregate $score)

--- a/resources/views/vendor/apidoc/partials/info.blade.php
+++ b/resources/views/vendor/apidoc/partials/info.blade.php
@@ -274,6 +274,9 @@ For a full list of changes, see the
 
 ## Breaking Changes
 
+### 2020-08-28
+- `/rooms/{room_id}/leaderboard` no longer returns an array at the top level; an object with keys is now returned.
+
 ### 2020-05-01
 - `users.read` scope removed, replace with more general `public` scope.
 


### PR DESCRIPTION
Breaking API response change as it will now return
```
{
  "leaderboard": [...scores],
  "own_score": {
    ...scoreProperties,
    position: 5,
  }
}
```

instead of just
```
[...scores]
```

closes #6540