### PR TITLE
Fix verification dialog error message position

### DIFF
--- a/resources/assets/less/bem/user-verification.less
+++ b/resources/assets/less/bem/user-verification.less
@@ -56,6 +56,7 @@
     margin: 10px 0;
 
     &--key {
+      position: relative;
       margin-top: 40px;
       margin-bottom: 60px;
     }


### PR DESCRIPTION
Should display under the input box instead of all the way to the side.

Although, it seems weird that this text has `position: absolute ` at all 🤔 
It'd only benefit multi-line text not changing the layout, but then, if there's too many lines, it'd just start overlapping the other text? `min-height` could be used to maintain a minimum space for 2 lines but still allow more lines to expand the space 🤷 