### PR TITLE
Return user recent events in consistent order

### DIFF
--- a/app/Models/Event.php
+++ b/app/Models/Event.php
@@ -410,7 +410,7 @@ class Event extends Model
 
     public function scopeRecent($query)
     {
-        return $query->orderBy('date', 'desc')->limit(5);
+        return $query->orderBy('date', 'desc')->orderBy('event_id', 'desc')->limit(5);
     }
 
     private static function userParams($user)


### PR DESCRIPTION
otherwise, events with the same date can show in any order and get duplicated or not show at all when they have the same date at offset cutoffs.

closes #6576