### PR TITLE
Add correctly-named rank history data in user json

### DIFF
--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -463,6 +463,7 @@ class UsersController extends Controller
             'previous_usernames',
             'ranked_and_approved_beatmapset_count',
             "rankHistory:mode({$currentMode})",
+            "rank_history:mode({$currentMode})",
             'replays_watched_counts',
             'statistics.rank',
             'statistics.variants',

--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -405,7 +405,7 @@ class UsersController extends Controller
      * monthly_playcounts                   | |
      * page                                 | |
      * previous_usernames                   | |
-     * rankHistory                          | For specified mode.
+     * rank_history                         | For specified mode.
      * ranked_and_approved_beatmapset_count | |
      * replays_watched_counts               | |
      * scores_first_count                   | For specified mode.

--- a/app/Transformers/UserCompactTransformer.php
+++ b/app/Transformers/UserCompactTransformer.php
@@ -50,6 +50,7 @@ class UserCompactTransformer extends TransformerAbstract
         // TODO: should be changed to rank_history
         // TODO: should be alphabetically ordered but lazer relies on being after statistics. can revert to alphabetical after 2020-05-01
         'rankHistory',
+        'rank_history',
     ];
 
     protected $permissions = [

--- a/resources/assets/coffee/react/profile-page/detail.coffee
+++ b/resources/assets/coffee/react/profile-page/detail.coffee
@@ -46,7 +46,7 @@ export class Detail extends React.PureComponent
           div className: "#{bn}__col #{bn}__col--bottom-left",
             if @props.stats.is_ranked
               el RankChart,
-                rankHistory: @props.user.rankHistory
+                rankHistory: @props.user.rank_history
                 stats: @props.stats
             else
               div className: "#{bn}__empty-chart",

--- a/resources/assets/coffee/react/profile-page/header.coffee
+++ b/resources/assets/coffee/react/profile-page/header.coffee
@@ -80,7 +80,7 @@ export class Header extends React.Component
                 el DetailMobile,
                   stats: @props.stats
                   userAchievements: @props.userAchievements
-                  rankHistory: @props.user.rankHistory
+                  rankHistory: @props.user.rank_history
 
                 el Stats, stats: @props.stats
 


### PR DESCRIPTION
I'm not going to document `rankHistory` key =)

Duplicated until other api users update the thing.