### PR TITLE
Fix recording last highest score id on multiplayer

### DIFF
--- a/app/Models/Multiplayer/UserScoreAggregate.php
+++ b/app/Models/Multiplayer/UserScoreAggregate.php
@@ -147,7 +147,7 @@ class UserScoreAggregate extends RoomUserHighScore
             $this->accuracy += $current->accuracy;
             $this->pp += $current->pp;
             $this->completed++;
-            $this->last_score_id = $current->score_id;
+            $this->last_score_id = $current->getKey();
         }
 
         $this->save();


### PR DESCRIPTION
`$prev` and `$current` are of different type :face_with_head_bandage: 

It also means last_score_id hasn't been assigned correctly. And we need to run this again...

```
UPDATE multiplayer_rooms_high
SET last_score_id = (
    SELECT MAX(sh.score_id)
    FROM multiplayer_scores_high sh
    JOIN multiplayer_playlist_items pi
    ON (sh.playlist_item_id = pi.id)
    WHERE
        pi.room_id = multiplayer_rooms_high.room_id
        AND sh.user_id = multiplayer_rooms_high.user_id
)
WHERE
    completed > 0
    AND last_score_id IS NULL
```