### PR TITLE
Switch UserBestScoreCheck to cursor over score_id

### DIFF
--- a/app/Libraries/UserBestScoresCheck.php
+++ b/app/Libraries/UserBestScoresCheck.php
@@ -55,7 +55,7 @@ class UserBestScoresCheck
         $clazz = Best\Model::getClassByString($mode);
 
         $search = $this->newSearch($mode);
-        $cursor = [''];
+        $cursor = [0];
 
         $missingIds = [];
 
@@ -111,7 +111,7 @@ class UserBestScoresCheck
         $search->connectionName = 'scores';
 
         return $search
-            ->sort(new Sort('_id', 'asc'))
+            ->sort(new Sort('score_id', 'asc'))
             ->size(static::BATCH_SIZE)
             ->query((new BoolQuery)->filter(['term' => ['user_id' => $this->user->getKey()]]));
     }


### PR DESCRIPTION
Apparently sorting over `_id` uses too much memory (because it's text fielddata?). 
Fortunately, `score_id` is still indexed and is the same value (and a number)