### PR TITLE
Add bundled filter to beatmapset search

### DIFF
--- a/app/Models/Beatmapset.php
+++ b/app/Models/Beatmapset.php
@@ -36,6 +36,8 @@ use Illuminate\Database\QueryException;
  * @property int $beatmapset_id
  * @property mixed|null $body_hash
  * @property float $bpm
+ * @property bool $bundled
+ * @property bool $can_bundle
  * @property Comment $comments
  * @property \Carbon\Carbon|null $cover_updated_at
  * @property string $creator
@@ -94,6 +96,8 @@ class Beatmapset extends Model implements AfterCommit, Commentable
 
     protected $casts = [
         'active' => 'boolean',
+        'bundled' => 'boolean',
+        'can_bundle' => 'boolean',
         'download_disabled' => 'boolean',
         'epilepsy' => 'boolean',
         'storyboard' => 'boolean',

--- a/app/Models/Beatmapset.php
+++ b/app/Models/Beatmapset.php
@@ -332,6 +332,11 @@ class Beatmapset extends Model implements AfterCommit, Commentable
         });
     }
 
+    public function scopeBundled($query)
+    {
+        return $query->where('bundled', true);
+    }
+
     // one-time checks
 
     public function isGraveyard()

--- a/config/schemas/beatmaps.json
+++ b/config/schemas/beatmaps.json
@@ -42,6 +42,12 @@
         "bpm": {
           "type": "double"
         },
+        "bundled": {
+          "type": "boolean"
+        },
+        "can_bundle": {
+          "type": "boolean"
+        },
         "creator": {
           "type": "text",
           "fields": {

--- a/database/migrations/2020_09_02_033245_add_bundled_flags_to_beatmapsets.php
+++ b/database/migrations/2020_09_02_033245_add_bundled_flags_to_beatmapsets.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2020_09_02_033245_add_bundled_flags_to_beatmapsets.php
+++ b/database/migrations/2020_09_02_033245_add_bundled_flags_to_beatmapsets.php
@@ -1,0 +1,36 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddBundledFlagsToBeatmapsets extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('osu_beatmapsets', function (Blueprint $table) {
+            $table->boolean('bundled')->default(false);
+            $table->boolean('can_bundle')->default(false);
+            $table->index('bundled');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('osu_beatmapsets', function (Blueprint $table) {
+            $table->dropIndex(['bundled']);
+            $table->dropColumn('bundled');
+            $table->dropColumn('can_bundle');
+        });
+    }
+}

--- a/resources/lang/en/beatmaps.php
+++ b/resources/lang/en/beatmaps.php
@@ -331,6 +331,7 @@ return [
     'extra' => [
         'video' => 'Has Video',
         'storyboard' => 'Has Storyboard',
+        'bundled' => 'Bundled',
     ],
     'rank' => [
         'any' => 'Any',

--- a/routes/web.php
+++ b/routes/web.php
@@ -443,6 +443,7 @@ Route::group(['as' => 'api.', 'prefix' => 'api', 'middleware' => ['api', 'requir
 
 // Callbacks for legacy systems to interact with
 Route::group(['prefix' => '_lio', 'middleware' => 'lio', 'as' => 'interop.'], function () {
+    Route::post('bundle-beatmapsets', 'LegacyInterOpController@bundleBeatmapsets');
     Route::post('generate-notification', 'LegacyInterOpController@generateNotification');
     Route::post('index-beatmapset/{beatmapset}', 'LegacyInterOpController@indexBeatmapset');
     Route::post('/refresh-beatmapset-cache/{beatmapset}', 'LegacyInterOpController@refreshBeatmapsetCache');


### PR DESCRIPTION
closes #5169 , not sure if this method to mark maps as bundled would work well with the current system though

this expects
- `can_bundle` to be set manually
- `/_lio/bundle-beatmapsets` to be hit with an array (`beatmapsets`) of map ids when cycling new bundled maps