### PR TITLE
Fix missing beatmap fail rate charts when switching difficulties

### DIFF
--- a/resources/assets/coffee/_classes/stacked-bar-chart.coffee
+++ b/resources/assets/coffee/_classes/stacked-bar-chart.coffee
@@ -2,7 +2,7 @@
 # See the LICENCE file in the repository root for full licence text.
 
 class @StackedBarChart
-  constructor: (area, @options = {}) ->
+  constructor: (@area, @options = {}) ->
     @margins =
       top: 0
       right: 0
@@ -16,8 +16,7 @@ class @StackedBarChart
     blockClass = 'stacked-bar-chart'
     blockClass += " stacked-bar-chart--#{mod}" for mod in @options.modifiers
 
-    @area = d3.select area
-    @svg = @area
+    @svg = d3.select(@area)
       .append 'svg'
       .attr 'class', blockClass
 
@@ -42,8 +41,15 @@ class @StackedBarChart
     @resize()
 
 
+  reattach: (newArea) =>
+    return if !newArea? || newArea == @area
+
+    @area = newArea
+    @area.append(@svg.node())
+
+
   setDimensions: ->
-    areaDims = @area.node().getBoundingClientRect()
+    areaDims = @area.getBoundingClientRect()
 
     @width = areaDims.width - (@margins.left + @margins.right)
     @height = areaDims.height - (@margins.top + @margins.bottom)

--- a/resources/assets/coffee/react/beatmapset-page/info.coffee
+++ b/resources/assets/coffee/react/beatmapset-page/info.coffee
@@ -112,6 +112,7 @@ export class Info extends React.Component
       $(window).on 'resize.beatmapsetPageInfo', @_failurePointsChart.resize
 
     @_failurePointsChart.loadData @props.beatmap.failtimes
+    @_failurePointsChart.reattach @chartAreaRef.current
 
 
   renderEditMetadataButton: =>


### PR DESCRIPTION
- ~~fix broken chart when the data is all zero~~
- fix missing chart when toggling between beatmap with and without plays (resolves #6570)
- ~~hide data for converted maps (I think those pass/play counts in osu_beatmaps don't include converts? @peppy )~~

Split off the fixes.