### PR TITLE
Show failtime for all modes

### DIFF
--- a/app/Transformers/BeatmapCompactTransformer.php
+++ b/app/Transformers/BeatmapCompactTransformer.php
@@ -47,19 +47,16 @@ class BeatmapCompactTransformer extends TransformerAbstract
     {
         $failtimes = $beatmap->failtimes;
 
-        // adding a set of empty failtimes, so that the chart transitions
-        // to 0 when a map has no failtimes (for now non-standard modes)
-        if ($failtimes->isEmpty() || $beatmap->convert) {
-            $failtimes = [
-                new BeatmapFailtimes(['type' => 'fail']),
-                new BeatmapFailtimes(['type' => 'exit']),
-            ];
-        }
-
         $result = [];
 
         foreach ($failtimes as $failtime) {
             $result[$failtime->type] = $failtime->data;
+        }
+
+        foreach (['exit', 'fail'] as $type) {
+            if (!isset($result[$type])) {
+                $result[$type] = (new BeatmapFailtimes)->data;
+            }
         }
 
         return $this->primitive($result);


### PR DESCRIPTION
The chart data are actually shared between modes. Additionally make sure the response always include both attributes (exit and fail).