### PR TITLE
Fix top bar colour of discussion review post

### DIFF
--- a/resources/assets/coffee/react/beatmap-discussions/discussion.coffee
+++ b/resources/assets/coffee/react/beatmap-discussions/discussion.coffee
@@ -77,8 +77,7 @@ export class Discussion extends React.PureComponent
         div className: "#{bn}__discussion",
           div
             className: "#{bn}__top"
-            style:
-              color: osu.groupColour(group)
+            style: osu.groupColour(group)
             div className: "#{bn}__discussion-header",
               el UserCard,
                 user: user


### PR DESCRIPTION
That was weird.

Also weird the bar doesn't appear for non-review posts even though they look pretty similar.

![](https://s.myconan.net/2020-09/firefox_2020-09-10_15-40-39.png)