### PR TITLE
Add FastRandom PRNG

### DIFF
--- a/app/Libraries/FastRandom.php
+++ b/app/Libraries/FastRandom.php
@@ -1,0 +1,82 @@
+<?php
+
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
+namespace App\Libraries;
+
+use InvalidArgumentException;
+
+/**
+ * A fast PRNG used in the osu! client
+ *
+ * @see https://github.com/ppy/osu/blob/bf1c5a3b1f6d48a23a8ab89d90dfb4838def0911/osu.Game.Rulesets.Catch/MathUtils/FastRandom.cs osu!lazer implementation
+ * @see http://heliosphan.org/fastrandom.html Algorithm specification
+ */
+class FastRandom
+{
+    private $x;
+    private $y = 842502087;
+    private $z = -715159705;
+    private $w = 273326509;
+
+    /**
+     * @param int $seed A 32-bit seed for the PRNG.
+     */
+    public function __construct(int $seed)
+    {
+        if (PHP_INT_SIZE > 4) {
+            if ($seed < -0x80000000 || $seed > 0x7FFFFFFF) {
+                throw new InvalidArgumentException('Seed must be between -2^31 and 2^31-1');
+            }
+
+            // Mask out high bits from two's complement
+            $seed &= 0xFFFFFFFF;
+            $this->z &= 0xFFFFFFFF;
+        }
+
+        $this->x = $seed;
+    }
+
+    public function nextDouble(): float
+    {
+        // WARNING: These results won't be exactly the same as the osu! client on PHP installations
+        //          that aren't 64-bit due to less precision, but they'll be close
+        static $intToReal = 1 / 0x80000000;
+
+        return $intToReal * $this->nextNonnegativeInt();
+    }
+
+    public function nextInt(): int
+    {
+        $t = $this->x ^ static::maskedLeftShift($this->x, 11);
+
+        $this->x = $this->y;
+        $this->y = $this->z;
+        $this->z = $this->w;
+
+        return $this->w = $this->w ^ static::logicalRightShift($this->w, 19) ^ $t ^ static::logicalRightShift($t, 8);
+    }
+
+    public function nextNonnegativeInt(): int
+    {
+        return $this->nextInt() & 0x7FFFFFFF;
+    }
+
+    private static function logicalRightShift(int $number, int $shift): int
+    {
+        return ($number >> $shift) & (PHP_INT_MAX >> ($shift - 1));
+    }
+
+    private static function maskedLeftShift(int $number, int $shift, int $bits = 32): int
+    {
+        $shifted = $number << $shift;
+        $phpIntBits = PHP_INT_SIZE * 8;
+
+        if ($phpIntBits > $bits) {
+            $shifted &= PHP_INT_MAX >> ($phpIntBits - $bits - 1);
+        }
+
+        return $shifted;
+    }
+}

--- a/tests/Libraries/FastRandomTest.php
+++ b/tests/Libraries/FastRandomTest.php
@@ -1,0 +1,100 @@
+<?php
+
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
+namespace Tests\Libraries;
+
+use App\Libraries\FastRandom;
+use InvalidArgumentException;
+use Tests\TestCase;
+
+class FastRandomTest extends TestCase
+{
+    /**
+     * @dataProvider doubleExamples
+     */
+    public function testNextDouble(int $seed, array $expectedResults)
+    {
+        $random = new FastRandom($seed);
+
+        foreach ($expectedResults as $expected) {
+            $this->assertSame($random->nextDouble(), $expected);
+        }
+    }
+
+    /**
+     * @dataProvider intExamples
+     */
+    public function testNextInt(int $seed, array $expectedResults)
+    {
+        $random = new FastRandom($seed);
+
+        foreach ($expectedResults as $expected) {
+            $this->assertSame($random->nextInt(), $expected);
+        }
+    }
+
+    /**
+     * @dataProvider nonnegativeIntExamples
+     */
+    public function testNextNonnegativeInt(int $seed, array $expectedResults)
+    {
+        $random = new FastRandom($seed);
+
+        foreach ($expectedResults as $expected) {
+            $this->assertSame($random->nextNonnegativeInt(), $expected);
+        }
+    }
+
+    /**
+     * @dataProvider invalidSeeds
+     */
+    public function testInvalidSeed(int $seed)
+    {
+        if (PHP_INT_SIZE === 4) {
+            $this->markTestSkipped('Every FastRandom seed is valid on 32-bit installations of PHP');
+        }
+
+        $this->expectException(InvalidArgumentException::class);
+        new FastRandom($seed);
+    }
+
+    public function doubleExamples()
+    {
+        return [
+            [0, [0.1272778082638979, 0.23868940630927682, 0.4355649743229151, 0.896547231823206, 0.4360586660914123]],
+            [1, [0.1272787661291659, 0.23868844844400883, 0.43556593218818307, 0.8965462748892605, 0.4341065245680511]],
+            [-1, [0.12727789394557476, 0.2386884861625731, 0.43556406162679195, 0.896546445786953, 0.4369882270693779]],
+            [100000, [0.2222310910001397, 0.1461768727749586, 0.4685103828087449, 0.9920269143767655, 0.8947864421643317]],
+        ];
+    }
+
+    public function intExamples()
+    {
+        return [
+            [0, [273327012, 2660065245, 3082852308, 4072804168, 3083912503]],
+            [1, [273329069, 2660063188, 3082854365, 4072802113, 3079720311]],
+            [-1, [273327196, 2660063269, 3082850348, 4072802480, 3085908720]],
+            [100000, [477237634, 2461396092, 3153602034, 4277845225, 1921539253]],
+        ];
+    }
+
+    public function nonnegativeIntExamples()
+    {
+        return [
+            [0, [273327012, 512581597, 935368660, 1925320520, 936428855]],
+            [1, [273329069, 512579540, 935370717, 1925318465, 932236663]],
+            [-1, [273327196, 512579621, 935366700, 1925318832, 938425072]],
+            [100000, [477237634, 313912444, 1006118386, 2130361577, 1921539253]],
+        ];
+    }
+
+    public function invalidSeeds()
+    {
+        return [
+            [0x80000000],
+            [-0x80000001],
+        ];
+    }
+}


### PR DESCRIPTION
will be required for logic of selecting bundled maps, and maybe more stuff in the future since this is used for a few different things in the osu client. there's a lot of weird bit masking going on here because PHP doesn't have the data types for fastrandom...