### PR TITLE
Fix error when viewing discussions through user modding profile

### DIFF
--- a/resources/assets/coffee/react/beatmap-discussions/discussion.coffee
+++ b/resources/assets/coffee/react/beatmap-discussions/discussion.coffee
@@ -252,7 +252,7 @@ export class Discussion extends React.PureComponent
 
 
   isRead: (post) =>
-    @props.readPostIds.has(post.id) || @isOwner(post) || @props.preview
+    @props.readPostIds?.has(post.id) || @isOwner(post) || @props.preview
 
 
   isVisible: (object) =>


### PR DESCRIPTION
page broke in #6627 because `readPostIds` can be undefined, and previously `_.includes` was silently handling it