### PR TITLE
Show username change history even for admin changes

### DIFF
--- a/app/Models/UsernameChangeHistory.php
+++ b/app/Models/UsernameChangeHistory.php
@@ -23,6 +23,6 @@ class UsernameChangeHistory extends Model
 
     public function scopeVisible($query)
     {
-        $query->whereIn('type', ['support', 'paid']);
+        $query->whereIn('type', ['support', 'paid', 'admin']);
     }
 }


### PR DESCRIPTION
In a distant past, we wanted to hide these to hide certain name changes (ie. when a user asked for a change due to their previous name being their legal name of social security number). This process has since changed and we actually want these to show, as they are the only name change type which allows admins to change a username without incrementing the cost of a name change.