### PR TITLE
Fix discussion post paddings

### DIFF
--- a/resources/assets/less/bem/beatmap-discussion-post.less
+++ b/resources/assets/less/bem/beatmap-discussion-post.less
@@ -117,18 +117,9 @@
       flex: 1;
     }
 
-    // Thread starter post is styled slightly differently.
-    // The post itself doesn't contain user card.
-    // On desktop, it means the left side should have slightly smaller gutter.
-    // On mobile, user card located on top of the content and already has
-    // bottom margin. Reduce the padding here to compensate.
+    // Paddings for thread starter is handled by its parent.
     .@{_top}--discussion & {
-      padding-top: 5px;
-
-      @media @desktop {
-        padding-top: 10px;
-        padding-left: 10px;
-      }
+      padding: 0;
     }
 
     .@{_top}--reply & {

--- a/resources/assets/less/bem/beatmap-discussion.less
+++ b/resources/assets/less/bem/beatmap-discussion.less
@@ -154,6 +154,11 @@
     .@{_top}--review & {
       border-top: 2px solid var(--group-colour, transparent);
     }
+
+    .@{_top}--single & {
+      display: block;
+      padding: @_top-padding-y @_top-padding-x;
+    }
   }
 
   &__top-actions {

--- a/resources/assets/less/bem/beatmap-discussion.less
+++ b/resources/assets/less/bem/beatmap-discussion.less
@@ -3,6 +3,10 @@
 
 .beatmap-discussion {
   @_top: beatmap-discussion;
+
+  @_top-padding-y: 10px;
+  @_top-padding-x: 15px;
+
   .own-layer();
   display: flex;
 
@@ -129,6 +133,7 @@
     display: grid;
     grid-template-areas: "user actions" "message message";
     grid-template-columns: 1fr auto;
+    gap: 10px;
 
     .@{_top}--horizontal-desktop & {
       @media @desktop {
@@ -160,15 +165,22 @@
 
   &__top-message {
     grid-area: message;
-  }
-
-  &__top-user {
-    margin-top: 10px;
-    margin-left: 15px;
+    margin: 0 @_top-padding-x @_top-padding-y;
 
     .@{_top}--horizontal-desktop & {
       @media @desktop {
-        margin-bottom: 10px;
+        margin: @_top-padding-y 0;
+      }
+    }
+  }
+
+  &__top-user {
+    margin-top: @_top-padding-y;
+    margin-left: @_top-padding-x;
+
+    .@{_top}--horizontal-desktop & {
+      @media @desktop {
+        margin-bottom: @_top-padding-y;
         border-right: 2px solid var(--group-colour, hsl(var(--hsl-b5)));
       }
     }

--- a/resources/views/beatmap_discussion_posts/_item.blade.php
+++ b/resources/views/beatmap_discussion_posts/_item.blade.php
@@ -4,7 +4,7 @@
 --}}
 
 <div class="beatmap-discussions__discussion beatmapset-activities__discussion-post">
-    <div class="beatmap-discussion beatmapset-activities__post-grow">
+    <div class="beatmap-discussion beatmap-discussion--single beatmapset-activities__post-grow">
         <div class="beatmap-discussion-timestamp__icons-container">
             <div class="beatmap-discussion-timestamp__icons">
                 <a href="{{ route('beatmapsets.discussion', $post->beatmapDiscussion->beatmapset) }}#/{{ $post->beatmapDiscussion->getKey() }}">

--- a/resources/views/beatmap_discussions/_item.blade.php
+++ b/resources/views/beatmap_discussions/_item.blade.php
@@ -13,7 +13,7 @@
     ];
 @endphp
 <div class="beatmap-discussions__discussion beatmapset-activities__discussion-post">
-    <div class="beatmap-discussion beatmapset-activities__post-grow{{ $discussion->trashed() ? ' beatmap-discussion--deleted' : ''}}">
+    <div class="beatmap-discussion beatmap-discussion--single beatmapset-activities__post-grow{{ $discussion->trashed() ? ' beatmap-discussion--deleted' : ''}}">
         <div class="beatmap-discussion-timestamp__icons-container">
             <div class="beatmap-discussion-timestamp__icons">
                 <a href="{{ route('beatmapsets.discussion', $discussion->beatmapset) }}#/{{ $discussion->getKey() }}">


### PR DESCRIPTION
I kinda broke the padding for review posts (left padding too small).

Trapped into trying to fix `beatmap-discussion-post` block until I noticed some of the elements are being used everywhere without the accompanying block and fixing them will be rather involved (not to mention it's getting a redesign).