### PR TITLE
Extract timestamp decoration style out into separate BEM block

### DIFF
--- a/resources/assets/coffee/_classes/beatmap-discussion-helper.coffee
+++ b/resources/assets/coffee/_classes/beatmap-discussion-helper.coffee
@@ -63,7 +63,7 @@ class @BeatmapDiscussionHelper
     text = _.escape text
     text = text.trim()
     text = @discussionLinkify text
-    text = @linkTimestamp text, ["#{blockName}__timestamp"]
+    text = @linkTimestamp text, ['beatmap-discussion-timestamp-decoration']
 
     if options.newlines ? true
       # replace newlines with <br>

--- a/resources/assets/less/bem-index.less
+++ b/resources/assets/less/bem-index.less
@@ -41,6 +41,7 @@
 @import "bem/beatmap-discussion-review-post-embed-preview";
 @import "bem/beatmap-discussion-system-post";
 @import "bem/beatmap-discussion-timestamp";
+@import "bem/beatmap-discussion-timestamp-decoration";
 @import "bem/beatmap-discussion-user-card";
 @import "bem/beatmap-discussion-vote";
 @import "bem/beatmap-discussions";

--- a/resources/assets/less/bem/beatmap-discussion-timestamp-decoration.less
+++ b/resources/assets/less/bem/beatmap-discussion-timestamp-decoration.less
@@ -1,0 +1,21 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
+.beatmap-discussion-timestamp-decoration {
+  .link-plain();
+
+  border-radius: @border-radius-large;
+  padding: 1px 5px;
+  background-color: @osu-colour-b6;
+  font-weight: 600;
+  font-size: 85%;
+  color: @osu-colour-f1;
+
+  // required for the cursor to be visible when contentEditable is used (for the beatmap review editor)
+  display: inline-block;
+
+  .link-hover({
+    background-color: @osu-colour-b5;
+    color: @osu-colour-l1;
+  });
+}

--- a/resources/assets/less/bem/beatmapset-discussion-message.less
+++ b/resources/assets/less/bem/beatmapset-discussion-message.less
@@ -2,26 +2,6 @@
 // See the LICENCE file in the repository root for full licence text.
 
 .beatmapset-discussion-message {
-  @_top: beatmapset-discussion-message;
   display: inline;
   color: white;
-
-  &__timestamp {
-    .link-plain();
-
-    border-radius: @border-radius-large;
-    padding: 1px 5px;
-    background-color: @osu-colour-b6;
-    font-weight: 600;
-    font-size: 85%;
-    color: @osu-colour-f1;
-
-    // required for the cursor to be visible when contentEditable is used (for the beatmap review editor)
-    display: inline-block;
-
-    .link-hover({
-      background-color: @osu-colour-b5;
-      color: @osu-colour-l1;
-    });
-  }
 }

--- a/resources/assets/lib/beatmap-discussions/editor.tsx
+++ b/resources/assets/lib/beatmap-discussions/editor.tsx
@@ -350,8 +350,7 @@ export default class Editor extends React.Component<Props, State> {
     }
 
     if (props.leaf.timestamp) {
-      // TODO: fix this nested stuff
-      return <span className='beatmapset-discussion-message' {...props.attributes}><span className={'beatmapset-discussion-message__timestamp'}>{children}</span></span>;
+      return <span className='beatmap-discussion-timestamp-decoration' {...props.attributes}>{children}</span>;
     }
 
     return (

--- a/resources/assets/lib/beatmap-discussions/review-post.tsx
+++ b/resources/assets/lib/beatmap-discussions/review-post.tsx
@@ -46,7 +46,7 @@ export class ReviewPost extends React.Component<Props> {
                 <div className='beatmapset-discussion-message' {...props}/>
               </div>;
             },
-            timestamp: (props) => <a className='beatmapset-discussion-message__timestamp' {...props}/>,
+            timestamp: (props) => <a className='beatmap-discussion-timestamp-decoration' {...props}/>,
           }}
         />
     );


### PR DESCRIPTION
Saves having to add arbitrary `beatmapset-discussion-message` wrappers when utilising the style