### PR TITLE
Add option to disable minimum play count on verified sessions for certain actions

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -208,6 +208,7 @@ SITE_SWITCHER_JS_HASH=
 # USER_POST_ACTION_VERIFICATION=true
 # USER_MAX_LOGIN_ATTEMPTS=10
 # USER_MIN_PLAYS_FOR_POSTING=10
+# USER_MIN_PLAYS_ALLOW_VERIFIED_BYPASS=true
 # space delimited, list of groups (the identifier) which user can be renamed when inactive
 # USER_ALLOWED_RENAME_GROUPS="default"
 

--- a/app/Libraries/OsuAuthorize.php
+++ b/app/Libraries/OsuAuthorize.php
@@ -1764,14 +1764,14 @@ class OsuAuthorize
             return;
         }
 
-        if ($user->isSessionVerified()) {
-            if (config('osu.user.min_plays_allow_verified_bypass')) {
+        if (config('osu.user.min_plays_allow_verified_bypass')) {
+            if ($user->isSessionVerified()) {
                 return;
             }
 
-            throw new AuthorizationException('play_more');
+            throw new AuthorizationException('require_verification');
         }
 
-        throw new AuthorizationException('require_verification');
+        throw new AuthorizationException('play_more');
     }
 }

--- a/app/Libraries/OsuAuthorize.php
+++ b/app/Libraries/OsuAuthorize.php
@@ -1765,7 +1765,11 @@ class OsuAuthorize
         }
 
         if ($user->isSessionVerified()) {
-            return;
+            if (config('osu.user.min_plays_allow_verified_bypass')) {
+                return;
+            }
+
+            throw new AuthorizationException('play_more');
         }
 
         throw new AuthorizationException('require_verification');

--- a/config/osu.php
+++ b/config/osu.php
@@ -213,6 +213,7 @@ return [
         'allowed_rename_groups' => explode(' ', env('USER_ALLOWED_RENAME_GROUPS', 'default')),
         'inactive_days_verification' => get_int(env('USER_INACTIVE_DAYS_VERIFICATION')) ?? 180,
         'min_plays_for_posting' => get_int(env('USER_MIN_PLAYS_FOR_POSTING')) ?? 10,
+        'min_plays_allow_verified_bypass' => get_bool(env('USER_MIN_PLAYS_ALLOW_VERIFIED_BYPASS')) ?? true,
         'post_action_verification' => get_bool(env('USER_POST_ACTION_VERIFICATION')) ?? true,
         'user_page_forum_id' => intval(env('USER_PAGE_FORUM_ID', 70)),
         'verification_key_length_hex' => 8,

--- a/resources/lang/en/authorization.php
+++ b/resources/lang/en/authorization.php
@@ -4,6 +4,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 return [
+    'play_more' => 'How about playing some osu! instead?',
     'require_login' => 'Please sign in to proceed.',
     'require_verification' => 'Please verify to proceed.',
     'restricted' => "Can't do that while restricted.",


### PR DESCRIPTION
defaults to true (allows verified sessions to skip play count requirement)
add `USER_MIN_PLAYS_ALLOW_VERIFIED_BYPASS=false` to .env to disable the play count bypass.

Effects
- chat
- posting to beatmap discussions
- posting to forum


known issues:
~~Failing the check when not verified will automatically send a verification email out - the issue is, on chat, the verification dialog doesn't show when the message fails to send and doesn't show what the error is.~~ It should only attempt verification if the option is enabled, now. Chat still has the issue where if doesn't show the reason for error.