### PR TITLE
Add support for user registration email domain block list

### DIFF
--- a/database/migrations/2020_09_25_092826_create_phpbb_banlist.php
+++ b/database/migrations/2020_09_25_092826_create_phpbb_banlist.php
@@ -1,0 +1,55 @@
+<?php
+
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreatePhpbbBanlist extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        if (Schema::hasTable('phpbb_banlist')) {
+            return;
+        }
+
+        Schema::create('phpbb_banlist', function (Blueprint $table) {
+            $table->charset = 'utf8';
+            $table->collation = 'utf8_bin';
+
+            $table->mediumIncrements('ban_id');
+            $table->unsignedMediumInteger('ban_userid')->default(0);
+            $table->string('ban_ip', 40)->default('');
+            $table->string('ban_email', 100)->default('');
+            $table->unsignedInteger('ban_start')->default(0);
+            $table->unsignedInteger('ban_end')->default(0);
+            $table->unsignedTinyInteger('ban_exclude')->default(0);
+            $table->string('ban_reason', 255)->default('');
+            $table->string('ban_give_reason', 255)->default('');
+
+            $table->index(['ban_end'], 'ban_end');
+            $table->index(['ban_userid', 'ban_exclude'], 'ban_user');
+            $table->index(['ban_email', 'ban_exclude'], 'ban_email');
+            $table->index(['ban_ip', 'ban_exclude'], 'ban_ip');
+        });
+
+        DB::statement('ALTER TABLE `phpbb_banlist` ROW_FORMAT=DYNAMIC;');
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        // no going back =)
+    }
+}

--- a/resources/lang/en/model_validation.php
+++ b/resources/lang/en/model_validation.php
@@ -121,6 +121,7 @@ return [
     'user' => [
         'contains_username' => 'Password may not contain username.',
         'email_already_used' => 'Email address already used.',
+        'email_not_allowed' => 'Email address not allowed.',
         'invalid_country' => 'Country not in database.',
         'invalid_discord' => 'Discord username invalid.',
         'invalid_email' => "Doesn't seem to be a valid email address.",


### PR DESCRIPTION
Migrates a missing feature from old web.
Check is similar to the one for usernames and `phpbb_disallow`.
The format is `*@domain` or even `*@domain*` where `*` becomes the regex equivalent of `.*?`
`ban_start` is not checked.

`isValidEmail()` is a bit janky as it'll just append additional errors on multiple calls.

Not sure if the migration should just go into the base tables, but then we added this `2020_05_15_083037_sync_structure` 🤔 

- [ ] add `2020_09_25_092826_create_phpbb_banlist` to migrations