### PR TITLE
Fix Safari auto scrolling to comments box

### DIFF
--- a/resources/assets/coffee/react/_components/comment-editor.coffee
+++ b/resources/assets/coffee/react/_components/comment-editor.coffee
@@ -25,8 +25,9 @@ export class CommentEditor extends React.PureComponent
 
 
   componentDidMount: =>
-    @textarea.current?.selectionStart = -1
-    @textarea.current?.focus() if (@props.focus ? true)
+    if @props.focus ? true
+      @textarea.current?.selectionStart = -1
+      @textarea.current?.focus()
 
 
   componentWillUnmount: =>


### PR DESCRIPTION
setting `selectionStart` causes iOS safari to scroll to the element when a keyboard is active.

closes #6670 