### PR TITLE
Add correct momentjs locale mapping for Norwegian

### DIFF
--- a/app/helpers.php
+++ b/app/helpers.php
@@ -441,19 +441,6 @@ function locale_for_moment($locale)
     return $locale;
 }
 
-function locale_for_timeago($locale)
-{
-    if ($locale === 'zh') {
-        return 'zh-CN';
-    }
-
-    if ($locale === 'zh-tw') {
-        return 'zh-TW';
-    }
-
-    return $locale;
-}
-
 function log_error($exception)
 {
     Log::error($exception);

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -434,6 +434,10 @@ function locale_for_moment($locale)
         return 'zh-cn';
     }
 
+    if ($locale === 'no') {
+        return 'nb';
+    }
+
     return $locale;
 }
 

--- a/tests/LocaleTest.php
+++ b/tests/LocaleTest.php
@@ -71,19 +71,19 @@ class LocaleTest extends TestCase
     /**
      * @dataProvider availableLocalesProvider
      */
-    public function testCorrespondingMomentLocaleFile($locale)
+    public function testCorrespondingLocaleFile($locale)
     {
-        $momentLocale = locale_for_moment($locale);
-
-        $this->assertTrue(unmix("js/moment-locales/{$momentLocale}.js") !== null);
+        $this->assertTrue(unmix("js/locales/{$locale}.js") !== null);
     }
 
     /**
      * @dataProvider availableLocalesProvider
      */
-    public function testCorrespondingLocaleFile($locale)
+    public function testCorrespondingMomentLocaleFile($locale)
     {
-        $this->assertTrue(unmix("js/locales/{$locale}.js") !== null);
+        $momentLocale = locale_for_moment($locale);
+
+        $this->assertTrue(unmix("js/moment-locales/{$momentLocale}.js") !== null);
     }
 
     public function availableLocalesProvider()

--- a/tests/LocaleTest.php
+++ b/tests/LocaleTest.php
@@ -67,4 +67,29 @@ class LocaleTest extends TestCase
         $this->assertSame('', trans('key_1.empty_empty'));
         $this->assertSame('', trans('key_1.empty_missing'));
     }
+
+    /**
+     * @dataProvider availableLocalesProvider
+     */
+    public function testCorrespondingMomentLocaleFile($locale)
+    {
+        $momentLocale = locale_for_moment($locale);
+
+        $this->assertTrue(unmix("js/moment-locales/{$momentLocale}.js") !== null);
+    }
+
+    /**
+     * @dataProvider availableLocalesProvider
+     */
+    public function testCorrespondingLocaleFile($locale)
+    {
+        $this->assertTrue(unmix("js/locales/{$locale}.js") !== null);
+    }
+
+    public function availableLocalesProvider()
+    {
+        return array_map(function ($locale) {
+            return [$locale];
+        }, config('app.available_locales'));
+    }
 }


### PR DESCRIPTION
Er ( ﾟ ヮﾟ)

(using `nb` / Bokmål as it seems to be the most common and has some words in it in current general `no` translations)