### PR TITLE
Fix pluralization issue

### DIFF
--- a/resources/assets/lib/globals.d.ts
+++ b/resources/assets/lib/globals.d.ts
@@ -133,9 +133,8 @@ interface BeatmapsetDiscussionPostJson {
 }
 
 interface LangClass {
-  _getPluralForm: (count: number) => number;
-  _origGetPluralForm: (count: number) => number;
-  locale: string;
+  _getPluralForm: (count: number, locale: string) => number;
+  _origGetPluralForm: (count: number, locale: string) => number;
   has(key: string): boolean;
 }
 

--- a/resources/assets/lib/lang-overrides.ts
+++ b/resources/assets/lib/lang-overrides.ts
@@ -5,16 +5,12 @@ Lang._origGetPluralForm = Lang._getPluralForm;
 
 // pt-br isn't in original getPluralForm so the locale needs to be
 // temporarily changed to pt for the function to return correct form.
-Lang._getPluralForm = (count) => {
-  const origLocale = Lang.locale;
-
-  if (origLocale === 'pt-br') {
-    Lang.locale = 'pt';
+Lang._getPluralForm = (count, locale) => {
+  if (locale === 'pt-br') {
+    locale = 'pt';
   }
 
-  const form = Lang._origGetPluralForm(count);
-
-  Lang.locale = origLocale;
+  const form = Lang._origGetPluralForm(count, locale);
 
   return form;
 };


### PR DESCRIPTION
Resolves #6709 

I was debugging this issue and it seems like the original function for getPluralForm takes two arguments instead of just one. The missing argument that we currently have causes Lang.js to always pick the first of the two choices (singular). This PR fixes this issue by taking in consideration of the second argument. 