### PR TITLE
Change nomination requirement for 'hybrid' beatmapsets

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -164,6 +164,11 @@ OSU_RUNNING_COST=
 # BEATMAPSET_USER_FAVOURITE_LIMIT=100
 # BEATMAPSET_USER_FAVOURITE_LIMIT_SUPPORTER=1000
 
+# Nominations required for a Beatmapset to be qualified
+# BEATMAPSET_REQUIRED_NOMINATIONS=2
+# Nominations required (per game mode) for a hybrid Beatmapset to be qualified
+# BEATMAPSET_REQUIRED_NOMINATIONS_HYBRID=2
+
 # BAN_PERSIST_DAYS=28
 
 # ES_HOST=localhost:9200

--- a/app/Models/Beatmapset.php
+++ b/app/Models/Beatmapset.php
@@ -843,7 +843,9 @@ class Beatmapset extends Model implements AfterCommit, Commentable
 
     public function requiredNominationCount()
     {
-        return 2;
+        return $this->isHybridSet()
+            ? $this->playmodes()->count() * config('osu.beatmapset.required_nominations_hybrid')
+            : config('osu.beatmapset.required_nominations');
     }
 
     public function currentNominationCount()
@@ -1153,6 +1155,11 @@ class Beatmapset extends Model implements AfterCommit, Commentable
     public function validationErrorsTranslationPrefix()
     {
         return 'beatmapset';
+    }
+
+    public function isHybridSet(): bool
+    {
+        return $this->playmodes()->count() > 1;
     }
 
     public function isValid()

--- a/config/osu.php
+++ b/config/osu.php
@@ -46,6 +46,8 @@ return [
         'rank_per_day' => get_int(env('BEATMAPSET_RANK_PER_DAY')) ?? 8,
         'rank_per_run' => get_int(env('BEATMAPSET_RANK_PER_RUN')) ?? 2,
         'required_hype' => get_int(env('BEATMAPSET_REQUIRED_HYPE')) ?? 5,
+        'required_nominations' => get_int(env('BEATMAPSET_REQUIRED_NOMINATIONS')) ?? 2,
+        'required_nominations_hybrid' => get_int(env('BEATMAPSET_REQUIRED_NOMINATIONS_HYBRID')) ?? 2,
         'storage' => env('BEATMAPSET_STORAGE'),
         'upload_allowed' => get_int(env('BEATMAPSET_UPLOAD_ALLOWED')) ?? 4,
         'upload_bonus_per_ranked' => get_int(env('BEATMAPSET_UPLOAD_BONUS_PER_RANKED')) ?? 1,


### PR DESCRIPTION
Changes the nominations required for 'Hybrid' Beatmapsets to be (by default) 2*(playmode count).

Note that while the required nominations number has been moved to a `.env` variable, _decreasing_ the number may result in Beatmapsets being left in limbo and not entering a qualified state if the new value is below their current nomination count.

(this is the first part in addressing #6689)