### PR TITLE
Fix incorrectly nesting array for elasticsearch query

### DIFF
--- a/app/Libraries/Elasticsearch/QueryHelper.php
+++ b/app/Libraries/Elasticsearch/QueryHelper.php
@@ -16,7 +16,7 @@ class QueryHelper
      */
     public static function clauseToArray($clause): array
     {
-        if (is_array($clause)) {
+        if (is_array($clause) && (!empty($clause) && !isset($clause[0]))) {
             return $clause;
         }
 
@@ -24,7 +24,7 @@ class QueryHelper
             return $clause->toArray();
         }
 
-        throw new Exception('$clause should be array or Queryable.');
+        throw new Exception('$clause should be associative array or Queryable.');
     }
 
     /**

--- a/app/Libraries/Elasticsearch/SearchResponse.php
+++ b/app/Libraries/Elasticsearch/SearchResponse.php
@@ -126,7 +126,10 @@ class SearchResponse implements \ArrayAccess, \Countable, \Iterator
 
     public function total()
     {
-        return $this->raw()['hits']['total'];
+        $total = $this->raw()['hits']['total'];
+
+        // total an object in elasticsearch 7+
+        return is_array($total) ? $total['value'] : $total;
     }
 
     //================

--- a/app/Libraries/Search/BeatmapsetSearch.php
+++ b/app/Libraries/Search/BeatmapsetSearch.php
@@ -206,10 +206,9 @@ class BeatmapsetSearch extends RecordSearch
             case 'any':
                 break;
             case 'ranked':
-                $query->should([
-                    ['match' => ['approved' => Beatmapset::STATES['ranked']]],
-                    ['match' => ['approved' => Beatmapset::STATES['approved']]],
-                ]);
+                $query
+                    ->should(['match' => ['approved' => Beatmapset::STATES['ranked']]])
+                    ->should(['match' => ['approved' => Beatmapset::STATES['approved']]]);
                 break;
             case 'loved':
                 $query->must(['match' => ['approved' => Beatmapset::STATES['loved']]]);
@@ -219,15 +218,12 @@ class BeatmapsetSearch extends RecordSearch
                 $query->must(['ids' => ['type' => 'beatmaps', 'values' => $favs]]);
                 break;
             case 'qualified':
-                $query->should([
-                    ['match' => ['approved' => Beatmapset::STATES['qualified']]],
-                ]);
+                $query->should(['match' => ['approved' => Beatmapset::STATES['qualified']]]);
                 break;
             case 'pending':
-                $query->should([
-                    ['match' => ['approved' => Beatmapset::STATES['wip']]],
-                    ['match' => ['approved' => Beatmapset::STATES['pending']]],
-                ]);
+                $query
+                    ->should(['match' => ['approved' => Beatmapset::STATES['wip']]])
+                    ->should(['match' => ['approved' => Beatmapset::STATES['pending']]]);
                 break;
             case 'graveyard':
                 $query->must(['match' => ['approved' => Beatmapset::STATES['graveyard']]]);
@@ -239,11 +235,10 @@ class BeatmapsetSearch extends RecordSearch
                 $query->must(['ids' => ['type' => 'beatmaps', 'values' => $maps ?? []]]);
                 break;
             default: // null, etc
-                $query->should([
-                    ['match' => ['approved' => Beatmapset::STATES['ranked']]],
-                    ['match' => ['approved' => Beatmapset::STATES['approved']]],
-                    ['match' => ['approved' => Beatmapset::STATES['loved']]],
-                ]);
+                $query
+                    ->should(['match' => ['approved' => Beatmapset::STATES['ranked']]])
+                    ->should(['match' => ['approved' => Beatmapset::STATES['approved']]])
+                    ->should(['match' => ['approved' => Beatmapset::STATES['loved']]]);
                 break;
         }
 


### PR DESCRIPTION
Found this when trying the latest elasticsearch.

Some queries currently incorrectly generate nested array [which is not actually supported and finally disallowed in later version (7.7?)](https://discuss.elastic.co/t/must-not-boolean-query-in-7-7/233269).

Also added a minor compat layer for updated total value in 7.x.

Haven't actually done thorough check yet.