### PR TITLE
Correctly escape user id part when generating profile link

### DIFF
--- a/app/helpers.php
+++ b/app/helpers.php
@@ -827,6 +827,7 @@ function link_to_user($id, $username = null, $color = null, $classNames = null)
         $color ?? ($color = $id->user_colour);
         $id = $id->getKey();
     }
+    $id = e($id);
     $username = e($username);
     $style = user_color_style($color, 'color');
 


### PR DESCRIPTION
Resolves #6737.