### PR TITLE
Exclude no_profile user group from user lookup

### DIFF
--- a/app/Libraries/BBCodeForDB.php
+++ b/app/Libraries/BBCodeForDB.php
@@ -251,7 +251,7 @@ class BBCodeForDB
 
                 $user = $usersBy['user_id'][$id] ?? $usersBy['username'][$nameNormalized] ?? $usersBy['username_clean'][$nameNormalized] ?? null;
 
-                if ($user === null || !$user->hasProfile()) {
+                if ($user === null || !$user->hasProfileVisible()) {
                     $idText = '';
                 } else {
                     $idText = "={$user->getKey()}";

--- a/app/Libraries/OsuAuthorize.php
+++ b/app/Libraries/OsuAuthorize.php
@@ -1662,7 +1662,7 @@ class OsuAuthorize
             return 'ok';
         }
 
-        if ($owner->hasProfile()) {
+        if ($owner->hasProfileVisible()) {
             return 'ok';
         } else {
             return $prefix.'no_access';

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -433,10 +433,10 @@ class User extends Model implements AuthenticatableContract, HasLocalePreference
         return (new ChangeUsername($this, $username, $type))->validate();
     }
 
-    public static function lookup($usernameOrId, $type = null, $findAll = false)
+    public static function lookup($usernameOrId, $type = null, $findAll = false): ?self
     {
         if (!present($usernameOrId)) {
-            return;
+            return null;
         }
 
         switch ($type) {
@@ -462,7 +462,13 @@ class User extends Model implements AuthenticatableContract, HasLocalePreference
             $user->where('user_type', 0)->where('user_warnings', 0);
         }
 
-        return $user->first();
+        $user = $user->first();
+
+        if ($user !== null && $user->hasProfile()) {
+            return $user;
+        }
+
+        return null;
     }
 
     public static function lookupWithHistory($usernameOrId, $type = null, $findAll = false)
@@ -1458,8 +1464,12 @@ class User extends Model implements AuthenticatableContract, HasLocalePreference
     public function hasProfile()
     {
         return $this->user_id !== null
-            && !$this->isRestricted()
             && $this->group_id !== app('groups')->byIdentifier('no_profile')->getKey();
+    }
+
+    public function hasProfileVisible()
+    {
+        return $this->hasProfile() && !$this->isRestricted();
     }
 
     public function updatePage($text)

--- a/resources/views/forum/topics/_post_info.blade.php
+++ b/resources/views/forum/topics/_post_info.blade.php
@@ -3,7 +3,7 @@
     See the LICENCE file in the repository root for full licence text.
 --}}
 <div class="forum-post-info">
-    @if ($user->hasProfile())
+    @if ($user->hasProfileVisible())
         @if ($user->user_avatar)
             <div class="forum-post-info__row forum-post-info__row--avatar">
                 <a


### PR DESCRIPTION
Shouldn't be a need to be able to `User::lookup` users in the `no_profile` group

closes #6736