### PR TITLE
Remove promise wrapping for chat api calls

### DIFF
--- a/resources/assets/lib/chat/chat-api.ts
+++ b/resources/assets/lib/chat/chat-api.ts
@@ -2,85 +2,48 @@
 // See the LICENCE file in the repository root for full licence text.
 
 import { route } from 'laroute';
+import Message from 'models/chat/message';
 import * as ApiResponses from './chat-api-responses';
 
 export default class ChatAPI {
-  getMessages(channelId: number, params?: { since?: number; until?: number }): Promise<ApiResponses.GetMessagesJSON> {
-    return new Promise((resolve, reject) => {
-      $.get(route('chat.channels.messages.index', { channel: channelId, ...params }))
-        .done((response) => {
-          resolve(response as ApiResponses.GetMessagesJSON);
-        }).fail((error) => {
-          reject(error);
-        });
+  getMessages(channelId: number, params?: { since?: number; until?: number }): JQuery.jqXHR<ApiResponses.GetMessagesJSON> {
+    return $.get(route('chat.channels.messages.index', { channel: channelId, ...params }));
+  }
+
+  getUpdates(since: number, lastHistoryId?: number | null): JQuery.jqXHR<ApiResponses.GetUpdatesJSON> {
+    return $.get(route('chat.updates'), { since, history_since: lastHistoryId });
+  }
+
+  markAsRead(channelId: number, messageId: number): JQuery.jqXHR<ApiResponses.MarkAsReadJSON> {
+    return $.ajax({
+      type: 'PUT',
+      url: route('chat.channels.mark-as-read', {channel: channelId, message: messageId}),
     });
   }
 
-  getUpdates(since: number, lastHistoryId?: number | null): Promise<ApiResponses.GetUpdatesJSON> {
-    return new Promise((resolve, reject) => {
-      $.get(route('chat.updates'), { since, history_since: lastHistoryId })
-      .done((response) => {
-        resolve(response as ApiResponses.GetUpdatesJSON);
-      }).fail((error) => {
-        reject(error);
-      });
-    });
-  }
-
-  markAsRead(channelId: number, messageId: number): Promise<ApiResponses.MarkAsReadJSON> {
-    return new Promise((resolve, reject) => {
-      $.ajax({
-        type: 'PUT',
-        url: route('chat.channels.mark-as-read', {channel: channelId, message: messageId}),
-      }).done((response) => {
-        resolve(response as ApiResponses.MarkAsReadJSON);
-      }).fail((error) => {
-        reject(error);
-      });
-    });
-  }
-
-  newConversation(userId: number, message: string, action?: boolean): Promise<ApiResponses.NewConversationJSON> {
-    return new Promise((resolve, reject) => {
-      $.post(route('chat.new'), {
-        is_action: action,
-        message,
-        target_id: userId,
-      }).done((response) => {
-        resolve(response as ApiResponses.NewConversationJSON);
-      }).fail((error) => {
-        reject(error);
-      });
+  newConversation(userId: number, message: Message): JQuery.jqXHR<ApiResponses.NewConversationJSON> {
+    return $.post(route('chat.new'), {
+      is_action: message.isAction,
+      message: message.content,
+      target_id: userId,
     });
   }
 
   partChannel(channelId: number, userId: number) {
-    return new Promise((resolve, reject) => {
-      $.ajax(route('chat.channels.part', {
-        channel: channelId,
-        user: userId,
-      }), {
-        method: 'DELETE',
-      }).done((response) => {
-        resolve(response);
-      }).fail((error) => {
-        reject(error);
-      });
+    return $.ajax(route('chat.channels.part', {
+      channel: channelId,
+      user: userId,
+    }), {
+      method: 'DELETE',
     });
   }
 
-  sendMessage(channelId: number, message: string, action?: boolean): Promise<ApiResponses.SendMessageJSON> {
-    return new Promise((resolve, reject) => {
-      $.post(route('chat.channels.messages.store', {channel: channelId}), {
-        is_action: action,
-        message,
-        target_id: channelId,
-        target_type: 'channel',
-      }).done((response) => {
-        resolve(response as ApiResponses.SendMessageJSON);
-      }).fail((error) => {
-        reject(error);
-      });
+  sendMessage(message: Message) {
+    return $.post(route('chat.channels.messages.store', { channel: message.channelId }), {
+      is_action: message.isAction,
+      message: message.content,
+      target_id: message.channelId,
+      target_type: 'channel',
     });
   }
 }

--- a/resources/assets/lib/chat/chat-orchestrator.ts
+++ b/resources/assets/lib/chat/chat-orchestrator.ts
@@ -202,7 +202,7 @@ export default class ChatOrchestrator implements DispatchListener {
 
     if (action.shouldSync && action.channelId !== -1) {
       try {
-        this.api.partChannel(action.channelId, window.currentUser.id)
+        this.api.partChannel(action.channelId, window.currentUser.id);
       } catch (err) {
         console.debug('leaveChannel error', err);
       }

--- a/resources/assets/lib/chat/chat-orchestrator.ts
+++ b/resources/assets/lib/chat/chat-orchestrator.ts
@@ -126,12 +126,12 @@ export default class ChatOrchestrator implements DispatchListener {
       const messages = await this.api.getMessages(channelId);
       transaction(() => {
         this.addMessages(channelId, messages);
-        channel.loading = false;
         channel.loaded = true;
       });
     } catch (err) {
-      channel.loading = false;
       console.debug('loadChannel error', err);
+    } finally {
+      channel.loading = false;
     }
   }
 
@@ -147,12 +147,12 @@ export default class ChatOrchestrator implements DispatchListener {
     this.api.getMessages(channel.channelId, { until: channel.minMessageId })
       .then((messages) => {
         transaction(() => {
-          channel.loadingEarlierMessages = false;
           this.addMessages(channelId, messages);
         });
       }).catch((err) => {
-        channel.loadingEarlierMessages = false;
         console.debug('loadChannelEarlierMessages error', err);
+      }).always(() => {
+        channel.loadingEarlierMessages = false;
       });
   }
 

--- a/resources/assets/lib/chat/chat-worker.ts
+++ b/resources/assets/lib/chat/chat-worker.ts
@@ -120,7 +120,7 @@ export default class ChatWorker implements DispatchListener {
         return;
       }
 
-      this.api.newConversation(userId, message.content, message.isAction)
+      this.api.newConversation(userId, message)
         .then((response) => {
           transaction(() => {
             this.rootDataStore.channelStore.channels.delete(channelId);
@@ -133,7 +133,7 @@ export default class ChatWorker implements DispatchListener {
           dispatch(new ChatMessageUpdateAction(message));
         });
     } else {
-      this.api.sendMessage(channelId, message.content, message.isAction)
+      this.api.sendMessage(message)
         .then((updateJson) => {
           if (updateJson) {
             message.messageId = updateJson.message_id;


### PR DESCRIPTION
contains part of #6731

Wrapping jquery calls with `Promise` isn't needed anymore.
Also converts some of the calls to use `await`.

This doesn't fix any of the `action`/`transaction` bits