### PR TITLE
Prevent invisible username history from blocking other elements

### DIFF
--- a/resources/assets/less/bem/profile-info.less
+++ b/resources/assets/less/bem/profile-info.less
@@ -157,6 +157,7 @@
   &__previous-usernames {
     transform: translateY(-0.3em);
     display: inline-block;
+    pointer-events: none;
 
     @media @desktop {
       transform: translateY(-0.7em);


### PR DESCRIPTION
The box itself already has correct pointer events but the container doesn't.

![](https://s.myconan.net/2020-10/firefox_2020-10-08_13-19-04.png)