### PR TITLE
Use _doc as _type for Elasticsearch

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,7 +32,7 @@ env:
     - CACHE_DRIVER=redis
     - CACHE_DRIVER_LOCAL=array
     - DB_USERNAME=root
-    - ES_VERSION=6.6.0 ES_DOWNLOAD_URL=https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-${ES_VERSION}.zip
+    - ES_VERSION=6.8.12 ES_DOWNLOAD_URL=https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-${ES_VERSION}.zip
     - GITHUB_TOKEN=98cbc568911ef1e060a3a31623f2c80c1786d5ff
     - NOTIFICATION_ENDPOINT=ws://127.0.0.1:3000
     - NOTIFICATION_SERVER_LISTEN_PORT=3000

--- a/app/Console/Commands/EsIndexDocuments.php
+++ b/app/Console/Commands/EsIndexDocuments.php
@@ -130,7 +130,7 @@ class EsIndexDocuments extends Command
 
         if ($alias !== $indexName) {
             $this->info("Aliasing {$alias} to {$indexName}");
-            Indexing::updateAlias($alias, [$indexName]);
+            Indexing::updateAlias($alias, $indexName);
             $this->line('');
         }
     }

--- a/app/Console/Commands/EsIndexWiki.php
+++ b/app/Console/Commands/EsIndexWiki.php
@@ -68,7 +68,7 @@ class EsIndexWiki extends Command
 
         $this->reindex();
 
-        Indexing::updateAlias($alias, [$this->indexName]);
+        Indexing::updateAlias($alias, $this->indexName);
 
         $this->updateSitemap();
 

--- a/app/Jobs/EsIndexDocumentBulk.php
+++ b/app/Jobs/EsIndexDocumentBulk.php
@@ -42,7 +42,7 @@ class EsIndexDocumentBulk implements ShouldQueue
                 // TODO: handling response would be nice =)
                 Es::getClient()->bulk([
                     'index' => $this->className::esIndexName(),
-                    'type' => $this->className::esType(),
+                    'type' => '_doc',
                     'body' => $actions,
                     'client' => ['timeout' => 0],
                 ]);

--- a/app/Libraries/Elasticsearch/Indexing.php
+++ b/app/Libraries/Elasticsearch/Indexing.php
@@ -49,7 +49,7 @@ class Indexing
         }
 
         foreach ($indices as $index) {
-            $actions[] = ['add' => ['index' => $index, 'alias' => $alias]];
+            $actions[] = ['add' => ['index' => $index, 'alias' => $alias, 'is_write_index' => true]];
         }
 
         return Es::getClient()->indices()->updateAliases([

--- a/app/Libraries/Elasticsearch/Indexing.php
+++ b/app/Libraries/Elasticsearch/Indexing.php
@@ -38,11 +38,6 @@ class Indexing
     {
         $oldIndices = static::getOldIndices($alias);
 
-        // updateAliases doesn't work if the alias doesn't exist :D
-        if (count($oldIndices) === 0) {
-            return Es::getClient()->indices()->putAlias(['index' => $indices, 'name' => $alias]);
-        }
-
         $actions = [];
         foreach ($oldIndices as $oldIndex) {
             $actions[] = ['remove' => ['index' => $oldIndex, 'alias' => $alias]];

--- a/app/Libraries/Elasticsearch/Indexing.php
+++ b/app/Libraries/Elasticsearch/Indexing.php
@@ -34,7 +34,7 @@ class Indexing
      * @param string $alias Name of the alias.
      * @param array $indices Names of the indices to alias.
      */
-    public static function updateAlias(string $alias, array $indices)
+    public static function updateAlias(string $alias, string $index)
     {
         $oldIndices = static::getOldIndices($alias);
 
@@ -43,9 +43,7 @@ class Indexing
             $actions[] = ['remove' => ['index' => $oldIndex, 'alias' => $alias]];
         }
 
-        foreach ($indices as $index) {
-            $actions[] = ['add' => ['index' => $index, 'alias' => $alias, 'is_write_index' => true]];
-        }
+        $actions[] = ['add' => ['index' => $index, 'alias' => $alias, 'is_write_index' => true]];
 
         return Es::getClient()->indices()->updateAliases([
             'body' => [

--- a/app/Models/Elasticsearch/BeatmapsetTrait.php
+++ b/app/Models/Elasticsearch/BeatmapsetTrait.php
@@ -33,11 +33,6 @@ trait BeatmapsetTrait
         return config_path('schemas/beatmaps.json');
     }
 
-    public static function esType()
-    {
-        return 'beatmaps';
-    }
-
     public function esShouldIndex()
     {
         return !$this->trashed() && !present($this->download_disabled_url);

--- a/app/Models/Elasticsearch/PostTrait.php
+++ b/app/Models/Elasticsearch/PostTrait.php
@@ -30,11 +30,6 @@ trait PostTrait
         return config_path('schemas/posts.json');
     }
 
-    public static function esType()
-    {
-        return 'posts';
-    }
-
     public function esRouting()
     {
         // Post and Topic should have the same routing for relationships to work.

--- a/app/Models/Elasticsearch/TopicTrait.php
+++ b/app/Models/Elasticsearch/TopicTrait.php
@@ -30,11 +30,6 @@ trait TopicTrait
         return Post::esSchemaFile();
     }
 
-    public static function esType()
-    {
-        return Post::esType();
-    }
-
     public function esRouting()
     {
         // Post and Topic should have the same routing for relationships to work.

--- a/app/Models/Elasticsearch/UserTrait.php
+++ b/app/Models/Elasticsearch/UserTrait.php
@@ -33,11 +33,6 @@ trait UserTrait
         return config_path('schemas/users.json');
     }
 
-    public static function esType()
-    {
-        return 'users';
-    }
-
     public function toEsJson()
     {
         $mappings = $this->esFilterFields();

--- a/app/Models/Elasticsearch/WikiPageTrait.php
+++ b/app/Models/Elasticsearch/WikiPageTrait.php
@@ -20,9 +20,4 @@ trait WikiPageTrait
     {
         return config_path('schemas/wiki_page.json');
     }
-
-    public static function esType()
-    {
-        return 'wiki_page';
-    }
 }

--- a/app/Models/Wiki/Page.php
+++ b/app/Models/Wiki/Page.php
@@ -50,14 +50,6 @@ class Page implements WikiObject
         return strtolower(str_replace(['-', '/', '_'], ' ', $path));
     }
 
-    public static function searchIndexConfig($params = [])
-    {
-        return array_merge([
-            'index' => static::esIndexName(),
-            'type' => '_doc',
-        ], $params);
-    }
-
     public static function fromEs($hit)
     {
         $source = $hit->source();
@@ -176,11 +168,12 @@ class Page implements WikiObject
     {
         $this->log('delete document');
 
-        return Es::getClient()->delete(static::searchIndexConfig([
+        return Es::getClient()->delete([
+            'client' => ['ignore' => 404],
             'id' => $this->pagePath(),
             'index' => $options['index'] ?? static::esIndexName(),
-            'client' => ['ignore' => 404],
-        ]));
+            'type' => '_doc',
+        ]);
     }
 
     public function esIndexDocument(array $options = [])
@@ -191,11 +184,12 @@ class Page implements WikiObject
             $this->log('index document');
         }
 
-        return Es::getClient()->index(static::searchIndexConfig([
+        return Es::getClient()->index([
+            'body' => $this->source,
             'id' => $this->pagePath(),
             'index' => $options['index'] ?? static::esIndexName(),
-            'body' => $this->source,
-        ]));
+            'type' => '_doc',
+        ]);
     }
 
     public function esFetch()

--- a/app/Models/Wiki/Page.php
+++ b/app/Models/Wiki/Page.php
@@ -54,7 +54,7 @@ class Page implements WikiObject
     {
         return array_merge([
             'index' => static::esIndexName(),
-            'type' => static::esType(),
+            'type' => '_doc',
         ], $params);
     }
 

--- a/app/Traits/EsIndexable.php
+++ b/app/Traits/EsIndexable.php
@@ -14,12 +14,11 @@ trait EsIndexable
 
     abstract public static function esSchemaFile();
 
-    abstract public static function esType();
-
     public static function esCreateIndex(string $name = null)
     {
         // TODO: allow overriding of certain settings (shards, replicas, etc)?
         $params = [
+            'include_type_name' => 'true',
             'index' => $name ?? static::esIndexName(),
             'body' => static::esSchemaConfig(),
         ];
@@ -29,7 +28,7 @@ trait EsIndexable
 
     public static function esMappings()
     {
-        return static::esSchemaConfig()['mappings'][static::esType()]['properties'];
+        return static::esSchemaConfig()['mappings']['_doc']['properties'];
     }
 
     public static function esSchemaConfig()

--- a/app/Traits/EsIndexableModel.php
+++ b/app/Traits/EsIndexableModel.php
@@ -43,7 +43,7 @@ trait EsIndexableModel
             if ($actions !== []) {
                 $result = Es::getClient()->bulk([
                     'index' => $options['index'] ?? static::esIndexName(),
-                    'type' => static::esType(),
+                    'type' => '_doc',
                     'body' => $actions,
                     'client' => ['timeout' => 0],
                 ]);
@@ -76,7 +76,7 @@ trait EsIndexableModel
     {
         $document = array_merge([
             'index' => static::esIndexName(),
-            'type' => static::esType(),
+            'type' => '_doc',
             'routing' => $this->esRouting(),
             'id' => $this->getEsId(),
             'client' => ['ignore' => 404],
@@ -93,7 +93,7 @@ trait EsIndexableModel
 
         $document = array_merge([
             'index' => static::esIndexName(),
-            'type' => static::esType(),
+            'type' => '_doc',
             'routing' => $this->esRouting(),
             'id' => $this->getEsId(),
             'body' => $this->toEsJson(),

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
     "chaseconey/laravel-datadog-helper": ">=1.2.0",
     "doctrine/dbal": "*",
     "egulias/email-validator": "*",
-    "elasticsearch/elasticsearch": ">=6.0, <6.6",
+    "elasticsearch/elasticsearch": "^6.7.0",
     "ezyang/htmlpurifier": "*",
     "graham-campbell/github": "*",
     "guzzlehttp/guzzle": "*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "4b9c0da14ba8c45f8e3a9c5faebf986b",
+    "content-hash": "0142acf797f4a986c5a5a88db1b84248",
     "packages": [
         {
             "name": "anhskohbo/no-captcha",
@@ -903,16 +903,16 @@
         },
         {
             "name": "elasticsearch/elasticsearch",
-            "version": "v6.5.1",
+            "version": "v6.7.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/elastic/elasticsearch-php.git",
-                "reference": "0c93d0e5b852634159d9f349b1848acde845400b"
+                "reference": "9ba89f905ebf699e72dacffa410331c7fecc8255"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/elastic/elasticsearch-php/zipball/0c93d0e5b852634159d9f349b1848acde845400b",
-                "reference": "0c93d0e5b852634159d9f349b1848acde845400b",
+                "url": "https://api.github.com/repos/elastic/elasticsearch-php/zipball/9ba89f905ebf699e72dacffa410331c7fecc8255",
+                "reference": "9ba89f905ebf699e72dacffa410331c7fecc8255",
                 "shasum": ""
             },
             "require": {
@@ -922,7 +922,7 @@
                 "psr/log": "~1.0"
             },
             "require-dev": {
-                "cpliakas/git-wrapper": "~1.0",
+                "cpliakas/git-wrapper": "^1.7 || ^2.1",
                 "doctrine/inflector": "^1.1",
                 "mockery/mockery": "^1.2",
                 "phpstan/phpstan-shim": "^0.9 || ^0.11",
@@ -959,7 +959,7 @@
                 "elasticsearch",
                 "search"
             ],
-            "time": "2019-07-19T13:34:35+00:00"
+            "time": "2019-07-19T14:48:24+00:00"
         },
         {
             "name": "erusev/parsedown",
@@ -2004,6 +2004,16 @@
                 "platform",
                 "user agent",
                 "useragent"
+            ],
+            "funding": [
+                {
+                    "url": "https://github.com/jenssegers",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/jenssegers/agent",
+                    "type": "tidelift"
+                }
             ],
             "time": "2020-06-13T08:05:20+00:00"
         },
@@ -5332,6 +5342,16 @@
                 "logging",
                 "sentry"
             ],
+            "funding": [
+                {
+                    "url": "https://sentry.io/",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://sentry.io/pricing/",
+                    "type": "custom"
+                }
+            ],
             "time": "2020-08-13T10:54:32+00:00"
         },
         {
@@ -5400,6 +5420,16 @@
                 "log",
                 "logging",
                 "sentry"
+            ],
+            "funding": [
+                {
+                    "url": "https://sentry.io/",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://sentry.io/pricing/",
+                    "type": "custom"
+                }
             ],
             "time": "2020-06-02T12:39:20+00:00"
         },
@@ -5786,6 +5816,20 @@
             ],
             "description": "Symfony Debug Component",
             "homepage": "https://symfony.com",
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
             "time": "2020-08-10T07:47:39+00:00"
         },
         {
@@ -5843,6 +5887,20 @@
             ],
             "description": "Symfony ErrorHandler Component",
             "homepage": "https://symfony.com",
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
             "time": "2020-08-17T09:56:45+00:00"
         },
         {
@@ -5913,6 +5971,20 @@
             ],
             "description": "Symfony EventDispatcher Component",
             "homepage": "https://symfony.com",
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
             "time": "2020-08-13T14:18:44+00:00"
         },
         {
@@ -5974,6 +6046,20 @@
                 "interfaces",
                 "interoperability",
                 "standards"
+            ],
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
             ],
             "time": "2020-07-06T13:19:58+00:00"
         },
@@ -6079,6 +6165,20 @@
             ],
             "description": "Symfony HttpFoundation Component",
             "homepage": "https://symfony.com",
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
             "time": "2020-08-17T07:39:58+00:00"
         },
         {
@@ -6170,6 +6270,20 @@
             ],
             "description": "Symfony HttpKernel Component",
             "homepage": "https://symfony.com",
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
             "time": "2020-09-02T08:09:29+00:00"
         },
         {
@@ -6232,6 +6346,20 @@
             "keywords": [
                 "mime",
                 "mime-type"
+            ],
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
             ],
             "time": "2020-08-17T10:01:29+00:00"
         },
@@ -6348,6 +6476,20 @@
                 "ctype",
                 "polyfill",
                 "portable"
+            ],
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
             ],
             "time": "2020-07-14T12:35:20+00:00"
         },
@@ -6479,6 +6621,20 @@
                 "portable",
                 "shim"
             ],
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
             "time": "2020-08-04T06:02:08+00:00"
         },
         {
@@ -6546,6 +6702,20 @@
                 "portable",
                 "shim"
             ],
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
             "time": "2020-07-14T12:35:20+00:00"
         },
         {
@@ -6608,6 +6778,20 @@
                 "polyfill",
                 "portable",
                 "shim"
+            ],
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
             ],
             "time": "2020-07-14T12:35:20+00:00"
         },
@@ -6672,6 +6856,20 @@
                 "portable",
                 "shim"
             ],
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
             "time": "2020-07-14T12:35:20+00:00"
         },
         {
@@ -6730,6 +6928,20 @@
                 "polyfill",
                 "portable",
                 "shim"
+            ],
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
             ],
             "time": "2020-07-14T12:35:20+00:00"
         },
@@ -6792,6 +7004,20 @@
                 "polyfill",
                 "portable",
                 "shim"
+            ],
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
             ],
             "time": "2020-07-14T12:35:20+00:00"
         },
@@ -6859,6 +7085,20 @@
                 "portable",
                 "shim"
             ],
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
+            ],
             "time": "2020-07-14T12:35:20+00:00"
         },
         {
@@ -6921,6 +7161,20 @@
                 "polyfill",
                 "portable",
                 "uuid"
+            ],
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
             ],
             "time": "2020-07-14T12:35:20+00:00"
         },
@@ -7379,6 +7633,20 @@
             "keywords": [
                 "debug",
                 "dump"
+            ],
+            "funding": [
+                {
+                    "url": "https://symfony.com/sponsor",
+                    "type": "custom"
+                },
+                {
+                    "url": "https://github.com/fabpot",
+                    "type": "github"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/symfony/symfony",
+                    "type": "tidelift"
+                }
             ],
             "time": "2020-08-17T07:31:35+00:00"
         },
@@ -10043,5 +10311,6 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": [],
-    "platform-dev": []
+    "platform-dev": [],
+    "plugin-api-version": "1.1.0"
 }

--- a/config/schemas/beatmaps.json
+++ b/config/schemas/beatmaps.json
@@ -1,6 +1,6 @@
 {
   "mappings": {
-    "beatmaps": {
+    "_doc": {
       "dynamic": false,
       "properties": {
         "approved": {

--- a/config/schemas/posts.json
+++ b/config/schemas/posts.json
@@ -1,6 +1,6 @@
 {
   "mappings": {
-    "posts": {
+    "_doc": {
       "dynamic": false,
       "properties": {
         "forum_id": {

--- a/config/schemas/users.json
+++ b/config/schemas/users.json
@@ -1,6 +1,6 @@
 {
   "mappings": {
-    "users": {
+    "_doc": {
       "dynamic": false,
       "properties": {
         "is_old": {

--- a/config/schemas/wiki_page.json
+++ b/config/schemas/wiki_page.json
@@ -1,6 +1,6 @@
 {
   "mappings": {
-    "wiki_page": {
+    "_doc": {
       "dynamic": false,
       "properties": {
         "indexed_at": {


### PR DESCRIPTION
Types have been removed from Elasticsearch, so they're going to eventually have to be removed from our schemas.
Setting `_type` to `_doc` as part of the migration path forwards.

It appears that `_doc` can be used as a substitute for what was originally set for the schema's `_type` in the current version of Elasticsearch we're using.

`elasticsearch-php` updated for an updated param list that includes `include_type_name`