### PR TITLE
Mark notifications (the model) as read direct from its store

### DIFF
--- a/resources/assets/lib/models/notification-stack.ts
+++ b/resources/assets/lib/models/notification-stack.ts
@@ -53,10 +53,6 @@ export default class NotificationStack implements NotificationReadable {
     return `${this.objectType}-${this.objectId}-${this.category}`;
   }
 
-  set isRead(value: boolean) {
-    this.notifications.forEach((notification) => notification.isRead = value);
-  }
-
   @computed
   get isSingle() {
     return this.total === 1;

--- a/resources/assets/lib/stores/notification-stack-store.ts
+++ b/resources/assets/lib/stores/notification-stack-store.ts
@@ -13,7 +13,7 @@ import NotificationStack, { idFromJson } from 'models/notification-stack';
 import NotificationType, { Name as NotificationTypeName  } from 'models/notification-type';
 import { categoryFromName } from 'notification-maps/category';
 import { NotificationEventMoreLoaded, NotificationEventNew, NotificationEventRead } from 'notifications/notification-events';
-import { fromJson, NotificationIdentity, resolveIdentityType, resolveStackId } from 'notifications/notification-identity';
+import { fromJson, NotificationIdentity, resolveStackId } from 'notifications/notification-identity';
 import { NotificationResolver } from 'notifications/notification-resolver';
 import NotificationStore from './notification-store';
 
@@ -122,16 +122,10 @@ export default class NotificationStackStore implements DispatchListener {
 
   @action
   handleNotificationEventRead(event: NotificationEventRead) {
-    if (event.data.length === 0) return;
-    const first = event.data[0];
-    const identityType = resolveIdentityType(first);
-
-    if (identityType === 'stack') {
-      const stack = this.getStack(first);
-      if (stack != null) {
-        stack.isRead = true;
-      }
-    }
+    // Base stack store (this class) shows read notifications so nothing
+    // needs to be handled here as the per-Notification-model read marking
+    // is done by NotificationStore.
+    return;
   }
 
   orderedStacksOfType(name: NotificationTypeName) {


### PR DESCRIPTION
Noticed this weird dependency on WidgetNotificationStackStore for handling notifications as read (especially when it's by notification id).

Move responsibility of marking Notification objects from WidgetNotificationStackStore (and partially from NotificationStackStore) to NotificationStore. 

This slows things down a bit for type/stack read as the NotificationStore doesn't have the grouping so it has to loop the entire array.

As a bonus, this fixes bug where "clear :type" <del>for non-"all" type</del> from notification popup widget sometimes doesn't mark notifications in history page read.