### PR TITLE
Save Paypal API transaction id when processing orders

### DIFF
--- a/app/Http/Controllers/Payments/PaypalController.php
+++ b/app/Http/Controllers/Payments/PaypalController.php
@@ -66,6 +66,8 @@ class PaypalController extends Controller
         $order = Order::where('user_id', Auth::user()->user_id)->processing()->findOrFail($orderId);
         $command = new PaypalCreatePayment($order);
         $link = $command->getApprovalLink();
+        // getId() is only available after the payment is created which getApprovalLink() calls.
+        $order->update(['tracking_code' => $command->getPayment()->getId()]);
 
         return $link;
     }

--- a/app/Http/Controllers/Payments/PaypalController.php
+++ b/app/Http/Controllers/Payments/PaypalController.php
@@ -67,7 +67,7 @@ class PaypalController extends Controller
         $command = new PaypalCreatePayment($order);
         $link = $command->getApprovalLink();
         // getId() is only available after the payment is created which getApprovalLink() calls.
-        $order->update(['tracking_code' => $command->getPayment()->getId()]);
+        $order->update(['reference' => $command->getPayment()->getId()]);
 
         return $link;
     }

--- a/app/Libraries/Payments/PaymentProcessor.php
+++ b/app/Libraries/Payments/PaymentProcessor.php
@@ -157,7 +157,7 @@ abstract class PaymentProcessor implements \ArrayAccess
         $this->sandboxAssertion();
 
         $order = $this->getOrder();
-        $order->update(['transaction_id' => $this->getTransactionId()]);
+        optional($order)->update(['transaction_id' => $this->getTransactionId()]);
 
         if (!$this->validateTransaction()) {
             $this->throwValidationFailed(new PaymentProcessorException($this->validationErrors()));

--- a/app/Libraries/Payments/PaymentProcessor.php
+++ b/app/Libraries/Payments/PaymentProcessor.php
@@ -156,14 +156,15 @@ abstract class PaymentProcessor implements \ArrayAccess
     {
         $this->sandboxAssertion();
 
+        $order = $this->getOrder();
+        $order->update(['transaction_id' => $this->getTransactionId()]);
+
         if (!$this->validateTransaction()) {
             $this->throwValidationFailed(new PaymentProcessorException($this->validationErrors()));
         }
 
-        DB::connection('mysql-store')->transaction(function () {
+        DB::connection('mysql-store')->transaction(function () use ($order) {
             try {
-                $order = $this->getOrder();
-
                 // FIXME: less hacky
                 if ($order->tracking_code === Order::PENDING_ECHECK) {
                     $order->tracking_code = Order::ECHECK_CLEARED;

--- a/app/Models/Store/Order.php
+++ b/app/Models/Store/Order.php
@@ -233,6 +233,21 @@ class Order extends Model
         return (float) $total;
     }
 
+    public function setTransactionIdAttribute($value)
+    {
+        // TODO: migrate to always using provider and reference instead of transaction_id.
+        $this->attributes['transaction_id'] = $value;
+
+        $split = static::splitTransactionId($value);
+        $this->provider = $split[0] ?? null;
+
+        $reference = $split[1] ?? null;
+        // For Paypal we're going to use the PAYID number for reference instead of the IPN txn_id
+        if ($this->provider !== static::PROVIDER_PAYPAL && $reference !== 'failed') {
+            $this->reference = $reference;
+        }
+    }
+
     public function requiresShipping()
     {
         foreach ($this->items as $i) {

--- a/app/Models/Store/Order.php
+++ b/app/Models/Store/Order.php
@@ -71,6 +71,11 @@ class Order extends Model
     protected $dates = ['deleted_at', 'shipped_at', 'paid_at'];
     public $macros = ['itemsQuantities'];
 
+    protected static function splitTransactionId($value)
+    {
+        return explode('-', $value, 2);
+    }
+
     public function items()
     {
         return $this->hasMany(OrderItem::class);
@@ -178,7 +183,7 @@ class Order extends Model
             return;
         }
 
-        return explode('-', $this->transaction_id)[0];
+        return static::splitTransactionId($this->transaction_id)[0];
     }
 
     public function getPaymentStatusText()
@@ -211,7 +216,7 @@ class Order extends Model
             return null;
         }
 
-        return explode('-', $this->transaction_id)[1] ?? null;
+        return static::splitTransactionId($this->transaction_id)[1] ?? null;
     }
 
     public function getSubtotal($forShipping = false)

--- a/app/Models/Store/Order.php
+++ b/app/Models/Store/Order.php
@@ -33,8 +33,10 @@ use Illuminate\Database\Eloquent\SoftDeletes;
  * @property \Illuminate\Database\Eloquent\Collection $items OrderItem
  * @property string|null $last_tracking_state
  * @property int $order_id
+ * @property string|null $provider
  * @property \Carbon\Carbon|null $paid_at
  * @property \Illuminate\Database\Eloquent\Collection $payments Payment
+ * @property string|null $reference
  * @property \Carbon\Carbon|null $shipped_at
  * @property float|null $shipping
  * @property mixed $status

--- a/database/migrations/2020_10_13_064901_add_provider_reference_to_orders.php
+++ b/database/migrations/2020_10_13_064901_add_provider_reference_to_orders.php
@@ -1,0 +1,39 @@
+<?php
+
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddProviderReferenceToOrders extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::connection('mysql-store')->table('orders', function (Blueprint $table) {
+            $table->string('provider', 50)->nullable();
+            $table->string('reference', 255)->nullable();
+            $table->index(['provider', 'reference']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::connection('mysql-store')('orders', function (Blueprint $table) {
+            $table->dropColumn('provider');
+            $table->dropColumn('reference');
+            $table->dropIndex(['provider', 'reference']);
+        });
+    }
+}


### PR DESCRIPTION
Save more metadata when processing Paypal payments. This is mostly useful for looking up failed orders, etc.

The main changes are the transaction's `PAYID` number (which is what their API uses) is stored when starting the transaction, and the IPN transaction number is written even if the order fails processing.

Moving forwards, the payment provider and the transaction reference id from the provider will be recorded in separate columns. In the case of Paypal, the PAYID is used for the reference since this is the one that's available at the start of the transaction and supports API lookups.
This PR doesn't make any changes to how they are currently read and used, but moving forwards we'll want to read from `provider` and `reference` instead of `transaction_id` on `Order`.