### PR TITLE
Require verification to send chat message

### DIFF
--- a/app/Libraries/OsuAuthorize.php
+++ b/app/Libraries/OsuAuthorize.php
@@ -821,8 +821,9 @@ class OsuAuthorize
     {
         $prefix = 'chat.';
 
-        $this->ensureLoggedIn($user);
+        $this->ensureSessionVerified($user);
         $this->ensureCleanRecord($user, $prefix);
+        // This check becomes useless when min_plays_allow_verified_bypass is enabled.
         $this->ensureHasPlayed($user);
 
         if (!$this->doCheckUser($user, 'ChatChannelRead', $channel)->can()) {
@@ -1773,5 +1774,20 @@ class OsuAuthorize
         }
 
         throw new AuthorizationException('play_more');
+    }
+
+    /**
+     * Ensure User is logged in and verified.
+     *
+     * @param User|null $user
+     * @throws AuthorizationException
+     */
+    public function ensureSessionVerified(?User $user)
+    {
+        $this->ensureLoggedIn($user);
+
+        if (!$user->isSessionVerified()) {
+            throw new AuthorizationException('require_verification');
+        }
     }
 }

--- a/tests/Libraries/ChatTest.php
+++ b/tests/Libraries/ChatTest.php
@@ -5,6 +5,7 @@
 
 namespace Tests\Libraries;
 
+use App\Exceptions\VerificationRequiredException;
 use App\Libraries\Chat;
 use App\Models\Chat\Channel;
 use App\Models\Chat\Message;
@@ -14,6 +15,28 @@ use Tests\TestCase;
 
 class ChatTest extends TestCase
 {
+    /**
+     * @dataProvider verifiedDataProvider
+     */
+    public function testSendMessage(bool $verified, $expectedException)
+    {
+        $sender = factory(User::class)->create();
+        $channel = factory(Channel::class)->state('public')->create();
+        $channel->addUser($sender);
+
+        if ($verified) {
+            $sender->markSessionVerified();
+        }
+
+        if ($expectedException === null) {
+            $this->expectNotToPerformAssertions();
+        } else {
+            $this->expectException($expectedException);
+        }
+
+        Chat::sendMessage($sender, $channel, 'test', false);
+    }
+
     public function testSendPM()
     {
         $sender = factory(User::class)->create();
@@ -114,6 +137,14 @@ class ChatTest extends TestCase
             ['gmt', true],
             ['nat', true],
             [[], false],
+        ];
+    }
+
+    public function verifiedDataProvider()
+    {
+        return [
+            [false, VerificationRequiredException::class],
+            [true, null],
         ];
     }
 }


### PR DESCRIPTION
Adds `ensureSessionVerified` that can be used as a replacement for `ensureLoggedIn`.

#6688 still needs to be addressed.
This means there's now:
- toggle for requiring verification on write HTTP verbs (`USER_POST_ACTION_VERIFICATION`)
- toggle for skipping min plays when verified (`USER_MIN_PLAYS_ALLOW_VERIFIED_BYPASS`)
- requiring verification separate from the above

closes #6726