### PR TITLE
Simplify notifications history header links

### DIFF
--- a/resources/assets/lib/notifications-index/main.tsx
+++ b/resources/assets/lib/notifications-index/main.tsx
@@ -4,7 +4,7 @@
 import HeaderV4 from 'header-v4';
 import HeaderLink from 'interfaces/header-link';
 import { route } from 'laroute';
-import { observe } from 'mobx';
+import { computed } from 'mobx';
 import { observer } from 'mobx-react';
 import { Name as NotificationTypeName, TYPES } from 'models/notification-type';
 import Stack from 'notification-widget/stack';
@@ -19,29 +19,22 @@ import { ShowMoreLink } from 'show-more-link';
 export class Main extends React.Component {
   static readonly contextType = NotificationContext;
 
-  readonly links: HeaderLink[];
-
   private readonly controller: NotificationController;
+
+  @computed
+  get links(): HeaderLink[] {
+    return TYPES.map((obj) => ({
+      active: this.controller.currentFilter === obj.type,
+      data: { 'data-type': obj.type },
+      title: osu.trans(`notifications.filters.${obj.type ?? '_'}`),
+      url: route('notifications.index', { type: obj.type }),
+    }));
+  }
 
   constructor(props: {}, context: NotificationContextData) {
     super(props, context);
 
     this.controller = new NotificationController(core.dataStore.notificationStore, this.context);
-    this.links = TYPES.map((obj) => {
-      const type = obj.type;
-      return {
-        active: this.controller.currentFilter === obj.type,
-        data: { 'data-type': type },
-        title: osu.trans(`notifications.filters.${type ?? '_'}`),
-        url: route('notifications.index', { type }),
-      };
-    });
-
-    observe(this.controller, 'currentFilter', (change) => {
-      this.links.forEach((link) => {
-        link.active = link.data['data-type'] === change.newValue;
-      });
-    });
   }
 
   render() {


### PR DESCRIPTION
Seems weird using `observe` instead of simply `computed` for the links :thinking: 