### PR TITLE
Remove display of user lastfm

### DIFF
--- a/resources/assets/coffee/react/profile-page/links.coffee
+++ b/resources/assets/coffee/react/profile-page/links.coffee
@@ -39,9 +39,6 @@ export class Links extends React.PureComponent
     skype: (val) ->
       icon: 'fab fa-skype'
       url: "skype:#{val}?chat"
-    lastfm: (val) ->
-      icon: 'fab fa-lastfm'
-      url: "https://last.fm/user/#{val}"
     location: ->
       icon: 'fas fa-map-marker-alt'
     occupation: ->
@@ -92,7 +89,7 @@ export class Links extends React.PureComponent
     rows = [
       ['join_date', 'last_visit', 'playstyle', 'post_count'].map @renderText
       ['location', 'interests', 'occupation'].map @renderLink
-      ['twitter', 'discord', 'skype', 'lastfm', 'website'].map @renderLink
+      ['twitter', 'discord', 'skype', 'website'].map @renderLink
     ]
 
     div className: bn,

--- a/resources/docs/source/includes/_structures/user.md
+++ b/resources/docs/source/includes/_structures/user.md
@@ -22,7 +22,6 @@
     "total": 20,
     "available": 10
   },
-  "lastfm": null,
   "location": null,
   "max_blocks": 50,
   "max_friends": 500,
@@ -172,7 +171,6 @@ interests        | string?                            | |
 join_date        | Timestamp                          | |
 kudosu.available | number                             | |
 kudosu.total     | number                             | |
-lastfm           | string?                            | |
 location         | string?                            | |
 max_blocks       | number                             | maximum number of users allowed to be blocked
 max_friends      | number                             | maximum number of friends allowed to be added

--- a/resources/lang/en/users.php
+++ b/resources/lang/en/users.php
@@ -347,7 +347,6 @@ return [
         'info' => [
             'discord' => 'Discord',
             'interests' => 'Interests',
-            'lastfm' => 'Last.fm',
             'location' => 'Current Location',
             'occupation' => 'Occupation',
             'skype' => 'Skype',


### PR DESCRIPTION
The integration has been broken for a while (and never got added to new web) so remove it.

Keeping backend removal separate as lazer seems to be still using it.