### PR TITLE
Hide user lastfm from API

### DIFF
--- a/app/Models/DeletedUser.php
+++ b/app/Models/DeletedUser.php
@@ -47,8 +47,6 @@ namespace App\Models;
  * @property int $user_last_privmsg
  * @property int $user_last_search
  * @property int $user_last_warning
- * @property string $user_lastfm
- * @property string $user_lastfm_session
  * @property int $user_lastmark
  * @property string $user_lastpage
  * @property int $user_lastpost_time

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -123,8 +123,6 @@ use Request;
  * @property int $user_last_privmsg
  * @property int $user_last_search
  * @property int $user_last_warning
- * @property string $user_lastfm
- * @property string $user_lastfm_session
  * @property int $user_lastmark
  * @property string $user_lastpage
  * @property int $user_lastpost_time
@@ -684,11 +682,6 @@ class User extends Model implements AuthenticatableContract, HasLocalePreference
     public function setUserTwitterAttribute($value)
     {
         $this->attributes['user_twitter'] = ltrim($value, '@');
-    }
-
-    public function getUserLastfmAttribute($value)
-    {
-        return presence($value);
     }
 
     public function getUserDiscordAttribute($value)

--- a/app/Models/UserNotFound.php
+++ b/app/Models/UserNotFound.php
@@ -47,8 +47,6 @@ namespace App\Models;
  * @property int $user_last_privmsg
  * @property int $user_last_search
  * @property int $user_last_warning
- * @property string $user_lastfm
- * @property string $user_lastfm_session
  * @property int $user_lastmark
  * @property string $user_lastpage
  * @property int $user_lastpost_time

--- a/app/Transformers/UserTransformer.php
+++ b/app/Transformers/UserTransformer.php
@@ -39,8 +39,6 @@ class UserTransformer extends UserCompactTransformer
                 'total' => $user->osu_kudostotal,
                 'available' => $user->osu_kudosavailable,
             ],
-            // deprecated, now always returns null. Remove when no API consumer is using it.
-            'lastfm' => null,
             'location' => $user->user_from,
             'max_blocks' => $user->maxBlocks(),
             'max_friends' => $user->maxFriends(),

--- a/app/Transformers/UserTransformer.php
+++ b/app/Transformers/UserTransformer.php
@@ -39,7 +39,8 @@ class UserTransformer extends UserCompactTransformer
                 'total' => $user->osu_kudostotal,
                 'available' => $user->osu_kudosavailable,
             ],
-            'lastfm' => $user->user_lastfm,
+            // deprecated, now always returns null. Remove when no API consumer is using it.
+            'lastfm' => null,
             'location' => $user->user_from,
             'max_blocks' => $user->maxBlocks(),
             'max_friends' => $user->maxFriends(),


### PR DESCRIPTION
Keep the attribute but make sure the value is always null. Also remove from model phpdoc so it doesn't crowd the autocomplete...?

Docs cleanup is accidentally in #6768 whoops ( ﾟ ヮﾟ)