### PR TITLE
Match docker's elasticsearch image version with composer.json

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -85,7 +85,8 @@ services:
     image: redis:latest
 
   elasticsearch:
-    image: docker.elastic.co/elasticsearch/elasticsearch-oss:6.6.0
+    # Version must be kept up to date with library defined in: composer.json
+    image: docker.elastic.co/elasticsearch/elasticsearch-oss:6.7.2
     volumes:
       - elasticsearch:/usr/share/elasticsearch/data
     environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -86,7 +86,7 @@ services:
 
   elasticsearch:
     # Version must be kept up to date with library defined in: composer.json
-    image: docker.elastic.co/elasticsearch/elasticsearch-oss:6.7.2
+    image: docker.elastic.co/elasticsearch/elasticsearch-oss:6.8.12
     volumes:
       - elasticsearch:/usr/share/elasticsearch/data
     environment:


### PR DESCRIPTION
Current elasticsearch PHP version is 6.7.2 updated in d21fb10c6130c3cad4596acb1ea1b29fa15e6167 but docker-compose.yml was not similarly updated, breaking search and seed functionality under the Docker image. This commit rectifies this missing change.