### PR TITLE
Fix missing tooltip on some cut off text

### DIFF
--- a/resources/assets/coffee/_classes/tooltip-default.coffee
+++ b/resources/assets/coffee/_classes/tooltip-default.coffee
@@ -4,7 +4,7 @@
 class @TooltipDefault
   constructor: ->
     $(document).on 'mouseover touchstart', '[title]:not(iframe)', @onMouseOver
-    $(document).on 'mouseenter touchstart', '.u-ellipsis-overflow, .u-ellipsis-overflow-desktop', @autoAddTooltip
+    $(document).on 'mouseenter touchstart', '.u-ellipsis-overflow, .u-ellipsis-overflow-desktop, .u-ellipsis-pre-overflow', @autoAddTooltip
     $(document).on 'turbolinks:before-cache', @rollback
 
 


### PR DESCRIPTION
Forgot to add the tooltip handler when adding the new ellipsis overflow thing.