### PR TITLE
Use composer v1

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -10,10 +10,9 @@ if [ -z "${OSU_SKIP_CACHE_PERMISSION_OVERRIDE:-}" ]; then
 fi
 
 if [ -f composer.phar ]; then
-  php composer.phar self-update
+  php composer.phar self-update --1
 else
-  curl -sL https://getcomposer.org/installer > composer-installer
-  php composer-installer
+  curl -sL https://getcomposer.org/composer-1.phar > composer.phar
 fi
 
 # dummy user, no privilege github token to avoid github api limit


### PR DESCRIPTION
Some dependencies require upgrade to work on v2. Some also require php v7.4 whereas live is currently running 7.3.

Stuff will break if composer version is too old and doesn't recognize the `--1` argument :shrug: 