### PR TITLE
Fix fallback routing

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -468,4 +468,4 @@ Route::group(['prefix' => '_lio', 'middleware' => 'lio', 'as' => 'interop.'], fu
     });
 });
 
-Route::fallback('FallbackController@index');
+Route::any('{catchall}', 'FallbackController@index')->where('catchall', '.*')->fallback();


### PR DESCRIPTION
Laravel routing fallback (`Route::fallback`) will return 405 for non-GET/HEAD requests on invalid routes.
Apparently it's a feature [1] and not a bug.

It seems weird so instead manually do what `fallback(...)` thing does but accept all HTTP verbs.

[1] https://github.com/laravel/framework/issues/25555 (probably should've linked this one instead of 25550)