### PR TITLE
Return json-formatted 404 for json requests on invalid routes

### DIFF
--- a/app/Http/Controllers/FallbackController.php
+++ b/app/Http/Controllers/FallbackController.php
@@ -22,7 +22,7 @@ class FallbackController extends Controller
 
     public function index()
     {
-        if (is_api_request()) {
+        if (is_json_request()) {
             return response([], 404);
         }
 


### PR DESCRIPTION
Seems more logical returning json if the request explicitly requested json format even on invalid routes...? :thinking: 

Now I looked at the response not sure if empty array (`[]`) makes sense though as opposed to maybe empty object (`{}`).