### PR TITLE
Only show valid languages in wiki language menu

### DIFF
--- a/app/Models/Wiki/Page.php
+++ b/app/Models/Wiki/Page.php
@@ -9,6 +9,7 @@ use App\Exceptions\GitHubNotFoundException;
 use App\Libraries\Elasticsearch\BoolQuery;
 use App\Libraries\Elasticsearch\Es;
 use App\Libraries\Elasticsearch\Sort;
+use App\Libraries\LocaleMeta;
 use App\Libraries\Markdown\OsuMarkdown;
 use App\Libraries\OsuWiki;
 use App\Libraries\Search\BasicSearch;
@@ -178,7 +179,7 @@ class Page implements WikiObject
         $locales = [];
         foreach ($response->hits() as $hit) {
             $locale = $hit['_source']['locale'] ?? null;
-            if ($locale !== null && $locale !== $this->locale) {
+            if ($locale !== null && $locale !== $this->locale && LocaleMeta::sanitizeCode($locale) !== null) {
                 $locales[] = $locale;
             }
         }


### PR DESCRIPTION
There should be another fix of not indexing them in the first place but this should do for now.

Related: #6834