### PR TITLE
Log orders made directly from Shopify

### DIFF
--- a/tests/Controllers/Payments/ShopifyControllerTest.php
+++ b/tests/Controllers/Payments/ShopifyControllerTest.php
@@ -135,7 +135,8 @@ class ShopifyControllerTest extends TestCase
         return $this->json('POST', $this->url, $this->payload, $headers);
     }
 
-    private function setShopifyPayload(array $params) {
+    private function setShopifyPayload(array $params)
+    {
         $this->payload = array_merge([
             'id' => 1,
             'order_number' => 1,

--- a/tests/Controllers/Payments/ShopifyControllerTest.php
+++ b/tests/Controllers/Payments/ShopifyControllerTest.php
@@ -12,17 +12,6 @@ use Tests\TestCase;
 
 class ShopifyControllerTest extends TestCase
 {
-    public function testWebhookOrdersIdIsRequired()
-    {
-        $this->payload = [
-            'note_attributes' => [],
-        ];
-
-        $response = $this->sendCallbackRequest();
-
-        $response->assertStatus(500);
-    }
-
     public function testWebhookOrdersCancelled()
     {
         $order = factory(Order::class, 'paid')->states('shopify')->create();
@@ -35,9 +24,9 @@ class ShopifyControllerTest extends TestCase
         $order->payments()->save($payment);
         $order->paid($payment);
 
-        $this->payload = [
+        $this->setShopifyPayload([
             'note_attributes' => [['name' => 'orderId', 'value' => $order->getKey()]],
-        ];
+        ]);
 
         $response = $this->sendCallbackRequest(['X-Shopify-Topic' => 'orders/cancelled']);
 
@@ -51,9 +40,9 @@ class ShopifyControllerTest extends TestCase
     public function testWebhookOrdersCreate()
     {
         $order = factory(Order::class)->states('shopify', 'processing')->create();
-        $this->payload = [
+        $this->setShopifyPayload([
             'note_attributes' => [['name' => 'orderId', 'value' => $order->getKey()]],
-        ];
+        ]);
 
         $response = $this->sendCallbackRequest(['X-Shopify-Topic' => 'orders/create']);
 
@@ -65,9 +54,9 @@ class ShopifyControllerTest extends TestCase
     public function testWebhookOrdersFulfilled()
     {
         $order = factory(Order::class)->states('shopify', 'checkout')->create();
-        $this->payload = [
+        $this->setShopifyPayload([
             'note_attributes' => [['name' => 'orderId', 'value' => $order->getKey()]],
-        ];
+        ]);
 
         $response = $this->sendCallbackRequest(['X-Shopify-Topic' => 'orders/fulfilled']);
 
@@ -80,9 +69,9 @@ class ShopifyControllerTest extends TestCase
     public function testWebhookOrdersPaid()
     {
         $order = factory(Order::class)->states('shopify', 'processing')->create();
-        $this->payload = [
+        $this->setShopifyPayload([
             'note_attributes' => [['name' => 'orderId', 'value' => $order->getKey()]],
-        ];
+        ]);
 
         $response = $this->sendCallbackRequest(['X-Shopify-Topic' => 'orders/paid']);
 
@@ -94,12 +83,12 @@ class ShopifyControllerTest extends TestCase
 
     public function testReplacementOrdersManuallyCreatedShouldBeIgnored()
     {
-        $this->payload = [
+        $this->setShopifyPayload([
             'note_attributes' => [],
             'gateway' => 'manual',
             'payment_gateway_names' => ['manual'],
             'processing_method' => 'manual',
-        ];
+        ]);
 
         $response = $this->sendCallbackRequest();
 
@@ -113,13 +102,13 @@ class ShopifyControllerTest extends TestCase
         $order = factory(Order::class)->states('shopify', 'shipped')->create();
         $oldUpdatedAt = $order->updated_at->copy();
 
-        $this->payload = [
+        $this->setShopifyPayload([
             'note_attributes' => [['name' => 'orderId', 'value' => $order->getKey()]],
             'gateway' => 'manual',
             'payment_gateway_names' => ['manual'],
             'processing_method' => 'manual',
             'source_name' => 'shopify_draft_order',
-        ];
+        ]);
 
         $response = $this->sendCallbackRequest();
 
@@ -144,5 +133,12 @@ class ShopifyControllerTest extends TestCase
         $headers = array_merge(['X-Shopify-Hmac-Sha256' => $validSignature], $extraHeaders);
 
         return $this->json('POST', $this->url, $this->payload, $headers);
+    }
+
+    private function setShopifyPayload(array $params) {
+        $this->payload = array_merge([
+            'id' => 1,
+            'order_number' => 1,
+        ], $params);
     }
 }


### PR DESCRIPTION
There aren't any records to match on our end, so record some data for tracing instead of exploding.
The Shopify stuff seems to be reliable enough that we don't need to force a hard fail here.