### PR TITLE
Fix exception handler returning wrong type of response to middleware

### DIFF
--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -12,6 +12,7 @@ use Illuminate\Auth\Access\AuthorizationException as LaravelAuthorizationExcepti
 use Illuminate\Auth\AuthenticationException;
 use Illuminate\Database\Eloquent\ModelNotFoundException;
 use Illuminate\Foundation\Exceptions\Handler as ExceptionHandler;
+use Illuminate\Http\Exceptions\HttpResponseException;
 use Illuminate\Session\TokenMismatchException;
 use Laravel\Passport\Exceptions\MissingScopeException;
 use Laravel\Passport\Exceptions\OAuthServerException as PassportOAuthServerException;
@@ -115,7 +116,7 @@ class Handler extends ExceptionHandler
      */
     public function render($request, Exception $e)
     {
-        if (method_exists($e, 'getResponse')) {
+        if ($e instanceof HttpResponseException) {
             return $e->getResponse();
         }
 


### PR DESCRIPTION
Exceptions thrown from the guzzle http client also have a `getReponse` method which shouldn't be passed to the middleware.

This also removes rendering `getResponse` from laravel's `ValidationException`, but we don't use those validators anymore; there's one instance in the store pages for updating addresses, but we don't make use of the page anymore, so maybe we should remove it?