### PR TITLE
Add check for php strict comparisons

### DIFF
--- a/phpcs.xml
+++ b/phpcs.xml
@@ -62,9 +62,11 @@
             <property name="searchAnnotations" type="boolean" value="true"/>
         </properties>
     </rule>
+    <rule ref="SlevomatCodingStandard.Functions.StrictCall"/>
     <rule ref="SlevomatCodingStandard.Namespaces.UseDoesNotStartWithBackslash"/>
     <rule ref="SlevomatCodingStandard.Namespaces.UseFromSameNamespace"/>
     <rule ref="SlevomatCodingStandard.Namespaces.UseSpacing"/>
+    <rule ref="SlevomatCodingStandard.Operators.DisallowEqualOperators"/>
     <rule ref="SlevomatCodingStandard.PHP.ShortList"/>
     <rule ref="SlevomatCodingStandard.PHP.UselessParentheses"/>
     <rule ref="SlevomatCodingStandard.PHP.UselessSemicolon"/>
@@ -145,10 +147,8 @@
     <rule ref="SlevomatCodingStandard.Classes.ClassConstantVisibility.MissingConstantVisibility">
         <type>warning</type>
     </rule>
-    <rule ref="SlevomatCodingStandard.Functions.StrictCall"/>
     <!-- To silence complaints about @urlParam/@bodyParam variable names/references within API documentation -->
     <rule ref="SlevomatCodingStandard.Namespaces.UnusedUses.MismatchingCaseSensitivity">
         <type>warning</type>
     </rule>
-    <rule ref="SlevomatCodingStandard.Operators.DisallowEqualOperators"/>
 </ruleset>

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -145,8 +145,10 @@
     <rule ref="SlevomatCodingStandard.Classes.ClassConstantVisibility.MissingConstantVisibility">
         <type>warning</type>
     </rule>
+    <rule ref="SlevomatCodingStandard.Functions.StrictCall"/>
     <!-- To silence complaints about @urlParam/@bodyParam variable names/references within API documentation -->
     <rule ref="SlevomatCodingStandard.Namespaces.UnusedUses.MismatchingCaseSensitivity">
         <type>warning</type>
     </rule>
+    <rule ref="SlevomatCodingStandard.Operators.DisallowEqualOperators"/>
 </ruleset>

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -52,6 +52,7 @@
     <rule ref="SlevomatCodingStandard.ControlStructures.LanguageConstructWithParentheses"/>
     <rule ref="SlevomatCodingStandard.ControlStructures.RequireNullCoalesceOperator"/>
     <rule ref="SlevomatCodingStandard.Exceptions.DeadCatch"/>
+    <rule ref="SlevomatCodingStandard.Functions.StrictCall"/>
     <rule ref="SlevomatCodingStandard.Namespaces.AlphabeticallySortedUses"/>
     <rule ref="SlevomatCodingStandard.Namespaces.FullyQualifiedClassNameInAnnotation">
         <exclude-pattern>*/tests/*</exclude-pattern>
@@ -62,7 +63,6 @@
             <property name="searchAnnotations" type="boolean" value="true"/>
         </properties>
     </rule>
-    <rule ref="SlevomatCodingStandard.Functions.StrictCall"/>
     <rule ref="SlevomatCodingStandard.Namespaces.UseDoesNotStartWithBackslash"/>
     <rule ref="SlevomatCodingStandard.Namespaces.UseFromSameNamespace"/>
     <rule ref="SlevomatCodingStandard.Namespaces.UseSpacing"/>


### PR DESCRIPTION
I noticed `in_array` with missing strict parameter isn't being checked. And `==`/`!=` as well.