### PR TITLE
Skip trying to mark notifications as read if no ids were extracted from params

### DIFF
--- a/app/Models/UserNotification.php
+++ b/app/Models/UserNotification.php
@@ -63,9 +63,11 @@ class UserNotification extends Model
     {
         $ids = $batchIdentities->getNotificationIds();
         $identities = $batchIdentities->getIdentities();
-
         $now = now();
-        if ($ids instanceof Builder) {
+
+        if (empty($ids)) {
+            return;
+        } else if ($ids instanceof Builder) {
             $instance = new static();
             $tableName = $instance->getTable();
             // force mysql optimizer to optimize properly with a fake multi-table update


### PR DESCRIPTION
Using the wrong format in the request causes no ids to be extracted