### PR TITLE
Set php version for phpcs action

### DIFF
--- a/.github/workflows/phpcs.yml
+++ b/.github/workflows/phpcs.yml
@@ -12,6 +12,7 @@ jobs:
           uses: shivammathur/setup-php@v2
           with:
             tools: composer:v1
+            php-version: '7.4'
         - name: Get composer cache directory
           id: composercache
           run: echo "::set-output name=dir::$(composer config cache-files-dir)"


### PR DESCRIPTION
seems like `ubuntu-latest` defaults to php 8 now which breaks at least one thing due to optional function parameters no longer being allowed before required parameters