### PR TITLE
Fix beatmapset qualification check

### DIFF
--- a/app/Transformers/BeatmapsetCompactTransformer.php
+++ b/app/Transformers/BeatmapsetCompactTransformer.php
@@ -179,7 +179,7 @@ class BeatmapsetCompactTransformer extends TransformerAbstract
             if ($currentUser !== null) {
                 $result['nominated'] = $beatmapset->nominationsSinceReset()->where('user_id', $currentUser->user_id)->exists();
             }
-        } elseif ($beatmapset->qualified()) {
+        } elseif ($beatmapset->isQualified()) {
             $queueStatus = $beatmapset->rankingQueueStatus();
 
             $result['ranking_eta'] = json_time($queueStatus['eta']);


### PR DESCRIPTION
The previous function returns a builder which is always true. It doesn't fail on live site because php up to 7.3 allows array access on null

```
# php 7.3
>>> $a = null
=> null
>>> $a['x']
=> null

# php 7.4
>>> $a = null
=> null
>>> $a['x']
PHP Notice:  Trying to access array offset on value of type null in /home/edho/osu/osu-webeval()'d code on line 1
```