### PR TITLE
Fix states which beatmap hypes/nominations are shown

### DIFF
--- a/resources/assets/coffee/react/_components/beatmapset-panel.coffee
+++ b/resources/assets/coffee/react/_components/beatmapset-panel.coffee
@@ -20,7 +20,7 @@ export class BeatmapsetPanel extends React.PureComponent
     # this is actually "beatmapset"
     beatmapset = @props.beatmap
 
-    showHypeCounts = _.includes ['wip', 'pending', 'graveyard'], beatmapset.status
+    showHypeCounts = _.includes ['wip', 'pending', 'qualified'], beatmapset.status
     if showHypeCounts
       currentHype = osu.formatNumber(beatmapset.hype?.current)
       requiredHype = osu.formatNumber(beatmapset.hype?.required)

--- a/resources/assets/coffee/react/_components/beatmapset-panel.coffee
+++ b/resources/assets/coffee/react/_components/beatmapset-panel.coffee
@@ -20,7 +20,7 @@ export class BeatmapsetPanel extends React.PureComponent
     # this is actually "beatmapset"
     beatmapset = @props.beatmap
 
-    showHypeCounts = _.includes ['wip', 'pending', 'qualified'], beatmapset.status
+    showHypeCounts = beatmapset.hype?
     if showHypeCounts
       currentHype = osu.formatNumber(beatmapset.hype?.current)
       requiredHype = osu.formatNumber(beatmapset.hype?.required)


### PR DESCRIPTION
Matches the model's allowed states for hyping. Not sure if it makes sense showing hypes/nominations for qualified maps though? But it's still shown and I think people can still hype them :thinking: 

Resolves #6915.