### PR TITLE
Reduce username hover area on beatmap scoreboard

### DIFF
--- a/resources/assets/coffee/react/beatmapset-page/scoreboard-table-row.coffee
+++ b/resources/assets/coffee/react/beatmapset-page/scoreboard-table-row.coffee
@@ -54,7 +54,7 @@ export class ScoreboardTableRow extends React.PureComponent
               country: score.user.country
               modifiers: ['flat']
 
-      td className: "#{cell} u-relative",
+      td className: cell,
         a
           className: "#{bn}__cell-content #{bn}__cell-content--user-link js-usercard"
           'data-user-id': score.user.id

--- a/resources/assets/coffee/react/beatmapset-page/scoreboard-table-row.coffee
+++ b/resources/assets/coffee/react/beatmapset-page/scoreboard-table-row.coffee
@@ -54,12 +54,16 @@ export class ScoreboardTableRow extends React.PureComponent
               country: score.user.country
               modifiers: ['flat']
 
-      td className: cell,
+      td className: "#{cell} u-relative",
         a
           className: "#{bn}__cell-content #{bn}__cell-content--user-link js-usercard"
           'data-user-id': score.user.id
           href: laroute.route 'users.show', user: score.user.id, mode: @props.beatmap.mode
           score.user.username
+
+        a
+          className: "#{bn}__cell-content"
+          href: route('scores.show', mode: @props.score.mode, score: @props.score.best_id)
 
       el @tdLink,
         modifiers: ['perfect'] if score.max_combo == @props.beatmap.max_combo

--- a/resources/assets/less/bem/beatmap-scoreboard-table.less
+++ b/resources/assets/less/bem/beatmap-scoreboard-table.less
@@ -187,6 +187,8 @@
       .link-hover({
         text-decoration: underline;
       });
+
+      position: absolute;
     }
 
     &--zero {


### PR DESCRIPTION
I didn't want to this originally in #6886 because having overlapping links is silly and should be avoided, but after trying it some more, the usercard placement now looks silly.

This basically renders a link on top of another link.
