### PR TITLE
New multiplayer room type

### DIFF
--- a/app/Http/Controllers/Multiplayer/Rooms/Playlist/ScoresController.php
+++ b/app/Http/Controllers/Multiplayer/Rooms/Playlist/ScoresController.php
@@ -190,7 +190,6 @@ class ScoresController extends BaseController
     public function update($roomId, $playlistId, $scoreId)
     {
         $room = Room::findOrFail($roomId);
-        // todo: check against room's end time, check within window of start_time + beatmap_length + x
 
         $playlistItem = $room->playlist()
             ->where('id', $playlistId)

--- a/app/Models/Multiplayer/Room.php
+++ b/app/Models/Multiplayer/Room.php
@@ -149,7 +149,7 @@ class Room extends Model
 
     public function hasEnded()
     {
-        return Carbon::now()->gte($this->ends_at);
+        return $this->ends_at !== null && Carbon::now()->gte($this->ends_at);
     }
 
     public function isScoreSubmissionStillAllowed()

--- a/app/Models/Multiplayer/Room.php
+++ b/app/Models/Multiplayer/Room.php
@@ -60,7 +60,7 @@ class Room extends Model
 
         $category = presence(get_string($params['category'] ?? null)) ?? 'any';
         if ($category === 'any') {
-            $query->whereNot('category', 'realtime');
+            $query->where('category', '<>', 'realtime');
         } else {
             $query->where('category', $category);
         }

--- a/app/Models/Multiplayer/Room.php
+++ b/app/Models/Multiplayer/Room.php
@@ -75,11 +75,7 @@ class Room extends Model
                 $query->startedBy($user);
                 break;
             default:
-                if ($category === 'realtime') {
-                    $query->activeRealtime();
-                } else {
-                    $query->active();
-                }
+                $query->active();
         }
 
         $cursorHelper = new DbCursorHelper(static::SORTS, $sort);
@@ -126,14 +122,9 @@ class Room extends Model
     {
         return $query
             ->where('starts_at', '<', Carbon::now())
-            ->where('ends_at', '>', Carbon::now());
-    }
-
-    public function scopeActiveRealtime($query)
-    {
-        return $query
-            ->where('starts_at', '<', Carbon::now())
-            ->whereNull('ends_at');
+            ->where(function ($q) {
+                $q->where('ends_at', '>', Carbon::now())->orWhereNull('ends_at');
+            });
     }
 
     public function scopeEnded($query)

--- a/app/Models/Multiplayer/Room.php
+++ b/app/Models/Multiplayer/Room.php
@@ -154,8 +154,8 @@ class Room extends Model
 
     public function isScoreSubmissionStillAllowed()
     {
-        // TODO: move grace period to config.
-        return Carbon::now()->lte($this->ends_at->addMinutes(5));
+        // TODO: move grace period to config or use the beatmap's duration
+        return $this->ends_at === null || Carbon::now()->lte($this->ends_at->addMinutes(5));
     }
 
     /**

--- a/app/Models/Multiplayer/Room.php
+++ b/app/Models/Multiplayer/Room.php
@@ -317,10 +317,8 @@ class Room extends Model
             }
         }
 
-        if ($this->category === 'realtime') {
-            $this->ends_at = null;
-        } else {
-            if (!present($this->ends_at)) {
+        if ($this->category !== 'realtime') {
+            if ($this->ends_at === null) {
                 throw new InvariantException("'ends_at' is required");
             }
 

--- a/app/Models/Multiplayer/Room.php
+++ b/app/Models/Multiplayer/Room.php
@@ -59,7 +59,9 @@ class Room extends Model
         $sort = 'created';
 
         $category = presence(get_string($params['category'] ?? null)) ?? 'any';
-        if ($category !== 'any') {
+        if ($category === 'any') {
+            $query->whereNot('category', 'realtime');
+        } else {
             $query->where('category', $category);
         }
 

--- a/database/migrations/2020_12_03_075220_add_realtime_to_multiplayer_rooms.php
+++ b/database/migrations/2020_12_03_075220_add_realtime_to_multiplayer_rooms.php
@@ -1,0 +1,39 @@
+<?php
+
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
+use Illuminate\Database\Migrations\Migration;
+
+class AddRealtimeToMultiplayerRooms extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        DB::statement("ALTER TABLE multiplayer_rooms
+                       MODIFY COLUMN category
+                       enum('normal', 'spotlight', 'realtime')");
+        DB::statement("ALTER TABLE multiplayer_rooms
+                       MODIFY COLUMN ends_at
+                       TIMESTAMP NULL");
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        DB::statement("ALTER TABLE multiplayer_rooms
+                       MODIFY COLUMN category
+                       enum('normal', 'spotlight')");
+        DB::statement("ALTER TABLE multiplayer_rooms
+                       MODIFY COLUMN ends_at
+                       TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP");
+    }
+}

--- a/database/migrations/2020_12_03_075220_add_realtime_to_multiplayer_rooms.php
+++ b/database/migrations/2020_12_03_075220_add_realtime_to_multiplayer_rooms.php
@@ -16,7 +16,8 @@ class AddRealtimeToMultiplayerRooms extends Migration
     {
         DB::statement("ALTER TABLE multiplayer_rooms
                        MODIFY COLUMN category
-                       enum('normal', 'spotlight', 'realtime')");
+                       ENUM('normal', 'spotlight', 'realtime')
+                       NOT NULL DEFAULT 'normal'");
         DB::statement("ALTER TABLE multiplayer_rooms
                        MODIFY COLUMN ends_at
                        TIMESTAMP NULL");
@@ -31,7 +32,8 @@ class AddRealtimeToMultiplayerRooms extends Migration
     {
         DB::statement("ALTER TABLE multiplayer_rooms
                        MODIFY COLUMN category
-                       enum('normal', 'spotlight')");
+                       ENUM('normal', 'spotlight')
+                       NOT NULL DEFAULT 'normal'");
         DB::statement("ALTER TABLE multiplayer_rooms
                        MODIFY COLUMN ends_at
                        TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP");

--- a/resources/views/multiplayer/rooms/show.blade.php
+++ b/resources/views/multiplayer/rooms/show.blade.php
@@ -44,14 +44,16 @@
                     {{ $room->starts_at->formatLocalized('%Y-%m-%d') }}
                 </div>
             </div>
-            <div class="counter-box counter-box--info">
-                <div class="counter-box__title">
-                    {{ trans('rankings.spotlight.end_date') }}
+            @if ($room->ends_at !== null)
+                <div class="counter-box counter-box--info">
+                    <div class="counter-box__title">
+                        {{ trans('rankings.spotlight.end_date') }}
+                    </div>
+                    <div class="counter-box__count">
+                        {{ $room->ends_at->formatLocalized('%Y-%m-%d') }}
+                    </div>
                 </div>
-                <div class="counter-box__count">
-                    {{ $room->ends_at->formatLocalized('%Y-%m-%d') }}
-                </div>
-            </div>
+            @endif
             <div class="counter-box counter-box--info">
                 <div class="counter-box__title">
                     {{ trans('rankings.spotlight.map_count') }}

--- a/tests/Controllers/Multiplayer/RoomsControllerTest.php
+++ b/tests/Controllers/Multiplayer/RoomsControllerTest.php
@@ -1,0 +1,110 @@
+<?php
+
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
+namespace Tests\Controllers\Multiplayer;
+
+use App\Models\Beatmap;
+use App\Models\Beatmapset;
+use App\Models\Multiplayer\PlaylistItem;
+use App\Models\Multiplayer\Room;
+use App\Models\OAuth\Token;
+use App\Models\User;
+use Tests\TestCase;
+
+class RoomsControllerTest extends TestCase
+{
+    public function testIndex()
+    {
+        $room = factory(Room::class)->create();
+        $user = factory(User::class)->create();
+
+        $this->actAsScopedUser($user, ['*']);
+
+        $this->json('GET', route('api.rooms.index'))->assertSuccessful();
+    }
+
+    public function testStore()
+    {
+        $token = factory(Token::class)->create(['scopes' => ['*']]);
+        $beatmapset = factory(Beatmapset::class)->create();
+        $beatmap = factory(Beatmap::class)->create(['beatmapset_id' => $beatmapset->getKey()]);
+
+        $roomsCountInitial = Room::count();
+        $playlistItemsCountInitial = PlaylistItem::count();
+
+        $this
+            ->actingWithToken($token)
+            ->post(route('api.rooms.store'), [
+                'ends_at' => now()->addHour(),
+                'name' => 'test room',
+                'playlist' => [
+                    [
+                        'beatmap_id' => $beatmap->getKey(),
+                        'ruleset_id' => $beatmap->playmode,
+                    ],
+                ],
+            ])->assertSuccessful();
+
+        $this->assertSame($roomsCountInitial + 1, Room::count());
+        $this->assertSame($playlistItemsCountInitial + 1, PlaylistItem::count());
+    }
+
+    public function testStoreRealtime()
+    {
+        $token = factory(Token::class)->create(['scopes' => ['*']]);
+        $beatmapset = factory(Beatmapset::class)->create();
+        $beatmap = factory(Beatmap::class)->create(['beatmapset_id' => $beatmapset->getKey()]);
+
+        $roomsCountInitial = Room::count();
+        $playlistItemsCountInitial = PlaylistItem::count();
+
+        $this
+            ->actingWithToken($token)
+            ->post(route('api.rooms.store'), [
+                'category' => 'realtime',
+                'name' => 'test room',
+                'playlist' => [
+                    [
+                        'beatmap_id' => $beatmap->getKey(),
+                        'ruleset_id' => $beatmap->playmode,
+                    ],
+                ],
+            ])->assertSuccessful();
+
+        $this->assertSame($roomsCountInitial + 1, Room::count());
+        $this->assertSame($playlistItemsCountInitial + 1, PlaylistItem::count());
+    }
+
+    public function testStoreRealtimeFailWithTwoPlaylistItems()
+    {
+        $token = factory(Token::class)->create(['scopes' => ['*']]);
+        $beatmapset = factory(Beatmapset::class)->create();
+        $beatmap1 = factory(Beatmap::class)->create(['beatmapset_id' => $beatmapset->getKey()]);
+        $beatmap2 = factory(Beatmap::class)->create(['beatmapset_id' => $beatmapset->getKey()]);
+
+        $roomsCountInitial = Room::count();
+        $playlistItemsCountInitial = PlaylistItem::count();
+
+        $this
+            ->actingWithToken($token)
+            ->post(route('api.rooms.store'), [
+                'category' => 'realtime',
+                'name' => 'test room',
+                'playlist' => [
+                    [
+                        'beatmap_id' => $beatmap1->getKey(),
+                        'ruleset_id' => $beatmap1->playmode,
+                    ],
+                    [
+                        'beatmap_id' => $beatmap2->getKey(),
+                        'ruleset_id' => $beatmap2->playmode,
+                    ],
+                ],
+            ])->assertStatus(422);
+
+        $this->assertSame($roomsCountInitial, Room::count());
+        $this->assertSame($playlistItemsCountInitial, PlaylistItem::count());
+    }
+}


### PR DESCRIPTION
Add parameter `category` of `realtime` (also for listing). `ends_at` parameter can be skipped.

And then I noticed there's no way to indicate number of people inside the room :thinking: 

Todo:
- [x] test