### PR TITLE
Fix country name formatting for the State of Palestine

### DIFF
--- a/database/seeds/ModelSeeders/CountrySeeder.php
+++ b/database/seeds/ModelSeeders/CountrySeeder.php
@@ -228,7 +228,7 @@ class CountrySeeder extends Seeder
             ['acronym' => 'PM', 'name' => 'Saint Pierre and Miquelon', 'display' => 0],
             ['acronym' => 'PN', 'name' => 'Pitcairn', 'display' => 0],
             ['acronym' => 'PR', 'name' => 'Puerto Rico', 'display' => 0],
-            ['acronym' => 'PS', 'name' => 'Palestinian Territory Occupied', 'display' => 0],
+            ['acronym' => 'PS', 'name' => 'Palestine, State of', 'display' => 0],
             ['acronym' => 'PT', 'name' => 'Portugal', 'display' => 1],
             ['acronym' => 'PW', 'name' => 'Palau', 'display' => 0],
             ['acronym' => 'PY', 'name' => 'Paraguay', 'display' => 1],


### PR DESCRIPTION
closes #6742

Fixes ISO-3166 naming for the State of Palestine. This is also my first PR in this repository, so let me know if I edited the wrong file or if there are other files that need to be addressed regarding this fix.