### PR TITLE
Use composer 2 for phpcs Github action

### DIFF
--- a/.github/workflows/phpcs.yml
+++ b/.github/workflows/phpcs.yml
@@ -11,7 +11,7 @@ jobs:
         - name: Use Composer v1
           uses: shivammathur/setup-php@v2
           with:
-            tools: composer:v1
+            tools: composer:v2
             php-version: '7.4'
         - name: Get composer cache directory
           id: composercache

--- a/.github/workflows/phpcs.yml
+++ b/.github/workflows/phpcs.yml
@@ -8,7 +8,7 @@ jobs:
       runs-on: ubuntu-latest
       steps:
         - uses: actions/checkout@v2
-        - name: Use Composer v1
+        - name: Use Composer v2
           uses: shivammathur/setup-php@v2
           with:
             tools: composer:v2


### PR DESCRIPTION
We switched to v2 a while ago so this should be locked to v2.