### PR TITLE
Show spinner when clear all notifications

### DIFF
--- a/resources/assets/lib/notifications/notification-controller.ts
+++ b/resources/assets/lib/notifications/notification-controller.ts
@@ -63,12 +63,11 @@ export default class NotificationController {
 
   @action
   markCurrentTypeAsRead() {
+    this.type.markTypeAsRead();
     if (this.type.name == null) {
       for (const name of this.typeNamesWithoutNull) {
         this.store.getOrCreateType({ objectType: name }).markTypeAsRead();
       }
-    } else {
-      this.type.markTypeAsRead();
     }
   }
 


### PR DESCRIPTION
Resolved #6901

![spin](https://user-images.githubusercontent.com/4964985/101606697-3c585900-3a36-11eb-9517-5edaa7495af1.gif)

Method [markTypeAsRead](https://github.com/ppy/osu-web/blob/0bf85478f31fd4b881344cda6b264dd608f88df8/resources/assets/lib/notifications/notification-controller.ts#L65) was never called because the `name` of `NotificationType` is `null`, so `isMarkingAsRead` was never set to `true`.