### PR TITLE
Clean up TypeScript typing

### DIFF
--- a/resources/assets/lib/beatmaps/beatmapset-search.ts
+++ b/resources/assets/lib/beatmaps/beatmapset-search.ts
@@ -15,7 +15,7 @@ import { BeatmapsetStore } from 'stores/beatmapset-store';
 
 export interface SearchResponse {
   beatmapsets: BeatmapsetJson[];
-  cursor: JSON;
+  cursor: unknown;
   error?: string;
   recommended_difficulty: number;
   total: number;

--- a/resources/assets/lib/beatmaps/result-set.ts
+++ b/resources/assets/lib/beatmaps/result-set.ts
@@ -9,7 +9,7 @@ export default class ResultSet implements SearchResults {
   static CACHE_DURATION_MS = 60000;
 
   @observable beatmapsetIds = new Set<number>();
-  cursor?: JSON; // null -> end; undefined -> not set yet.
+  cursor?: unknown; // null -> end; undefined -> not set yet.
   fetchedAt?: Date;
   @observable hasMore = false;
   @observable total = 0;

--- a/resources/assets/lib/notifications/worker.ts
+++ b/resources/assets/lib/notifications/worker.ts
@@ -21,11 +21,6 @@ import {
   NotificationEventReadJson,
 } from './notification-events';
 
-export interface MessageJson {
-  data: JSON;
-  event: string;
-}
-
 interface NotificationBootJson extends NotificationBundleJson {
   notification_endpoint: string;
 }


### PR DESCRIPTION
`JSON` isn't what one may think it is. `unknown` should be fine if it's only being passed around.

Also removed one unused interface.

![](https://s.myconan.net/2020-12/Code_2020-12-14_17-23-16.png)