### PR TITLE
Declare correct context type for components

### DIFF
--- a/resources/assets/lib/beatmap-discussions/editor-beatmap-selector.tsx
+++ b/resources/assets/lib/beatmap-discussions/editor-beatmap-selector.tsx
@@ -17,6 +17,7 @@ interface Props {
 
 export default class EditorBeatmapSelector extends React.Component<Props> {
   static contextType = SlateContext;
+  context!: React.ContextType<typeof SlateContext>;
 
   render(): React.ReactNode {
     const menuOptions: MenuItem[] = [];

--- a/resources/assets/lib/beatmap-discussions/editor-discussion-component.tsx
+++ b/resources/assets/lib/beatmap-discussions/editor-discussion-component.tsx
@@ -36,6 +36,7 @@ export default class EditorDiscussionComponent extends React.Component<Props> {
 
   bn = 'beatmap-discussion-review-post-embed-preview';
   cache: Cache = {};
+  context!: React.ContextType<typeof SlateContext>;
   tooltipContent = React.createRef<HTMLScriptElement>();
   tooltipEl?: HTMLElement;
 

--- a/resources/assets/lib/beatmap-discussions/editor-insertion-menu.tsx
+++ b/resources/assets/lib/beatmap-discussions/editor-insertion-menu.tsx
@@ -16,6 +16,7 @@ interface Props {
 export class EditorInsertionMenu extends React.Component<Props> {
   static contextType = SlateContext;
   bn = 'beatmap-discussion-editor-insertion-menu';
+  context!: React.ContextType<typeof SlateContext>;
   hideInsertMenuTimer?: number;
   hoveredBlock: HTMLElement | undefined;
   insertPosition: 'above' | 'below' | undefined;

--- a/resources/assets/lib/beatmap-discussions/editor-issue-type-selector.tsx
+++ b/resources/assets/lib/beatmap-discussions/editor-issue-type-selector.tsx
@@ -27,6 +27,7 @@ interface Props {
 
 export default class EditorIssueTypeSelector extends React.Component<Props> {
   static contextType = SlateContext;
+  context!: React.ContextType<typeof SlateContext>;
 
   render(): React.ReactNode {
     const menuOptions: MenuItem[] = selectableTypes.map((type) => {

--- a/resources/assets/lib/beatmap-discussions/editor-toolbar.tsx
+++ b/resources/assets/lib/beatmap-discussions/editor-toolbar.tsx
@@ -13,6 +13,7 @@ const bn = 'beatmap-discussion-editor-toolbar';
 
 export class EditorToolbar extends React.Component {
   static contextType = SlateContext;
+  context!: React.ContextType<typeof SlateContext>;
   ref = React.createRef<HTMLDivElement>();
   scrollContainer: HTMLElement | undefined;
   private scrollTimer: number | undefined;

--- a/resources/assets/lib/beatmap-discussions/editor-toolbar.tsx
+++ b/resources/assets/lib/beatmap-discussions/editor-toolbar.tsx
@@ -106,7 +106,7 @@ export class EditorToolbar extends React.Component {
         return this.hide();
       }
 
-      for (const p of Editor.positions(this.context, { at: this.context.selection, unit: 'block' })) {
+      for (const p of Editor.positions(this.context, { at: this.context.selection ?? undefined, unit: 'block' })) {
         const block = Node.parent(this.context, p.path);
 
         if (block.type === 'embed') {

--- a/resources/assets/lib/beatmap-discussions/editor.tsx
+++ b/resources/assets/lib/beatmap-discussions/editor.tsx
@@ -67,6 +67,7 @@ export default class Editor extends React.Component<Props, State> {
 
   bn = 'beatmap-discussion-editor';
   cache: CacheInterface = {};
+  context!: React.ContextType<typeof ReviewEditorConfigContext>;
   emptyDocTemplate = [{children: [{text: ''}], type: 'paragraph'}];
   insertMenuRef: React.RefObject<EditorInsertionMenu>;
   localStorageKey: string;

--- a/resources/assets/lib/beatmap-discussions/icon-dropdown-menu.tsx
+++ b/resources/assets/lib/beatmap-discussions/icon-dropdown-menu.tsx
@@ -21,6 +21,7 @@ interface Props {
 
 export default class IconDropdownMenu extends React.Component<Props> {
   static contextType = SlateContext;
+  context!: React.ContextType<typeof SlateContext>;
 
   render(): React.ReactNode {
     return (

--- a/resources/assets/lib/beatmap-discussions/slate-context.ts
+++ b/resources/assets/lib/beatmap-discussions/slate-context.ts
@@ -4,4 +4,7 @@
 import * as React from 'react';
 import { ReactEditor } from 'slate-react';
 
-export const SlateContext = React.createContext<ReactEditor | null>(null);
+// null! is a workaround to remove the optional/nullable type for the context.
+// SlateContext should always be assigned a ReactEditor value before being used.
+// TODO: figure out how to remove the props dependency in editor.tsx when for initializing?
+export const SlateContext = React.createContext<ReactEditor>(null!);

--- a/resources/assets/lib/notification-widget/item-group.tsx
+++ b/resources/assets/lib/notification-widget/item-group.tsx
@@ -26,6 +26,7 @@ interface State {
 @observer
 export default class ItemGroup extends React.Component<Props, State> {
   static readonly contextType = NotificationContext;
+  context!: React.ContextType<typeof NotificationContext>;
   readonly state = {
     expanded: false,
   };

--- a/resources/assets/lib/notification-widget/item.tsx
+++ b/resources/assets/lib/notification-widget/item.tsx
@@ -27,6 +27,7 @@ interface Props {
 @observer
 export default class Item extends React.Component<Props> {
   static contextType = NotificationContext;
+  context!: React.ContextType<typeof NotificationContext>;
 
   private get canMarkAsRead() {
     return this.props.canMarkAsRead ?? this.props.item.canMarkRead;

--- a/resources/assets/lib/notifications-index/main.tsx
+++ b/resources/assets/lib/notifications-index/main.tsx
@@ -20,6 +20,7 @@ import { ShowMoreLink } from 'show-more-link';
 @observer
 export class Main extends React.Component {
   static readonly contextType = NotificationContext;
+  context!: React.ContextType<typeof NotificationContext>;
 
   private readonly controller: NotificationController;
 

--- a/resources/assets/lib/user-card-brick.tsx
+++ b/resources/assets/lib/user-card-brick.tsx
@@ -23,6 +23,8 @@ export default class UserCardBrick extends React.PureComponent<Props> {
     modifiers: [],
   };
 
+  context!: React.ContextType<typeof UserCardTypeContext>;
+
   readonly eventId = `user-card-brick-${osu.uuid()}`;
 
   componentDidMount() {


### PR DESCRIPTION
Typings when using the 'new' React context need to be explicitly declared.