### PR TITLE
Use proper date display for user account standing

### DIFF
--- a/resources/assets/coffee/react/profile-page/account-standing.coffee
+++ b/resources/assets/coffee/react/profile-page/account-standing.coffee
@@ -62,8 +62,8 @@ export class AccountStanding extends React.PureComponent
         key: i
 
         td
-          className: "#{bn}__table-cell #{bn}__table-cell--date",
-            el TimeWithTooltip, dateTime: event.timestamp, relative: true
+          className: "#{bn}__table-cell #{bn}__table-cell--date"
+          el TimeWithTooltip, dateTime: event.timestamp, relative: true
 
         td
           className: "#{bn}__table-cell #{bn}__table-cell--action"

--- a/resources/assets/coffee/react/profile-page/account-standing.coffee
+++ b/resources/assets/coffee/react/profile-page/account-standing.coffee
@@ -2,6 +2,7 @@
 # See the LICENCE file in the repository root for full licence text.
 
 import { ExtraHeader } from './extra-header'
+import TimeWithTooltip from 'time-with-tooltip'
 import * as React from 'react'
 import { a, div, span, h3, table, thead, tbody, tr, th, td } from 'react-dom-factories'
 el = React.createElement
@@ -61,8 +62,8 @@ export class AccountStanding extends React.PureComponent
         key: i
 
         td
-          className: "#{bn}__table-cell #{bn}__table-cell--date", dangerouslySetInnerHTML:
-            __html: osu.timeago(event.timestamp)
+          className: "#{bn}__table-cell #{bn}__table-cell--date",
+            el TimeWithTooltip, dateTime: event.timestamp, relative: true
 
         td
           className: "#{bn}__table-cell #{bn}__table-cell--action"

--- a/resources/assets/coffee/react/profile-page/account-standing.coffee
+++ b/resources/assets/coffee/react/profile-page/account-standing.coffee
@@ -3,7 +3,7 @@
 
 import { ExtraHeader } from './extra-header'
 import * as React from 'react'
-import { a, div, span, h3, table, thead, tbody, tr, th, td, time } from 'react-dom-factories'
+import { a, div, span, h3, table, thead, tbody, tr, th, td } from 'react-dom-factories'
 el = React.createElement
 
 bn = 'profile-extra-recent-infringements'
@@ -61,11 +61,8 @@ export class AccountStanding extends React.PureComponent
         key: i
 
         td
-          className: "#{bn}__table-cell #{bn}__table-cell--date"
-          time
-            className: "timeago"
-            dateTime: event.timestamp
-            moment(event.timestamp).fromNow()
+          className: "#{bn}__table-cell #{bn}__table-cell--date", dangerouslySetInnerHTML:
+            __html: osu.timeago(event.timestamp)
 
         td
           className: "#{bn}__table-cell #{bn}__table-cell--action"


### PR DESCRIPTION
Account standing dates used to be displayed manual way, not using ``TimeWithTooltip``, which resulted in them not having the tooltip with detailed information like other dates displayed on the site.

![](https://venix2.s-ul.eu/r7H9GzXo)