### PR TITLE
Show correct error message when changing username to different casing

### DIFF
--- a/app/Libraries/ChangeUsername.php
+++ b/app/Libraries/ChangeUsername.php
@@ -53,7 +53,7 @@ class ChangeUsername
             return $this->validationErrors()->addTranslated('username', static::requireSupportedMessage());
         }
 
-        if ($this->username === $this->user->username) {
+        if (User::cleanUsername($this->username) === $this->user->username_clean) {
             return $this->validationErrors()->add('username', '.change_username.username_is_same');
         }
 

--- a/tests/Libraries/ChangeUsernameTest.php
+++ b/tests/Libraries/ChangeUsernameTest.php
@@ -73,6 +73,17 @@ class ChangeUsernameTest extends TestCase
         $this->assertArraySubset($expected, $errors['username'], true);
     }
 
+    public function testUsernameWithDifferentCasingIsSame()
+    {
+        $user = $this->createUser();
+
+        $errors = $user->validateChangeUsername('iAmUser')->all();
+        $expected = [trans('model_validation.user.change_username.username_is_same')];
+
+        $this->assertArrayHasKey('username', $errors);
+        $this->assertArraySubset($expected, $errors['username'], true);
+    }
+
     public function testUserHasSupportedButExpired()
     {
         $user = $this->createUser(['osu_subscriptionexpiry' => Carbon::now()->subMonth()]);


### PR DESCRIPTION
Fixes #7005

Displays same username error message rather than username is in use. We had trouble trying this out in the local web environment, but the php unit tests reflect that it works.

Co-authored by @angelaz1
