### PR TITLE
Require verification for delete actions

### DIFF
--- a/app/Http/Middleware/VerifyUserAlways.php
+++ b/app/Http/Middleware/VerifyUserAlways.php
@@ -27,11 +27,12 @@ class VerifyUserAlways extends VerifyUser
             $user->markSessionVerified();
         }
 
+        $method = $request->getMethod();
         $isPostAction = config('osu.user.post_action_verification')
-            ? !in_array($request->getMethod(), ['GET', 'HEAD', 'OPTIONS'], true)
+            ? !in_array($method, ['GET', 'HEAD', 'OPTIONS'], true)
             : false;
 
-        $isRequired = $isPostAction || static::isRequired($user);
+        $isRequired = $isPostAction || static::isRequired($user) || $method === 'DELETE';
 
         if (session()->get('requires_verification') !== $isRequired) {
             session()->put('requires_verification', $isRequired);


### PR DESCRIPTION
Always require verification when performing any action that uses a http delete (separate from the optional env setting).

This does lead to some seemingly strange scenarios where watching something doesn't require verification, but unwatching it does. There's also still the issue where posts can be edited without verification.

The other option is explicitly requiring verification performing the permission checks; that requires a bit more work since displaying the delete button for some things share the same permission check as performing the action itself causing the button to not be there when not verified, e.g. `BeatmapsetDelete`.