### PR TITLE
Add database and elasticsearch explicit flag for beatmapsets

### DIFF
--- a/app/Models/Beatmapset.php
+++ b/app/Models/Beatmapset.php
@@ -73,6 +73,7 @@ use Illuminate\Database\QueryException;
  * @property int $language_id
  * @property \Carbon\Carbon $last_update
  * @property int $nominations
+ * @property bool $nsfw
  * @property int $offset
  * @property mixed|null $osz2_hash
  * @property int $play_count
@@ -107,6 +108,7 @@ class Beatmapset extends Model implements AfterCommit, Commentable, Indexable
         'active' => 'boolean',
         'download_disabled' => 'boolean',
         'epilepsy' => 'boolean',
+        'nsfw' => 'boolean',
         'storyboard' => 'boolean',
         'video' => 'boolean',
         'discussion_enabled' => 'boolean',

--- a/config/schemas/beatmaps.json
+++ b/config/schemas/beatmaps.json
@@ -140,6 +140,9 @@
         "nominations": {
           "type": "long"
         },
+        "nsfw": {
+          "type": "boolean"
+        },
         "offset": {
           "type": "long"
         },

--- a/database/migrations/2020_08_27_202640_add_nsfw_flag_to_beatmapsets.php
+++ b/database/migrations/2020_08_27_202640_add_nsfw_flag_to_beatmapsets.php
@@ -1,0 +1,35 @@
+<?php
+
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddNsfwFlagToBeatmapsets extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('osu_beatmapsets', function (Blueprint $table) {
+            $table->boolean('nsfw')->default(false);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('osu_beatmapsets', function (Blueprint $table) {
+            $table->dropColumn('nsfw');
+        });
+    }
+}


### PR DESCRIPTION
Data schema part of #6575 so they can be indexed beforehand. `es:index-documents --types=beatmapsets` will need to be run as well in addition to the migration.