### PR TITLE
Limit number of channels used for presence

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -203,6 +203,7 @@ SITE_SWITCHER_JS_HASH=
 # USER_ACHIEVEMENT_ICON_PREFIX=https://assets.ppy.sh/user-achievements/
 
 ## Limits for chat, throttles after a user sends more than CHAT_*_LIMIT messages in CHAT_*_WINDOW seconds
+# CHAT_CHANNEL_LIMIT=10000
 # CHAT_PUBLIC_LIMIT=1
 # CHAT_PUBLIC_WINDOW=1
 # CHAT_PRIVATE_LIMIT=1

--- a/app/Models/Chat/UserChannel.php
+++ b/app/Models/Chat/UserChannel.php
@@ -74,6 +74,7 @@ class UserChannel extends Model
         $userChannels = static::forUser($user)
             ->whereHas('channel')
             ->with('channel')
+            ->limit(config('osu.chat.channel_limit'))
             ->get();
 
         $channelIds = $userChannels->pluck('channel_id');

--- a/config/osu.php
+++ b/config/osu.php
@@ -71,6 +71,7 @@ return [
         'prefix' => env('CAMO_PREFIX', 'https://i.ppy.sh/'),
     ],
     'chat' => [
+        'channel_limit' => get_int(env('CHAT_CHANNEL_LIMIT')) ?? 10000,
         'message_length_limit' => get_int(env('CHAT_MESSAGE_LENGTH_LIMIT')) ?? 100,
         'public_backlog_limit' => get_int(env('CHAT_PUBLIC_BACKLOG_LIMIT_HOURS')) ?? 24,
         'rate_limits' => [


### PR DESCRIPTION
Doesn't return if limit was hit in the response yet, tacking that on is a bit messier (and the default of _visible_ channels is more than plenty)