### PR TITLE
Fix test data provider warnings

### DIFF
--- a/app/Transformers/FollowCommentTransformer.php
+++ b/app/Transformers/FollowCommentTransformer.php
@@ -16,7 +16,7 @@ class FollowCommentTransformer extends FollowTransformer
 
     private $latestComments;
 
-    public function __construct($latestComments)
+    public function __construct($latestComments = null)
     {
         // should be keyed by "type:id"
         $this->latestComments = $latestComments;

--- a/app/Transformers/FollowModdingTransformer.php
+++ b/app/Transformers/FollowModdingTransformer.php
@@ -16,7 +16,7 @@ class FollowModdingTransformer extends FollowTransformer
 
     private $latestBeatmapsets;
 
-    public function __construct($latestBeatmapsets)
+    public function __construct($latestBeatmapsets = null)
     {
         // should be keyed by "id"
         $this->latestBeatmapsets = $latestBeatmapsets;


### PR DESCRIPTION
` DeclaredPermissionsTest` expects all the transformers to be parameterless.
Failing to set up the data provider only prints a warning :|