### PR TITLE
Clarify API key origin in setup procedure

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -173,7 +173,7 @@ Note that if you use the bundled docker-compose setup, yarn/webpack will be alre
 $ php artisan migrate:fresh --seed
 ```
 
-Run the above command to rebuild the database and seed with sample data. In order for the seeder to seed beatmaps, you must enter a valid osu! API key into your `.env` configuration file as it obtains beatmap data from the osu! API.
+Run the above command to rebuild the database and seed with sample data. In order for the seeder to seed beatmaps, you must enter a valid osu! API key as the value of the `OSU_API_KEY` property in the `.env` configuration file, as the seeder obtains beatmap data from the osu! API. The key can be obtained at [the "osu! API Access" page](https://old.ppy.sh/p/api), which is currently only available on the old site.
 
 ## Continuous asset generation while developing
 


### PR DESCRIPTION
Possibly obvious, but still tripped me up when setting up. Wasn't expecting the key to be only available on the old site.

I had other issues - aside from me screwing up and assuming `docker-compose` will come from the same PPA as `docker`, resulting in me having a 2017 version of the former with the 2020 version of the latter and refusing to work with a relative path in `docker-compose.yml` (which I consider irrelevant to the setup document), `APP_KEY` was initially blank for some reason - but on consulting with another person that was setting up recently, that doesn't seem to be something universal. Might have been a weird linux thing? No idea.