### PR TITLE
Fix error on dashboard page when user has no profile settings

### DIFF
--- a/resources/views/home/_user_beatmapset.blade.php
+++ b/resources/views/home/_user_beatmapset.blade.php
@@ -4,7 +4,7 @@
 --}}
 
 <a class='user-home-beatmapset' href="{{route('beatmapsets.show', $beatmapset->beatmapset_id)}}">
-    @if ($beatmapset->nsfw && !auth()->user()->userProfileCustomization->beatmapset_show_nsfw)
+    @if ($beatmapset->nsfw && !$showNsfw)
         <div class="user-home-beatmapset__cover user-home-beatmapset__cover--blank"></div>
     @else
         <img

--- a/resources/views/home/user.blade.php
+++ b/resources/views/home/user.blade.php
@@ -4,6 +4,12 @@
 --}}
 @extends('master')
 
+@php
+    $user = auth()->user();
+    $profileCustomization = $user->userProfileCustomization ?? $user->userProfileCustomization()->make();
+    $beatmapsetShowNsfw = $profileCustomization->beatmapset_show_nsfw;
+@endphp
+
 @section('content')
     @include('home._user_header_default')
 
@@ -79,7 +85,7 @@
 
                 <div class="user-home__beatmapsets">
                     @foreach ($newBeatmapsets as $beatmapset)
-                        @include('home._user_beatmapset', ['type' => 'new'])
+                        @include('home._user_beatmapset', ['type' => 'new', 'showNsfw' => $beatmapsetShowNsfw])
                     @endforeach
                 </div>
 
@@ -89,7 +95,7 @@
 
                 <div class="user-home__beatmapsets">
                     @foreach ($popularBeatmapsets as $beatmapset)
-                        @include('home._user_beatmapset', ['type' => 'popular'])
+                        @include('home._user_beatmapset', ['type' => 'popular', 'showNsfw' => $beatmapsetShowNsfw])
                     @endforeach
                 </div>
             </div>


### PR DESCRIPTION
As I discovered that accessing `beatmapset_show_nsfw` casts `options` from json [twice](https://github.com/ppy/osu-web/issues/7055).