### PR TITLE
Log beatmap explicit state change

### DIFF
--- a/app/Http/Controllers/BeatmapsetsController.php
+++ b/app/Http/Controllers/BeatmapsetsController.php
@@ -258,10 +258,11 @@ class BeatmapsetsController extends Controller
         if (count($metadataParams) > 0) {
             priv_check('BeatmapsetMetadataEdit', $beatmapset)->ensureCan();
 
-            $oldGenreId = $beatmapset->genre_id;
-            $oldLanguageId = $beatmapset->language_id;
+            DB::transaction(function () use ($beatmapset, $metadataParams) {
+                $oldGenreId = $beatmapset->genre_id;
+                $oldLanguageId = $beatmapset->language_id;
+                $oldNsfw = $beatmapset->nsfw;
 
-            DB::transaction(function () use ($beatmapset, $metadataParams, $oldGenreId, $oldLanguageId) {
                 $beatmapset->fill($metadataParams)->saveOrExplode();
 
                 if ($oldGenreId !== $beatmapset->genre_id) {
@@ -275,6 +276,13 @@ class BeatmapsetsController extends Controller
                     BeatmapsetEvent::log(BeatmapsetEvent::LANGUAGE_EDIT, Auth::user(), $beatmapset, [
                         'old' => Language::find($oldLanguageId)->name,
                         'new' => $beatmapset->language->name,
+                    ])->saveOrExplode();
+                }
+
+                if ($oldNsfw !== $beatmapset->nsfw) {
+                    BeatmapsetEvent::log(BeatmapsetEvent::NSFW_TOGGLE, Auth::user(), $beatmapset, [
+                        'old' => $oldNsfw,
+                        'new' => $beatmapset->nsfw,
                     ])->saveOrExplode();
                 }
             });

--- a/app/Models/BeatmapsetEvent.php
+++ b/app/Models/BeatmapsetEvent.php
@@ -50,6 +50,7 @@ class BeatmapsetEvent extends Model
 
     const GENRE_EDIT = 'genre_edit';
     const LANGUAGE_EDIT = 'language_edit';
+    const NSFW_TOGGLE = 'nsfw_toggle';
 
     public static function log($type, $user, $object, $extraData = [])
     {
@@ -201,6 +202,7 @@ class BeatmapsetEvent extends Model
 
                     static::GENRE_EDIT,
                     static::LANGUAGE_EDIT,
+                    static::NSFW_TOGGLE,
                 ],
                 'kudosuModeration' => [
                     static::KUDOSU_ALLOW,

--- a/database/migrations/2021_01_15_092749_add_nsfw_toggle_to_beatmapset_events.php
+++ b/database/migrations/2021_01_15_092749_add_nsfw_toggle_to_beatmapset_events.php
@@ -1,0 +1,78 @@
+<?php
+
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
+use Illuminate\Database\Migrations\Migration;
+
+class AddNsfwToggleToBeatmapsetEvents extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        DB::statement("ALTER TABLE beatmapset_events CHANGE type type ENUM(
+            'nominate',
+            'qualify',
+            'disqualify',
+            'approve',
+            'rank',
+            'kudosu_allow',
+            'kudosu_deny',
+            'kudosu_gain',
+            'kudosu_lost',
+            'issue_resolve',
+            'issue_reopen',
+            'discussion_delete',
+            'discussion_restore',
+            'discussion_post_delete',
+            'discussion_post_restore',
+            'kudosu_recalculate',
+            'nomination_reset',
+            'love',
+            'discussion_lock',
+            'discussion_unlock',
+            'genre_edit',
+            'language_edit',
+            'remove_from_loved',
+            'nsfw_toggle'
+        )");
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        DB::statement("ALTER TABLE beatmapset_events CHANGE type type ENUM(
+            'nominate',
+            'qualify',
+            'disqualify',
+            'approve',
+            'rank',
+            'kudosu_allow',
+            'kudosu_deny',
+            'kudosu_gain',
+            'kudosu_lost',
+            'issue_resolve',
+            'issue_reopen',
+            'discussion_delete',
+            'discussion_restore',
+            'discussion_post_delete',
+            'discussion_post_restore',
+            'kudosu_recalculate',
+            'nomination_reset',
+            'love',
+            'discussion_lock',
+            'discussion_unlock',
+            'genre_edit',
+            'language_edit',
+            'remove_from_loved'
+        )");
+    }
+}

--- a/resources/assets/less/bem/beatmapset-event.less
+++ b/resources/assets/less/bem/beatmapset-event.less
@@ -44,6 +44,7 @@
     .type(love, @pink);
     .type(nominate, @blue);
     .type(nomination-reset, @red);
+    .type(nsfw-toggle, @blue);
     .type(qualify, @blue);
     .type(rank, @green);
     .type(remove-from-loved, @red);

--- a/resources/assets/lib/beatmap-discussions/event.tsx
+++ b/resources/assets/lib/beatmap-discussions/event.tsx
@@ -147,6 +147,11 @@ export default class Event extends React.PureComponent<Props> {
       params.modes = osu.transArray(nominationModes);
     }
 
+    if (eventType === 'nsfw_toggle') {
+      const newState = this.props.event.comment?.new ? 'to_1' : 'to_0';
+      eventType += `.${newState}`;
+    }
+
     const key = `beatmapset_events.event.${eventType}`;
     let message = osu.trans(key, params);
 

--- a/resources/lang/en/beatmapset_events.php
+++ b/resources/lang/en/beatmapset_events.php
@@ -30,6 +30,11 @@ return [
         'qualify' => 'This beatmap has reached the required number of nominations and has been qualified.',
         'rank' => 'Ranked.',
         'remove_from_loved' => 'Removed from Loved by :user. (:text)',
+
+        'nsfw_toggle' => [
+            'to_0' => 'Removed explicit mark',
+            'to_1' => 'Marked as explicit',
+        ]
     ],
 
     'index' => [
@@ -66,6 +71,7 @@ return [
         'love' => 'Love',
         'nominate' => 'Nomination',
         'nomination_reset' => 'Nomination resetting',
+        'nsfw_toggle' => 'Explicit mark',
         'qualify' => 'Qualification',
         'rank' => 'Ranking',
         'remove_from_loved' => 'Loved removal',

--- a/resources/lang/en/beatmapset_events.php
+++ b/resources/lang/en/beatmapset_events.php
@@ -34,7 +34,7 @@ return [
         'nsfw_toggle' => [
             'to_0' => 'Removed explicit mark',
             'to_1' => 'Marked as explicit',
-        ]
+        ],
     ],
 
     'index' => [


### PR DESCRIPTION
Not sure if should keep adding new event type or make a "metadata change" event instead.

The wording can use some improvement.

Use blue colour to follow other metadata edit. I wonder if explicit colour (`orange-2`) is better here.

Resolves #7042.