### PR TITLE
Refactor user profile page masking into component

### DIFF
--- a/resources/assets/coffee/react/modding-profile/main.coffee
+++ b/resources/assets/coffee/react/modding-profile/main.coffee
@@ -15,6 +15,7 @@ import { NotificationBanner } from 'notification-banner'
 import { Posts } from "./posts"
 import * as React from 'react'
 import { a, button, div, i, span } from 'react-dom-factories'
+import UserProfileContainer from 'user-profile-container'
 el = React.createElement
 
 pages = document.getElementsByClassName("js-switchable-mode-page--scrollspy")
@@ -147,64 +148,39 @@ export class Main extends React.PureComponent
 
   render: =>
     profileOrder = @state.profileOrder
-    isBlocked = _.find(currentUser.blocks, target_id: @state.user.id)
 
     el ReviewEditorConfigContext.Provider, value: @props.reviewsConfig,
       el DiscussionsContext.Provider, value: @discussions(),
         el BeatmapsContext.Provider, value: @beatmaps(),
-          div
-            className: 'osu-layout__no-scroll' if isBlocked && !@state.forceShow
-            if isBlocked
+          el UserProfileContainer,
+            user: @state.user,
+            el Header,
+              user: @state.user
+              stats: @state.user.statistics
+              userAchievements: @props.userAchievements
+
+            div
+              className: 'hidden-xs page-extra-tabs page-extra-tabs--profile-page js-switchable-mode-page--scrollspy-offset'
               div className: 'osu-page',
-                el NotificationBanner,
-                  type: 'warning'
-                  title: osu.trans('users.blocks.banner_text')
-                  message:
-                    div className: 'grid-items grid-items--notification-banner-buttons',
-                      div null,
-                        el BlockButton, userId: @props.user.id
-                      div null,
-                        button
-                          type: 'button'
-                          className: 'textual-button'
-                          onClick: =>
-                            @setState forceShow: !@state.forceShow
-                          span {},
-                            i className: 'textual-button__icon fas fa-low-vision'
-                            " "
-                            if @state.forceShow
-                              osu.trans('users.blocks.hide_profile')
-                            else
-                              osu.trans('users.blocks.show_profile')
+                div
+                  className: 'page-mode page-mode--profile-page-extra'
+                  ref: @tabs
+                  for m in profileOrder
+                    a
+                      className: 'page-mode__item'
+                      key: m
+                      'data-page-id': m
+                      onClick: @tabClick
+                      href: "##{m}"
+                      el ExtraTab,
+                        page: m
+                        currentPage: @state.currentPage
+                        currentMode: @state.currentMode
 
-            div className: "osu-layout osu-layout--full#{if isBlocked && !@state.forceShow then ' osu-layout--masked' else ''}",
-              el Header,
-                user: @state.user
-                stats: @state.user.statistics
-                userAchievements: @props.userAchievements
-
-              div
-                className: 'hidden-xs page-extra-tabs page-extra-tabs--profile-page js-switchable-mode-page--scrollspy-offset'
-                div className: 'osu-page',
-                  div
-                    className: 'page-mode page-mode--profile-page-extra'
-                    ref: @tabs
-                    for m in profileOrder
-                      a
-                        className: 'page-mode__item'
-                        key: m
-                        'data-page-id': m
-                        onClick: @tabClick
-                        href: "##{m}"
-                        el ExtraTab,
-                          page: m
-                          currentPage: @state.currentPage
-                          currentMode: @state.currentMode
-
-              div
-                className: 'user-profile-pages'
-                ref: @pages
-                @extraPage name for name in profileOrder
+            div
+              className: 'user-profile-pages'
+              ref: @pages
+              @extraPage name for name in profileOrder
 
 
   extraPage: (name) =>

--- a/resources/assets/coffee/react/profile-page/main.coffee
+++ b/resources/assets/coffee/react/profile-page/main.coffee
@@ -15,6 +15,7 @@ import { BlockButton } from 'block-button'
 import { NotificationBanner } from 'notification-banner'
 import * as React from 'react'
 import { a, button, div, i, li, span, ul } from 'react-dom-factories'
+import UserProfileContainer from 'user-profile-container'
 import * as BeatmapHelper from 'utils/beatmap-helper'
 el = React.createElement
 
@@ -131,64 +132,38 @@ export class Main extends React.PureComponent
     if @state.userPage.initialRaw.trim() == '' && !@props.withEdit
       _.pull profileOrder, 'me'
 
-    isBlocked = _.find(currentUser.blocks, target_id: @state.user.id)
+    el UserProfileContainer,
+      user: @state.user,
+      el Header,
+        user: @state.user
+        stats: @state.user.statistics
+        currentMode: @state.currentMode
+        withEdit: @props.withEdit
+        userAchievements: @props.userAchievements
 
-    div
-      className: 'osu-layout__no-scroll' if isBlocked && !@state.forceShow
-      if isBlocked
-        div className: 'osu-page',
-          el NotificationBanner,
-            type: 'warning'
-            title: osu.trans('users.blocks.banner_text')
-            message:
-              div className: 'grid-items grid-items--notification-banner-buttons',
-                div null,
-                  el BlockButton, userId: @props.user.id
-                div null,
-                  button
-                    type: 'button'
-                    className: 'textual-button'
-                    onClick: =>
-                      @setState forceShow: !@state.forceShow
-                    span {},
-                      i className: 'textual-button__icon fas fa-low-vision'
-                      " "
-                      if @state.forceShow
-                        osu.trans('users.blocks.hide_profile')
-                      else
-                        osu.trans('users.blocks.show_profile')
+      div
+        className: 'hidden-xs page-extra-tabs page-extra-tabs--profile-page js-switchable-mode-page--scrollspy-offset'
+        if profileOrder.length > 1
+          div className: 'osu-page',
+            div
+              className: 'page-mode page-mode--profile-page-extra'
+              ref: @tabs
+              for m in profileOrder
+                a
+                  className: "page-mode__item #{'js-sortable--tab' if @isSortablePage m}"
+                  key: m
+                  'data-page-id': m
+                  onClick: @tabClick
+                  href: "##{m}"
+                  el ExtraTab,
+                    page: m
+                    currentPage: @state.currentPage
+                    currentMode: @state.currentMode
 
-      div className: "osu-layout osu-layout--full#{if isBlocked && !@state.forceShow then ' osu-layout--masked' else ''}",
-        el Header,
-          user: @state.user
-          stats: @state.user.statistics
-          currentMode: @state.currentMode
-          withEdit: @props.withEdit
-          userAchievements: @props.userAchievements
-
-        div
-          className: 'hidden-xs page-extra-tabs page-extra-tabs--profile-page js-switchable-mode-page--scrollspy-offset'
-          if profileOrder.length > 1
-            div className: 'osu-page',
-              div
-                className: 'page-mode page-mode--profile-page-extra'
-                ref: @tabs
-                for m in profileOrder
-                  a
-                    className: "page-mode__item #{'js-sortable--tab' if @isSortablePage m}"
-                    key: m
-                    'data-page-id': m
-                    onClick: @tabClick
-                    href: "##{m}"
-                    el ExtraTab,
-                      page: m
-                      currentPage: @state.currentPage
-                      currentMode: @state.currentMode
-
-        div
-          className: 'user-profile-pages'
-          ref: @pages
-          @extraPage name for name in profileOrder
+      div
+        className: 'user-profile-pages'
+        ref: @pages
+        @extraPage name for name in profileOrder
 
 
   extraPage: (name) =>

--- a/resources/assets/lib/coffee-modules.d.ts
+++ b/resources/assets/lib/coffee-modules.d.ts
@@ -81,6 +81,16 @@ declare module 'modal' {
   class Modal extends React.PureComponent<Props> {}
 }
 
+declare module 'notification-banner' {
+  interface Props {
+    message: React.ReactFragment;
+    title: string;
+    type: string;
+  }
+
+  class NotificationBanner extends React.PureComponent<Props> {}
+}
+
 declare module 'popup-menu' {
   type Children = (dismiss: () => void) => React.ReactFragment;
 

--- a/resources/assets/lib/user-profile-container.tsx
+++ b/resources/assets/lib/user-profile-container.tsx
@@ -1,0 +1,69 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
+import { BlockButton } from 'block-button';
+import UserJson from 'interfaces/user-json';
+import { find } from 'lodash';
+import { NotificationBanner } from 'notification-banner';
+import * as React from 'react';
+
+interface Props {
+  user: UserJson;
+}
+
+interface State {
+  forceShow: boolean;
+}
+
+export default class UserProfileContainer extends React.PureComponent<Props, State> {
+  state = { forceShow: false };
+
+  render() {
+    const isBlocked = find(currentUser.blocks, { target_id: this.props.user.id });
+
+    let cssClass: string | undefined;
+    const modifiers = ['full'];
+    if (isBlocked && !this.state.forceShow) {
+      cssClass = 'osu-layout__no-scroll';
+      modifiers.push('masked');
+    }
+
+    return (
+      <div className={cssClass}>
+        {isBlocked && this.renderBanner()}
+        <div className={osu.classWithModifiers('osu-layout', modifiers)}>
+          {this.props.children}
+        </div>
+      </div>
+    );
+  }
+
+  renderBanner() {
+    const message = (
+      <div className='grid-items grid-items--notification-banner-buttons'>
+        <div>
+          <BlockButton userId={this.props.user.id} />
+        </div>
+        <div>
+          <button type='button' className='textual-button' onClick={this.handleClick}>
+            <span>
+              <i className='textual-button__icon fas fa-low-vision' />
+              {' '}
+              {this.state.forceShow ? osu.trans('users.blocks.hide_profile') : osu.trans('users.blocks.show_profile')}
+            </span>
+          </button>
+        </div>
+      </div>
+    );
+
+    return (
+      <div className='osu-page'>
+        <NotificationBanner type='warning' title={osu.trans('users.blocks.banner_text')} message={message} />
+      </div>
+    );
+  }
+
+  private handleClick = () => {
+    this.setState({ forceShow: !this.state.forceShow });
+  }
+}


### PR DESCRIPTION
While refactoring the beatmap discussion components, I've scrolled past this big block that looks the same so many times 🤔 
(The tree depth of the pages section of the modding profile version also appears to be wrong?)