### PR TITLE
Add follows page to the language folders

### DIFF
--- a/resources/lang/ar/follows.php
+++ b/resources/lang/ar/follows.php
@@ -1,0 +1,38 @@
+<?php
+
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
+return [
+    'comment' => [
+        'empty' => '',
+        'page_title' => '',
+        'title' => '',
+
+        'table' => [
+            'latest_comment_empty' => '',
+            'latest_comment_value' => '',
+        ],
+    ],
+
+    'forum_topic' => [
+        'title' => '',
+    ],
+
+    'index' => [
+        'title_compact' => '',
+    ],
+
+    'mapping' => [
+        'empty' => '',
+        'followers' => '',
+        'page_title' => '',
+        'title' => '',
+        'to_0' => '',
+        'to_1' => '',
+    ],
+
+    'modding' => [
+        'title' => '',
+    ],
+];

--- a/resources/lang/be/follows.php
+++ b/resources/lang/be/follows.php
@@ -1,0 +1,38 @@
+<?php
+
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
+return [
+    'comment' => [
+        'empty' => '',
+        'page_title' => '',
+        'title' => '',
+
+        'table' => [
+            'latest_comment_empty' => '',
+            'latest_comment_value' => '',
+        ],
+    ],
+
+    'forum_topic' => [
+        'title' => '',
+    ],
+
+    'index' => [
+        'title_compact' => '',
+    ],
+
+    'mapping' => [
+        'empty' => '',
+        'followers' => '',
+        'page_title' => '',
+        'title' => '',
+        'to_0' => '',
+        'to_1' => '',
+    ],
+
+    'modding' => [
+        'title' => '',
+    ],
+];

--- a/resources/lang/bg/follows.php
+++ b/resources/lang/bg/follows.php
@@ -1,0 +1,38 @@
+<?php
+
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
+return [
+    'comment' => [
+        'empty' => '',
+        'page_title' => '',
+        'title' => '',
+
+        'table' => [
+            'latest_comment_empty' => '',
+            'latest_comment_value' => '',
+        ],
+    ],
+
+    'forum_topic' => [
+        'title' => '',
+    ],
+
+    'index' => [
+        'title_compact' => '',
+    ],
+
+    'mapping' => [
+        'empty' => '',
+        'followers' => '',
+        'page_title' => '',
+        'title' => '',
+        'to_0' => '',
+        'to_1' => '',
+    ],
+
+    'modding' => [
+        'title' => '',
+    ],
+];

--- a/resources/lang/cs/follows.php
+++ b/resources/lang/cs/follows.php
@@ -1,0 +1,38 @@
+<?php
+
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
+return [
+    'comment' => [
+        'empty' => '',
+        'page_title' => '',
+        'title' => '',
+
+        'table' => [
+            'latest_comment_empty' => '',
+            'latest_comment_value' => '',
+        ],
+    ],
+
+    'forum_topic' => [
+        'title' => '',
+    ],
+
+    'index' => [
+        'title_compact' => '',
+    ],
+
+    'mapping' => [
+        'empty' => '',
+        'followers' => '',
+        'page_title' => '',
+        'title' => '',
+        'to_0' => '',
+        'to_1' => '',
+    ],
+
+    'modding' => [
+        'title' => '',
+    ],
+];

--- a/resources/lang/da/follows.php
+++ b/resources/lang/da/follows.php
@@ -1,0 +1,38 @@
+<?php
+
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
+return [
+    'comment' => [
+        'empty' => '',
+        'page_title' => '',
+        'title' => '',
+
+        'table' => [
+            'latest_comment_empty' => '',
+            'latest_comment_value' => '',
+        ],
+    ],
+
+    'forum_topic' => [
+        'title' => '',
+    ],
+
+    'index' => [
+        'title_compact' => '',
+    ],
+
+    'mapping' => [
+        'empty' => '',
+        'followers' => '',
+        'page_title' => '',
+        'title' => '',
+        'to_0' => '',
+        'to_1' => '',
+    ],
+
+    'modding' => [
+        'title' => '',
+    ],
+];

--- a/resources/lang/de/follows.php
+++ b/resources/lang/de/follows.php
@@ -1,0 +1,38 @@
+<?php
+
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
+return [
+    'comment' => [
+        'empty' => '',
+        'page_title' => '',
+        'title' => '',
+
+        'table' => [
+            'latest_comment_empty' => '',
+            'latest_comment_value' => '',
+        ],
+    ],
+
+    'forum_topic' => [
+        'title' => '',
+    ],
+
+    'index' => [
+        'title_compact' => '',
+    ],
+
+    'mapping' => [
+        'empty' => '',
+        'followers' => '',
+        'page_title' => '',
+        'title' => '',
+        'to_0' => '',
+        'to_1' => '',
+    ],
+
+    'modding' => [
+        'title' => '',
+    ],
+];

--- a/resources/lang/el/follows.php
+++ b/resources/lang/el/follows.php
@@ -1,0 +1,38 @@
+<?php
+
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
+return [
+    'comment' => [
+        'empty' => '',
+        'page_title' => '',
+        'title' => '',
+
+        'table' => [
+            'latest_comment_empty' => '',
+            'latest_comment_value' => '',
+        ],
+    ],
+
+    'forum_topic' => [
+        'title' => '',
+    ],
+
+    'index' => [
+        'title_compact' => '',
+    ],
+
+    'mapping' => [
+        'empty' => '',
+        'followers' => '',
+        'page_title' => '',
+        'title' => '',
+        'to_0' => '',
+        'to_1' => '',
+    ],
+
+    'modding' => [
+        'title' => '',
+    ],
+];

--- a/resources/lang/es/follows.php
+++ b/resources/lang/es/follows.php
@@ -1,0 +1,38 @@
+<?php
+
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
+return [
+    'comment' => [
+        'empty' => '',
+        'page_title' => '',
+        'title' => '',
+
+        'table' => [
+            'latest_comment_empty' => '',
+            'latest_comment_value' => '',
+        ],
+    ],
+
+    'forum_topic' => [
+        'title' => '',
+    ],
+
+    'index' => [
+        'title_compact' => '',
+    ],
+
+    'mapping' => [
+        'empty' => '',
+        'followers' => '',
+        'page_title' => '',
+        'title' => '',
+        'to_0' => '',
+        'to_1' => '',
+    ],
+
+    'modding' => [
+        'title' => '',
+    ],
+];

--- a/resources/lang/fi/follows.php
+++ b/resources/lang/fi/follows.php
@@ -1,0 +1,38 @@
+<?php
+
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
+return [
+    'comment' => [
+        'empty' => '',
+        'page_title' => '',
+        'title' => '',
+
+        'table' => [
+            'latest_comment_empty' => '',
+            'latest_comment_value' => '',
+        ],
+    ],
+
+    'forum_topic' => [
+        'title' => '',
+    ],
+
+    'index' => [
+        'title_compact' => '',
+    ],
+
+    'mapping' => [
+        'empty' => '',
+        'followers' => '',
+        'page_title' => '',
+        'title' => '',
+        'to_0' => '',
+        'to_1' => '',
+    ],
+
+    'modding' => [
+        'title' => '',
+    ],
+];

--- a/resources/lang/fr/follows.php
+++ b/resources/lang/fr/follows.php
@@ -1,0 +1,38 @@
+<?php
+
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
+return [
+    'comment' => [
+        'empty' => '',
+        'page_title' => '',
+        'title' => '',
+
+        'table' => [
+            'latest_comment_empty' => '',
+            'latest_comment_value' => '',
+        ],
+    ],
+
+    'forum_topic' => [
+        'title' => '',
+    ],
+
+    'index' => [
+        'title_compact' => '',
+    ],
+
+    'mapping' => [
+        'empty' => '',
+        'followers' => '',
+        'page_title' => '',
+        'title' => '',
+        'to_0' => '',
+        'to_1' => '',
+    ],
+
+    'modding' => [
+        'title' => '',
+    ],
+];

--- a/resources/lang/hu/follows.php
+++ b/resources/lang/hu/follows.php
@@ -1,0 +1,38 @@
+<?php
+
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
+return [
+    'comment' => [
+        'empty' => '',
+        'page_title' => '',
+        'title' => '',
+
+        'table' => [
+            'latest_comment_empty' => '',
+            'latest_comment_value' => '',
+        ],
+    ],
+
+    'forum_topic' => [
+        'title' => '',
+    ],
+
+    'index' => [
+        'title_compact' => '',
+    ],
+
+    'mapping' => [
+        'empty' => '',
+        'followers' => '',
+        'page_title' => '',
+        'title' => '',
+        'to_0' => '',
+        'to_1' => '',
+    ],
+
+    'modding' => [
+        'title' => '',
+    ],
+];

--- a/resources/lang/id/follows.php
+++ b/resources/lang/id/follows.php
@@ -1,0 +1,38 @@
+<?php
+
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
+return [
+    'comment' => [
+        'empty' => '',
+        'page_title' => '',
+        'title' => '',
+
+        'table' => [
+            'latest_comment_empty' => '',
+            'latest_comment_value' => '',
+        ],
+    ],
+
+    'forum_topic' => [
+        'title' => '',
+    ],
+
+    'index' => [
+        'title_compact' => '',
+    ],
+
+    'mapping' => [
+        'empty' => '',
+        'followers' => '',
+        'page_title' => '',
+        'title' => '',
+        'to_0' => '',
+        'to_1' => '',
+    ],
+
+    'modding' => [
+        'title' => '',
+    ],
+];

--- a/resources/lang/it/follows.php
+++ b/resources/lang/it/follows.php
@@ -1,0 +1,38 @@
+<?php
+
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
+return [
+    'comment' => [
+        'empty' => '',
+        'page_title' => '',
+        'title' => '',
+
+        'table' => [
+            'latest_comment_empty' => '',
+            'latest_comment_value' => '',
+        ],
+    ],
+
+    'forum_topic' => [
+        'title' => '',
+    ],
+
+    'index' => [
+        'title_compact' => '',
+    ],
+
+    'mapping' => [
+        'empty' => '',
+        'followers' => '',
+        'page_title' => '',
+        'title' => '',
+        'to_0' => '',
+        'to_1' => '',
+    ],
+
+    'modding' => [
+        'title' => '',
+    ],
+];

--- a/resources/lang/ja/follows.php
+++ b/resources/lang/ja/follows.php
@@ -1,0 +1,38 @@
+<?php
+
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
+return [
+    'comment' => [
+        'empty' => '',
+        'page_title' => '',
+        'title' => '',
+
+        'table' => [
+            'latest_comment_empty' => '',
+            'latest_comment_value' => '',
+        ],
+    ],
+
+    'forum_topic' => [
+        'title' => '',
+    ],
+
+    'index' => [
+        'title_compact' => '',
+    ],
+
+    'mapping' => [
+        'empty' => '',
+        'followers' => '',
+        'page_title' => '',
+        'title' => '',
+        'to_0' => '',
+        'to_1' => '',
+    ],
+
+    'modding' => [
+        'title' => '',
+    ],
+];

--- a/resources/lang/ko/follows.php
+++ b/resources/lang/ko/follows.php
@@ -1,0 +1,38 @@
+<?php
+
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
+return [
+    'comment' => [
+        'empty' => '',
+        'page_title' => '',
+        'title' => '',
+
+        'table' => [
+            'latest_comment_empty' => '',
+            'latest_comment_value' => '',
+        ],
+    ],
+
+    'forum_topic' => [
+        'title' => '',
+    ],
+
+    'index' => [
+        'title_compact' => '',
+    ],
+
+    'mapping' => [
+        'empty' => '',
+        'followers' => '',
+        'page_title' => '',
+        'title' => '',
+        'to_0' => '',
+        'to_1' => '',
+    ],
+
+    'modding' => [
+        'title' => '',
+    ],
+];

--- a/resources/lang/nl/follows.php
+++ b/resources/lang/nl/follows.php
@@ -1,0 +1,38 @@
+<?php
+
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
+return [
+    'comment' => [
+        'empty' => '',
+        'page_title' => '',
+        'title' => '',
+
+        'table' => [
+            'latest_comment_empty' => '',
+            'latest_comment_value' => '',
+        ],
+    ],
+
+    'forum_topic' => [
+        'title' => '',
+    ],
+
+    'index' => [
+        'title_compact' => '',
+    ],
+
+    'mapping' => [
+        'empty' => '',
+        'followers' => '',
+        'page_title' => '',
+        'title' => '',
+        'to_0' => '',
+        'to_1' => '',
+    ],
+
+    'modding' => [
+        'title' => '',
+    ],
+];

--- a/resources/lang/no/follows.php
+++ b/resources/lang/no/follows.php
@@ -1,0 +1,38 @@
+<?php
+
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
+return [
+    'comment' => [
+        'empty' => '',
+        'page_title' => '',
+        'title' => '',
+
+        'table' => [
+            'latest_comment_empty' => '',
+            'latest_comment_value' => '',
+        ],
+    ],
+
+    'forum_topic' => [
+        'title' => '',
+    ],
+
+    'index' => [
+        'title_compact' => '',
+    ],
+
+    'mapping' => [
+        'empty' => '',
+        'followers' => '',
+        'page_title' => '',
+        'title' => '',
+        'to_0' => '',
+        'to_1' => '',
+    ],
+
+    'modding' => [
+        'title' => '',
+    ],
+];

--- a/resources/lang/pl/follows.php
+++ b/resources/lang/pl/follows.php
@@ -1,0 +1,38 @@
+<?php
+
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
+return [
+    'comment' => [
+        'empty' => '',
+        'page_title' => '',
+        'title' => '',
+
+        'table' => [
+            'latest_comment_empty' => '',
+            'latest_comment_value' => '',
+        ],
+    ],
+
+    'forum_topic' => [
+        'title' => '',
+    ],
+
+    'index' => [
+        'title_compact' => '',
+    ],
+
+    'mapping' => [
+        'empty' => '',
+        'followers' => '',
+        'page_title' => '',
+        'title' => '',
+        'to_0' => '',
+        'to_1' => '',
+    ],
+
+    'modding' => [
+        'title' => '',
+    ],
+];

--- a/resources/lang/pt-br/follows.php
+++ b/resources/lang/pt-br/follows.php
@@ -1,0 +1,38 @@
+<?php
+
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
+return [
+    'comment' => [
+        'empty' => '',
+        'page_title' => '',
+        'title' => '',
+
+        'table' => [
+            'latest_comment_empty' => '',
+            'latest_comment_value' => '',
+        ],
+    ],
+
+    'forum_topic' => [
+        'title' => '',
+    ],
+
+    'index' => [
+        'title_compact' => '',
+    ],
+
+    'mapping' => [
+        'empty' => '',
+        'followers' => '',
+        'page_title' => '',
+        'title' => '',
+        'to_0' => '',
+        'to_1' => '',
+    ],
+
+    'modding' => [
+        'title' => '',
+    ],
+];

--- a/resources/lang/pt/follows.php
+++ b/resources/lang/pt/follows.php
@@ -1,0 +1,38 @@
+<?php
+
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
+return [
+    'comment' => [
+        'empty' => '',
+        'page_title' => '',
+        'title' => '',
+
+        'table' => [
+            'latest_comment_empty' => '',
+            'latest_comment_value' => '',
+        ],
+    ],
+
+    'forum_topic' => [
+        'title' => '',
+    ],
+
+    'index' => [
+        'title_compact' => '',
+    ],
+
+    'mapping' => [
+        'empty' => '',
+        'followers' => '',
+        'page_title' => '',
+        'title' => '',
+        'to_0' => '',
+        'to_1' => '',
+    ],
+
+    'modding' => [
+        'title' => '',
+    ],
+];

--- a/resources/lang/ro/follows.php
+++ b/resources/lang/ro/follows.php
@@ -1,0 +1,38 @@
+<?php
+
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
+return [
+    'comment' => [
+        'empty' => '',
+        'page_title' => '',
+        'title' => '',
+
+        'table' => [
+            'latest_comment_empty' => '',
+            'latest_comment_value' => '',
+        ],
+    ],
+
+    'forum_topic' => [
+        'title' => '',
+    ],
+
+    'index' => [
+        'title_compact' => '',
+    ],
+
+    'mapping' => [
+        'empty' => '',
+        'followers' => '',
+        'page_title' => '',
+        'title' => '',
+        'to_0' => '',
+        'to_1' => '',
+    ],
+
+    'modding' => [
+        'title' => '',
+    ],
+];

--- a/resources/lang/ru/follows.php
+++ b/resources/lang/ru/follows.php
@@ -1,0 +1,38 @@
+<?php
+
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
+return [
+    'comment' => [
+        'empty' => '',
+        'page_title' => '',
+        'title' => '',
+
+        'table' => [
+            'latest_comment_empty' => '',
+            'latest_comment_value' => '',
+        ],
+    ],
+
+    'forum_topic' => [
+        'title' => '',
+    ],
+
+    'index' => [
+        'title_compact' => '',
+    ],
+
+    'mapping' => [
+        'empty' => '',
+        'followers' => '',
+        'page_title' => '',
+        'title' => '',
+        'to_0' => '',
+        'to_1' => '',
+    ],
+
+    'modding' => [
+        'title' => '',
+    ],
+];

--- a/resources/lang/sk/follows.php
+++ b/resources/lang/sk/follows.php
@@ -1,0 +1,38 @@
+<?php
+
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
+return [
+    'comment' => [
+        'empty' => '',
+        'page_title' => '',
+        'title' => '',
+
+        'table' => [
+            'latest_comment_empty' => '',
+            'latest_comment_value' => '',
+        ],
+    ],
+
+    'forum_topic' => [
+        'title' => '',
+    ],
+
+    'index' => [
+        'title_compact' => '',
+    ],
+
+    'mapping' => [
+        'empty' => '',
+        'followers' => '',
+        'page_title' => '',
+        'title' => '',
+        'to_0' => '',
+        'to_1' => '',
+    ],
+
+    'modding' => [
+        'title' => '',
+    ],
+];

--- a/resources/lang/sv/follows.php
+++ b/resources/lang/sv/follows.php
@@ -1,0 +1,38 @@
+<?php
+
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
+return [
+    'comment' => [
+        'empty' => '',
+        'page_title' => '',
+        'title' => '',
+
+        'table' => [
+            'latest_comment_empty' => '',
+            'latest_comment_value' => '',
+        ],
+    ],
+
+    'forum_topic' => [
+        'title' => '',
+    ],
+
+    'index' => [
+        'title_compact' => '',
+    ],
+
+    'mapping' => [
+        'empty' => '',
+        'followers' => '',
+        'page_title' => '',
+        'title' => '',
+        'to_0' => '',
+        'to_1' => '',
+    ],
+
+    'modding' => [
+        'title' => '',
+    ],
+];

--- a/resources/lang/th/follows.php
+++ b/resources/lang/th/follows.php
@@ -1,0 +1,38 @@
+<?php
+
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
+return [
+    'comment' => [
+        'empty' => '',
+        'page_title' => '',
+        'title' => '',
+
+        'table' => [
+            'latest_comment_empty' => '',
+            'latest_comment_value' => '',
+        ],
+    ],
+
+    'forum_topic' => [
+        'title' => '',
+    ],
+
+    'index' => [
+        'title_compact' => '',
+    ],
+
+    'mapping' => [
+        'empty' => '',
+        'followers' => '',
+        'page_title' => '',
+        'title' => '',
+        'to_0' => '',
+        'to_1' => '',
+    ],
+
+    'modding' => [
+        'title' => '',
+    ],
+];

--- a/resources/lang/tr/follows.php
+++ b/resources/lang/tr/follows.php
@@ -1,0 +1,38 @@
+<?php
+
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
+return [
+    'comment' => [
+        'empty' => '',
+        'page_title' => '',
+        'title' => '',
+
+        'table' => [
+            'latest_comment_empty' => '',
+            'latest_comment_value' => '',
+        ],
+    ],
+
+    'forum_topic' => [
+        'title' => '',
+    ],
+
+    'index' => [
+        'title_compact' => '',
+    ],
+
+    'mapping' => [
+        'empty' => '',
+        'followers' => '',
+        'page_title' => '',
+        'title' => '',
+        'to_0' => '',
+        'to_1' => '',
+    ],
+
+    'modding' => [
+        'title' => '',
+    ],
+];

--- a/resources/lang/uk/follows.php
+++ b/resources/lang/uk/follows.php
@@ -1,0 +1,38 @@
+<?php
+
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
+return [
+    'comment' => [
+        'empty' => '',
+        'page_title' => '',
+        'title' => '',
+
+        'table' => [
+            'latest_comment_empty' => '',
+            'latest_comment_value' => '',
+        ],
+    ],
+
+    'forum_topic' => [
+        'title' => '',
+    ],
+
+    'index' => [
+        'title_compact' => '',
+    ],
+
+    'mapping' => [
+        'empty' => '',
+        'followers' => '',
+        'page_title' => '',
+        'title' => '',
+        'to_0' => '',
+        'to_1' => '',
+    ],
+
+    'modding' => [
+        'title' => '',
+    ],
+];

--- a/resources/lang/vi/follows.php
+++ b/resources/lang/vi/follows.php
@@ -1,0 +1,38 @@
+<?php
+
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
+return [
+    'comment' => [
+        'empty' => '',
+        'page_title' => '',
+        'title' => '',
+
+        'table' => [
+            'latest_comment_empty' => '',
+            'latest_comment_value' => '',
+        ],
+    ],
+
+    'forum_topic' => [
+        'title' => '',
+    ],
+
+    'index' => [
+        'title_compact' => '',
+    ],
+
+    'mapping' => [
+        'empty' => '',
+        'followers' => '',
+        'page_title' => '',
+        'title' => '',
+        'to_0' => '',
+        'to_1' => '',
+    ],
+
+    'modding' => [
+        'title' => '',
+    ],
+];

--- a/resources/lang/zh-tw/follows.php
+++ b/resources/lang/zh-tw/follows.php
@@ -1,0 +1,38 @@
+<?php
+
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
+return [
+    'comment' => [
+        'empty' => '',
+        'page_title' => '',
+        'title' => '',
+
+        'table' => [
+            'latest_comment_empty' => '',
+            'latest_comment_value' => '',
+        ],
+    ],
+
+    'forum_topic' => [
+        'title' => '',
+    ],
+
+    'index' => [
+        'title_compact' => '',
+    ],
+
+    'mapping' => [
+        'empty' => '',
+        'followers' => '',
+        'page_title' => '',
+        'title' => '',
+        'to_0' => '',
+        'to_1' => '',
+    ],
+
+    'modding' => [
+        'title' => '',
+    ],
+];

--- a/resources/lang/zh/follows.php
+++ b/resources/lang/zh/follows.php
@@ -1,0 +1,38 @@
+<?php
+
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
+return [
+    'comment' => [
+        'empty' => '',
+        'page_title' => '',
+        'title' => '',
+
+        'table' => [
+            'latest_comment_empty' => '',
+            'latest_comment_value' => '',
+        ],
+    ],
+
+    'forum_topic' => [
+        'title' => '',
+    ],
+
+    'index' => [
+        'title_compact' => '',
+    ],
+
+    'mapping' => [
+        'empty' => '',
+        'followers' => '',
+        'page_title' => '',
+        'title' => '',
+        'to_0' => '',
+        'to_1' => '',
+    ],
+
+    'modding' => [
+        'title' => '',
+    ],
+];


### PR DESCRIPTION
For some reason, `follows.php` wasn't added to the language folders besides English, which prevented the file to be localized on Crowdin. This PR aims to resolve the issue, *hopefully*. 

I'm guessing this change needs to be synchronized on Crowdin as well, so tagging @peppy here.