### PR TITLE
Remove unindexed date order from user events query

### DIFF
--- a/app/Models/Event.php
+++ b/app/Models/Event.php
@@ -410,7 +410,7 @@ class Event extends Model
 
     public function scopeRecent($query)
     {
-        return $query->orderBy('date', 'desc')->orderBy('event_id', 'desc')->limit(5);
+        return $query->orderBy('event_id', 'desc')->limit(5);
     }
 
     private static function userParams($user)


### PR DESCRIPTION
Not sure why they were being ordered by `date`, there's no index on `date`; `event_id` should be in the correct order?