### PR TITLE
Send user notification digest by user_notification.id

### DIFF
--- a/app/Console/Commands/NotificationsSendMail.php
+++ b/app/Console/Commands/NotificationsSendMail.php
@@ -7,7 +7,6 @@ namespace App\Console\Commands;
 
 use App\Jobs\UserNotificationDigest;
 use App\Models\Count;
-use App\Models\Notification;
 use App\Models\User;
 use App\Models\UserNotification;
 use Illuminate\Console\Command;
@@ -35,12 +34,12 @@ class NotificationsSendMail extends Command
      */
     public function handle()
     {
-        $lastIdRow = Count::lastMailNotificationIdSent();
+        $lastIdRow = Count::lastMailUserNotificationIdSent();
 
         $fromId = get_int($this->option('from')) ?? $lastIdRow->count;
-        $toId = get_int($this->option('to')) ?? optional(Notification::last())->getKey();
+        $toId = get_int($this->option('to')) ?? optional(UserNotification::last())->getKey();
 
-        $chunkSize = get_int($this->option('chunk-size')) ?? 100;
+        $chunkSize = get_int($this->option('chunk-size')) ?? 1000;
 
         if ($toId === null) {
             $this->warn('No notifications to send!');
@@ -48,14 +47,14 @@ class NotificationsSendMail extends Command
             return;
         }
 
-        $this->line("Sending notifications > {$fromId} <= {$toId}");
+        $this->line("Sending user notifications > {$fromId} <= {$toId}");
 
         // TODO: this query needs more investigation with larger dataset
         // on whether an index over (notification_id, delivery) would actually be useful;
         // currently getting inconsistent results...
         $userIds = UserNotification
-            ::where('notification_id', '>', $fromId)
-            ->where('notification_id', '<=', $toId)
+            ::where('id', '>', $fromId)
+            ->where('id', '<=', $toId)
             ->groupBy('user_id')
             ->pluck('user_id');
 

--- a/app/Jobs/UserNotificationDigest.php
+++ b/app/Jobs/UserNotificationDigest.php
@@ -87,14 +87,18 @@ class UserNotificationDigest implements ShouldQueue
 
     private function getNotifications()
     {
-        return Notification
-            ::whereHas('userNotifications', function ($q) {
-                $q->where('user_id', $this->user->getKey())
-                    ->where('is_read', false)
-                    ->hasMailDelivery();
-            })
+        $notificationIds = $this
+            ->user
+            ->userNotifications()
+            ->where('is_read', false)
+            ->hasMailDelivery()
             ->where('id', '>', $this->fromId)
             ->where('id', '<=', $this->toId)
+            ->select('notification_id')
+            ->pluck('notification_id');
+
+        return Notification
+            ::whereIn('id', $notificationIds)
             ->get();
     }
 

--- a/app/Jobs/UserNotificationDigest.php
+++ b/app/Jobs/UserNotificationDigest.php
@@ -10,6 +10,7 @@ use App\Jobs\Notifications\BroadcastNotificationBase;
 use App\Mail\UserNotificationDigest as UserNotificationDigestMail;
 use App\Models\Notification;
 use App\Models\User;
+use App\Models\UserNotification;
 use DB;
 use Illuminate\Bus\Queueable;
 use Illuminate\Contracts\Queue\ShouldQueue;
@@ -87,19 +88,15 @@ class UserNotificationDigest implements ShouldQueue
 
     private function getNotifications()
     {
-        $notificationIds = $this
-            ->user
-            ->userNotifications()
+        $notificationIdsQuery = UserNotification
+            ::where('user_id', $this->user->getKey())
             ->where('is_read', false)
             ->hasMailDelivery()
             ->where('id', '>', $this->fromId)
             ->where('id', '<=', $this->toId)
-            ->select('notification_id')
-            ->pluck('notification_id');
+            ->select('notification_id');
 
-        return Notification
-            ::whereIn('id', $notificationIds)
-            ->get();
+        return Notification::whereIn('id', $notificationIdsQuery)->get();
     }
 
     private function shouldSend(Notification $notification): bool

--- a/app/Models/Count.php
+++ b/app/Models/Count.php
@@ -26,8 +26,8 @@ class Count extends Model
         return static::find('usercount')->count ?? 0;
     }
 
-    public static function lastMailNotificationIdSent()
+    public static function lastMailUserNotificationIdSent()
     {
-        return static::firstOrNew(['name' => 'last_mail_notification_id_sent'], ['count' => 0]);
+        return static::firstOrNew(['name' => 'last_mail_user_notification_id_sent'], ['count' => 0]);
     }
 }

--- a/database/migrations/2020_06_12_112518_set_last_mail_notification_id_sent.php
+++ b/database/migrations/2020_06_12_112518_set_last_mail_notification_id_sent.php
@@ -4,7 +4,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 use App\Models\Count;
-use App\Models\UserNotification;
+//use App\Models\UserNotification;
 use Illuminate\Database\Migrations\Migration;
 
 class SetLastMailNotificationIdSent extends Migration
@@ -16,12 +16,13 @@ class SetLastMailNotificationIdSent extends Migration
      */
     public function up()
     {
-        $userNotification = UserNotification::where('is_read', false)->hasMailDelivery()->first();
-        if ($userNotification) {
-            $last = Count::lastMailNotificationIdSent();
-            $last->count = $userNotification->notification_id;
-            $last->save();
-        }
+        // 2021-01-25: The method has been removed
+        //$userNotification = UserNotification::where('is_read', false)->hasMailDelivery()->first();
+        //if ($userNotification) {
+        //    $last = Count::lastMailNotificationIdSent();
+        //    $last->count = $userNotification->notification_id;
+        //    $last->save();
+        //}
     }
 
     /**
@@ -31,6 +32,6 @@ class SetLastMailNotificationIdSent extends Migration
      */
     public function down()
     {
-        Count::lastMailNotificationIdSent()->delete();
+        Count::where('name', 'last_mail_notification_id_sent')->delete();
     }
 }

--- a/database/migrations/2021_01_25_050834_add_count_last_mail_user_notification_id_sent.php
+++ b/database/migrations/2021_01_25_050834_add_count_last_mail_user_notification_id_sent.php
@@ -22,8 +22,7 @@ class AddCountLastMailUserNotificationIdSent extends Migration
             $lastNotificationId = $lastNotificationIdSent->count;
 
             // prevent existing job from sending more digests
-            // 63-bit because otherwise php turns it into float
-            $lastNotificationIdSent->update(['count' => 0x7fffffffffffffff]);
+            $lastNotificationIdSent->update(['count' => PHP_INT_MAX]);
 
             $currentMaxId = UserNotification::max('id');
 

--- a/database/migrations/2021_01_25_050834_add_count_last_mail_user_notification_id_sent.php
+++ b/database/migrations/2021_01_25_050834_add_count_last_mail_user_notification_id_sent.php
@@ -1,0 +1,64 @@
+<?php
+
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
+use App\Models\Count;
+use App\Models\UserNotification;
+use Illuminate\Database\Migrations\Migration;
+
+class AddCountLastMailUserNotificationIdSent extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        $lastNotificationIdSent = Count::where('name', 'last_mail_notification_id_sent')->first();
+
+        if ($lastNotificationIdSent !== null) {
+            $lastNotificationId = $lastNotificationIdSent->count;
+
+            // prevent existing job from sending more digests
+            $lastNotificationIdSent->update(['count' => $lastNotificationId * 10000]);
+
+            $currentMaxId = UserNotification::max('id');
+
+            $lastUserNotificationId = UserNotification
+                ::where('notification_id', '<=', $lastNotificationId)
+                ->where('id', '>', max($currentMaxId - 1000000, 1))
+                ->max('id');
+
+            if ($lastUserNotificationId !== null) {
+                Count::updateOrCreate(
+                    ['name' => 'last_mail_user_notification_id_sent'],
+                    ['count' => $lastUserNotificationId]
+                );
+            }
+        }
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        $lastUserNotificationIdSent = Count::where('name', 'last_mail_user_notification_id_sent')->first();
+
+        if ($lastUserNotificationIdSent !== null) {
+            $lastUserNotification = UserNotification::find($lastUserNotificationIdSent->count);
+
+            if ($lastUserNotification !== null) {
+                Count::where('name', 'last_mail_user_notification_id_sent')->delete();
+                Count::updateOrCreate(
+                    ['name' => 'last_mail_notification_id_sent'],
+                    ['count' => $lastUserNotification->notification_id]
+                );
+            }
+        }
+    }
+}

--- a/database/migrations/2021_01_25_050834_add_count_last_mail_user_notification_id_sent.php
+++ b/database/migrations/2021_01_25_050834_add_count_last_mail_user_notification_id_sent.php
@@ -22,7 +22,8 @@ class AddCountLastMailUserNotificationIdSent extends Migration
             $lastNotificationId = $lastNotificationIdSent->count;
 
             // prevent existing job from sending more digests
-            $lastNotificationIdSent->update(['count' => $lastNotificationId * 10000]);
+            // 63-bit because otherwise php turns it into float
+            $lastNotificationIdSent->update(['count' => 0x7fffffffffffffff]);
 
             $currentMaxId = UserNotification::max('id');
 

--- a/tests/Commands/NotificationsSendMailTest.php
+++ b/tests/Commands/NotificationsSendMailTest.php
@@ -8,8 +8,8 @@ namespace Tests\Commands;
 use App\Mail\UserNotificationDigest;
 use App\Models\Beatmapset;
 use App\Models\Count;
-use App\Models\Notification;
 use App\Models\User;
+use App\Models\UserNotification;
 use App\Models\UserNotificationOption;
 use Mail;
 use Tests\TestCase;
@@ -18,8 +18,8 @@ class NotificationsSendMailTest extends TestCase
 {
     public function testDoesNotSendMailAlreadySent()
     {
-        $lastId = Count::lastMailNotificationIdSent();
-        $lastId->count = Notification::orderBy('id', 'desc')->first()->getKey();
+        $lastId = Count::lastMailUserNotificationIdSent();
+        $lastId->count = UserNotification::orderBy('id', 'desc')->first()->getKey();
         $lastId->save();
 
         $this->artisan('notifications:send-mail');
@@ -29,14 +29,14 @@ class NotificationsSendMailTest extends TestCase
 
     public function testLastNotificationIdSentDoesNotGoBackwards()
     {
-        $to = Notification::orderBy('id', 'desc')->first()->getKey();
-        $lastId = Count::lastMailNotificationIdSent();
+        $to = UserNotification::orderBy('id', 'desc')->first()->getKey();
+        $lastId = Count::lastMailUserNotificationIdSent();
         $lastId->count = $to + 10;
         $lastId->save();
 
         $this->artisan('notifications:send-mail', ['--from' => 0, '--to' => $to]);
         Mail::assertSent(UserNotificationDigest::class, 1);
-        $this->assertSame($to + 10, Count::lastMailNotificationIdSent()->count);
+        $this->assertSame($to + 10, Count::lastMailUserNotificationIdSent()->count);
     }
 
     public function testSendsMailAndUpdatesCounter()
@@ -46,7 +46,7 @@ class NotificationsSendMailTest extends TestCase
         // both notifications should go into the same mail
         // TODO: split out multiple notification test after making it easier to trigger notifications for testing.
         Mail::assertSent(UserNotificationDigest::class, 1);
-        $this->assertSame(Notification::orderBy('id', 'desc')->first()->getKey(), Count::lastMailNotificationIdSent()->count);
+        $this->assertSame(UserNotification::orderBy('id', 'desc')->first()->getKey(), Count::lastMailUserNotificationIdSent()->count);
     }
 
     protected function setUp(): void


### PR DESCRIPTION
There's currently no index on user_notification.notification_id.

The migration should probably work as is and not take too long.