### PR TITLE
Update PP display on score details

### DIFF
--- a/app/Transformers/BeatmapCompactTransformer.php
+++ b/app/Transformers/BeatmapCompactTransformer.php
@@ -25,6 +25,7 @@ class BeatmapCompactTransformer extends TransformerAbstract
             'difficulty_rating' => $beatmap->difficultyrating,
             'id' => $beatmap->beatmap_id,
             'mode' => $beatmap->mode,
+            'status' => $beatmap->status(),
             'total_length' => $beatmap->total_length,
             'version' => $beatmap->version,
         ];

--- a/app/Transformers/BeatmapTransformer.php
+++ b/app/Transformers/BeatmapTransformer.php
@@ -35,7 +35,6 @@ class BeatmapTransformer extends BeatmapCompactTransformer
             'passcount' => $beatmap->passcount,
             'playcount' => $beatmap->playcount,
             'ranked' => $beatmap->approved,
-            'status' => $beatmap->status(),
             'url' => route('beatmaps.show', ['beatmap' => $beatmap->beatmap_id]),
         ]);
     }

--- a/resources/assets/coffee/react/beatmapset-page/score-top.coffee
+++ b/resources/assets/coffee/react/beatmapset-page/score-top.coffee
@@ -4,9 +4,11 @@
 import FlagCountry from 'flag-country'
 import { route } from 'laroute'
 import Mod from 'mod'
+import PpValue from 'scores/pp-value'
 import * as React from 'react'
 import { a, div, span } from 'react-dom-factories'
 import ScoreboardTime from 'scoreboard-time'
+import { shouldShowPp } from 'utils/beatmap-helper'
 import { classWithModifiers } from 'utils/css'
 
 el = React.createElement
@@ -18,6 +20,7 @@ export ScoreTop = (props) ->
     .join ' '
 
   position = if props.position? then "##{props.position}" else '-'
+  showPp = shouldShowPp(props.score.beatmap)
 
   div className: "#{bn} #{topClasses}",
     a
@@ -106,11 +109,12 @@ export ScoreTop = (props) ->
             div className: "#{bn}__stat-value #{bn}__stat-value--smaller",
               osu.formatNumber(props.score.statistics.count_miss)
 
-          div className: "#{bn}__stat",
-            div className: "#{bn}__stat-header",
-              osu.trans 'beatmapsets.show.scoreboard.headers.pp'
-            div className: "#{bn}__stat-value #{bn}__stat-value--smaller",
-              _.round props.score.pp
+          if showPp
+            div className: "#{bn}__stat",
+              div className: "#{bn}__stat-header",
+                osu.trans 'beatmapsets.show.scoreboard.headers.pp'
+              div className: "#{bn}__stat-value #{bn}__stat-value--smaller",
+                el PpValue, score: props.score
 
           div className: "#{bn}__stat",
             div className: "#{bn}__stat-header",

--- a/resources/assets/coffee/react/beatmapset-page/scoreboard-table-row.coffee
+++ b/resources/assets/coffee/react/beatmapset-page/scoreboard-table-row.coffee
@@ -10,6 +10,7 @@ import * as React from 'react'
 import { a, div, span, tr, td } from 'react-dom-factories'
 import { hasMenu } from 'score-helper'
 import ScoreboardTime from 'scoreboard-time'
+import PpValue from 'scores/pp-value'
 el = React.createElement
 bn = 'beatmap-scoreboard-table'
 
@@ -82,9 +83,10 @@ export class ScoreboardTableRow extends React.PureComponent
         modifiers: ['zero'] if score.statistics.count_miss == 0
         osu.formatNumber(score.statistics.count_miss)
 
-      el @tdLink,
-        {}
-        round score.pp
+      if @props.showPp
+        el @tdLink,
+          {}
+          el PpValue, score: score
 
       el @tdLink,
         modifiers: ['time']

--- a/resources/assets/coffee/react/beatmapset-page/scoreboard-table.coffee
+++ b/resources/assets/coffee/react/beatmapset-page/scoreboard-table.coffee
@@ -5,6 +5,7 @@ import { ScoreboardTableRow } from './scoreboard-table-row'
 import * as React from 'react'
 import { a, div, table, tr, th, thead, tbody } from 'react-dom-factories'
 import { activeKeyDidChange, ContainerContext, KeyContext } from 'stateful-activation-context'
+import { shouldShowPp } from 'utils/beatmap-helper'
 el = React.createElement
 bn = 'beatmap-scoreboard-table'
 
@@ -19,6 +20,7 @@ export class ScoreboardTable extends React.PureComponent
 
   render: =>
     classMods = ['menu-active'] if @state.activeKey?
+    showPp = shouldShowPp(@props.beatmap)
 
     el ContainerContext.Provider,
       value:
@@ -39,7 +41,8 @@ export class ScoreboardTable extends React.PureComponent
               for stat in @props.hitTypeMapping
                 th key: stat[0], className: "#{bn}__header #{bn}__header--hitstat", stat[0]
               th className: "#{bn}__header #{bn}__header--miss", osu.trans('beatmapsets.show.scoreboard.headers.miss')
-              th className: "#{bn}__header #{bn}__header--pp", osu.trans('beatmapsets.show.scoreboard.headers.pp')
+              if showPp
+                th className: "#{bn}__header #{bn}__header--pp", osu.trans('beatmapsets.show.scoreboard.headers.pp')
               th className: "#{bn}__header #{bn}__header--time", osu.trans('beatmapsets.show.scoreboard.headers.time')
               th className: "#{bn}__header #{bn}__header--mods", osu.trans('beatmapsets.show.scoreboard.headers.mods')
               th className: "#{bn}__header #{bn}__header--popup-menu"
@@ -52,6 +55,7 @@ export class ScoreboardTable extends React.PureComponent
                 el ScoreboardTableRow,
                   activated: @state.activeKey == index
                   beatmap: @props.beatmap
+                  showPp: showPp
                   hitTypeMapping: @props.hitTypeMapping
                   index: index
                   score: score

--- a/resources/assets/less/bem/beatmap-score-top.less
+++ b/resources/assets/less/bem/beatmap-score-top.less
@@ -130,6 +130,10 @@
 
   &__user-box {
     flex: none;
+
+    @media @desktop {
+      margin-right: 10px;
+    }
   }
 
   &__username {
@@ -137,7 +141,6 @@
     font-weight: 700;
     margin-bottom: 2px;
     display: block;
-    margin-right: 10px;
     .link-inverted();
   }
 

--- a/resources/assets/lib/interfaces/beatmap-json.ts
+++ b/resources/assets/lib/interfaces/beatmap-json.ts
@@ -8,5 +8,6 @@ export default interface BeatmapJson {
   id: number;
   max_combo?: number;
   mode: GameMode;
+  status: string;
   version: string;
 }

--- a/resources/assets/lib/play-detail.coffee
+++ b/resources/assets/lib/play-detail.coffee
@@ -7,7 +7,8 @@ import { createElement as el, PureComponent } from 'react'
 import * as React from 'react'
 import { a, button, div, i, img, small, span } from 'react-dom-factories'
 import { hasMenu } from 'score-helper'
-import { getArtist, getTitle } from 'utils/beatmap-helper'
+import PpValue from 'scores/pp-value'
+import { getArtist, getTitle, shouldShowPp } from 'utils/beatmap-helper'
 
 osu = window.osu
 bn = 'play-detail'
@@ -28,6 +29,9 @@ export class PlayDetail extends PureComponent
     else
       blockClass += " #{bn}--highlightable"
     blockClass += " #{bn}--compact" if @state.compact
+
+    hasPp = score.beatmapset.status in ['ranked', 'approved']
+    validPp = hasPp && score.pp > 0
 
     div
       className: blockClass
@@ -87,19 +91,15 @@ export class PlayDetail extends PureComponent
 
         div
           className: "#{bn}__pp"
-          if score.pp > 0
-            span null,
-              osu.formatNumber(Math.round(score.pp))
-              span className: "#{bn}__pp-unit", 'pp'
+          if shouldShowPp(score.beatmapset)
+            el React.Fragment, null,
+              el PpValue, score: score
+              if score.pp? && score.pp > 0
+                span className: "#{bn}__pp-unit", 'pp'
           else
-            if score.beatmapset.status in ['ranked', 'approved']
-              span
-                className: 'fas fa-exclamation-triangle'
-                title: osu.trans('scores.status.processing')
-            else
-              span
-                title: osu.trans('users.show.extra.top_ranks.not_ranked')
-                '-'
+            span
+              title: osu.trans('users.show.extra.top_ranks.not_ranked')
+              '-'
 
         div
           className: "#{bn}__more"

--- a/resources/assets/lib/scores-show/stats.tsx
+++ b/resources/assets/lib/scores-show/stats.tsx
@@ -4,7 +4,9 @@
 import BeatmapJson from 'interfaces/beatmap-json';
 import ScoreJson from 'interfaces/score-json';
 import * as React from 'react';
+import PpValue from 'scores/pp-value';
 import { UserCard } from 'user-card';
+import { shouldShowPp } from 'utils/beatmap-helper';
 import { classWithModifiers } from 'utils/css';
 import { modeAttributesMap } from 'utils/score';
 
@@ -44,15 +46,13 @@ export default function Stats(props: Props) {
             </div>
           </div>
 
-          {props.score.pp != null && (
+          {shouldShowPp(props.beatmap) && (
             <div className='score-stats__stat'>
               <div className='score-stats__stat-row score-stats__stat-row--label'>
                 {osu.trans('beatmapsets.show.scoreboard.headers.pp')}
               </div>
               <div className='score-stats__stat-row'>
-                <span title={osu.formatNumber(props.score.pp)}>
-                  {osu.formatNumber(props.score.pp, 0)}
-                </span>
+                <PpValue score={props.score} />
               </div>
             </div>
           )}

--- a/resources/assets/lib/scores/pp-value.tsx
+++ b/resources/assets/lib/scores/pp-value.tsx
@@ -1,0 +1,26 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
+import ScoreJson from 'interfaces/score-json';
+import * as React from 'react';
+
+interface Props {
+  score: ScoreJson;
+}
+
+export default function PpValue(props: Props) {
+  if (props.score.pp == null || props.score.pp === 0) {
+    return (
+      <span
+        className='fas fa-exclamation-triangle'
+        title={osu.trans('scores.status.processing')}
+      />
+    );
+  }
+
+  return (
+    <span title={osu.formatNumber(props.score.pp)}>
+      {osu.formatNumber(Math.round(props.score.pp))}
+    </span>
+  );
+}

--- a/resources/assets/lib/utils/beatmap-helper.ts
+++ b/resources/assets/lib/utils/beatmap-helper.ts
@@ -97,6 +97,10 @@ export function group<T extends BeatmapJson>(beatmaps: T[]): Partial<Record<Game
   return grouped;
 }
 
+export function shouldShowPp(beatmap: BeatmapJson) {
+  return beatmap.status === 'ranked' || beatmap.status === 'approved';
+}
+
 export function sort<T extends BeatmapJson>(beatmaps: T[]): T[] {
   if (beatmaps.length === 0) {
     return [];

--- a/resources/docs/source/includes/_structures/beatmap.md
+++ b/resources/docs/source/includes/_structures/beatmap.md
@@ -24,5 +24,4 @@ mode_int       | integer                  | |
 passcount      | integer                  | |
 playcount      | integer                  | |
 ranked         | integer                  | See [Rank status](#beatmapsetcompact-rank-status) for list of possible values.
-status         | string                   | See [Rank status](#beatmapsetcompact-rank-status) for list of possible values.
 url            | string                   | |

--- a/resources/docs/source/includes/_structures/beatmap_compact.md
+++ b/resources/docs/source/includes/_structures/beatmap_compact.md
@@ -7,6 +7,7 @@ Field             | Type                  | Description
 difficulty_rating | float                 | |
 id                | integer               | |
 mode              | [GameMode](#gamemode) | |
+status            | string                | See [Rank status](#beatmapsetcompact-rank-status) for list of possible values.
 total_length      | integer               | |
 version           | string                | |
 


### PR DESCRIPTION
- no pp column for scores on non-ranked maps
- detailed pp value tooltip
- notice of score processing when value is 0 or null
- beatmap status in json always visible (moved to BeatmapCompactTransformer)

Continues off #7124.