### PR TITLE
User notification loading optimizations

### DIFF
--- a/app/Jobs/Notifications/BroadcastNotificationBase.php
+++ b/app/Jobs/Notifications/BroadcastNotificationBase.php
@@ -175,9 +175,13 @@ abstract class BroadcastNotificationBase implements ShouldQueue
 
             foreach ($deliverySettings as $userId => $delivery) {
                 $userNotification = $notification->userNotifications()->create([
-                    'delivery' => $delivery,
-                    'user_id' => $userId,
+                    'category' => $notification->category,
                     'created_at' => $timestamp,
+                    'delivery' => $delivery,
+                    'notifiable_type' => $notification->notifiable_type,
+                    'notifiable_id' => $notification->notifiable_id,
+                    'user_id' => $userId,
+
                 ]);
                 $userNotification->isPush() && $pushReceiverIds[] = $userId;
             }

--- a/app/Libraries/NotificationsBundle.php
+++ b/app/Libraries/NotificationsBundle.php
@@ -42,9 +42,9 @@ class NotificationsBundle
     public function toArray()
     {
         if ($this->objectId && $this->objectType && $this->category) {
-            $this->fillStacks($this->objectType, $this->objectId, $this->category);
+            $this->fillStack($this->objectType, $this->objectId, $this->category);
         } else {
-            $this->fillTypes($this->objectType);
+            $this->fillType($this->objectType);
         }
 
         $notifications = Notification::whereIn('id', $this->notificationIdsToFetch)->get();
@@ -63,7 +63,7 @@ class NotificationsBundle
         return $response;
     }
 
-    private function fillStacks(string $objectType, int $objectId, string $category)
+    private function fillStack(string $objectType, int $objectId, string $category)
     {
         $key = "{$objectType}-{$objectId}-{$category}";
 
@@ -107,7 +107,7 @@ class NotificationsBundle
         ];
     }
 
-    private function fillTypes(?string $type = null)
+    private function fillType(?string $type = null)
     {
         $heads = $this->getStackHeads($type);
         $batches = [];
@@ -132,7 +132,7 @@ class NotificationsBundle
                 ];
             } else {
                 // TODO: it's possible to union query these as well; it just looks really bad reading the query.
-                $this->fillStacks($head->notifiable_type, $head->notifiable_id, $head->category);
+                $this->fillStack($head->notifiable_type, $head->notifiable_id, $head->category);
             }
         }
 
@@ -169,7 +169,7 @@ class NotificationsBundle
 
         // when notifications for all types, fill in the cursor and totals for the other types.
         if ($type === null) {
-            $this->fillTypesWhenNull($cursor);
+            $this->fillTypeWhenNull($cursor);
         }
     }
 
@@ -215,7 +215,7 @@ class NotificationsBundle
         return $query->limit(static::STACK_LIMIT)->get();
     }
 
-    private function fillTypesWhenNull($cursor)
+    private function fillTypeWhenNull($cursor)
     {
         foreach (Notification::NOTIFIABLE_CLASSES as $class) {
             $type = MorphMap::getType($class);

--- a/app/Libraries/NotificationsBundle.php
+++ b/app/Libraries/NotificationsBundle.php
@@ -63,7 +63,7 @@ class NotificationsBundle
         return $response;
     }
 
-    private function fillStack(string $objectType, int $objectId, string $category)
+    private function fillStack(string $objectType, int $objectId, string $category, ?int $stackSize = null)
     {
         $key = "{$objectType}-{$objectId}-{$category}";
 
@@ -77,8 +77,8 @@ class NotificationsBundle
             $query->where('is_read', false);
         }
 
-        // get count before applying cursor.
-        $total = $query->count();
+        // use pre-fetched value; otherwise get count before applying cursor.
+        $total = $stackSize ?? $query->count();
 
         $query->orderBy('id', 'desc')->limit(static::PER_STACK_LIMIT);
 
@@ -132,7 +132,7 @@ class NotificationsBundle
                 ];
             } else {
                 // TODO: it's possible to union query these as well; it just looks really bad reading the query.
-                $this->fillStack($head->notifiable_type, $head->notifiable_id, $head->category);
+                $this->fillStack($head->notifiable_type, $head->notifiable_id, $head->category, $head->stack_size);
             }
         }
 

--- a/app/Libraries/NotificationsBundle.php
+++ b/app/Libraries/NotificationsBundle.php
@@ -143,7 +143,7 @@ class NotificationsBundle
             // need to group by all the where conditions for mysql to consider using the index;
             // for smaller sets, the analyzer may use a different index.
             // TODO: add migrations
-            ->groupBy('group_key', 'user_id', 'delivery')
+            ->groupBy('notifiable_type', 'notifiable_id', 'category', 'user_id', 'delivery')
             ->orderBy('max_id', 'DESC')
             ->select(DB::raw('MAX(notification_id) as max_id'));
 

--- a/app/Libraries/NotificationsBundle.php
+++ b/app/Libraries/NotificationsBundle.php
@@ -138,7 +138,8 @@ class NotificationsBundle
 
         foreach ($batches as $batchKey => $notifiableIds) {
             [$notifiableType, $category] = explode('-', $batchKey, 2);
-            $query = UserNotification::where('notifiable_type', $notifiableType)
+            $query = UserNotification::where('user_id', $this->user->getKey())
+                ->where('notifiable_type', $notifiableType)
                 ->whereIn('notifiable_id', $notifiableIds)
                 ->where('category', $category)
                 ->select('notification_id');

--- a/app/Libraries/NotificationsBundle.php
+++ b/app/Libraries/NotificationsBundle.php
@@ -228,25 +228,4 @@ class NotificationsBundle
             ];
         }
     }
-
-    private function stackToJson($stack)
-    {
-        $last = $stack->last();
-        if ($last === null) {
-            return;
-        }
-
-        $last = $last instanceof UserNotification ? $last->notification : $last;
-        $cursor = $stack->count() < static::PER_STACK_LIMIT ? null : [
-            'id' => $last->id,
-        ];
-
-        return [
-            'category' => $last->category,
-            'cursor' => $cursor,
-            'name' => $last->name,
-            'object_type' => $last->notifiable_type,
-            'object_id' => $last->notifiable_id,
-        ];
-    }
 }

--- a/app/Libraries/NotificationsBundle.php
+++ b/app/Libraries/NotificationsBundle.php
@@ -175,12 +175,10 @@ class NotificationsBundle
 
     private function getTotalNotificationCount(?string $type = null)
     {
-        $query = Notification::whereHas('userNotifications', function ($q) {
-            $q->hasPushDelivery()->where('user_id', $this->user->getKey());
-            if ($this->unreadOnly) {
-                $q->where('is_read', false);
-            }
-        });
+        $query = UserNotification::hasPushDelivery()->where('user_id', $this->user->getKey());
+        if ($this->unreadOnly) {
+            $query->where('is_read', false);
+        }
 
         if ($type !== null) {
             $query->where('notifiable_type', $type);

--- a/app/Libraries/NotificationsBundle.php
+++ b/app/Libraries/NotificationsBundle.php
@@ -193,15 +193,12 @@ class NotificationsBundle
         $query = $this->user
             ->userNotifications()
             ->hasPushDelivery()
-            // need to group by all the where conditions for mysql to consider using the index;
-            // for smaller sets, the analyzer may use a different index.
-            // TODO: add migrations
-            ->groupBy('notifiable_type', 'notifiable_id', 'category', 'user_id', 'delivery')
+            ->groupBy('notifiable_type', 'notifiable_id', 'category')
             ->orderBy('max_id', 'DESC')
             ->select(DB::raw('MAX(notification_id) as max_id'), DB::raw('COUNT(*) as stack_size'), 'notifiable_type', 'notifiable_id', 'category');
 
         if ($this->unreadOnly) {
-            $query->where('is_read', false)->groupBy('is_read');
+            $query->where('is_read', false);
         }
 
         if ($type !== null) {

--- a/app/Models/Notification.php
+++ b/app/Models/Notification.php
@@ -128,6 +128,11 @@ class Notification extends Model
         return static::NAME_TO_CATEGORY[$this->name] ?? $this->name;
     }
 
+    public function getStackKey()
+    {
+        return "{$this->notifiable_type}-{$this->notifiable_id}-{$this->name}";
+    }
+
     public function notifiable()
     {
         return $this->morphTo();

--- a/app/Models/Notification.php
+++ b/app/Models/Notification.php
@@ -130,7 +130,7 @@ class Notification extends Model
 
     public function getStackKey()
     {
-        return "{$this->notifiable_type}-{$this->notifiable_id}-{$this->name}";
+        return "{$this->notifiable_type}-{$this->notifiable_id}-{$this->category}";
     }
 
     public function notifiable()

--- a/database/migrations/2021_01_29_100738_add_notification_grouping_to_user_notifications.php
+++ b/database/migrations/2021_01_29_100738_add_notification_grouping_to_user_notifications.php
@@ -1,0 +1,57 @@
+<?php
+
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
+use App\Models\Notification;
+use App\Models\UserNotification;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddNotificationGroupingToUserNotifications extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('user_notifications', function (Blueprint $table) {
+            $table->string('notifiable_type', 255)->nullable();
+            $table->unsignedBigInteger('notifiable_id')->nullable();
+            $table->string('category', 255)->nullable();
+            $table->index(['user_id', 'notifiable_type', 'notifiable_id', 'category'], 'user_notification_group_lookup');
+        });
+
+        // duplicate grouping; temporary assign name to category.
+        DB::statement('UPDATE user_notifications u JOIN notifications n on n.id = u.notification_id set u.notifiable_type = n.notifiable_type, u.notifiable_id = n.notifiable_id, u.category = n.name');
+
+        // remap name to category.
+        foreach (Notification::NAME_TO_CATEGORY as $name => $category) {
+            UserNotification::where(['category' => $name])->update(['category' => $category]);
+        }
+
+        Schema::table('user_notifications', function (Blueprint $table) {
+            $table->string('notifiable_type', 255)->nullable(false)->change();
+            $table->unsignedBigInteger('notifiable_id')->nullable(false)->change();
+            $table->string('category', 255)->nullable(false)->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('user_notifications', function (Blueprint $table) {
+            $table->dropIndex('user_notification_group_lookup');
+            $table->dropColumn('notifiable_type');
+            $table->dropColumn('notifiable_id');
+            $table->dropColumn('category');
+        });
+    }
+}

--- a/resources/assets/lib/interfaces/notification-json.ts
+++ b/resources/assets/lib/interfaces/notification-json.ts
@@ -27,7 +27,6 @@ export interface NotificationBundleJson {
 export interface NotificationStackJson extends NotificationIdentityJson {
   category: string;
   cursor: NotificationCursor | null;
-  name: string;
   object_id: number;
   object_type: Name;
   total: number;

--- a/resources/assets/lib/models/notification-stack.ts
+++ b/resources/assets/lib/models/notification-stack.ts
@@ -5,7 +5,6 @@ import { NotificationStackJson } from 'interfaces/notification-json';
 import { action, computed, observable } from 'mobx';
 import Notification from 'models/notification';
 import { Name } from 'models/notification-type';
-import { categoryFromName } from 'notification-maps/category';
 import { NotificationContextData } from 'notifications-context';
 import { NotificationCursor } from 'notifications/notification-cursor';
 import NotificationDeletable from 'notifications/notification-deletable';
@@ -86,7 +85,7 @@ export default class NotificationStack implements NotificationReadable, Notifica
   ) {}
 
   static fromJson(json: NotificationStackJson, resolver: NotificationResolver) {
-    const obj = new NotificationStack(json.object_id, json.object_type, categoryFromName(json.name), resolver);
+    const obj = new NotificationStack(json.object_id, json.object_type, json.category, resolver);
     obj.updateWithJson(json);
     return obj;
   }
@@ -154,5 +153,5 @@ export default class NotificationStack implements NotificationReadable, Notifica
 }
 
 export function idFromJson(json: NotificationStackJson) {
-  return `${json.object_type}-${json.object_id}-${categoryFromName(json.name)}`;
+  return `${json.object_type}-${json.object_id}-${json.category}`;
 }

--- a/tests/Models/UserNotificationTest.php
+++ b/tests/Models/UserNotificationTest.php
@@ -20,15 +20,8 @@ class UserNotificationTest extends TestCase
         $notificationA = factory(Notification::class)->create();
         $notificationB = factory(Notification::class)->create();
 
-        $userNotificationA = factory(UserNotification::class)->create([
-            'notification_id' => $notificationA->getKey(),
-            'user_id' => $user->getKey(),
-        ]);
-
-        $userNotificationB = factory(UserNotification::class)->create([
-            'notification_id' => $notificationB->getKey(),
-            'user_id' => $user->getKey(),
-        ]);
+        $userNotificationA = $this->createUserNotification($user, $notificationA);
+        $userNotificationB = $this->createUserNotification($user, $notificationB);
 
         $initialUserNotificationCount = UserNotification::count();
 
@@ -63,20 +56,9 @@ class UserNotificationTest extends TestCase
             'notifiable_type' => $notificationA->notifiable_type,
         ]);
 
-        $userNotificationA = factory(UserNotification::class)->create([
-            'notification_id' => $notificationA->getKey(),
-            'user_id' => $user->getKey(),
-        ]);
-
-        $userNotificationB = factory(UserNotification::class)->create([
-            'notification_id' => $notificationB->getKey(),
-            'user_id' => $user->getKey(),
-        ]);
-
-        $userNotificationC = factory(UserNotification::class)->create([
-            'notification_id' => $notificationC->getKey(),
-            'user_id' => $user->getKey(),
-        ]);
+        $userNotificationA = $this->createUserNotification($user, $notificationA);
+        $userNotificationB = $this->createUserNotification($user, $notificationB);
+        $userNotificationC = $this->createUserNotification($user, $notificationC);
 
         $initialUserNotificationCount = UserNotification::count();
 
@@ -113,20 +95,9 @@ class UserNotificationTest extends TestCase
             'notifiable_type' => 'news_post',
         ]);
 
-        $userNotificationA = factory(UserNotification::class)->create([
-            'notification_id' => $notificationA->getKey(),
-            'user_id' => $user->getKey(),
-        ]);
-
-        $userNotificationB = factory(UserNotification::class)->create([
-            'notification_id' => $notificationB->getKey(),
-            'user_id' => $user->getKey(),
-        ]);
-
-        $userNotificationC = factory(UserNotification::class)->create([
-            'notification_id' => $notificationC->getKey(),
-            'user_id' => $user->getKey(),
-        ]);
+        $userNotificationA = $this->createUserNotification($user, $notificationA);
+        $userNotificationB = $this->createUserNotification($user, $notificationB);
+        $userNotificationC = $this->createUserNotification($user, $notificationC);
 
         $initialUserNotificationCount = UserNotification::count();
 
@@ -164,7 +135,10 @@ class UserNotificationTest extends TestCase
 
         for ($i = 0; $i < $max; $i++) {
             UserNotification::create([
+                'category' => 'ignored',
                 'delivery' => $i,
+                'notifiable_id' => 1,
+                'notifiable_type' => 'ignored',
                 'notification_id' => 1,
                 'user_id' => $i,
             ]);
@@ -193,5 +167,16 @@ class UserNotificationTest extends TestCase
             [3, 'mail', true],
             [3, 'push', true],
         ];
+    }
+
+    private function createUserNotification(User $user, Notification $notification)
+    {
+        return factory(UserNotification::class)->create([
+            'category' => $notification->category,
+            'notifiable_id' => $notification->notifiable_id,
+            'notifiable_type' => $notification->notifiable_type,
+            'notification_id' => $notification->getKey(),
+            'user_id' => $user->getKey(),
+        ]);
     }
 }


### PR DESCRIPTION
This tries to optimize user notification loading:
- the grouping fields from `notifications` are duplicated to `user_notifications` to make querying them simpler and avoid combining `group by` with a dependent query; 
- `user_notifications` uses `category` instead of `name` since that's what the notifications are grouped by;
- try to reduce the number of queries used to load notifications; currently, each notification stack uses multiple separate queries to get the various pieces of data needed; due to pagination and count displays, it's not practical to have an index for every query combination, not to mention `count` ends up requiring some sort of scan, anyway.
- if a notification stack is smaller than the page size, the order they're returned in doesn't matter since there's no pagination to deal with; these can be batched together in the same query.

There are some combination of indices that help with the `group by` queries, but the need to support ordering for  pagination and counts end up making them useless; instead, we just amortize the cost of getting the stack size together with it.

Some empirical differences when loading the notifications page:
Before:
![image](https://user-images.githubusercontent.com/1694544/106280992-f7a4ad80-6281-11eb-861c-e7f11bb9ca03.png)

After:
![image](https://user-images.githubusercontent.com/1694544/106280755-abf20400-6281-11eb-96e8-fa4ccb972678.png)
