### PR TITLE
Validate score best_id

### DIFF
--- a/app/Transformers/ScoreTransformer.php
+++ b/app/Transformers/ScoreTransformer.php
@@ -26,7 +26,6 @@ class ScoreTransformer extends TransformerAbstract
     {
         $ret = [
             'id' => $score->score_id,
-            'best_id' => $score->best_id,
             'user_id' => $score->user_id,
             'accuracy' => $score->accuracy(),
             'mods' => $score->enabled_mods,
@@ -41,11 +40,20 @@ class ScoreTransformer extends TransformerAbstract
                 'count_katu' => $score->countkatu,
                 'count_miss' => $score->countmiss,
             ],
-            'pp' => $score instanceof ScoreBest ? $score->pp : optional($score->best)->pp,
             // ranks are hardcoded to "0" for game_scores atm (i.e. scores from a mp game), return null instead for now
             'rank' => $score->rank === '0' ? null : $score->rank,
             'created_at' => json_time($score->date),
         ];
+
+        $best = $score instanceof ScoreBest ? $score : $score->best;
+
+        if ($best === null) {
+            $ret['best_id'] = null;
+            $ret['pp'] = null;
+        } else {
+            $ret['best_id'] = $best->getKey();
+            $ret['pp'] = $best->pp;
+        }
 
         if ($score instanceof ScoreModel) {
             $ret['mode'] = $score->getMode();


### PR DESCRIPTION
`->best` is already assumed loaded so always use it instead of relying on potentially outdated `high_score_id`.

Resolves #7137. Also removes link to nonexistent score (when it's not high score anymore).