### PR TITLE
Better error message when exceeding download limit

### DIFF
--- a/app/Http/Controllers/BeatmapsetsController.php
+++ b/app/Http/Controllers/BeatmapsetsController.php
@@ -166,7 +166,7 @@ class BeatmapsetsController extends Controller
             ->count();
 
         if ($recentlyDownloaded > Auth::user()->beatmapsetDownloadAllowance()) {
-            abort(403);
+            abort(429, trans('beatmapsets.download.limit_exceeded'));
         }
 
         $noVideo = get_bool(Request::input('noVideo', false));

--- a/resources/lang/en/beatmapsets.php
+++ b/resources/lang/en/beatmapsets.php
@@ -11,6 +11,10 @@ return [
         'rule_violation' => 'Some assets contained within this map have been removed after being judged as not being suitable for use in osu!.',
     ],
 
+    'download' => [
+        'limit_exceeded' => 'Slow down, play more.',
+    ],
+
     'index' => [
         'title' => 'Beatmaps Listing',
         'guest_title' => 'Beatmaps',

--- a/resources/lang/en/layout.php
+++ b/resources/lang/en/layout.php
@@ -159,6 +159,10 @@ return [
             'error' => 'Invalid request parameter',
             'description' => '',
         ],
+        '429' => [
+            'error' => 'Rate limit exceeded',
+            'description' => '',
+        ],
         '500' => [
             'error' => 'Oh no! Something broke! ;_;',
             'description' => "We're automatically notified of every error.",

--- a/resources/lang/en/page_title.php
+++ b/resources/lang/en/page_title.php
@@ -22,6 +22,7 @@ return [
             '401-verification' => 'account verification',
             '405' => 'missing',
             '422' => 'invalid request',
+            '429' => 'too many requests',
             '500' => 'something broke',
             '503' => 'maintenance',
         ],


### PR DESCRIPTION
Things get a bit weird because of how redirect for `GET` is handled ಠ_ಠ

The wordings can be improved.

Resolves #3634.