### PR TITLE
Don't percent decode url for media proxy

### DIFF
--- a/app/helpers.php
+++ b/app/helpers.php
@@ -950,7 +950,7 @@ function proxy_media($url)
         $url = config('app.url').$url;
     }
 
-    $decoded = urldecode(html_entity_decode_better($url));
+    $decoded = html_entity_decode_better($url);
 
     if (config('osu.camo.key') === null) {
         return $decoded;

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -941,6 +941,12 @@ function concat_path($paths)
 
 function proxy_media($url)
 {
+    $url = html_entity_decode_better($url);
+
+    if (config('osu.camo.key') === null) {
+        return $url;
+    }
+
     // turn relative urls into absolute urls
     if (!preg_match('/^https?\:\/\//', $url)) {
         // ensure url is relative to the site root
@@ -950,21 +956,15 @@ function proxy_media($url)
         $url = config('app.url').$url;
     }
 
-    $decoded = html_entity_decode_better($url);
-
-    if (config('osu.camo.key') === null) {
-        return $decoded;
-    }
-
-    $isProxied = starts_with($decoded, config('osu.camo.prefix'));
+    $isProxied = starts_with($url, config('osu.camo.prefix'));
     if ($isProxied) {
-        return $decoded;
+        return $url;
     }
 
-    $url = bin2hex($decoded);
-    $secret = hash_hmac('sha1', $decoded, config('osu.camo.key'));
+    $hexUrl = bin2hex($url);
+    $secret = hash_hmac('sha1', $url, config('osu.camo.key'));
 
-    return config('osu.camo.prefix')."{$secret}/{$url}";
+    return config('osu.camo.prefix')."{$secret}/{$hexUrl}";
 }
 
 function lazy_load_image($url, $class = '', $alt = '')

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -941,6 +941,10 @@ function concat_path($paths)
 
 function proxy_media($url)
 {
+    if (!present($url)) {
+        return '';
+    }
+
     $url = html_entity_decode_better($url);
 
     if (config('osu.camo.key') === null) {

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -947,6 +947,12 @@ function proxy_media($url)
         return $url;
     }
 
+    $isProxied = starts_with($url, config('osu.camo.prefix'));
+
+    if ($isProxied) {
+        return $url;
+    }
+
     // turn relative urls into absolute urls
     if (!preg_match('/^https?\:\/\//', $url)) {
         // ensure url is relative to the site root
@@ -956,10 +962,6 @@ function proxy_media($url)
         $url = config('app.url').$url;
     }
 
-    $isProxied = starts_with($url, config('osu.camo.prefix'));
-    if ($isProxied) {
-        return $url;
-    }
 
     $hexUrl = bin2hex($url);
     $secret = hash_hmac('sha1', $url, config('osu.camo.key'));


### PR DESCRIPTION
If anything, url passed to camo should be percent-encoded. Especially the query strings.

Resolves #7155.

Also adjusted timing of various other checks.