### PR TITLE
Adjust padding of tournament description area

### DIFF
--- a/resources/assets/less/bem/tournament.less
+++ b/resources/assets/less/bem/tournament.less
@@ -54,6 +54,8 @@
   &__page {
     background-color: @osu-colour-b4;
     .default-box-shadow();
-    padding: 20px;
+    .default-gutter-v2();
+    padding-top: 20px;
+    padding-bottom: $padding-top;
   }
 }


### PR DESCRIPTION
That was weird. Also the body is somehow already using correct padding.