### PR TITLE
Fix score pp display check on mixed state beatmap

### DIFF
--- a/resources/assets/lib/play-detail.coffee
+++ b/resources/assets/lib/play-detail.coffee
@@ -91,7 +91,7 @@ export class PlayDetail extends PureComponent
 
         div
           className: "#{bn}__pp"
-          if shouldShowPp(score.beatmapset)
+          if shouldShowPp(score.beatmap)
             el React.Fragment, null,
               el PpValue,
                 score: score


### PR DESCRIPTION
Should always check beatmap instead of beatmapset.

Resolves #7163.