### PR TITLE
Move notifications endpoint

### DIFF
--- a/app/Libraries/RouteSection.php
+++ b/app/Libraries/RouteSection.php
@@ -136,7 +136,7 @@ class RouteSection
 
     public function getCurrent($key = null)
     {
-        $data = request()->attributes->get('route_section_error') ?? $this->getDefault();
+        $data = request()->attributes->get('route_section_error') ?? $this->getOriginal();
 
         if ($key === null) {
             return $data;
@@ -145,17 +145,7 @@ class RouteSection
         return $data[$key];
     }
 
-    public function setError($statusCode)
-    {
-        request()->attributes->set('route_section_error', [
-            'action' => $statusCode,
-            'controller' => 'error',
-            'namespace' => 'error',
-            'section' => 'error',
-        ]);
-    }
-
-    private function getDefault()
+    public function getOriginal()
     {
         $default = request()->attributes->get('route_section');
 
@@ -190,5 +180,15 @@ class RouteSection
         }
 
         return $default;
+    }
+
+    public function setError($statusCode)
+    {
+        request()->attributes->set('route_section_error', [
+            'action' => $statusCode,
+            'controller' => 'error',
+            'namespace' => 'error',
+            'section' => 'error',
+        ]);
     }
 }

--- a/app/Libraries/UserVerification.php
+++ b/app/Libraries/UserVerification.php
@@ -57,8 +57,11 @@ class UserVerification
 
         // Workaround race condition causing $this->issue() to be called in parallel.
         // Mainly observed when logging in as privileged user.
-        if ($this->request->ajax() && $this->request->getMethod() === 'GET' && $this->request->is('home/notifications')) {
-            return response(['error' => 'verification'], $statusCode);
+        if ($this->request->ajax()) {
+            $routeData = app('route-section')->getOriginal();
+            if ($routeData['controller'] === 'notifications_controller' && $routeData['action'] === 'index') {
+                return response(['error' => 'verification'], $statusCode);
+            }
         }
 
         $email = $this->user->user_email;

--- a/routes/web.php
+++ b/routes/web.php
@@ -225,10 +225,6 @@ Route::group(['middleware' => ['web']], function () {
         Route::resource('blocks', 'BlocksController', ['only' => ['store', 'destroy']]);
         Route::resource('friends', 'FriendsController', ['only' => ['index', 'store', 'destroy']]);
         Route::resource('news', 'NewsController', ['only' => ['index', 'show', 'store', 'update']]);
-        Route::resource('notifications', 'NotificationsController', ['only' => ['index']]);
-        Route::get('notifications/endpoint', 'NotificationsController@endpoint')->name('notifications.endpoint');
-        Route::post('notifications/mark-read', 'NotificationsController@markRead')->name('notifications.mark-read');
-        Route::delete('notifications', 'NotificationsController@batchDestroy');
 
         Route::get('messages/users/{user}', 'HomeController@messageUser')->name('messages.users.show');
 
@@ -236,6 +232,11 @@ Route::group(['middleware' => ['web']], function () {
         Route::get('follows/{subtype?}', 'FollowsController@index')->name('follows.index');
         Route::delete('follows', 'FollowsController@destroy')->name('follows.destroy');
     });
+
+    Route::resource('notifications', 'NotificationsController', ['only' => ['index']]);
+    Route::get('notifications/endpoint', 'NotificationsController@endpoint')->name('notifications.endpoint');
+    Route::post('notifications/mark-read', 'NotificationsController@markRead')->name('notifications.mark-read');
+    Route::delete('notifications', 'NotificationsController@batchDestroy');
 
     Route::get('legal/{locale?}/{path?}', 'LegalController@show')->name('legal');
     Route::put('legal/{locale}/{path}', 'LegalController@update');


### PR DESCRIPTION
Avoids old sessions from retrying with invalid sessions and just generally better without `/home` prefix.