### PR TITLE
Fix multiplayer allowed mods check failing

### DIFF
--- a/app/Models/Multiplayer/Score.php
+++ b/app/Models/Multiplayer/Score.php
@@ -131,6 +131,7 @@ class Score extends Model
         if (!empty($this->playlistItem->allowed_mods)) {
             $missingMods = array_diff(
                 array_column($this->mods, 'acronym'),
+                array_column($this->playlistItem->required_mods, 'acronym'),
                 array_column($this->playlistItem->allowed_mods, 'acronym')
             );
 


### PR DESCRIPTION
The user's mods list contains both the required mods and the allowed mods they selected.
```
allowed_mods = HR
required_mods = DT

mods = [DT, HR]
```
Please advise if there are tests to be updated here or if this is improper code style w.r.t. performance and all that :).