### PR TITLE
Support null output for empty transforms

### DIFF
--- a/app/Libraries/Transformers/Scope.php
+++ b/app/Libraries/Transformers/Scope.php
@@ -23,7 +23,13 @@ class Scope extends Fractal\Scope
             }
         }
 
-        return parent::fireTransformer($transformer, $data);
+        [$transformedData, $includedData] = parent::fireTransformer($transformer, $data);
+
+        if (empty($transformedData) && empty($includedData)) {
+            return [null, []];
+        }
+
+        return [$transformedData, $includedData];
     }
 
     protected function serializeResource(SerializerAbstract $serializer, $data)

--- a/resources/assets/coffee/react/modding-profile/header.coffee
+++ b/resources/assets/coffee/react/modding-profile/header.coffee
@@ -43,7 +43,7 @@ export class Header extends React.Component
 
 
   renderTournamentBanner: ({modifiers} = {}) =>
-    return if !@props.user.active_tournament_banner.id?
+    return if !@props.user.active_tournament_banner?.id?
 
     a
       href: laroute.route('tournaments.show', tournament: @props.user.active_tournament_banner.tournament_id)

--- a/resources/assets/coffee/react/profile-page/header.coffee
+++ b/resources/assets/coffee/react/profile-page/header.coffee
@@ -120,7 +120,7 @@ export class Header extends React.Component
 
 
   renderTournamentBanner: ({modifiers} = {}) =>
-    return if !@props.user.active_tournament_banner.id?
+    return if !@props.user.active_tournament_banner?.id?
 
     a
       href: laroute.route('tournaments.show', tournament: @props.user.active_tournament_banner.tournament_id)

--- a/resources/docs/source/includes/_structures/user.md
+++ b/resources/docs/source/includes/_structures/user.md
@@ -56,7 +56,7 @@
     "id": null
   },
   "account_history": [],
-  "active_tournament_banner": [],
+  "active_tournament_banner": null,
   "badges": [
     {
       "awarded_at": "2015-01-01T00:00:00+00:00",


### PR DESCRIPTION
Returns `null` instead of `[]` if the transformer and its includes are empty. This is an issue with the `UserStatisticsRulesetsTransformer` if there are no statistics since empty arrays get serialized as `[]`

Serializing empty `stdClass` results in proper empty object `{}`, however, the transformer library used can't handle anything but array which would require a lot more stuff to be reimplemented.

I don't think there's any case where the main transformer returns a non-associative array with values, so an option shouldn't be necessary.