### PR TITLE
Add `expired` property to multiplayer playlist items

### DIFF
--- a/app/Http/Controllers/Multiplayer/Rooms/Playlist/ScoresController.php
+++ b/app/Http/Controllers/Multiplayer/Rooms/Playlist/ScoresController.php
@@ -193,6 +193,8 @@ class ScoresController extends BaseController
             ->where('id', $playlistId)
             ->firstOrFail();
 
+        abort_if($playlistItem->expired, 422, 'expired playlist item');
+
         $roomScore = $playlistItem->scores()
             ->where('user_id', auth()->user()->getKey())
             ->where('id', $scoreId)

--- a/app/Http/Controllers/Multiplayer/Rooms/Playlist/ScoresController.php
+++ b/app/Http/Controllers/Multiplayer/Rooms/Playlist/ScoresController.php
@@ -193,8 +193,6 @@ class ScoresController extends BaseController
             ->where('id', $playlistId)
             ->firstOrFail();
 
-        abort_if($playlistItem->expired, 422, 'expired playlist item');
-
         $roomScore = $playlistItem->scores()
             ->where('user_id', auth()->user()->getKey())
             ->where('id', $scoreId)

--- a/app/Models/Multiplayer/PlaylistItem.php
+++ b/app/Models/Multiplayer/PlaylistItem.php
@@ -24,6 +24,7 @@ use App\Models\Model;
  * @property int|null $ruleset_id
  * @property \Illuminate\Database\Eloquent\Collection $scores Score
  * @property \Carbon\Carbon|null $updated_at
+ * @property bool expired
  */
 class PlaylistItem extends Model
 {

--- a/app/Models/Multiplayer/Room.php
+++ b/app/Models/Multiplayer/Room.php
@@ -355,5 +355,9 @@ class Room extends Model
                 throw new InvariantException('You have reached the maximum number of tries allowed.');
             }
         }
+
+        if ($playlistItem->expired) {
+            throw new InvariantException('Cannot play an expired playlist item.');
+        }
     }
 }

--- a/app/Transformers/Multiplayer/PlaylistItemTransformer.php
+++ b/app/Transformers/Multiplayer/PlaylistItemTransformer.php
@@ -24,6 +24,7 @@ class PlaylistItemTransformer extends TransformerAbstract
             'ruleset_id' => $item->ruleset_id,
             'allowed_mods' => $item->allowed_mods,
             'required_mods' => $item->required_mods,
+            'expired' => $item->expired,
         ];
     }
 

--- a/database/migrations/2021_02_17_073637_add-expired-column-to-playlist-items.php
+++ b/database/migrations/2021_02_17_073637_add-expired-column-to-playlist-items.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2021_02_17_073637_add-expired-column-to-playlist-items.php
+++ b/database/migrations/2021_02_17_073637_add-expired-column-to-playlist-items.php
@@ -16,8 +16,7 @@ class AddExpiredColumnToPlaylistItems extends Migration
      */
     public function up()
     {
-        Schema::table('multiplayer_playlist_items', function (Blueprint $table)
-        {
+        Schema::table('multiplayer_playlist_items', function (Blueprint $table) {
             $table->boolean('expired')->default(false);
         });
     }
@@ -29,8 +28,7 @@ class AddExpiredColumnToPlaylistItems extends Migration
      */
     public function down()
     {
-        Schema::table('multiplayer_playlist_items', function (Blueprint $table)
-        {
+        Schema::table('multiplayer_playlist_items', function (Blueprint $table) {
             $table->dropColumn('expired');
         });
     }

--- a/database/migrations/2021_02_17_073637_add-expired-column-to-playlist-items.php
+++ b/database/migrations/2021_02_17_073637_add-expired-column-to-playlist-items.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddExpiredColumnToPlaylistItems extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('multiplayer_playlist_items', function (Blueprint $table)
+        {
+            $table->boolean('expired')->default(false);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('multiplayer_playlist_items', function (Blueprint $table)
+        {
+            $table->dropColumn('expired');
+        });
+    }
+}


### PR DESCRIPTION
I was debating whether to name this `played` or `expired`, but picked `expired` in the end as it could be used for more than multiplayer. For example if a host is ever to be able to "delete" playlist items then we could also set `expired = 1` in that case and preserve scores/etc. Whether such functionality should exist or not is a different question altogether, but I hope the example demonstrates why I didn't want to tie this property down to _just_ the playlist item having been "played" in multiplayer.