### PR TITLE
Remove redundant rank data

### DIFF
--- a/app/Http/Controllers/FriendsController.php
+++ b/app/Http/Controllers/FriendsController.php
@@ -8,6 +8,7 @@ namespace App\Http\Controllers;
 use App\Jobs\UpdateUserFollowerCountCache;
 use App\Models\User;
 use App\Models\UserRelation;
+use App\Transformers\UserCompactTransformer;
 use Auth;
 use Request;
 
@@ -31,20 +32,22 @@ class FriendsController extends Controller
 
     public function index()
     {
-        $currentUser = Auth::user();
-        $currentMode = studly_case($currentUser->playmode);
+        $currentUser = auth()->user();
+        $currentMode = default_mode();
 
         $friends = $currentUser
             ->friends()
-            ->with('statistics'.$currentMode)
+            ->with('statistics'.studly_case($currentMode))
             ->eagerloadForListing()
             ->orderBy('username', 'asc')
             ->get();
 
-        $usersJson = json_collection($friends, 'UserCompact', [
+        $transformer = new UserCompactTransformer();
+        $transformer->mode = $currentMode;
+        $usersJson = json_collection($friends, $transformer, [
             'cover',
             'country',
-            'current_mode_rank',
+            'statistics',
             'groups',
             'support_level',
         ]);

--- a/app/Http/Controllers/GroupsController.php
+++ b/app/Http/Controllers/GroupsController.php
@@ -6,27 +6,30 @@
 namespace App\Http\Controllers;
 
 use App\Models\Group;
+use App\Transformers\UserCompactTransformer;
 
 class GroupsController extends Controller
 {
     public function show($id)
     {
         $group = Group::visible()->findOrFail($id);
-        $currentMode = studly_case(default_mode());
+        $currentMode = default_mode();
 
         $users = $group->users()
-            ->with('statistics'.$currentMode)
+            ->with('statistics'.studly_case($currentMode))
             ->eagerloadForListing()
             ->default()
             ->orderBy('username', 'asc')
             ->get();
 
         $groupJson = $group->only('group_name', 'group_desc', 'has_playmodes');
-        $usersJson = json_collection($users, 'UserCompact', [
-            'cover',
+        $transformer = new UserCompactTransformer();
+        $transformer->mode = $currentMode;
+        $usersJson = json_collection($users, $transformer, [
             'country',
-            'current_mode_rank',
+            'cover',
             'groups',
+            'statistics',
             'support_level',
         ]);
 

--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -530,6 +530,7 @@ class UsersController extends Controller
             'scores_first_count',
             'scores_recent_count',
             'statistics',
+            'statistics.country_rank',
             'statistics.rank',
             'statistics.variants',
             'support_level',

--- a/app/Libraries/ModdingHistoryEventsBundle.php
+++ b/app/Libraries/ModdingHistoryEventsBundle.php
@@ -152,6 +152,7 @@ class ModdingHistoryEventsBundle
                         'previous_usernames',
                         'ranked_and_approved_beatmapset_count',
                         'statistics',
+                        'statistics.country_rank',
                         'statistics.rank',
                         'support_level',
                         'unranked_beatmapset_count',

--- a/app/Models/UserStatistics/Model.php
+++ b/app/Models/UserStatistics/Model.php
@@ -10,6 +10,7 @@ use App\Models\Beatmap;
 use App\Models\Model as BaseModel;
 use App\Models\Score\Best;
 use App\Models\User;
+use App\Traits\Memoizes;
 
 /**
  * @property mixed $country_acronym
@@ -17,6 +18,8 @@ use App\Models\User;
  */
 abstract class Model extends BaseModel
 {
+    use Memoizes;
+
     protected $primaryKey = 'user_id';
 
     public $timestamps = false;
@@ -148,24 +151,26 @@ abstract class Model extends BaseModel
 
     public function countryRank()
     {
-        if (!$this->isRanked()) {
-            return;
-        }
+        return $this->memoize(__FUNCTION__, function () {
+            if (!$this->isRanked()) {
+                return;
+            }
 
-        if ($this->country_acronym === null) {
-            return;
-        }
+            if ($this->country_acronym === null) {
+                return;
+            }
 
-        // Using $this->rank_score isn't accurate because it's a float value.
-        // Hence the raw sql query.
-        // There's this alternative
-        //   rank_score_index < $this->rank_score_index AND rank_score_index > 0 AND rank_score > 0
-        // but it is slower.
-        return static::where('country_acronym', $this->country_acronym)
-            ->where('rank_score', '>', function ($q) {
-                $q->from($this->table)->where('user_id', $this->user_id)->select('rank_score');
-            })
-            ->count() + 1;
+            // Using $this->rank_score isn't accurate because it's a float value.
+            // Hence the raw sql query.
+            // There's this alternative
+            //   rank_score_index < $this->rank_score_index AND rank_score_index > 0 AND rank_score > 0
+            // but it is slower.
+            return static::where('country_acronym', $this->country_acronym)
+                ->where('rank_score', '>', function ($q) {
+                    $q->from($this->table)->where('user_id', $this->user_id)->select('rank_score');
+                })
+                ->count() + 1;
+        });
     }
 
     public function globalRank()

--- a/app/Transformers/UserCompactTransformer.php
+++ b/app/Transformers/UserCompactTransformer.php
@@ -34,7 +34,6 @@ class UserCompactTransformer extends TransformerAbstract
         'blocks',
         'country',
         'cover',
-        'current_mode_rank',
         'favourite_beatmapset_count',
         'follow_user_mapping',
         'follower_count',
@@ -165,13 +164,6 @@ class UserCompactTransformer extends TransformerAbstract
             'url' => $profileCustomization->cover()->url(),
             'id' => $profileCustomization->cover()->id(),
         ]);
-    }
-
-    public function includeCurrentModeRank(User $user)
-    {
-        $currentModeStatistics = $user->statistics(auth()->user()->playmode ?? 'osu');
-
-        return $this->primitive($currentModeStatistics ? $currentModeStatistics->globalRank() : null);
     }
 
     public function includeFavouriteBeatmapsetCount(User $user)

--- a/app/Transformers/UserStatisticsTransformer.php
+++ b/app/Transformers/UserStatisticsTransformer.php
@@ -30,7 +30,6 @@ class UserStatisticsTransformer extends TransformerAbstract
 
             'global_rank' => $stats->globalRank(),
             'pp' => $stats->rank_score,
-            'pp_rank' => $stats->rank_score_index,
             'ranked_score' => $stats->ranked_score,
             'hit_accuracy' => $stats->hit_accuracy,
             'play_count' => $stats->playcount,

--- a/app/Transformers/UserStatisticsTransformer.php
+++ b/app/Transformers/UserStatisticsTransformer.php
@@ -11,6 +11,7 @@ use App\Models\UserStatistics;
 class UserStatisticsTransformer extends TransformerAbstract
 {
     protected $availableIncludes = [
+        'country_rank',
         'rank',
         'user',
         'variants',
@@ -49,7 +50,14 @@ class UserStatisticsTransformer extends TransformerAbstract
         ];
     }
 
-    // TODO: split this into global_rank (already exists) and country_rank
+    public function includeCountryRank(UserStatistics\Model $stats = null)
+    {
+        if ($stats !== null) {
+            return $this->primitive($stats->countryRank());
+        }
+    }
+
+    // TODO: remove this after country_rank is deployed
     public function includeRank(UserStatistics\Model $stats = null)
     {
         if ($stats === null) {
@@ -58,7 +66,6 @@ class UserStatisticsTransformer extends TransformerAbstract
 
         return $this->item($stats, function ($stats) {
             return [
-                'global' => $stats->globalRank(),
                 'country' => $stats->countryRank(),
             ];
         });

--- a/resources/assets/coffee/react/profile-page/rank-chart.coffee
+++ b/resources/assets/coffee/react/profile-page/rank-chart.coffee
@@ -78,10 +78,10 @@ export class RankChart extends React.Component
       lastData = _.last(data)
 
       if lastData.x == 0
-        lastData.y = -@props.stats.rank.global
+        lastData.y = -@props.stats.global_rank
       else
         data.push
           x: 0
-          y: -@props.stats.rank.global
+          y: -@props.stats.global_rank
 
     @rankChart.loadData data

--- a/resources/assets/coffee/react/profile-page/rank.coffee
+++ b/resources/assets/coffee/react/profile-page/rank.coffee
@@ -25,7 +25,7 @@ export Rank = ({type, stats, modifiers}) ->
       div
         title: ''
         "data-html-title": variantTooltip.join('')
-        if stats.rank[type]?
-          "##{osu.formatNumber(stats.rank[type])}"
+        if stats["#{type}_rank"]?
+          "##{osu.formatNumber(stats["#{type}_rank"])}"
         else
           '-'

--- a/resources/assets/lib/interfaces/user-json.ts
+++ b/resources/assets/lib/interfaces/user-json.ts
@@ -2,13 +2,13 @@
 // See the LICENCE file in the repository root for full licence text.
 
 import GroupJson from './group-json';
+import UserStatisticsJson from './user-statistics-json';
 
 export default interface UserJson {
   avatar_url: string;
   country?: Country;
   country_code: string; // TODO: country object?
   cover?: Cover;
-  current_mode_rank?: number;
   default_group: string;
   follower_count?: number;
   groups?: GroupJson[];
@@ -21,6 +21,7 @@ export default interface UserJson {
   last_visit: string | null;
   pm_friends_only: boolean;
   profile_colour: string | null;
+  statistics?: UserStatisticsJson;
   support_level?: number;
   username: string;
 }

--- a/resources/assets/lib/interfaces/user-statistics-json.ts
+++ b/resources/assets/lib/interfaces/user-statistics-json.ts
@@ -1,0 +1,6 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
+export default interface UserStatisticsJson {
+  global_rank?: number;
+}

--- a/resources/assets/lib/user-list.tsx
+++ b/resources/assets/lib/user-list.tsx
@@ -34,13 +34,7 @@ interface State {
 }
 
 function rankSortDescending(x: UserJson, y: UserJson) {
-  if (x.current_mode_rank != null && y.current_mode_rank != null) {
-    return x.current_mode_rank > y.current_mode_rank ? 1 : -1;
-  } else if (x.current_mode_rank === null) {
-    return 1;
-  } else {
-    return -1;
-  }
+  return (x.statistics?.global_rank ?? Number.MAX_VALUE) - (y.statistics?.global_rank ?? Number.MAX_VALUE);
 }
 
 function usernameSortAscending(x: UserJson, y: UserJson) {

--- a/resources/docs/source/includes/_structures/rankings.md
+++ b/resources/docs/source/includes/_structures/rankings.md
@@ -23,7 +23,7 @@
       "play_count": 228050,
       "play_time": null,
       "pp": 990,
-      "pp_rank": 87468,
+      "global_rank": 87468,
       "ranked_score": 1502995536,
       "replays_watched_by_others": 0,
       "total_hits": 5856573,

--- a/resources/docs/source/includes/_structures/user.md
+++ b/resources/docs/source/includes/_structures/user.md
@@ -120,7 +120,7 @@
       "progress": 55
     },
     "pp": 100,
-    "pp_rank": 2000,
+    "global_rank": 2000,
     "ranked_score": 2000000,
     "hit_accuracy": 90.5,
     "play_count": 1000,

--- a/resources/docs/source/includes/_structures/user_compact.md
+++ b/resources/docs/source/includes/_structures/user_compact.md
@@ -45,7 +45,6 @@ beatmap_playcounts_count             | number
 blocks                               | |
 country                              | |
 cover                                | |
-current_mode_rank                    | |
 favourite_beatmapset_count           | number
 follower_count                       | number
 friends                              | |

--- a/resources/docs/source/includes/_structures/user_statistics.md
+++ b/resources/docs/source/includes/_structures/user_statistics.md
@@ -18,7 +18,7 @@
   "play_count": 228050,
   "play_time": null,
   "pp": 990,
-  "pp_rank": 87468,
+  "global_rank": 87468,
   "ranked_score": 1502995536,
   "replays_watched_by_others": 0,
   "total_hits": 5856573,
@@ -66,7 +66,7 @@ maximum_combo             | number                      | Highest maximum combo.
 play_count                | number                      | Number of maps played.
 play_time                 | number                      | Cumulative time played.
 pp                        | number                      | Performance points
-pp_rank                   | number                      | Current rank according to pp.
+global_rank               | number?                     | Current rank according to pp.
 ranked_score              | number                      | Current ranked score.
 replays_watched_by_others | number                      | Number of replays watched by other users.
 total_hits                | number                      | Total number of hits.

--- a/resources/views/vendor/apidoc/partials/info.blade.php
+++ b/resources/views/vendor/apidoc/partials/info.blade.php
@@ -303,6 +303,12 @@ For a full list of changes, see the
 
 ## Breaking Changes
 
+### 2021-02-25
+- `current_mode_rank` has been removed from [UserCompact](#usercompact)
+- attributes in [UserStatistics](#userstatistics) have been moved around
+  - `rank.country` is deprecated, replaced by `country_rank`
+  - `rank.global` and `pp_rank` are removed, replaced by `global_rank`
+
 ### 2020-09-08
 - `presence` removed from `chat/new` response.
 


### PR DESCRIPTION
Resolves #7240. `rank.country` will be removed later once everything is moved to use `country_rank`.

I'm not sure the current usage state in osu though :thinking: This assumes they moved to use `global_rank` already.