### PR TITLE
Fix spunout being incompatible with too many mods

### DIFF
--- a/app/Libraries/Multiplayer/Mod.php
+++ b/app/Libraries/Multiplayer/Mod.php
@@ -92,6 +92,9 @@ class Mod
             self::NOFAIL,
             self::PERFECT,
             self::OSU_AUTOPILOT,
+        ],
+        [
+            self::OSU_AUTOPILOT,
             self::OSU_SPUNOUT,
         ],
         [


### PR DESCRIPTION
Just noticed this while going through mod incompatibilities - spunout is incompatible _only_ with autopilot, and not with nofail and all others.