### PR TITLE
Improved remembering of selected chat channel

### DIFF
--- a/resources/assets/lib/chat.ts
+++ b/resources/assets/lib/chat.ts
@@ -19,7 +19,7 @@ reactTurbolinks.register('chat', MainView, () => {
     dataStore.channelStore.lastPolledMessageId = initial.last_message_id ?? 0;
   }
 
-  let initialChannel: number | undefined;
+  let initialChannel = dataStore.chatState.selected;
   const sendTo = initial?.send_to;
 
   if ((sendTo != null)) {
@@ -35,18 +35,15 @@ reactTurbolinks.register('chat', MainView, () => {
       dataStore.channelStore.loaded = true;
       initialChannel = channel.channelId;
     }
-  } else if (dataStore.channelStore.loaded) {
-    const hasNonPmChannels = dataStore.channelStore.nonPmChannels.length > 0;
-    const hasPmChannels = dataStore.channelStore.pmChannels.length > 0;
-
-    if (hasNonPmChannels) {
+  } else if (initialChannel === 0 && dataStore.channelStore.loaded) {
+    if (dataStore.channelStore.nonPmChannels.length > 0) {
       initialChannel = dataStore.channelStore.nonPmChannels[0].channelId;
-    } else if (hasPmChannels) {
+    } else if (dataStore.channelStore.pmChannels.length > 0) {
       initialChannel = dataStore.channelStore.pmChannels[0].channelId;
     }
   }
 
-  if (initialChannel != null) {
+  if (initialChannel !== 0) {
     dataStore.chatState.selectChannel(initialChannel);
   }
 

--- a/resources/assets/lib/chat.ts
+++ b/resources/assets/lib/chat.ts
@@ -6,19 +6,21 @@ import MainView from 'chat/main-view';
 import Channel from 'models/chat/channel';
 import core from 'osu-core-singleton';
 
-const dataStore = core.dataStore;
-const initial = osu.parseJson<ChatInitialJson>('json-chat-initial');
-
-if (Array.isArray(initial.presence)) {
-  // initial population of channel/presence data
-  dataStore.channelStore.updateWithPresence(initial.presence);
-}
-
-dataStore.channelStore.lastPolledMessageId = initial.last_message_id ?? 0;
-
 reactTurbolinks.register('chat', MainView, () => {
+  const dataStore = core.dataStore;
+  const initial = osu.parseJson<ChatInitialJson | null>('json-chat-initial', true);
+
+  if (initial != null) {
+    if (Array.isArray(initial.presence)) {
+      // initial population of channel/presence data
+      dataStore.channelStore.updateWithPresence(initial.presence);
+    }
+
+    dataStore.channelStore.lastPolledMessageId = initial.last_message_id ?? 0;
+  }
+
   let initialChannel: number | undefined;
-  const sendTo = initial.send_to;
+  const sendTo = initial?.send_to;
 
   if ((sendTo != null)) {
     const target = dataStore.userStore.getOrCreate(sendTo.target.id, sendTo.target); // pre-populate userStore with target

--- a/resources/assets/lib/chat/chat-state-store.ts
+++ b/resources/assets/lib/chat/chat-state-store.ts
@@ -22,6 +22,8 @@ export default class ChatStateStore {
     return this.selectedBoxed.get();
   }
 
+  // This setter should be considered private.
+  // Use selectChannel to change channel.
   set selected(value: number) {
     this.selectedBoxed.set(value);
   }


### PR DESCRIPTION
Better handling of selected chat channel when navigating back to chat.
It now selects the channel you were previously on; this also means `sendto` in the url is ignored when loading from history if another channel was selected before navigating away; `sendto` in the url should be removed when changing channels in a future update since it doesn't reflect the actual state of the UI.

fixes #7249 
