### PR TITLE
Fix osu classic mod settings from multiplayer mod

### DIFF
--- a/app/Libraries/Multiplayer/Mod.php
+++ b/app/Libraries/Multiplayer/Mod.php
@@ -181,6 +181,12 @@ class Mod
         self::OSU_DEFLATE => [
             'start_scale' => 'float',
         ],
+        self::OSU_CLASSIC => [
+            'classic_note_lock' => 'bool',
+            'fixed_follow_circle_hit_area' => 'bool',
+            'no_slider_head_accuracy' => 'bool',
+            'no_slider_head_movement' => 'bool',
+        ],
     ];
 
     public static function assertValidExclusivity($requiredIds, $allowedIds, $ruleset)


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/37479424/109154419-9b19ad00-77b1-11eb-81a4-1ee047d35dcf.png)
Creating multiplayer room with CL (classic_note_lock=false etc) required_mods will throw "unknown setting for CL (no_slider_head_accuracy)"

This pr adds classic mod's options at multiplayer/mod.php
https://github.com/ppy/osu-web/pull/7195 (Classic PR)