### PR TITLE
Fix token check on callbacks and user registration

### DIFF
--- a/app/Http/Middleware/VerifyCsrfToken.php
+++ b/app/Http/Middleware/VerifyCsrfToken.php
@@ -14,7 +14,6 @@ class VerifyCsrfToken extends BaseVerifier
 {
     protected $except = [
         'home/changelog/github',
-        'oauth/access_token',
         'oauth/authorize',
         'payments/centili/callback',
         'payments/paypal/ipn',

--- a/app/Http/Middleware/VerifyCsrfToken.php
+++ b/app/Http/Middleware/VerifyCsrfToken.php
@@ -13,8 +13,14 @@ use Illuminate\Session\TokenMismatchException;
 class VerifyCsrfToken extends BaseVerifier
 {
     protected $except = [
-        'oauth/authorize',
+        'home/changelog/github',
         'oauth/access_token',
+        'oauth/authorize',
+        'payments/centili/callback',
+        'payments/paypal/ipn',
+        'payments/shopify/callback',
+        'payments/xsolla/callback',
+        'users',
     ];
 
     public function handle($request, Closure $next)


### PR DESCRIPTION
I hope I didn't miss anything :thinking: 

The exception check logic is a bit worrying (repeated url parsing for each entry, twice) but it's probably fine...