### PR TITLE
Exclude nulls from transformer collections

### DIFF
--- a/app/Libraries/Transformers/Scope.php
+++ b/app/Libraries/Transformers/Scope.php
@@ -29,9 +29,10 @@ class Scope extends Fractal\Scope
             [$transformedData, $includedData[]] = $this->fireTransformer($transformer, $data);
         } elseif ($this->resource instanceof Collection) {
             foreach ($data as $value) {
-                [$itemTransformedData, $includedData[]] = $this->fireTransformer($transformer, $value);
+                [$itemTransformedData, $itemIncludedData] = $this->fireTransformer($transformer, $value);
                 if ($itemTransformedData !== null) {
                     $transformedData[] = $itemTransformedData;
+                    $includedData[] = $itemIncludedData;
                 }
             }
         } elseif ($this->resource instanceof NullResource) {

--- a/app/Libraries/Transformers/Scope.php
+++ b/app/Libraries/Transformers/Scope.php
@@ -6,11 +6,47 @@
 namespace App\Libraries\Transformers;
 
 use App\Transformers\TransformerAbstract;
+use InvalidArgumentException;
 use League\Fractal;
+use League\Fractal\Resource\Collection;
+use League\Fractal\Resource\Item;
+use League\Fractal\Resource\NullResource;
 use League\Fractal\Serializer\SerializerAbstract;
 
 class Scope extends Fractal\Scope
 {
+    /**
+     * {@inheritdoc}
+     */
+    protected function executeResourceTransformers()
+    {
+        $transformer = $this->resource->getTransformer();
+        $data = $this->resource->getData();
+
+        $transformedData = $includedData = [];
+
+        if ($this->resource instanceof Item) {
+            [$transformedData, $includedData[]] = $this->fireTransformer($transformer, $data);
+        } elseif ($this->resource instanceof Collection) {
+            foreach ($data as $value) {
+                [$itemTransformedData, $includedData[]] = $this->fireTransformer($transformer, $value);
+                if ($itemTransformedData !== null) {
+                    $transformedData[] = $itemTransformedData;
+                }
+            }
+        } elseif ($this->resource instanceof NullResource) {
+            $transformedData = null;
+            $includedData = [];
+        } else {
+            throw new InvalidArgumentException(
+                'Argument $resource should be an instance of League\Fractal\Resource\Item'
+                .' or League\Fractal\Resource\Collection'
+            );
+        }
+
+        return [$transformedData, $includedData];
+    }
+
     /**
      * {@inheritdoc}
      */

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -1201,7 +1201,7 @@ function json_collection($model, $transformer, $includes = null)
 
 function json_item($model, $transformer, $includes = null)
 {
-    return json_collection([$model], $transformer, $includes)[0];
+    return json_collection([$model], $transformer, $includes)[0] ?? null;
 }
 
 function fast_imagesize($url)


### PR DESCRIPTION
If an item in a transformer collection `null`, it wasn't supposed to be there in the first place.
This works around fractal's limitation and doesn't include the `null` by duplicating `executeResourceTransformers` and adding an extra check.

(hopefully we don't have anything that actually relies on the `null` being there to work) 🤔 