### PR TITLE
Update Github Actions Tests action

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -54,6 +54,7 @@ jobs:
       - name: Set php version
         uses: shivammathur/setup-php@v2
         with:
+          extensions: redis
           tools: composer:v2
           php-version: '7.4'
 


### PR DESCRIPTION
Seems like redis extension needs to be explicitly specified for the Ubuntu 20 runner