### PR TITLE
Delete comments when deleting Beatmapset

### DIFF
--- a/app/Jobs/BeatmapsetDelete.php
+++ b/app/Jobs/BeatmapsetDelete.php
@@ -65,6 +65,13 @@ class BeatmapsetDelete implements ShouldQueue
                 throw new Exception('Failed to delete beatmapset.');
             }
 
+            // only update the non-deleted comments.
+            $this->beatmapset->comments()->withoutTrashed()->update([
+                'deleted_by_id' => $this->user->getKey(),
+                // can restore comments >= than this date if really needed when undeleting.
+                'deleted_at' => $this->beatmapset->deleted_at,
+            ]);
+
             $this->beatmapset->removeCovers();
         });
     }


### PR DESCRIPTION
Seems like something that shouldn't be in comments after a beatmapset gets deleted (and `whereHas()` on `commentable` is probably not something we want to do on listing 🤔 )

closes #7264