### PR TITLE
Move beatmap attributes to per-beatmap document

### DIFF
--- a/config/schemas/beatmaps.json
+++ b/config/schemas/beatmaps.json
@@ -25,39 +25,14 @@
           "dynamic": false,
           "type": "nested",
           "properties": {
-            "beatmap_id": {
-              "type": "long"
-            },
-            "convert": {
-              "type": "boolean"
-            },
-            "difficultyrating": {
-              "type": "double"
-            },
-            "playmode": {
-              "type": "byte"
-            }
-          }
-        },
-        "bpm": {
-          "type": "double"
-        },
-        "creator": {
-          "type": "text",
-          "fields": {
-            "raw": {
-              "type": "keyword"
-            }
-          }
-        },
-        "difficulties": {
-          "dynamic": false,
-          "properties": {
             "approved": {
               "type": "long"
             },
             "beatmap_id": {
               "type": "long"
+            },
+            "convert": {
+              "type": "boolean"
             },
             "countNormal": {
               "type": "long"
@@ -100,6 +75,25 @@
             },
             "version": {
               "type": "text"
+            }
+          }
+        },
+        "bpm": {
+          "type": "double"
+        },
+        "creator": {
+          "type": "text",
+          "fields": {
+            "raw": {
+              "type": "keyword"
+            }
+          }
+        },
+        "difficulties": {
+          "dynamic": false,
+          "properties": {
+            "playmode": {
+              "type": "byte"
             }
           }
         },

--- a/config/schemas/beatmaps.json
+++ b/config/schemas/beatmaps.json
@@ -68,7 +68,7 @@
               "type": "long"
             },
             "playmode": {
-              "type": "long"
+              "type": "byte"
             },
             "total_length": {
               "type": "long"
@@ -93,7 +93,7 @@
           "dynamic": false,
           "properties": {
             "playmode": {
-              "type": "byte"
+              "type": "long"
             }
           }
         },


### PR DESCRIPTION
This will allow searching for beatmaps with specific combination of attributes.

For example, searching for beatmap with difficulty rating of 3 and drain rate of 8 using the old structure may return beatmapset which contain two different beatmaps, one with diff 3 (but maybe drain 7) and another one with drain 8 (but maybe diff 4).

This is required to match lazer behavior for advanced query search.

Removed the old attributes except playmodes because it's the field still in use by legacy web although I think it could be easily updated to use the nested one?