### PR TITLE
Workaround tournament support banner previews being cutoff in store

### DIFF
--- a/resources/assets/less/bem/gallery-previews.less
+++ b/resources/assets/less/bem/gallery-previews.less
@@ -15,8 +15,9 @@
     .full-size();
     .fade-element(0.5s);
     display: block;
-    background-size: cover;
+    background-size: contain;
     background-position: 50%;
+    background-repeat: no-repeat;
 
     &.js-gallery {
       cursor: zoom-in;


### PR DESCRIPTION
A side-effect of `background-size: cover` is it will zoom in to "fit" the image into the container; in the case of wider containers, this causes the bottom of the image to be truncated.

![image](https://user-images.githubusercontent.com/1694544/110986191-b212ee80-83b0-11eb-92d1-e556ecda32f3.png)

Note that at certain viewport widths, it's fine:
![image](https://user-images.githubusercontent.com/1694544/110986661-45e4ba80-83b1-11eb-8657-41f15172711b.png)

after (`background-size: contain`):
![image](https://user-images.githubusercontent.com/1694544/110986126-9c9dc480-83b0-11eb-9752-c09a1627a387.png)

It's not really an issue on other preview images in the store that view fine when zoomed in, but it's really noticeable if there's anything in the edges that should be visible.