### PR TITLE
Update Beatmapset title search tokenizer

### DIFF
--- a/config/schemas/beatmaps.json
+++ b/config/schemas/beatmaps.json
@@ -214,8 +214,10 @@
             "min_gram": "2",
             "max_gram": "20",
             "token_chars": [
+              "digit",
               "letter",
-              "digit"
+              "punctuation",
+              "symbol"
             ]
           }
         }


### PR DESCRIPTION
This should be the more appropriate prefix tokenizer when `es_query_and_words` is removed with #7293

together with changes from #7293 should close #6446.

reindex is required: `php artisan es:index-documents --types=beatmapsets --yes --cleanup`