### PR TITLE
Fix notification not sent in some cases

### DIFF
--- a/app/Jobs/Notifications/BroadcastNotificationBase.php
+++ b/app/Jobs/Notifications/BroadcastNotificationBase.php
@@ -81,28 +81,34 @@ abstract class BroadcastNotificationBase implements ShouldQueue
         static $defaults = ['mail' => true, 'push' => true];
 
         if (static::NOTIFICATION_OPTION_NAME !== null) {
-            // FIXME: filtering all the ids could get quite large?
-            $notificationOptions = UserNotificationOption
-                ::whereIn('user_id', $userIds)
-                ->where(['name' => static::NOTIFICATION_OPTION_NAME])
-                ->whereNotNull('details')
-                ->get()
-                ->keyBy('user_id');
-        } else {
-            $notificationOptions = [];
+            $notificationOptionsQuery = UserNotificationOption
+                ::where(['name' => static::NOTIFICATION_OPTION_NAME])
+                ->whereNotNull('details');
         }
 
         $deliverySettings = [];
-        foreach ($userIds as $userId) {
-            $details = $notificationOptions[$userId]->details ?? $defaults;
-            $delivery = 0;
-            foreach (UserNotification::DELIVERY_OFFSETS as $type => $_offset) {
-                if ($details[$type] ?? $defaults[$type]) {
-                    $delivery |= UserNotification::deliveryMask($type);
-                }
+
+        foreach (array_chunk($userIds, 10000) as $chunkedUserIds) {
+            if (isset($notificationOptionsQuery)) {
+                $notificationOptions = (clone $notificationOptionsQuery)
+                    ->whereIntegerInRaw('user_id', $chunkedUserIds)
+                    ->get()
+                    ->keyBy('user_id');
+            } else {
+                $notificationOptions = [];
             }
 
-            $deliverySettings[$userId] = $delivery;
+            foreach ($chunkedUserIds as $userId) {
+                $details = $notificationOptions[$userId]->details ?? $defaults;
+                $delivery = 0;
+                foreach (UserNotification::DELIVERY_OFFSETS as $type => $_offset) {
+                    if ($details[$type] ?? $defaults[$type]) {
+                        $delivery |= UserNotification::deliveryMask($type);
+                    }
+                }
+
+                $deliverySettings[$userId] = $delivery;
+            }
         }
 
         return $deliverySettings;


### PR DESCRIPTION
Mainly for "global" type notifications. Avoid doing large `whereIn` query.

Resolves #7325.