### PR TITLE
Add 'external' contest type

### DIFF
--- a/database/migrations/2021_03_19_065458_add_external_contest_type.php
+++ b/database/migrations/2021_03_19_065458_add_external_contest_type.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 use Illuminate\Database\Migrations\Migration;
 
 class AddExternalContestType extends Migration

--- a/database/migrations/2021_03_19_065458_add_external_contest_type.php
+++ b/database/migrations/2021_03_19_065458_add_external_contest_type.php
@@ -1,0 +1,35 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+
+class AddExternalContestType extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        DB::statement("ALTER TABLE contests CHANGE type type ENUM(
+            'art',
+            'beatmap',
+            'music',
+            'external'
+        )");
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        DB::statement("ALTER TABLE contests CHANGE type type ENUM(
+            'art',
+            'beatmap',
+            'music'
+        )");
+    }
+}

--- a/resources/assets/coffee/react/contest-voting.coffee
+++ b/resources/assets/coffee/react/contest-voting.coffee
@@ -12,7 +12,7 @@ propsFunction = (target) ->
     selected: data.userVotes
     options:
       showPreview: data.contest['type'] == 'music'
-      showLink: data.contest['type'] == 'beatmap' && _.some(data.contest.entries, 'preview')
+      showLink: data.contest['type'] == 'external' || (data.contest['type'] == 'beatmap' && _.some(data.contest.entries, 'preview'))
   }
 
 reactTurbolinks.register 'contestArtList', ArtEntryList, propsFunction

--- a/resources/assets/coffee/react/contest-voting/entry.coffee
+++ b/resources/assets/coffee/react/contest-voting/entry.coffee
@@ -13,6 +13,18 @@ export class Entry extends React.Component
 
     return null if @props.hideIfNotVoted && !selected
 
+    if @props.contest.type == 'external'
+      link_icon = 'fa-external-link-alt'
+      entry_title =
+        a
+          rel: 'nofollow noreferrer'
+          target: '_blank'
+          href: @props.entry.preview,
+          @props.entry.title
+    else
+      link_icon = 'fa-download'
+      entry_title = @props.entry.title
+
     if @props.contest.show_votes
       votePercentage = _.round((@props.entry.results.votes / @props.totalVotes)*100, 2)
       relativeVotePercentage = _.round((@props.entry.results.votes / @props.winnerVotes)*100, 2)
@@ -35,19 +47,19 @@ export class Entry extends React.Component
               i className: "fal fa-fw fa-lg fa-#{@props.contest.link_icon}"
         else
           div className: 'contest-voting-list__icon contest-voting-list__icon--bg',
-            a className: 'tracklist__link', href: @props.entry.preview,
-              i className: 'fas fa-fw fa-lg fa-download'
+            a className: 'tracklist__link', href: @props.entry.preview, rel: 'nofollow noreferrer', target: '_blank',
+              i className: "fas fa-fw fa-lg #{link_icon}"
       if @props.contest.show_votes
         div className: 'contest-voting-list__title contest-voting-list__title--show-votes',
           div className: 'contest-voting-list__votes-bar', style: { width: "#{relativeVotePercentage}%" }
-          div className: 'u-relative u-ellipsis-overflow', @props.entry.title
+          div className: 'u-relative u-ellipsis-overflow', entry_title
           a
             className: 'contest-voting-list__entrant js-usercard',
             'data-user-id': @props.entry.results.user_id,
             href: laroute.route('users.show', user: @props.entry.results.user_id),
               @props.entry.results.username
       else
-        div className: 'contest-voting-list__title u-ellipsis-overflow', @props.entry.title
+        div className: 'contest-voting-list__title u-ellipsis-overflow', entry_title
 
       div className: "contest__voting-star#{if @props.contest.show_votes then ' contest__voting-star--dark-bg' else ''}",
         el Voter, key: @props.entry.id, entry: @props.entry, waitingForResponse: @props.waitingForResponse, selected: @props.selected, contest: @props.contest


### PR DESCRIPTION
This new contest type allows for entries to link to... things.

(this is for an upcoming skinning contest, where we want to be able to link to forum threads... figured I'd make it generic enough for future uses instead of specifically linking to forum threads by id or whatever)