### PR TITLE
Remove old wiki index on database reset

### DIFF
--- a/app/Console/Commands/MigrateFreshAllCommand.php
+++ b/app/Console/Commands/MigrateFreshAllCommand.php
@@ -55,6 +55,7 @@ class MigrateFreshAllCommand extends FreshCommand
         ]);
 
         $this->call('es:index-wiki', [
+            '--cleanup' => true,
             '--create-only' => true,
             '--yes' => $this->option('yes'),
         ]);


### PR DESCRIPTION
I ended up with loads of old wiki index after a while. The other index already cleans up itself.

I wonder if it's because the new index is empty but anyone who cares about the content can reindex the thing afterwards or should just not run "fresh all" command.