### PR TITLE
Fix double escaped artist names on user profile beatmap play counts

### DIFF
--- a/resources/assets/coffee/react/profile-page/beatmap-playcount.coffee
+++ b/resources/assets/coffee/react/profile-page/beatmap-playcount.coffee
@@ -49,7 +49,7 @@ export class BeatmapPlaycount extends React.PureComponent
                   ':artist':
                     strong
                       key: 'artist'
-                      _.escape(getArtist(beatmapset))
+                      getArtist(beatmapset)
             ' ' # separator for overflow tooltip
             span
               className: "#{bn}__mapper"


### PR DESCRIPTION
Left over from when `dangerouslySetInnerHTML` was used, shouldn't be needed anymore.

closes #7384 