### PR TITLE
Fix display of beatmap discussion delete date

### DIFF
--- a/resources/assets/coffee/react/beatmap-discussions/post.coffee
+++ b/resources/assets/coffee/react/beatmap-discussions/post.coffee
@@ -184,7 +184,7 @@ export class Post extends React.PureComponent
                 editor: osu.link laroute.route('users.show', user: deleteModel.deleted_by_id),
                   @props.users[deleteModel.deleted_by_id]?.username
                   classNames: ["#{bn}__info-user"]
-                delete_time: osu.timeago @props.post.deleted_at
+                delete_time: osu.timeago deleteModel.deleted_at
 
         if @props.post.updated_at != @props.post.created_at && @props.lastEditor?.id
           span


### PR DESCRIPTION
Deleted discussion (thread starter) was missing deletion date display because it was using wrong model for the date.