### PR TITLE
Fix display of discussion post editor name

### DIFF
--- a/resources/assets/coffee/react/beatmap-discussions/discussion.coffee
+++ b/resources/assets/coffee/react/beatmap-discussions/discussion.coffee
@@ -287,7 +287,7 @@ export class Discussion extends React.PureComponent
       read: @isRead(post)
       users: @props.users
       user: @props.users[post.user_id] ? @props.users[null]
-      lastEditor: @props.users[post.last_editor_id] ? @props.users[null]
+      lastEditor: @props.users[post.last_editor_id] ? @props.users[null] if post.last_editor_id?
       canBeEdited: @props.currentUser.is_admin || canBeEdited
       canBeDeleted: canBeDeleted
       canBeRestored: canModeratePosts

--- a/resources/assets/coffee/react/beatmap-discussions/post.coffee
+++ b/resources/assets/coffee/react/beatmap-discussions/post.coffee
@@ -186,7 +186,7 @@ export class Post extends React.PureComponent
                   classNames: ["#{bn}__info-user"]
                 delete_time: osu.timeago @props.post.deleted_at
 
-        if @props.post.updated_at != @props.post.created_at && @props.post.last_editor_id?
+        if @props.post.updated_at != @props.post.created_at && @props.lastEditor?
           span
             className: "#{bn}__info #{bn}__info--edited"
             dangerouslySetInnerHTML:

--- a/resources/assets/coffee/react/beatmap-discussions/post.coffee
+++ b/resources/assets/coffee/react/beatmap-discussions/post.coffee
@@ -186,7 +186,7 @@ export class Post extends React.PureComponent
                   classNames: ["#{bn}__info-user"]
                 delete_time: osu.timeago @props.post.deleted_at
 
-        if @props.post.updated_at != @props.post.created_at && @props.lastEditor?.id
+        if @props.post.updated_at != @props.post.created_at && @props.post.last_editor_id?
           span
             className: "#{bn}__info #{bn}__info--edited"
             dangerouslySetInnerHTML:

--- a/resources/assets/coffee/react/modding-profile/posts.coffee
+++ b/resources/assets/coffee/react/modding-profile/posts.coffee
@@ -51,7 +51,7 @@ export class Posts extends React.Component
                       users: @props.users
                       user: @props.users[post.user_id]
                       read: true
-                      lastEditor: @props.users[post.last_editor_id]
+                      lastEditor: @props.users[post.last_editor_id] ? @props.users[null] if post.last_editor_id?
                       # FIXME: These permissions are more restrictive than the correct ones in discussion
                       # because they don't have the right data to check.
                       canBeEdited: currentUser.is_admin


### PR DESCRIPTION
Deleted user object no longer has null id.

Resolves #7345.