### PR TITLE
Always show deleted comment count

### DIFF
--- a/resources/assets/coffee/react/_components/comment.coffee
+++ b/resources/assets/coffee/react/_components/comment.coffee
@@ -184,7 +184,7 @@ export class Comment extends React.PureComponent
             className: repliesClass
             @children.map @renderComment
 
-            el DeletedCommentsCount, { comments: @children, showDeleted: uiState.comments.isShowDeleted }
+            el DeletedCommentsCount, { comments: @children }
 
             el CommentShowMore,
               parent: @props.comment

--- a/resources/assets/coffee/react/_components/comments.coffee
+++ b/resources/assets/coffee/react/_components/comments.coffee
@@ -54,7 +54,7 @@ export class Comments extends React.PureComponent
           div className: "comments__items #{if uiState.comments.loadingSort? then 'comments__items--loading' else ''}",
             @renderComments comments, false
 
-            el DeletedCommentsCount, { comments, showDeleted: uiState.comments.isShowDeleted, modifiers: ['top'] }
+            el DeletedCommentsCount, { comments, modifiers: ['top'] }
 
             el CommentShowMore,
               commentableType: @props.commentableType

--- a/resources/assets/lib/deleted-comments-count.tsx
+++ b/resources/assets/lib/deleted-comments-count.tsx
@@ -7,14 +7,13 @@ import * as React from 'react';
 interface Props {
   comments: Comment[];
   modifiers: string[] | undefined;
-  showDeleted: boolean;
 }
 
 export default class DeletedCommentsCount extends React.Component<Props> {
   render() {
     const deletedCount = this.props.comments.filter((c) => c.deletedAt != null).length;
 
-    if (this.props.showDeleted || deletedCount === 0) {
+    if (deletedCount === 0) {
       return null;
     }
 


### PR DESCRIPTION
Resolves #7254.

The comment hiding option stays as it's still useful for showing replies of deleted comment.