### PR TITLE
Cleanup observers when unmounting components

### DIFF
--- a/resources/assets/lib/beatmaps/main.tsx
+++ b/resources/assets/lib/beatmaps/main.tsx
@@ -6,7 +6,7 @@ import AvailableFilters from 'beatmaps/available-filters';
 import HeaderV4 from 'header-v4';
 import { isEqual } from 'lodash';
 import { IValueDidChange, Lambda, observe } from 'mobx';
-import { observer } from 'mobx-react';
+import { disposeOnUnmount, observer } from 'mobx-react';
 import core from 'osu-core-singleton';
 import * as React from 'react';
 import { SearchContent } from 'react/beatmaps/search-content';
@@ -27,11 +27,11 @@ export class Main extends React.Component<Props> {
   constructor(props: Props) {
     super(props);
 
-    this.observerDisposers.push(observe(controller, 'searchStatus', this.searchStatusErrorHandler));
+    disposeOnUnmount(this, observe(controller, 'searchStatus', this.searchStatusErrorHandler));
   }
 
   componentDidMount() {
-    this.observerDisposers.push(observe(controller, 'searchStatus', this.scrollPositionHandler));
+    disposeOnUnmount(this, observe(controller, 'searchStatus', this.scrollPositionHandler));
     $(document).on('turbolinks:before-visit.beatmaps-main', () => {
       controller.cancel();
     });
@@ -40,12 +40,6 @@ export class Main extends React.Component<Props> {
   componentWillUnmount() {
     $(document).off('.beatmaps-main');
     controller.cancel();
-
-    let disposer = this.observerDisposers.shift();
-    while (disposer) {
-      disposer();
-      disposer = this.observerDisposers.shift();
-    }
   }
 
   render() {

--- a/resources/assets/lib/beatmaps/main.tsx
+++ b/resources/assets/lib/beatmaps/main.tsx
@@ -5,7 +5,7 @@ import { BackToTop } from 'back-to-top';
 import AvailableFilters from 'beatmaps/available-filters';
 import HeaderV4 from 'header-v4';
 import { isEqual } from 'lodash';
-import { IValueDidChange, Lambda, observe } from 'mobx';
+import { IValueDidChange, observe } from 'mobx';
 import { disposeOnUnmount, observer } from 'mobx-react';
 import core from 'osu-core-singleton';
 import * as React from 'react';
@@ -22,7 +22,6 @@ interface Props {
 export class Main extends React.Component<Props> {
   readonly backToTop = React.createRef<BackToTop>();
   readonly backToTopAnchor = React.createRef<HTMLElement>();
-  readonly observerDisposers: Lambda[] = [];
 
   constructor(props: Props) {
     super(props);

--- a/resources/assets/lib/chat/conversation-view.tsx
+++ b/resources/assets/lib/chat/conversation-view.tsx
@@ -4,7 +4,7 @@
 import { route } from 'laroute';
 import { each, isEmpty, last, throttle } from 'lodash';
 import { computed, observe } from 'mobx';
-import { inject, observer } from 'mobx-react';
+import { disposeOnUnmount, inject, observer } from 'mobx-react';
 import Message from 'models/chat/message';
 import * as moment from 'moment';
 import * as React from 'react';
@@ -108,11 +108,14 @@ export default class ConversationView extends React.Component<Props> {
 
     this.dataStore = props.dataStore!;
 
-    observe(this.dataStore.chatState.selectedBoxed, (change) => {
-      if (change.newValue !== change.oldValue) {
-        this.didSwitchChannel = true;
-      }
-    });
+    disposeOnUnmount(
+      this,
+      observe(this.dataStore.chatState.selectedBoxed, (change) => {
+        if (change.newValue !== change.oldValue) {
+          this.didSwitchChannel = true;
+        }
+      }),
+    );
   }
 
   componentDidMount() {

--- a/resources/assets/lib/chat/input-box.tsx
+++ b/resources/assets/lib/chat/input-box.tsx
@@ -9,7 +9,7 @@ import { BigButton } from 'big-button';
 import DispatchListener from 'dispatch-listener';
 import * as _ from 'lodash';
 import { computed, observe } from 'mobx';
-import { inject, observer } from 'mobx-react';
+import { disposeOnUnmount, inject, observer } from 'mobx-react';
 import Message from 'models/chat/message';
 import * as React from 'react';
 import TextareaAutosize from 'react-autosize-textarea';
@@ -35,11 +35,15 @@ export default class InputBox extends React.Component<Props> implements Dispatch
   constructor(props: Props) {
     super(props);
 
-    observe(this.dataStore.chatState.selectedBoxed, (change) => {
-      if (change.newValue !== change.oldValue && osu.isDesktop()) {
-        this.focusInput();
-      }
-    });
+    disposeOnUnmount(
+      this,
+      observe(this.dataStore.chatState.selectedBoxed, (change) => {
+        console.log('change');
+        if (change.newValue !== change.oldValue && osu.isDesktop()) {
+          this.focusInput();
+        }
+      }),
+    );
   }
 
   buttonClicked = () => {


### PR DESCRIPTION
TIL `disposeOnUnmount` is a thing in mobx.
Only works on react components, though...