### PR TITLE
Allow css to control circular progress component

### DIFF
--- a/resources/assets/less/bem/circular-progress.less
+++ b/resources/assets/less/bem/circular-progress.less
@@ -8,6 +8,11 @@
   @thickness: 0.1em;
   @label-size: 0.4em;
 
+  .over50() {
+    --circle-fill-transform: rotate(0.5turn);
+    --slice-clip: rect(auto, auto, auto, auto);
+  }
+
   font-size: @size;
   width: 1em;
   height: 1em;
@@ -17,18 +22,37 @@
 
   background-color: @osu-colour-b4;
   --circle-center-fill: @osu-colour-b6;
+  --circle-transform: rotate(0turn);
+  --circle-fill-transform: rotate(0turn);
+  --slice-clip: rect(0em, 1em, 1em, 0.5em);
+  --circle-border-colour: hsl(var(--hsl-h1));
+  --label-colour: hsl(var(--hsl-h1));
+
+  &--warn {
+    --circle-border-colour: hsl(var(--hsl-orange-2));
+    --label-colour: hsl(var(--hsl-orange-2));
+  }
+
+  &--over {
+    --circle-border-colour: hsl(var(--hsl-red-2));
+    --label-colour: hsl(var(--hsl-red-2));
+  }
 
   &--lighter {
     background-color: @osu-colour-b3;
     --circle-center-fill: @osu-colour-b5;
   }
 
-  &:after {
+  &--over50 {
+    .over50();
+  }
+
+  &::after {
     position: absolute;
     margin-top: @thickness;
     margin-left: @thickness;
     display: block;
-    content: " ";
+    content: '';
     border-radius: 50%;
     background-color: var(--circle-center-fill);
     width: 1em - (@thickness * 2);
@@ -43,36 +67,21 @@
     font-size: @label-size;
     text-align: center;
     white-space: nowrap;
-    color: @osu-colour-h1;
-
-    .@{_top}--warn & {
-      color: @osu-colour-orange-2;
-    }
-    .@{_top}--over & {
-      color: @osu-colour-red-2;
-    }
+    color: var(--label-colour);
   }
 
 
   &__circle {
     position: absolute;
-    border: @thickness solid @osu-colour-h1;
+    border: @thickness solid var(--circle-border-colour);
     width: 1em;
     height: 1em;
     clip: rect(0em, 0.5em, 1em, 0em);
     border-radius: 50%;
-
-    .@{_top}--warn & {
-      border-color: @osu-colour-orange-2;
-    }
-    .@{_top}--over & {
-      border-color: @osu-colour-red-2;
-    }
+    transform: var(--circle-transform);
 
     &--fill {
-      .@{_top}--over50 & {
-        transform: rotate(180deg);
-      }
+      transform: var(--circle-fill-transform);
     }
   }
 
@@ -80,10 +89,6 @@
     position: absolute;
     width: 1em;
     height: 1em;
-    clip: rect(0em, 1em, 1em, 0.5em);
-
-    .@{_top}--over50 & {
-      clip: rect(auto, auto, auto, auto);
-    }
+    clip: var(--slice-clip);
   }
 }

--- a/resources/assets/lib/circular-progress.tsx
+++ b/resources/assets/lib/circular-progress.tsx
@@ -9,7 +9,7 @@ interface Props {
   ignoreProgress: boolean;
   max: number;
   onlyShowAsWarning: boolean;
-  theme?: string;
+  theme: string;
   tooltip?: string;
 }
 
@@ -17,6 +17,7 @@ export class CircularProgress extends React.PureComponent<Props, any> {
   static defaultProps = {
     ignoreProgress: false,
     onlyShowAsWarning: false,
+    theme: '',
   };
 
   bn = 'circular-progress';
@@ -40,7 +41,7 @@ export class CircularProgress extends React.PureComponent<Props, any> {
           over: percentage === 1,
           over50: percentage > 0.5,
           warn: percentage >= warnThreshold && percentage < 1,
-          [this.props.theme ?? '']: !!this.props.theme,
+          [this.props.theme]: osu.present(this.props.theme),
         })}
         title={this.props.tooltip || `${this.props.current} / ${this.props.max}`}
       >

--- a/resources/assets/lib/circular-progress.tsx
+++ b/resources/assets/lib/circular-progress.tsx
@@ -6,13 +6,19 @@ import { classWithModifiers } from './utils/css';
 
 interface Props {
   current: number;
+  ignoreProgress: boolean;
   max: number;
-  onlyShowAsWarning?: boolean;
+  onlyShowAsWarning: boolean;
   theme?: string;
   tooltip?: string;
 }
 
 export class CircularProgress extends React.PureComponent<Props, any> {
+  static defaultProps = {
+    ignoreProgress: false,
+    onlyShowAsWarning: false,
+  };
+
   bn = 'circular-progress';
 
   render() {
@@ -23,6 +29,10 @@ export class CircularProgress extends React.PureComponent<Props, any> {
     if (this.props.onlyShowAsWarning && percentage < warnThreshold) {
       return null;
     }
+
+    const transform = this.props.ignoreProgress
+      ? undefined
+      : { transform: `rotate(${percentage}turn)` };
 
     return (
       <div
@@ -36,12 +46,7 @@ export class CircularProgress extends React.PureComponent<Props, any> {
       >
         <div className={`${bn}__label`}>{this.props.max - this.props.current}</div>
         <div className={`${bn}__slice`}>
-          <div
-            className={`${bn}__circle`}
-            style={{
-              transform: `rotate(${percentage}turn)`,
-            }}
-          />
+          <div className={`${bn}__circle`} style={transform} />
           <div className={`${bn}__circle ${bn}__circle--fill`} />
         </div>
       </div>


### PR DESCRIPTION
Another part of new beatmap card.

The over50 data must still be added manually by whatever process updating the css which is kinda annoying but I couldn't figure out better way.

Usage example for audio player in beatmap card:

```less
  &--beatmapset-panel {
    font-size: 50px; // circle size
    pointer-events: none;
    background-color: transparent;
    --circle-center-fill: transparent;
    --label-colour: transparent;
    --circle-transform: rotate(calc(var(--progress) * 1turn));

    [data-audio-over50="1"] & {
      .over50();
    }
  }
```