### PR TITLE
Observable currentUser (in OsuCore)

### DIFF
--- a/resources/assets/lib/models/user.ts
+++ b/resources/assets/lib/models/user.ts
@@ -44,7 +44,7 @@ export default class User {
     });
   }
 
-  is(user: User | UserJson | null) {
+  is(user?: User | UserJson | null) {
     if (user == null) return false;
     return user.id === this.id;
   }


### PR DESCRIPTION
Being able to just observe it seemed useful but then I noticed bigger problem of a bunch of things assume full page reload on login :thinking: 

Not to mention things like beatmapset favourite data are only available during initial load.

At the moment it looks like `showIfGuest` function and `js-login-required--click` class are only reliable for page navigation links.