### PR TITLE
Fix detail menu button size in profile page

### DIFF
--- a/resources/assets/coffee/react/profile-page/detail-bar.coffee
+++ b/resources/assets/coffee/react/profile-page/detail-bar.coffee
@@ -124,11 +124,11 @@ export class DetailBar extends React.PureComponent
       button
         className: 'profile-page-toggle js-click-menu'
         title: osu.trans('common.buttons.show_more_options')
-        'data-click-menu-target': "profile-page-bar-#{@id}"
+        'data-click-menu-target': "profile-page-bar-#{@eventId}"
         span className: 'fas fa-ellipsis-v'
       div
         className: 'simple-menu simple-menu--profile-page-bar js-click-menu'
-        'data-click-menu-id': "profile-page-bar-#{@id}"
+        'data-click-menu-id': "profile-page-bar-#{@eventId}"
         'data-visibility': 'hidden'
         items
 

--- a/resources/assets/coffee/react/profile-page/detail-bar.coffee
+++ b/resources/assets/coffee/react/profile-page/detail-bar.coffee
@@ -122,7 +122,7 @@ export class DetailBar extends React.PureComponent
 
     div className: "#{bn}__entry",
       button
-        className: 'profile-page-toggle js-click-menu'
+        className: 'profile-page-toggle profile-page-toggle--detail js-click-menu'
         title: osu.trans('common.buttons.show_more_options')
         'data-click-menu-target': "profile-page-bar-#{@eventId}"
         span className: 'fas fa-ellipsis-v'

--- a/resources/assets/less/bem/profile-page-toggle.less
+++ b/resources/assets/less/bem/profile-page-toggle.less
@@ -14,4 +14,8 @@
   .link-hover({
     background-color: @osu-colour-b1;
   });
+
+  &--detail {
+    .circle(40px);
+  }
 }


### PR DESCRIPTION
The padding change accidentally also resized button in other place. Resized back to the closest correct size. Also fixed undefined variable.

![](https://s.myconan.net/2021-04/firefox_2021-04-07_14-28-38.png)