### PR TITLE
Update SearchSort component to observe changes

### DIFF
--- a/resources/assets/coffee/react/beatmaps/search-content.coffee
+++ b/resources/assets/coffee/react/beatmaps/search-content.coffee
@@ -15,8 +15,6 @@ import VirtualList from 'react-virtual-list'
 import { showVisual } from 'utils/beatmapset-helper'
 
 el = React.createElement
-beatmapsetStore = core.dataStore.beatmapsetStore
-controller = core.beatmapsetSearchController
 
 ITEM_HEIGHT = 205 # needs to be known in advance to calculate size of virtual scrolling area.
 
@@ -34,7 +32,7 @@ ListRender = ({ virtual, itemHeight }) ->
             div
               className: 'beatmapsets__item'
               key: beatmapsetId
-              el BeatmapsetPanel, beatmap: beatmapsetStore.get(beatmapsetId)
+              el BeatmapsetPanel, beatmap: core.dataStore.beatmapsetStore.get(beatmapsetId)
 
 # stored in an observable so a rerender will occur when the HOC gets updated.
 Observables = observable
@@ -59,9 +57,10 @@ export class SearchContent extends React.Component
 
   render: ->
     el Observer, null, () =>
+      controller = core.beatmapsetSearchController
       beatmapsetIds = controller.currentBeatmapsetIds
 
-      firstBeatmapset = beatmapsetStore.get(beatmapsetIds[0])
+      firstBeatmapset = core.dataStore.beatmapsetStore.get(beatmapsetIds[0])
       searchBackground = if firstBeatmapset? && showVisual(firstBeatmapset) then firstBeatmapset.covers?.cover else null
       supporterRequiredFilterText = controller.supporterRequiredFilterText
       listCssClasses = 'beatmapsets'
@@ -83,7 +82,7 @@ export class SearchContent extends React.Component
                 className: 'beatmapsets__sort'
                 el SearchSort,
                   filters: controller.filters
-                  sorting: sorting()
+                  sorting: controller.filters.searchSort # TODO: make SearchSort observable and move in.
 
             div
               className: 'beatmapsets__content js-audio--group'
@@ -117,12 +116,6 @@ export class SearchContent extends React.Component
                   error: controller.error
                   loading: controller.isPaging
                   more: controller.hasMore
-
-
-sorting = ->
-  [field, order] = controller.filters.displaySort.split('_')
-
-  { field, order }
 
 
 renderLinkToSupporterTag = (filterText) ->

--- a/resources/assets/coffee/react/beatmaps/search-content.coffee
+++ b/resources/assets/coffee/react/beatmaps/search-content.coffee
@@ -82,7 +82,6 @@ export class SearchContent extends React.Component
                 className: 'beatmapsets__sort'
                 el SearchSort,
                   filters: controller.filters
-                  sorting: controller.filters.searchSort # TODO: make SearchSort observable and move in.
 
             div
               className: 'beatmapsets__content js-audio--group'

--- a/resources/assets/coffee/react/beatmaps/search-sort.coffee
+++ b/resources/assets/coffee/react/beatmaps/search-sort.coffee
@@ -5,7 +5,6 @@ import core from 'osu-core-singleton'
 import * as React from 'react'
 import { div, a, i, span } from 'react-dom-factories'
 el = React.createElement
-controller = core.beatmapsetSearchController
 
 export class SearchSort extends React.PureComponent
   render: =>
@@ -68,7 +67,7 @@ export class SearchSort extends React.PureComponent
     else
       order = 'desc'
 
-    controller.updateFilters sort: "#{field}_#{order}"
+    core.beatmapsetSearchController.updateFilters sort: "#{field}_#{order}"
 
 
   selected: (field) =>

--- a/resources/assets/coffee/react/beatmaps/search-sort.coffee
+++ b/resources/assets/coffee/react/beatmaps/search-sort.coffee
@@ -1,29 +1,31 @@
 # Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 # See the LICENCE file in the repository root for full licence text.
 
+import { Observer } from 'mobx-react'
 import core from 'osu-core-singleton'
 import * as React from 'react'
 import { div, a, i, span } from 'react-dom-factories'
 el = React.createElement
 
-export class SearchSort extends React.PureComponent
+export class SearchSort extends React.Component
   render: =>
-    div className: 'sort sort--beatmapsets',
-      div className: 'sort__items',
-        span className: 'sort__item sort__item--title', osu.trans('sort._')
-        for field in @fields()
-          selected = @selected(field)
+    el Observer, null, () =>
+      div className: 'sort sort--beatmapsets',
+        div className: 'sort__items',
+          span className: 'sort__item sort__item--title', osu.trans('sort._')
+          for field in @fields()
+            selected = @selected(field)
 
-          a
-            key: field
-            href: '#'
-            className: "sort__item sort__item--button #{'sort__item--active' if selected}"
-            onClick: @select
-            'data-field': field
-            osu.trans "beatmaps.listing.search.sorting.#{field}"
-            span
-              className: 'sort__item-arrow'
-              i className: "fas fa-caret-#{if @props.sorting.order == 'asc' then 'up' else 'down'}"
+            a
+              key: field
+              href: '#'
+              className: "sort__item sort__item--button #{'sort__item--active' if selected}"
+              onClick: @select
+              'data-field': field
+              osu.trans "beatmaps.listing.search.sorting.#{field}"
+              span
+                className: 'sort__item-arrow'
+                i className: "fas fa-caret-#{if @props.filters.searchSort.order == 'asc' then 'up' else 'down'}"
 
 
   fields: =>
@@ -60,7 +62,7 @@ export class SearchSort extends React.PureComponent
   select: (e) =>
     e.preventDefault()
     field = e.currentTarget.dataset.field
-    order = @props.sorting.order
+    order = @props.filters.searchSort.order
 
     if @selected(field)
       order = if order == 'asc' then 'desc' else 'asc'
@@ -71,4 +73,4 @@ export class SearchSort extends React.PureComponent
 
 
   selected: (field) =>
-    @props.sorting.field == field
+    @props.filters.searchSort.field == field

--- a/resources/assets/lib/beatmapset-search-filters.ts
+++ b/resources/assets/lib/beatmapset-search-filters.ts
@@ -52,7 +52,7 @@ export class BeatmapsetSearchFilters implements BeatmapsetSearchParams {
 
   @computed
   get searchSort() {
-    const [field, order] = this.displaySort.split('_')
+    const [field, order] = this.displaySort.split('_');
     return { field, order };
   }
 

--- a/resources/assets/lib/beatmapset-search-filters.ts
+++ b/resources/assets/lib/beatmapset-search-filters.ts
@@ -50,6 +50,12 @@ export class BeatmapsetSearchFilters implements BeatmapsetSearchParams {
     return BeatmapsetFilter.queryParamsFromFilters(values);
   }
 
+  @computed
+  get searchSort() {
+    const [field, order] = this.displaySort.split('_')
+    return { field, order };
+  }
+
   selectedValue(key: FilterKey) {
     const value = this[key];
     if (value == null) {


### PR DESCRIPTION
Moves the calculation of `sorting` and makes it observable. This is part of a larger state store cleanup that also moves all the store references to use the current instance instead of the static one on module import.