### PR TITLE
Return empty response for json route not found

### DIFF
--- a/app/Http/Controllers/FallbackController.php
+++ b/app/Http/Controllers/FallbackController.php
@@ -23,7 +23,7 @@ class FallbackController extends Controller
     public function index()
     {
         if (is_json_request()) {
-            return response([], 404);
+            return response(null, 404);
         }
 
         return ext_view('layout.error', ['statusCode' => 404], 'html', 404);


### PR DESCRIPTION
Instead of `[]`