### PR TITLE
Use "list" image for beatmap card left side thumbnail

### DIFF
--- a/resources/assets/coffee/osu_common.coffee
+++ b/resources/assets/coffee/osu_common.coffee
@@ -126,7 +126,7 @@
 
   src2x: (mainUrl) ->
     src: mainUrl
-    srcSet: "#{mainUrl} 1x, #{mainUrl?.replace(/(\.[^.]+)$/, '@2x$1')} 2x"
+    srcSet: "#{mainUrl} 1x, #{_exported.make2x(mainUrl)} 2x"
 
 
   link: (url, text, options = {}) ->

--- a/resources/assets/lib/beatmapset-panel.tsx
+++ b/resources/assets/lib/beatmapset-panel.tsx
@@ -54,7 +54,7 @@ const BeatmapDot = observer(({ beatmap }: { beatmap: BeatmapJson }) => (
   />
 ));
 
-const BeatmapDots = observer(({ mode, beatmaps }: BeatmapGroup) => (
+const BeatmapDots = observer(({ beatmaps, mode }: BeatmapGroup) => (
   <div className='beatmapset-panel__beatmap-dots'>
     <div className='beatmapset-panel__beatmap-icon'>
       <i className={`fal fa-extra-mode-${mode}`} />

--- a/resources/assets/lib/beatmapset-panel.tsx
+++ b/resources/assets/lib/beatmapset-panel.tsx
@@ -19,7 +19,7 @@ import { UserLink } from 'user-link';
 import * as BeatmapHelper from 'utils/beatmap-helper';
 import { showVisual, toggleFavourite } from 'utils/beatmapset-helper';
 import { classWithModifiers } from 'utils/css';
-import { formatNumberSuffixed } from 'utils/html';
+import { formatNumberSuffixed, make2x } from 'utils/html';
 
 interface Props {
   beatmapset: BeatmapsetExtendedJson;
@@ -54,7 +54,7 @@ const BeatmapDot = observer(({ beatmap }: { beatmap: BeatmapJson }) => (
   />
 ));
 
-const BeatmapDots = observer(({ beatmaps, mode }: BeatmapGroup) => (
+const BeatmapDots = observer(({ mode, beatmaps }: BeatmapGroup) => (
   <div className='beatmapset-panel__beatmap-dots'>
     <div className='beatmapset-panel__beatmap-icon'>
       <i className={`fal fa-extra-mode-${mode}`} />
@@ -362,10 +362,10 @@ export default class BeatmapsetPanel extends React.Component<Props> {
         <div className='beatmapset-panel__cover-col beatmapset-panel__cover-col--play'>
           <div className='beatmapset-panel__cover beatmapset-panel__cover--default' />
           {this.showVisual && (
-            <Img2x
+            <img
               className='beatmapset-panel__cover'
               onError={hideImage}
-              src={this.props.beatmapset.covers.card}
+              src={make2x(this.props.beatmapset.covers.list)}
             />
           )}
         </div>

--- a/resources/assets/lib/import-shims.coffee
+++ b/resources/assets/lib/import-shims.coffee
@@ -11,6 +11,7 @@ import Promise from 'promise-polyfill'
 import OsuUrlHelper from 'osu-url-helper'
 import { fileuploadFailCallback } from 'utils/ajax'
 import { discussionLinkify } from 'utils/beatmapset-discussion-helper'
+import { make2x } from 'utils/html'
 
 # polyfill non-Edge IE
 window.Promise ?= Promise
@@ -23,6 +24,7 @@ window._exported = {
   OsuUrlHelper
   discussionLinkify
   fileuploadFailCallback
+  make2x
 }
 
 # FIXME: remove once everything imports instead of using global

--- a/resources/assets/lib/utils/html.ts
+++ b/resources/assets/lib/utils/html.ts
@@ -39,3 +39,9 @@ export function formatNumberSuffixed(num?: number, precision?: number, options?:
 
   return `${format(num / Math.pow(k, i))}${suffixes[i]}`;
 }
+
+export function make2x(url?: string) {
+  if (url == null) return;
+
+  return url.replace(/(\.[^.]+)$/, '@2x$1');
+}


### PR DESCRIPTION
Explicitly use `@2x` size because otherwise it'll be blurry mess (still blurry mess on 150dpi+ displays).

The version itself is used in a few places like discussion watchlist and discussion listing although maybe it's a good idea to unify them anyway? The styling will need some adjustments.

Also this doubles number of image requests ( ﾟ ヮﾟ)