### PR TITLE
Prevent text wrapping of explicit badge

### DIFF
--- a/resources/assets/less/bem/nsfw-badge.less
+++ b/resources/assets/less/bem/nsfw-badge.less
@@ -10,6 +10,7 @@
   margin-left: 10px;
   text-transform: uppercase;
   vertical-align: middle;
+  white-space: nowrap;
 
   &--panel {
     position: relative;


### PR DESCRIPTION
The label shouldn't be that long...

Resolves #7491