### PR TITLE
Prevent redirect loop on invalid topic

### DIFF
--- a/app/Http/Controllers/Forum/TopicsController.php
+++ b/app/Http/Controllers/Forum/TopicsController.php
@@ -323,7 +323,12 @@ class TopicsController extends Controller
             if ($skipLayout) {
                 return response(null, 204);
             } else {
-                return ujs_redirect(route('forum.topics.show', $topic));
+                // make sure topic has posts at all otherwise this will be a redirect loop
+                if ($topic->posts()->showDeleted($showDeleted)->exists()) {
+                    return ujs_redirect(route('forum.topics.show', $topic));
+                } else {
+                    abort(404);
+                }
             }
         }
 

--- a/tests/Controllers/ForumTopicsControllerTest.php
+++ b/tests/Controllers/ForumTopicsControllerTest.php
@@ -154,6 +154,55 @@ class ForumTopicsControllerTest extends TestCase
             ->assertStatus(200);
     }
 
+    public function testShowNoMorePosts()
+    {
+        $forum = factory(Forum\Forum::class, 'child')->create();
+        $topic = factory(Forum\Topic::class)->create([
+            'forum_id' => $forum->forum_id,
+        ]);
+        $post = factory(Forum\Post::class)->create([
+            'forum_id' => $forum->forum_id,
+            'topic_id' => $topic->topic_id,
+        ]);
+
+        $this
+            ->get(route('forum.topics.show', [
+                'start' => $post->getKey() + 1,
+                'topic' => $topic->getKey(),
+            ]))->assertStatus(302);
+    }
+
+    public function testShowNoMorePostsWithSkipLayout()
+    {
+        $forum = factory(Forum\Forum::class, 'child')->create();
+        $topic = factory(Forum\Topic::class)->create([
+            'forum_id' => $forum->forum_id,
+        ]);
+        $post = factory(Forum\Post::class)->create([
+            'forum_id' => $forum->forum_id,
+            'topic_id' => $topic->topic_id,
+        ]);
+
+        $this
+            ->get(route('forum.topics.show', [
+                'skip_layout' => 1,
+                'start' => $post->getKey() + 1,
+                'topic' => $topic->getKey(),
+            ]))->assertStatus(204);
+    }
+
+    public function testShowMissingPosts()
+    {
+        $forum = factory(Forum\Forum::class, 'child')->create();
+        $topic = factory(Forum\Topic::class)->create([
+            'forum_id' => $forum->forum_id,
+        ]);
+
+        $this
+            ->get(route('forum.topics.show', $topic->topic_id))
+            ->assertStatus(404);
+    }
+
     public function testShowNewUser()
     {
         $forum = factory(Forum\Forum::class, 'child')->create();


### PR DESCRIPTION
Accessing topic with no posts currently causes a redirect loop.

I'm not sure what the correct response should be in such case...

Resolves #7464 (osu-web side, beatmapset getting in weird state is fixed separately)