### PR TITLE
Contest extra_options and artMeta cleanup

### DIFF
--- a/app/Models/Contest.php
+++ b/app/Models/Contest.php
@@ -17,7 +17,7 @@ use Cache;
  * @property string|null $description_voting
  * @property \Illuminate\Database\Eloquent\Collection $entries ContestEntry
  * @property \Carbon\Carbon|null $entry_ends_at
- * @property mixed $entry_shape
+ * @property mixed $thumbnail_shape
  * @property \Carbon\Carbon|null $entry_starts_at
  * @property json|null $extra_options
  * @property string $header_url
@@ -107,16 +107,16 @@ class Contest extends Model
     public function hasEntryImages(): bool
     {
         return $this->type === 'art' ||
-            ($this->type === 'external' && isset($this->getExtraOptions()['shape']));
+            ($this->type === 'external' && isset($this->getExtraOptions()['thumbnail_shape']));
     }
 
-    public function getEntryShapeAttribute(): ?string
+    public function getThumbnailShapeAttribute(): ?string
     {
         if (!$this->hasEntryImages()) {
             return null;
         }
 
-        return $this->getExtraOptions()['shape'] ?? 'square';
+        return $this->getExtraOptions()['thumbnail_shape'] ?? 'square';
     }
 
     public function getUnmaskedAttribute()

--- a/app/Models/Contest.php
+++ b/app/Models/Contest.php
@@ -104,7 +104,7 @@ class Contest extends Model
         return 'over';
     }
 
-    public function hasEntryImages(): bool
+    public function hasThumbnails(): bool
     {
         return $this->type === 'art' ||
             ($this->type === 'external' && isset($this->getExtraOptions()['thumbnail_shape']));
@@ -112,7 +112,7 @@ class Contest extends Model
 
     public function getThumbnailShapeAttribute(): ?string
     {
-        if (!$this->hasEntryImages()) {
+        if (!$this->hasThumbnails()) {
             return null;
         }
 
@@ -230,7 +230,7 @@ class Contest extends Model
     {
         $includes = [];
 
-        if ($this->hasEntryImages()) {
+        if ($this->type === 'art') {
             $includes[] = 'artMeta';
         }
 

--- a/app/Models/ContestEntry.php
+++ b/app/Models/ContestEntry.php
@@ -10,6 +10,7 @@ namespace App\Models;
  * @property int $contest_id
  * @property \Carbon\Carbon|null $created_at
  * @property string|null $entry_url
+ * @property string|null $thumbnail_url
  * @property int $id
  * @property string $masked_name
  * @property string $name
@@ -33,5 +34,14 @@ class ContestEntry extends Model
     public function votes()
     {
         return $this->hasMany(ContestVote::class);
+    }
+
+    public function thumbnail(): ?string
+    {
+        if (!$this->contest->hasThumbnails()) {
+            return null;
+        }
+
+        return presence($this->thumbnail_url) ?? $this->entry_url;
     }
 }

--- a/app/Transformers/ContestEntryTransformer.php
+++ b/app/Transformers/ContestEntryTransformer.php
@@ -6,6 +6,7 @@
 namespace App\Transformers;
 
 use App\Models\ContestEntry;
+use App\Models\DeletedUser;
 
 class ContestEntryTransformer extends TransformerAbstract
 {
@@ -16,11 +17,17 @@ class ContestEntryTransformer extends TransformerAbstract
 
     public function transform(ContestEntry $entry)
     {
-        return [
+        $return = [
             'id' => $entry->id,
             'title' => $entry->contest->unmasked ? $entry->name : $entry->masked_name,
             'preview' => $entry->entry_url,
         ];
+
+        if ($entry->contest->hasThumbnails()) {
+            $return['thumbnail'] = mini_asset($entry->thumbnail());
+        }
+
+        return $return;
     }
 
     public function includeResults(ContestEntry $entry)
@@ -29,7 +36,7 @@ class ContestEntryTransformer extends TransformerAbstract
             return [
                 'actual_name' => $entry->name,
                 'user_id' => $entry->user_id,
-                'username' => ($entry->user ?? (new \App\Models\DeletedUser()))->username,
+                'username' => ($entry->user ?? (new DeletedUser()))->username,
                 'votes' => (int) $entry->votes_count,
             ];
         });
@@ -37,27 +44,23 @@ class ContestEntryTransformer extends TransformerAbstract
 
     public function includeArtMeta(ContestEntry $entry)
     {
-        if (!$entry->contest->hasEntryImages() || !presence($entry->entry_url)) {
+        if (!$entry->contest->hasThumbnails() || !presence($entry->entry_url)) {
             return $this->item($entry, function ($entry) {
                 return [];
             });
         }
 
         return $this->item($entry, function ($entry) {
-            $thumbnailUrl = presence($entry->thumbnail_url) ?? $entry->entry_url;
-
             // suffix urls when contests are made live to ensure image dimensions are forcibly rechecked
             if ($entry->contest->visible) {
-                $urlSuffix = str_contains($thumbnailUrl, '?') ? '&live' : '?live';
+                $urlSuffix = str_contains($entry->thumbnail(), '?') ? '&live' : '?live';
             }
 
-            $size = fast_imagesize($thumbnailUrl.($urlSuffix ?? ''));
-            $thumb = mini_asset($thumbnailUrl);
+            $size = fast_imagesize($entry->thumbnail().($urlSuffix ?? ''));
 
             return [
                 'width' => $size[0],
                 'height' => $size[1],
-                'thumb' => $thumb,
             ];
         });
     }

--- a/app/Transformers/ContestTransformer.php
+++ b/app/Transformers/ContestTransformer.php
@@ -32,7 +32,7 @@ class ContestTransformer extends TransformerAbstract
         ];
 
         if ($contest->hasEntryImages()) {
-            $response['shape'] = $contest->entry_shape;
+            $response['thumbnail_shape'] = $contest->thumbnail_shape;
         }
 
         if ($contest->isBestOf()) {

--- a/app/Transformers/ContestTransformer.php
+++ b/app/Transformers/ContestTransformer.php
@@ -31,7 +31,7 @@ class ContestTransformer extends TransformerAbstract
             'link_icon' => $contest->link_icon,
         ];
 
-        if ($contest->hasEntryImages()) {
+        if ($contest->hasThumbnails()) {
             $response['thumbnail_shape'] = $contest->thumbnail_shape;
         }
 

--- a/database/migrations/2021_04_16_083901_rename_contest_shape_extra_option.php
+++ b/database/migrations/2021_04_16_083901_rename_contest_shape_extra_option.php
@@ -1,0 +1,40 @@
+<?php
+
+use App\Models\Contest;
+use Illuminate\Database\Migrations\Migration;
+
+class RenameContestShapeExtraOption extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        $this->migrate('shape', 'thumbnail_shape');
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        $this->migrate('thumbnail_shape', 'shape');
+    }
+
+    private function migrate($from, $to): void
+    {
+        foreach (Contest::all() as $contest) {
+            if (isset($contest->extra_options[$from])) {
+                $options = $contest->extra_options;
+                $options[$to] = $options[$from];
+                unset($options[$from]);
+
+                $contest->update(['extra_options' => $options]);
+            }
+        }
+    }
+}

--- a/database/migrations/2021_04_16_083901_rename_contest_shape_extra_option.php
+++ b/database/migrations/2021_04_16_083901_rename_contest_shape_extra_option.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 use App\Models\Contest;
 use Illuminate\Database\Migrations\Migration;
 

--- a/resources/assets/coffee/react/contest-voting/art-entry.coffee
+++ b/resources/assets/coffee/react/contest-voting/art-entry.coffee
@@ -45,15 +45,20 @@ export class ArtEntry extends React.Component
           rel: 'nofollow noreferrer'
           target: '_blank'
 
-    divClasses = [
-      'contest-art-entry',
-      'contest-art-entry--result' if showVotes,
-      "contest-art-entry--placed contest-art-entry--placed-#{place}" if showVotes && top3,
-      'contest-art-entry--smaller' if showVotes && !top3,
-      "contest-art-entry--#{thumbnailShape}" if thumbnailShape
-    ]
+    divClasses = 'contest-art-entry'
+    divClasses += " contest-art-entry--#{thumbnailShape}" if thumbnailShape
 
-    div style: { backgroundImage: osu.urlPresence(@props.entry.artMeta.thumb) }, className: _.compact(divClasses).join(' '),
+    if showVotes
+      divClasses += ' contest-art-entry--result'
+      if top3
+        divClasses += " contest-art-entry--placed contest-art-entry--placed-#{place}"
+      else
+        divClasses += ' contest-art-entry--smaller'
+
+    div
+      style:
+        backgroundImage: osu.urlPresence(@props.entry.thumbnail)
+      className: divClasses
       entryLink
 
       div

--- a/resources/assets/coffee/react/contest-voting/art-entry.coffee
+++ b/resources/assets/coffee/react/contest-voting/art-entry.coffee
@@ -4,10 +4,13 @@
 import { Voter } from './voter'
 import * as React from 'react'
 import { div, span, a, i } from 'react-dom-factories'
+import { classWithModifiers } from 'utils/css'
+
 el = React.createElement
 
 export class ArtEntry extends React.Component
   render: ->
+    bn = 'contest-art-entry'
     isSelected = _.includes @props.selected, @props.entry.id
 
     return null if @props.hideIfNotVoted && !isSelected
@@ -24,8 +27,8 @@ export class ArtEntry extends React.Component
       place = @props.displayIndex + 1
       top3 = place <= 3
 
-    linkClasses = 'contest-art-entry__thumbnail'
-    linkClasses += ' contest-art-entry--selected' if isSelected
+    linkClasses = "#{bn}__thumbnail"
+    linkClasses += " #{bn}--selected" if isSelected
     linkClasses += ' js-gallery' if @props.contest.type == 'art'
 
     entryLink =
@@ -45,20 +48,15 @@ export class ArtEntry extends React.Component
           rel: 'nofollow noreferrer'
           target: '_blank'
 
-    divClasses = 'contest-art-entry'
-    divClasses += " contest-art-entry--#{thumbnailShape}" if thumbnailShape
-
-    if showVotes
-      divClasses += ' contest-art-entry--result'
-      if top3
-        divClasses += " contest-art-entry--placed contest-art-entry--placed-#{place}"
-      else
-        divClasses += ' contest-art-entry--smaller'
-
     div
       style:
         backgroundImage: osu.urlPresence(@props.entry.thumbnail)
-      className: divClasses
+      className: classWithModifiers bn,
+        "#{thumbnailShape}": thumbnailShape?
+        result: showVotes
+        placed: showVotes && top3
+        "placed-#{place}": showVotes && top3
+        smaller: showVotes && !top3
       entryLink
 
       div
@@ -79,23 +77,23 @@ export class ArtEntry extends React.Component
           buttonId: buttonId
 
       if showVotes
-        div className: 'contest-art-entry__result',
-          div className: 'contest-art-entry__result-ranking',
-            div className: 'contest-art-entry__result-place',
+        div className: "#{bn}__result",
+          div className: "#{bn}__result-ranking",
+            div className: "#{bn}__result-place",
               if top3
-                i className: "fas fa-fw fa-trophy contest-art-entry__trophy--#{place}"
+                i className: "fas fa-fw fa-trophy #{bn}__trophy--#{place}"
               span {}, "##{place}"
             if @props.entry.results.user_id
               a
-                className: 'contest-art-entry__entrant js-usercard',
+                className: "#{bn}__entrant js-usercard",
                 'data-user-id': @props.entry.results.user_id,
                 href: laroute.route('users.show', user: @props.entry.results.user_id),
                   @props.entry.results.username
             else
-              span className: 'contest-art-entry__entrant', @props.entry.results.actual_name
-          div className: 'contest-art-entry__result-pane',
-            span className: 'contest-art-entry__result-votes',
+              span className: "#{bn}__entrant', @props.entry.results.actual_name"
+          div className: "#{bn}__result-pane",
+            span className: "#{bn}__result-votes",
               osu.transChoice 'contest.vote.count', @props.entry.results.votes
             if not isNaN(votePercentage)
-              span className: 'contest-art-entry__result-votes contest-art-entry__result-votes--percentage',
+              span className: "#{bn}__result-votes #{bn}__result-votes--percentage",
                 " (#{osu.formatNumber(votePercentage)}%)"

--- a/resources/assets/coffee/react/contest-voting/art-entry.coffee
+++ b/resources/assets/coffee/react/contest-voting/art-entry.coffee
@@ -14,7 +14,7 @@ export class ArtEntry extends React.Component
 
     votingOver = moment(@props.contest.voting_ends_at).diff() <= 0
     showVotes = @props.contest.show_votes
-    shape = @props.contest.shape
+    thumbnailShape = @props.contest.thumbnail_shape
     galleryId = "contest-#{@props.contest.id}"
     buttonId = "#{galleryId}:#{@props.displayIndex}"
     hideVoteButton = (@props.selected.length >= @props.contest.max_votes || votingOver) && !isSelected
@@ -50,7 +50,7 @@ export class ArtEntry extends React.Component
       'contest-art-entry--result' if showVotes,
       "contest-art-entry--placed contest-art-entry--placed-#{place}" if showVotes && top3,
       'contest-art-entry--smaller' if showVotes && !top3,
-      "contest-art-entry--#{shape}" if shape
+      "contest-art-entry--#{thumbnailShape}" if thumbnailShape
     ]
 
     div style: { backgroundImage: osu.urlPresence(@props.entry.artMeta.thumb) }, className: _.compact(divClasses).join(' '),

--- a/resources/views/admin/contests/show.blade.php
+++ b/resources/views/admin/contests/show.blade.php
@@ -56,9 +56,9 @@
             <dd class="contest">
                 <div class="contest__description">{!! markdown($contest->description_voting) !!}</div>
             </dd>
-            @if ($contest->extra_options !== null)
+            @if ($contest->getExtraOptions() !== null)
                 <dt class="admin-contest__meta-row"><br />Extra Options</dt>
-                <dd><pre>{{json_encode($contest->extra_options, JSON_PRETTY_PRINT)}}</pre></dd>
+                <dd><pre>{{json_encode($contest->getExtraOptions(), JSON_PRETTY_PRINT)}}</pre></dd>
             @endif
         </dl>
         <div class="js-react--admin-contest-user-entry-list"></div>

--- a/resources/views/contests/_voting-entrylist.blade.php
+++ b/resources/views/contests/_voting-entrylist.blade.php
@@ -2,7 +2,7 @@
     Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
     See the LICENCE file in the repository root for full licence text.
 --}}
-@if ($contest->hasEntryImages())
+@if ($contest->hasThumbnails())
     <div class="js-react--contestArtList" data-src="contest-{{$contest->id}}"></div>
 @else
     <div class="js-react--contestList" data-src="contest-{{$contest->id}}"></div>


### PR DESCRIPTION
Renames `shape` to `thumbnail_shape` (within `extra_options`) and standardizes the derived attributes.
Also stops including the unused `artMeta` for non-art contests, plus general cleanups.

cc @Ephemeralis - be aware that once this is merged, you should start using `thumbnail_shape` instead of `shape` when making contests