### PR TITLE
Beatmap search adjustments

### DIFF
--- a/app/Libraries/Search/BeatmapsetQueryParser.php
+++ b/app/Libraries/Search/BeatmapsetQueryParser.php
@@ -40,7 +40,9 @@ class BeatmapsetQueryParser
                     $parsed = static::parseLength($m['value']);
                     $option = static::makeFloatRangeOption($op, $parsed['value'], $parsed['scale'] / 2.0);
                     break;
+                case 'key':
                 case 'keys':
+                    $key = 'keys';
                     $option = static::makeIntRangeOption($op, $m['value']);
                     break;
                 case 'divisor':

--- a/app/Libraries/Search/BeatmapsetSearch.php
+++ b/app/Libraries/Search/BeatmapsetSearch.php
@@ -74,6 +74,7 @@ class BeatmapsetSearch extends RecordSearch
         $this->addStatusFilter($query);
 
         $nested = new BoolQuery();
+        $this->addManiaKeysFilter($nested);
         $this->addModeFilter($nested);
         $this->addPlayedFilter($query, $nested);
         $this->addRankFilter($nested);
@@ -171,6 +172,17 @@ class BeatmapsetSearch extends RecordSearch
         }
     }
 
+    private function addManiaKeysFilter(BoolQuery $nestedQuery): void
+    {
+        if ($this->params->keys === null) {
+            return;
+        }
+
+        $nestedQuery
+            ->filter(['range' => ['beatmaps.diff_size' => $this->params->keys]])
+            ->filter(['term' => ['beatmaps.playmode' => Beatmap::MODES['mania']]]);
+    }
+
     private function addModeFilter($query)
     {
         if (!$this->params->includeConverts) {
@@ -252,7 +264,6 @@ class BeatmapsetSearch extends RecordSearch
             'difficultyRating' => ['field' => 'beatmaps.difficultyrating', 'type' => 'range'],
             'drain' => ['field' => 'beatmaps.diff_drain', 'type' => 'range'],
             'hitLength' => ['field' => 'beatmaps.hit_length', 'type' => 'range'],
-            'keys' => ['field' => 'beatmaps.diff_size', 'type' => 'range'],
             'statusRange' => ['field' => 'beatmaps.approved', 'type' => 'range'],
             // (unsupported) 'divisor' => ['field' => ???, 'type' => 'range'],
         ];

--- a/app/Libraries/Search/BeatmapsetSearch.php
+++ b/app/Libraries/Search/BeatmapsetSearch.php
@@ -234,8 +234,11 @@ class BeatmapsetSearch extends RecordSearch
     {
         if ($this->params->ranked !== null) {
             $query
-                ->filter(['term' => ['approved' => Beatmapset::STATES['ranked']]])
-                ->filter(['range' => ['approved_date' => $this->params->ranked]]);
+                ->filter(['terms' => ['approved' => [
+                    Beatmapset::STATES['ranked'],
+                    Beatmapset::STATES['approved'],
+                    Beatmapset::STATES['loved'],
+                ]]])->filter(['range' => ['approved_date' => $this->params->ranked]]);
         }
     }
 


### PR DESCRIPTION
Include loved and approved maps for search by ranked date, limit keys search to mania, and add "key" alias for keys search to match lazer.

Resolves #7483, resolves #7498.