### PR TITLE
Added avatars and rank summary to user profile cards

### DIFF
--- a/resources/lang/en/users.php
+++ b/resources/lang/en/users.php
@@ -141,6 +141,7 @@ return [
     ],
     'show' => [
         'age' => ':age years old',
+        'rank_summary' => ':username is rank :global worldwide and rank :local in :country.',
         'change_avatar' => 'change your avatar!',
         'first_members' => 'Here since the beginning',
         'is_developer' => 'osu!developer',

--- a/resources/views/users/show.blade.php
+++ b/resources/views/users/show.blade.php
@@ -12,7 +12,7 @@
       'country' => $data["country"]["name"],
     ]),
     'opengraph' => [
-        'title' => $user->username . "'s Profile",
+        'title' => trans('users.show.title', ["username" => $user->username]),
         'image' =>  str_replace('http://localhost:8080', 'https://ffvyiglk.tunnelto.dev', $data["avatar_url"])
         // 'image' =>  json_encode($data),
     ]

--- a/resources/views/users/show.blade.php
+++ b/resources/views/users/show.blade.php
@@ -3,8 +3,19 @@
     See the LICENCE file in the repository root for full licence text.
 --}}
 @extends('master', [
+    'canonicalUrl' => $user->url(),
     'titlePrepend' => blade_safe(str_replace(' ', '&nbsp;', e($user->username))),
-    'pageDescription' => page_description($user->username),
+    'pageDescription' => trans('users.show.rank_summary', [
+      'username' => $user->username,
+      'global' => $data["statistics"]["global_rank"],
+      'local' => $data["statistics"]["country_rank"],
+      'country' => $data["country"]["name"],
+    ]),
+    'opengraph' => [
+        'title' => $user->username . "'s Profile",
+        'image' =>  str_replace('http://localhost:8080', 'https://ffvyiglk.tunnelto.dev', $data["avatar_url"])
+        // 'image' =>  json_encode($data),
+    ]
 ])
 
 @section('content')

--- a/resources/views/users/show.blade.php
+++ b/resources/views/users/show.blade.php
@@ -13,8 +13,7 @@
     ]),
     'opengraph' => [
         'title' => trans('users.show.title', ["username" => $user->username]),
-        'image' =>  str_replace('http://localhost:8080', 'https://ffvyiglk.tunnelto.dev', $data["avatar_url"])
-        // 'image' =>  json_encode($data),
+        'image' => $data["avatar_url"]
     ]
 ])
 


### PR DESCRIPTION
Before: 
![image](https://user-images.githubusercontent.com/24978328/115764293-0f399100-a3ae-11eb-851a-05d1cdacb6c5.png)

After: 
![image](https://user-images.githubusercontent.com/24978328/115764305-1365ae80-a3ae-11eb-9e60-c7747cb1c281.png)

Users without avatars: 
![image](https://user-images.githubusercontent.com/24978328/115764451-3e500280-a3ae-11eb-9703-751817ec50d3.png)

Not sure if the ranks need to be formatted like `123,000`. Totally open to changing the wording of the description if needed of course.

I wasn't able to test for cases where the user doesn't have a global rank since mysql doesn't let me set null values on user ranks but I know profiles that don't have global ranks like https://osu.ppy.sh/users/4198271 exist. If that needs to be tested before this is merged I might need a little help with it 🙏.