### PR TITLE
Add class member sort lint for eslint

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -62,7 +62,8 @@ module.exports = {
       ],
       '@typescript-eslint/member-delimiter-style': 'error',
       '@typescript-eslint/member-ordering': [
-        'error',
+        // TODO: flip to error once tslint is turned off. The order is case sensitive while the tslint one isn't.
+        'warning',
         {
           default: {
             memberTypes: [

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -64,27 +64,30 @@ module.exports = {
       '@typescript-eslint/member-ordering': [
         'error',
         {
-          default: [
-            'public-static-field',
-            'protected-static-field',
-            'private-static-field',
+          default: {
+            memberTypes: [
+              'public-static-field',
+              'protected-static-field',
+              'private-static-field',
 
-            'public-instance-field',
-            'protected-instance-field',
-            'private-instance-field',
+              'public-instance-field',
+              'protected-instance-field',
+              'private-instance-field',
 
-            'public-constructor',
-            'protected-constructor',
-            'private-constructor',
+              'public-constructor',
+              'protected-constructor',
+              'private-constructor',
 
-            'public-static-method',
-            'protected-static-method',
-            'private-static-method',
+              'public-static-method',
+              'protected-static-method',
+              'private-static-method',
 
-            'public-instance-method',
-            'protected-instance-method',
-            'private-instance-method',
-          ],
+              'public-instance-method',
+              'protected-instance-method',
+              'private-instance-method',
+            ],
+            order: 'alphabetically',
+          },
         },
       ],
       '@typescript-eslint/naming-convention': 'off',

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -63,7 +63,7 @@ module.exports = {
       '@typescript-eslint/member-delimiter-style': 'error',
       '@typescript-eslint/member-ordering': [
         // TODO: flip to error once tslint is turned off. The order is case sensitive while the tslint one isn't.
-        'warning',
+        'warn',
         {
           default: {
             memberTypes: [


### PR DESCRIPTION
Annoyingly there's no fixer for this on eslint.

Even more annoying it is case sensitive while tslint one isn't.