### PR TITLE
Add option to show entry names for external/art contests.

### DIFF
--- a/app/Models/Contest.php
+++ b/app/Models/Contest.php
@@ -29,6 +29,7 @@ use Cache;
  * @property int $show_votes
  * @property mixed $type
  * @property mixed $unmasked
+ * @property bool $show_names
  * @property \Carbon\Carbon|null $updated_at
  * @property bool $visible
  * @property \Illuminate\Database\Eloquent\Collection $votes ContestVote
@@ -122,6 +123,11 @@ class Contest extends Model
     public function getUnmaskedAttribute()
     {
         return $this->getExtraOptions()['unmasked'] ?? false;
+    }
+
+    public function getShowNamesAttribute()
+    {
+        return $this->getExtraOptions()['show_names'] ?? false;
     }
 
     public function getLinkIconAttribute()

--- a/app/Transformers/ContestTransformer.php
+++ b/app/Transformers/ContestTransformer.php
@@ -28,6 +28,7 @@ class ContestTransformer extends TransformerAbstract
             'entry_ends_at' => json_time($contest->entry_ends_at),
             'voting_ends_at' => json_time($contest->voting_ends_at),
             'show_votes' => $contest->show_votes,
+            'show_names' => $contest->show_names,
             'link_icon' => $contest->link_icon,
         ];
 

--- a/resources/assets/coffee/react/contest-voting/art-entry.coffee
+++ b/resources/assets/coffee/react/contest-voting/art-entry.coffee
@@ -17,6 +17,7 @@ export class ArtEntry extends React.Component
 
     votingOver = moment(@props.contest.voting_ends_at).diff() <= 0
     showVotes = @props.contest.show_votes
+    showNames = @props.contest.show_names
     thumbnailShape = @props.contest.thumbnail_shape
     galleryId = "contest-#{@props.contest.id}"
     buttonId = "#{galleryId}:#{@props.displayIndex}"
@@ -54,6 +55,7 @@ export class ArtEntry extends React.Component
       className: classWithModifiers bn,
         "#{thumbnailShape}": thumbnailShape?
         result: showVotes
+        'show-name': showNames && !showVotes
         placed: showVotes && top3
         "placed-#{place}": showVotes && top3
         smaller: showVotes && !top3
@@ -97,3 +99,11 @@ export class ArtEntry extends React.Component
             if not isNaN(votePercentage)
               span className: "#{bn}__result-votes #{bn}__result-votes--percentage",
                 " (#{osu.formatNumber(votePercentage)}%)"
+      else if showNames
+        div className: "#{bn}__result",
+          a
+            href: @props.entry.preview
+            rel: 'nofollow noreferrer'
+            target: '_blank'
+
+            @props.entry.title

--- a/resources/assets/less/bem/contest-art-entry.less
+++ b/resources/assets/less/bem/contest-art-entry.less
@@ -47,6 +47,10 @@
     margin-bottom: 58px;
   }
 
+  &--show-name {
+    margin-bottom: 40px;
+  }
+
   &--placed {
     margin-bottom: 68px;
   }


### PR DESCRIPTION
Enabled by setting `"show_names": true` under `extra_options`