### PR TITLE
Workaround getting size of contest entry missing image

### DIFF
--- a/app/Transformers/ContestEntryTransformer.php
+++ b/app/Transformers/ContestEntryTransformer.php
@@ -59,8 +59,8 @@ class ContestEntryTransformer extends TransformerAbstract
             $size = fast_imagesize($entry->thumbnail().($urlSuffix ?? ''));
 
             return [
-                'width' => $size[0],
-                'height' => $size[1],
+                'width' => $size[0] ?? 0,
+                'height' => $size[1] ?? 0,
             ];
         });
     }


### PR DESCRIPTION
Just set the dimensions to 0 instead of dying; it doesn't fix the issue to stale data being in the cache in the event the image gets fixed but the url doesn't have its cache busting updated.