### PR TITLE
Add taiko swap mod

### DIFF
--- a/app/Libraries/Multiplayer/Mod.php
+++ b/app/Libraries/Multiplayer/Mod.php
@@ -63,6 +63,7 @@ class Mod
 
     // taiko-specific
     const TAIKO_RANDOM = 'RD';
+    const TAIKO_SWAP = 'SW';
 
     // non-scorable
     const AUTOPLAY = 'AT';
@@ -276,6 +277,7 @@ class Mod
                     self::SCORABLE_COMMON,
                     [
                         self::TAIKO_RANDOM,
+                        self::TAIKO_SWAP,
                     ]
                 ),
 
@@ -320,7 +322,15 @@ class Mod
         if (!$value) {
             $value = [
                 Ruleset::OSU => self::EXCLUSIVITY_COMMON,
-                Ruleset::TAIKO => self::EXCLUSIVITY_COMMON,
+                Ruleset::TAIKO => array_merge(
+                    self::EXCLUSIVITY_COMMON,
+                    [
+                        [
+                            self::TAIKO_RANDOM,
+                            self::TAIKO_SWAP,
+                        ],
+                    ]
+                ),
                 Ruleset::CATCH => self::EXCLUSIVITY_COMMON,
                 Ruleset::MANIA => array_merge(
                     self::EXCLUSIVITY_COMMON,


### PR DESCRIPTION
Reference: https://github.com/ppy/osu/pull/12834

Should also probably hoist up other exclusivities present in `EXCLUSIVITY_COMMON` into here at some point...? Quite a few are ruleset-specific.