### PR TITLE
Update short name for Relax mod

### DIFF
--- a/app/Libraries/ModsHelper.php
+++ b/app/Libraries/ModsHelper.php
@@ -15,7 +15,7 @@ class ModsHelper
         [4, 'HR'],
         [9, 'NC', [6]],
         [6, 'DT'],
-        [7, 'Relax'],
+        [7, 'RX'],
         [8, 'HT'],
         [10, 'FL'],
         [12, 'SO'],

--- a/resources/assets/less/bem/mod.less
+++ b/resources/assets/less/bem/mod.less
@@ -37,7 +37,7 @@
   .all(NF, 'no-fail');
   .all(NM, 'no-mod');
   .all(PF, 'perfect');
-  .all(Relax, 'relax');
+  .all(RX, 'relax');
   .all(SD, 'sudden-death');
   .all(SO, 'spun-out');
   .all(TD, 'touchdevice');

--- a/resources/lang/en/beatmaps.php
+++ b/resources/lang/en/beatmaps.php
@@ -310,7 +310,7 @@ return [
         'NF' => 'No Fail',
         'NM' => 'No mods',
         'PF' => 'Perfect',
-        'Relax' => 'Relax',
+        'RX' => 'Relax',
         'SD' => 'Sudden Death',
         'SO' => 'Spun Out',
         'TD' => 'Touch Device',


### PR DESCRIPTION
Matches current lazer naming and allows more correct mods conversion from lazer score.