### PR TITLE
Remove `beatmapset` terminology from the site localisation

### DIFF
--- a/resources/lang/en/admin.php
+++ b/resources/lang/en/admin.php
@@ -10,10 +10,10 @@ return [
             'regenerating' => 'Regenerating...',
             'remove' => 'Remove',
             'removing' => 'Removing...',
-            'title' => 'Beatmapset covers',
+            'title' => 'Beatmap covers',
         ],
         'show' => [
-            'covers' => 'Manage Beatmapset Covers',
+            'covers' => 'Manage Beatmap Covers',
             'discussion' => [
                 '_' => 'Modding v2',
                 'activate' => 'activate',
@@ -57,7 +57,7 @@ return [
     'pages' => [
         'root' => [
             'sections' => [
-                'beatmapsets' => 'Beatmapsets',
+                'beatmapsets' => 'Beatmaps',
                 'forum' => 'Forum',
                 'general' => 'General',
                 'store' => 'Store',

--- a/resources/lang/en/beatmaps.php
+++ b/resources/lang/en/beatmaps.php
@@ -55,7 +55,7 @@ return [
         ],
 
         'message_hint' => [
-            'in_general' => 'This post will go to general beatmapset discussion. To mod this beatmap, start message with timestamp (e.g. 00:12:345).',
+            'in_general' => 'This post will go to general beatmap discussion. To mod this difficulty, start message with timestamp (e.g. 00:12:345).',
             'in_timeline' => 'To mod multiple timestamps, post multiple times (one post per timestamp).',
         ],
 

--- a/resources/lang/en/beatmapsets.php
+++ b/resources/lang/en/beatmapsets.php
@@ -32,7 +32,7 @@ return [
     ],
 
     'nominate' => [
-        'hybrid_requires_modes' => 'A hybrid beatmapset requires you to select at least one playmode to nominate for.',
+        'hybrid_requires_modes' => 'A hybrid beatmap requires you to select at least one playmode to nominate for.',
         'incorrect_mode' => 'You do not have permission to nominate for mode: :mode',
         'full_bn_required' => 'You must be a full nominator to perform this qualifying nomination.',
         'too_many' => 'Nomination requirement already fulfilled.',
@@ -54,11 +54,11 @@ return [
 
         'details' => [
             'by_artist' => 'by :artist',
-            'favourite' => 'Favourite this beatmapset',
+            'favourite' => 'Favourite this beatmap',
             'favourite_login' => 'Sign in to favourite this beatmap',
             'logged-out' => 'You need to sign in before downloading any beatmaps!',
             'mapped_by' => 'mapped by :mapper',
-            'unfavourite' => 'Unfavourite this beatmapset',
+            'unfavourite' => 'Unfavourite this beatmap',
             'updated_timeago' => 'last updated :timeago',
 
             'download' => [

--- a/resources/lang/en/model_validation.php
+++ b/resources/lang/en/model_validation.php
@@ -11,7 +11,7 @@ return [
     'wrong_confirmation' => 'Confirmation does not match.',
 
     'beatmapset_discussion' => [
-        'beatmap_missing' => 'Timestamp is specified but beatmap is missing.',
+        'beatmap_missing' => 'Timestamp is specified but beatmap difficulty is missing.',
         'beatmapset_no_hype' => "Beatmap can't be hyped.",
         'hype_requires_null_beatmap' => 'Hype must be done in the General (all difficulties) section.',
         'invalid_beatmap_id' => 'Invalid difficulty specified.',


### PR DESCRIPTION
Removes the `beatmapset` terminology from the site based on [https://github.com/ppy/osu-wiki/issues/4723](https://github.com/ppy/osu-wiki/issues/4723)