### PR TITLE
Show user last visit as relative time

### DIFF
--- a/resources/assets/lib/profile-page/links.tsx
+++ b/resources/assets/lib/profile-page/links.tsx
@@ -112,7 +112,7 @@ const textMapping: Record<TextKey, (user: UserJsonExtended) => StringWithCompone
     }
 
     return {
-      mappings: { ':date': <TimeWithTooltip key='date' dateTime={user.last_visit ?? ''} /> },
+      mappings: { ':date': <TimeWithTooltip key='date' dateTime={user.last_visit ?? ''} relative /> },
       pattern: osu.trans('users.show.lastvisit'),
     };
   },


### PR DESCRIPTION
Forgot to add `relative` in #7505 as the previously used `osu.timeago` sets `js-timeago`

fixes #7658