### PR TITLE
Update beatmap cover size

### DIFF
--- a/resources/assets/less/bem/beatmap-playcount.less
+++ b/resources/assets/less/bem/beatmap-playcount.less
@@ -40,15 +40,12 @@
     .cover-border-radius();
     .at2x-simple('~@images/layout/beatmaps/default-bg.png');
     flex: none;
-    width: 80px;
+    width: 70px;
+    height: 60px;
     background-size: cover;
     background-repeat: no-repeat;
     background-position: center;
     position: relative;
-
-    @media @desktop {
-      width: 100px;
-    }
   }
 
   &__cover-count {

--- a/resources/assets/less/bem/beatmapset-search-card.less
+++ b/resources/assets/less/bem/beatmapset-search-card.less
@@ -22,7 +22,7 @@
   }
 
   &__cover-container {
-    width: 80px;
+    width: 50px;
     flex: none;
     border-radius: @border-radius-large;
     overflow: hidden;

--- a/resources/assets/less/bem/beatmapset-watches.less
+++ b/resources/assets/less/bem/beatmapset-watches.less
@@ -25,7 +25,7 @@
 
   &__cover {
     .default-border-radius();
-    width: 80px;
+    width: 50px;
     height: 50px;
     background-size: cover;
     background-position: center;


### PR DESCRIPTION
- Quick search
- Beatmap discussion watchlist
- Profile page's most played (kinda follows size in new design)

For some reason the mapper watchlist uses card (400&times;140 (new) full, 80&times;40 scaled on page) which is actually closer compared to previous full size of 400&times;100