### PR TITLE
Decode uri in ziggy route

### DIFF
--- a/resources/assets/lib/laroute.ts
+++ b/resources/assets/lib/laroute.ts
@@ -20,7 +20,7 @@ export function route(name: string, params?: Attributes | null, absolute?: boole
     params = {};
   }
 
-  return ziggyRoute(name, params, absolute, Ziggy).toString();
+  return decodeURIComponent(ziggyRoute(name, params, absolute, Ziggy).toString());
 }
 
 export function link_to_route(name: string, text: string, params?: Attributes | null, attrs?: Attributes | null) {


### PR DESCRIPTION
Closes #7693 

The real problem in that issue is the link of suggestion result is not decoded.

Not sure if I want to decode inside the `route` function itself or do it locally at this code.

https://github.com/ppy/osu-web/blob/e43a7eca9384e2ab32b0ed45d0de1a61fc967b8e/resources/assets/lib/wiki-search.tsx#L109