### PR TITLE
Fix UserGroup group attribute return type

### DIFF
--- a/app/Models/UserGroup.php
+++ b/app/Models/UserGroup.php
@@ -34,7 +34,7 @@ class UserGroup extends Model
         return $this->belongsTo(User::class, 'user_id');
     }
 
-    public function getGroupAttribute(): Group
+    public function getGroupAttribute(): ?Group
     {
         return app('groups')->byId($this->group_id);
     }


### PR DESCRIPTION
`Groups::byId` returns `?Group`, `group` should return the same.