### PR TITLE
Store auth data in request object

### DIFF
--- a/app/Jobs/NotifyForumUpdateMail.php
+++ b/app/Jobs/NotifyForumUpdateMail.php
@@ -44,6 +44,8 @@ class NotifyForumUpdateMail implements ShouldQueue
             ->get()
             ->keyBy('user_id');
 
+        app('OsuAuthorize')->cacheReset();
+
         foreach ($watches as $watch) {
             $user = $watch->user;
 

--- a/app/Jobs/UpdateUserForumTopicFollows.php
+++ b/app/Jobs/UpdateUserForumTopicFollows.php
@@ -37,6 +37,8 @@ class UpdateUserForumTopicFollows implements ShouldQueue
      */
     public function handle()
     {
+        app('OsuAuthorize')->cacheReset();
+
         foreach ($this->topic->watches()->with(['user', 'topic.forum'])->get() as $watch) {
             $user = $watch->user;
             $topic = $watch->topic;

--- a/app/Libraries/OsuAuthorize.php
+++ b/app/Libraries/OsuAuthorize.php
@@ -27,21 +27,28 @@ use App\Models\OAuth\Client;
 use App\Models\User;
 use App\Models\UserContestEntry;
 use Carbon\Carbon;
+use Ds;
 
 class OsuAuthorize
 {
-    const ALWAYS_CHECK = [
-        'IsOwnClient',
-        'IsNotOAuth',
-        'IsSpecialScope',
-    ];
+    const REQUEST_ATTRIBUTE_KEY = 'auth_map';
 
-    /** @var AuthorizationResult[] */
-    private $cache = [];
+    public static function alwaysCheck($ability)
+    {
+        static $set;
+
+        $set ??= new Ds\Set([
+            'IsOwnClient',
+            'IsNotOAuth',
+            'IsSpecialScope',
+        ]);
+
+        return $set->contains($ability);
+    }
 
     public function cacheReset(): void
     {
-        $this->cache = [];
+        request()->attributes->remove(static::REQUEST_ATTRIBUTE_KEY);
     }
 
     /**
@@ -58,8 +65,17 @@ class OsuAuthorize
             $object === null ? null : [$object->getTable(), $object->getKey()],
         ]);
 
-        if (!isset($this->cache[$cacheKey])) {
-            if ($user !== null && $user->isAdmin() && !in_array($ability, static::ALWAYS_CHECK, true)) {
+        $authMap = request()->attributes->get(static::REQUEST_ATTRIBUTE_KEY);
+
+        if ($authMap === null) {
+            $authMap = new Ds\Map();
+            request()->attributes->set(static::REQUEST_ATTRIBUTE_KEY, $authMap);
+        }
+
+        $auth = $authMap->get($cacheKey, null);
+
+        if ($auth === null) {
+            if ($user !== null && $user->isAdmin() && !static::alwaysCheck($ability)) {
                 $message = 'ok';
             } else {
                 $function = "check{$ability}";
@@ -71,10 +87,11 @@ class OsuAuthorize
                 }
             }
 
-            $this->cache[$cacheKey] = new AuthorizationResult($message);
+            $auth = new AuthorizationResult($message);
+            $authMap->put($cacheKey, $auth);
         }
 
-        return $this->cache[$cacheKey];
+        return $auth;
     }
 
     /**

--- a/tests/Controllers/BeatmapDiscussionPostsControllerTest.php
+++ b/tests/Controllers/BeatmapDiscussionPostsControllerTest.php
@@ -55,7 +55,6 @@ class BeatmapDiscussionPostsControllerTest extends TestCase
         Event::assertNotDispatched(NewPrivateNotificationEvent::class);
 
         $this->user->statisticsOsu->update(['playcount' => $this->minPlays]);
-        app()->make('OsuAuthorize')->cacheReset();
 
         $this
             ->actingAsVerified($this->user)

--- a/tests/Controllers/Chat/ChatControllerTest.php
+++ b/tests/Controllers/Chat/ChatControllerTest.php
@@ -90,7 +90,6 @@ class ChatControllerTest extends TestCase
         )->assertStatus(200);
 
         // should return existing conversation and not error
-        app('OsuAuthorize')->cacheReset();
         $this->json(
             'POST',
             route('api.chat.new'),
@@ -116,7 +115,6 @@ class ChatControllerTest extends TestCase
         $channelId = $request->json('new_channel_id');
         $request->assertSuccessful();
 
-        app('OsuAuthorize')->cacheReset();
         $this->json(
             'DELETE',
             route('api.chat.channels.part', [
@@ -125,7 +123,6 @@ class ChatControllerTest extends TestCase
             ])
         )->assertSuccessful();
 
-        app('OsuAuthorize')->cacheReset();
         $this->json(
             'POST',
             route('api.chat.new'),
@@ -305,7 +302,6 @@ class ChatControllerTest extends TestCase
         ]);
 
         // ensure conversation with $this->anotherUser isn't visible
-        app('OsuAuthorize')->cacheReset();
         $this->json('GET', route('api.chat.presence'))
             ->assertStatus(200)
             ->assertJsonMissing(['users' => [
@@ -343,7 +339,6 @@ class ChatControllerTest extends TestCase
         $this->anotherUser->update(['user_warnings' => 1]);
 
         // ensure conversation with $this->anotherUser isn't visible
-        app('OsuAuthorize')->cacheReset();
         $this->json('GET', route('api.chat.presence'))
             ->assertStatus(200)
             ->assertJsonMissing(['users' => [
@@ -355,7 +350,6 @@ class ChatControllerTest extends TestCase
         $this->anotherUser->update(['user_warnings' => 0]);
 
         // ensure conversation with $this->anotherUser is visible again
-        app('OsuAuthorize')->cacheReset();
         $this->json('GET', route('api.chat.presence'))
             ->assertStatus(200)
             ->assertJsonFragment(['users' => [
@@ -381,7 +375,6 @@ class ChatControllerTest extends TestCase
         $channelId = $presenceData['new_channel_id'];
 
         // leave PM with $this->anotherUser
-        app('OsuAuthorize')->cacheReset();
         $this->json('DELETE', route('api.chat.channels.part', [
             'channel' => $channelId,
             'user' => $this->user->user_id,
@@ -389,7 +382,6 @@ class ChatControllerTest extends TestCase
             ->assertStatus(204);
 
         // ensure conversation with $this->anotherUser isn't visible
-        app('OsuAuthorize')->cacheReset();
         $this->json('GET', route('api.chat.presence'))
             ->assertStatus(200)
             ->assertJsonMissing(['users' => [
@@ -398,7 +390,6 @@ class ChatControllerTest extends TestCase
             ]]);
 
         // reopen PM with $this->anotherUser
-        app('OsuAuthorize')->cacheReset();
         $this->json(
             'POST',
             route('api.chat.new'),
@@ -409,7 +400,6 @@ class ChatControllerTest extends TestCase
         )->assertStatus(200);
 
         // ensure conversation with $this->anotherUser is visible again
-        app('OsuAuthorize')->cacheReset();
         $this->json('GET', route('api.chat.presence'))
             ->assertStatus(200)
             ->assertJsonFragment(['users' => [
@@ -440,7 +430,6 @@ class ChatControllerTest extends TestCase
         ]))
             ->assertSuccessful();
 
-        app('OsuAuthorize')->cacheReset();
         $this->json('GET', route('api.chat.updates'), ['since' => $publicMessage->message_id])
             ->assertStatus(204);
     }
@@ -458,7 +447,6 @@ class ChatControllerTest extends TestCase
         ]))
             ->assertSuccessful();
 
-        app('OsuAuthorize')->cacheReset();
         $this->json('GET', route('api.chat.updates'), ['since' => 0])
             ->assertStatus(200)
             ->assertJsonFragment(['content' => $publicMessage->content]);
@@ -487,7 +475,6 @@ class ChatControllerTest extends TestCase
         ]);
 
         // ensure reply is visible
-        app('OsuAuthorize')->cacheReset();
         $this->json('GET', route('api.chat.updates'), ['since' => 0])
             ->assertStatus(200)
             ->assertJsonFragment(['content' => $publicMessage->content]);
@@ -496,7 +483,6 @@ class ChatControllerTest extends TestCase
         $this->anotherUser->update(['user_warnings' => 1]);
 
         // ensure reply is no longer visible
-        app('OsuAuthorize')->cacheReset();
         $this->json('GET', route('api.chat.updates'), ['since' => 0])
             ->assertStatus(204);
     }

--- a/tests/Controllers/ForumTopicsControllerTest.php
+++ b/tests/Controllers/ForumTopicsControllerTest.php
@@ -47,8 +47,6 @@ class ForumTopicsControllerTest extends TestCase
 
         // add some plays so it passes
         $this->addPlaycount($user);
-        // reset auth
-        app()->make('OsuAuthorize')->cacheReset();
 
         $this
             ->actingAsVerified($user)
@@ -96,8 +94,6 @@ class ForumTopicsControllerTest extends TestCase
 
         // add some plays so it passes
         $this->addPlaycount($user);
-        // reset auth
-        app()->make('OsuAuthorize')->cacheReset();
 
         $this
             ->actingAsVerified($user)
@@ -256,8 +252,6 @@ class ForumTopicsControllerTest extends TestCase
 
         // add some plays so it passes
         $this->addPlaycount($user);
-        // reset auth
-        app()->make('OsuAuthorize')->cacheReset();
 
         $this
             ->actingAsVerified($user)

--- a/tests/Jobs/UpdateUserForumTopicFollowsTest.php
+++ b/tests/Jobs/UpdateUserForumTopicFollowsTest.php
@@ -45,7 +45,6 @@ class UpdateUserForumTopicFollowsTest extends TestCase
         $this->assertSame($watchesCount, TopicWatch::count());
         $this->assertSame($userNotificationsCount, UserNotification::count());
 
-        app()->make('OsuAuthorize')->cacheReset();
         $topic->moveTo($adminForum);
 
         $this->assertSame($watchesCount - 1, TopicWatch::count());


### PR DESCRIPTION
Automatically reset on new requests (both for octane and test).

Jobs auth is manually reset every time as needed. Probably also fixes bug as job runner is a long running process.

Using Map so it's passed around by reference instead of value when using array.

Also changed admin check to use Set instead of array lookup.