### PR TITLE
Make sure to pass int group id

### DIFF
--- a/app/Http/Controllers/GroupsController.php
+++ b/app/Http/Controllers/GroupsController.php
@@ -11,7 +11,7 @@ class GroupsController extends Controller
 {
     public function show($id)
     {
-        $group = app('groups')->byId($id);
+        $group = app('groups')->byId(get_int($id));
         abort_if($group === null || !$group->hasListing(), 404);
 
         $currentMode = default_mode();


### PR DESCRIPTION
PHP somehow allows string parameter passed to a function which requires int... :raised_eyebrow: 

```
>>> $a = fn (int $val) => $val;
=> Closure(int $val) {#4857 …2}
>>> $a(1)
=> 1
>>> $a('1')
=> 1
>>> $a('1 ')
=> 1
>>> $a('1 wat')
TypeError: {closure}(): Argument #1 ($val) must be of type int, string given on line 1
>>>
```