### PR TITLE
Update usage of deprecated `sendNow` method

### DIFF
--- a/app/Jobs/UserNotificationDigest.php
+++ b/app/Jobs/UserNotificationDigest.php
@@ -49,7 +49,7 @@ class UserNotificationDigest implements ShouldQueue
         }
 
         // TODO: catch and log errors?
-        Mail::to($this->user)->sendNow(new UserNotificationDigestMail($notifications, $this->user));
+        Mail::to($this->user)->send(new UserNotificationDigestMail($notifications, $this->user));
     }
 
     private function filterNotifications(Collection $notifications)


### PR DESCRIPTION
`sendNow` and `send` are the same since 6.10 and the former is removed in 8.x.

Sure would be nice if they actually put up a notice instead of just silently deprecating it in a PR (laravel/framework#30999) and then suddenly removing it in 8.x :neutral_face: 