### PR TITLE
Clean up factories

### DIFF
--- a/database/factories/BeatmapDiscussionFactory.php
+++ b/database/factories/BeatmapDiscussionFactory.php
@@ -16,28 +16,22 @@
 
 use App\Models\BeatmapDiscussion;
 
-$factory->define(BeatmapDiscussion::class, function (Faker\Generator $faker) use ($factory) {
-    $type = rand(0, 1) === 0 ? 'timeline' : 'general';
-
-    return $factory->raw(BeatmapDiscussion::class, [], $type);
-});
-
-$factory->defineAs(BeatmapDiscussion::class, 'timeline', function () {
-    return [
+$states = [
+    'timeline' => [
         'timestamp' => 0,
         'message_type' => 'problem',
-    ];
-});
-
-$factory->defineAs(BeatmapDiscussion::class, 'general', function () {
-    return [
+    ],
+    'general' => [
         'timestamp' => null,
         'message_type' => 'problem',
-    ];
-});
-
-$factory->defineAs(BeatmapDiscussion::class, 'review', function () {
-    return [
+    ],
+    'review' => [
         'message_type' => 'review',
-    ];
-});
+    ],
+];
+
+$factory->define(BeatmapDiscussion::class, fn () => array_rand_val($states));
+
+foreach ($states as $state => $attributes) {
+    $factory->state(BeatmapDiscussion::class, $state, $attributes);
+}

--- a/database/factories/BeatmapDiscussionPostFactory.php
+++ b/database/factories/BeatmapDiscussionPostFactory.php
@@ -22,7 +22,7 @@ $factory->define(BeatmapDiscussionPost::class, function (Faker\Generator $faker)
     ];
 });
 
-$factory->defineAs(BeatmapDiscussionPost::class, 'timeline', function (Faker\Generator $faker) {
+$factory->state(BeatmapDiscussionPost::class, 'timeline', function (Faker\Generator $faker) {
     return [
         'message' => "00:00.000 {$faker->sentence(10)}",
     ];

--- a/database/factories/BeatmapFailtimesFactory.php
+++ b/database/factories/BeatmapFailtimesFactory.php
@@ -13,14 +13,6 @@ $factory->define(App\Models\BeatmapFailtimes::class, function (Faker\Generator $
     return $array;
 });
 
-$factory->defineAs(App\Models\BeatmapFailtimes::class, 'fail', function (Faker\Generator $faker) use ($factory) {
-    $array = $factory->raw(App\Models\BeatmapFailtimes::class);
+$factory->state(App\Models\BeatmapFailtimes::class, 'fail', ['type' => 'fail']);
 
-    return array_merge($array, ['type' => 'fail']);
-});
-
-$factory->defineAs(App\Models\BeatmapFailtimes::class, 'retry', function (Faker\Generator $faker) use ($factory) {
-    $array = $factory->raw(App\Models\BeatmapFailtimes::class);
-
-    return array_merge($array, ['type' => 'exit']);
-});
+$factory->state(App\Models\BeatmapFailtimes::class, 'retry', ['type' => 'exit']);

--- a/database/factories/BeatmapsetFactory.php
+++ b/database/factories/BeatmapsetFactory.php
@@ -20,7 +20,7 @@ use App\Models\Beatmapset;
 $factory->define(Beatmapset::class, function (Faker\Generator $faker) {
     $artist = $faker->name;
     $title = $faker->sentence(rand(0, 5));
-    $isApproved = (rand(0, 2) > 0);
+    $isApproved = (int) (rand(0, 2) > 0);
 
     return [
         'creator' => $faker->userName,
@@ -79,7 +79,7 @@ $factory->afterCreatingState(Beatmapset::class, 'with_discussion', function (App
 
     if (
         !$beatmapset->beatmapDiscussions()->save(
-            factory(BeatmapDiscussion::class, 'general')->make(['user_id' => $beatmapset->user_id])
+            factory(BeatmapDiscussion::class)->states('general')->make(['user_id' => $beatmapset->user_id])
         )
     ) {
         throw new Exception();

--- a/database/factories/ForumFactory.php
+++ b/database/factories/ForumFactory.php
@@ -4,9 +4,12 @@
 // See the LICENCE file in the repository root for full licence text.
 
 use App\Models\Forum\AuthOption;
+use App\Models\Forum\Authorize;
 use App\Models\User;
 
-$factory->defineAs(App\Models\Forum\Forum::class, 'parent', function (Faker\Generator $faker) {
+$factory->define(App\Models\Forum\Forum::class, fn () => []);
+
+$factory->state(App\Models\Forum\Forum::class, 'parent', function (Faker\Generator $faker) {
     return [
         'forum_name' => $faker->catchPhrase,
         'forum_desc' => $faker->realtext(80),
@@ -16,7 +19,7 @@ $factory->defineAs(App\Models\Forum\Forum::class, 'parent', function (Faker\Gene
     ];
 });
 
-$factory->defineAs(App\Models\Forum\Forum::class, 'child', function (Faker\Generator $faker) {
+$factory->state(App\Models\Forum\Forum::class, 'child', function (Faker\Generator $faker) {
     return [
         'forum_name' => $faker->catchPhrase,
         'forum_desc' => $faker->realtext(80),
@@ -56,31 +59,27 @@ $factory->define(App\Models\Forum\Post::class, function (Faker\Generator $faker)
     ];
 });
 
-$factory->defineAs(AuthOption::class, 'post', function (Faker\Generator $faker) {
-    return [
-        'auth_option' => 'f_post',
-    ];
-});
+$factory->define(AuthOption::class, fn () => []);
 
-$factory->defineAs(AuthOption::class, 'reply', function (Faker\Generator $faker) {
-    return [
-        'auth_option' => 'f_reply',
-    ];
-});
+$factory->state(AuthOption::class, 'post', ['auth_option' => 'f_post']);
 
-$factory->defineAs(App\Models\Forum\Authorize::class, 'post', function (Faker\Generator $faker) {
+$factory->state(AuthOption::class, 'reply', ['auth_option' => 'f_reply']);
+
+$factory->define(Authorize::class, fn () => []);
+
+$factory->state(Authorize::class, 'post', function (Faker\Generator $faker) {
     return [
         'auth_option_id' => function () {
-            return AuthOption::where('auth_option', 'f_post')->first() ?? factory(AuthOption::class, 'post');
+            return AuthOption::where('auth_option', 'f_post')->first() ?? factory(AuthOption::class)->states('post');
         },
         'auth_setting' => 1,
     ];
 });
 
-$factory->defineAs(App\Models\Forum\Authorize::class, 'reply', function (Faker\Generator $faker) {
+$factory->state(Authorize::class, 'reply', function (Faker\Generator $faker) {
     return [
         'auth_option_id' => function () {
-            return AuthOption::where('auth_option', 'f_reply')->first() ?? factory(AuthOption::class, 'reply');
+            return AuthOption::where('auth_option', 'f_reply')->first() ?? factory(AuthOption::class)->states('reply');
         },
         'auth_setting' => 1,
     ];

--- a/database/factories/OrderFactory.php
+++ b/database/factories/OrderFactory.php
@@ -11,15 +11,14 @@ $factory->define(App\Models\Store\Order::class, function (Faker\Generator $faker
     ];
 });
 
-$factory->defineAs(App\Models\Store\Order::class, 'paid', function (Faker\Generator $faker) use ($factory) {
-    $raw = $factory->raw(App\Models\Store\Order::class);
+$factory->state(App\Models\Store\Order::class, 'paid', function (Faker\Generator $faker) use ($factory) {
     $date = Carbon\Carbon::now();
 
-    return array_merge($raw, [
+    return [
         'paid_at' => $date,
         'status' => 'paid',
         'transaction_id' => "test-{$date->timestamp}",
-    ]);
+    ];
 });
 
 $factory->state(App\Models\Store\Order::class, 'incart', function (Faker\Generator $faker) {

--- a/database/factories/OrderItemFactory.php
+++ b/database/factories/OrderItemFactory.php
@@ -16,10 +16,8 @@ $factory->define(App\Models\Store\OrderItem::class, function (Faker\Generator $f
     ];
 });
 
-$factory->defineAs(App\Models\Store\OrderItem::class, 'supporter_tag', function (Faker\Generator $faker) use ($factory) {
-    $raw = $factory->raw(App\Models\Store\OrderItem::class);
-
-    return array_merge($raw, [
+$factory->state(App\Models\Store\OrderItem::class, 'supporter_tag', function (Faker\Generator $faker) use ($factory) {
+    return [
         'product_id' => App\Models\Store\Product::customClass('supporter-tag')->first(),
         'cost' => 4,
         'extra_data' => function (array $self) {
@@ -33,15 +31,13 @@ $factory->defineAs(App\Models\Store\OrderItem::class, 'supporter_tag', function 
                 'duration' => 1,
             ];
         },
-    ]);
+    ];
 });
 
-$factory->defineAs(App\Models\Store\OrderItem::class, 'username_change', function (Faker\Generator $faker) use ($factory) {
-    $raw = $factory->raw(App\Models\Store\OrderItem::class);
-
-    return array_merge($raw, [
+$factory->state(App\Models\Store\OrderItem::class, 'username_change', function (Faker\Generator $faker) use ($factory) {
+    return [
         'product_id' => App\Models\Store\Product::customClass('username-change')->first(),
         'cost' => 0,
         'extra_info' => 'new_username',
-    ]);
+    ];
 });

--- a/database/factories/ProductFactory.php
+++ b/database/factories/ProductFactory.php
@@ -26,7 +26,7 @@ $factory->define(App\Models\Store\Product::class, function (Faker\Generator $fak
     ];
 });
 
-$factory->defineAs(App\Models\Store\Product::class, 'master_tshirt', function (Faker\Generator $faker) {
+$factory->state(App\Models\Store\Product::class, 'master_tshirt', function (Faker\Generator $faker) {
     return [
         'name' => 'osu! t-shirt (triangles) / '.$faker->colorName,
         'cost' => 16.00,
@@ -62,7 +62,7 @@ NOTE: These are Japanese sizes. Overseas customers are advised to check the size
     ];
 });
 
-$factory->defineAs(App\Models\Store\Product::class, 'child_tshirt', function (Faker\Generator $faker) {
+$factory->state(App\Models\Store\Product::class, 'child_tshirt', function (Faker\Generator $faker) {
     return [
         'name' => 'osu! t-shirt (triangles) / '.$faker->colorName,
         'cost' => 16.00,
@@ -74,7 +74,7 @@ $factory->defineAs(App\Models\Store\Product::class, 'child_tshirt', function (Fa
     ];
 });
 
-$factory->defineAs(App\Models\Store\Product::class, 'child_banners', function (Faker\Generator $faker) {
+$factory->state(App\Models\Store\Product::class, 'child_banners', function (Faker\Generator $faker) {
     $params = [
         // 'name' => 'supply your own name',
         'cost' => 5.00,

--- a/database/factories/SpotlightFactory.php
+++ b/database/factories/SpotlightFactory.php
@@ -18,7 +18,7 @@ $factory->define(App\Models\Spotlight::class, function (Faker\Generator $faker) 
     ];
 });
 
-$factory->defineAs(App\Models\Spotlight::class, 'monthly', function (Faker\Generator $faker) {
+$factory->state(App\Models\Spotlight::class, 'monthly', function (Faker\Generator $faker) {
     $chartDate = Carbon\Carbon::instance($faker->dateTimeBetween('-6 years', 'now'))->startOfMonth();
 
     return [
@@ -41,7 +41,7 @@ $factory->defineAs(App\Models\Spotlight::class, 'monthly', function (Faker\Gener
     ];
 });
 
-$factory->defineAs(App\Models\Spotlight::class, 'bestof', function (Faker\Generator $faker) {
+$factory->state(App\Models\Spotlight::class, 'bestof', function (Faker\Generator $faker) {
     $chartDate = Carbon\Carbon::instance($faker->dateTimeBetween('-6 years', 'now'))->endOfYear();
 
     return [

--- a/database/seeds/ModelSeeders/BeatmapSeeder.php
+++ b/database/seeds/ModelSeeders/BeatmapSeeder.php
@@ -168,8 +168,8 @@ class BeatmapSeeder extends Seeder
         BeatmapFailtimes::where('beatmap_id', $beatmap->beatmap_id)->delete();
 
         $beatmap->failtimes()->saveMany([
-            factory(App\Models\BeatmapFailtimes::class, 'fail')->make(),
-            factory(App\Models\BeatmapFailtimes::class, 'retry')->make(),
+            factory(App\Models\BeatmapFailtimes::class)->states('fail')->make(),
+            factory(App\Models\BeatmapFailtimes::class)->states('retry')->make(),
         ]);
     }
 

--- a/database/seeds/ModelSeeders/ForumSeeder.php
+++ b/database/seeds/ModelSeeders/ForumSeeder.php
@@ -81,7 +81,7 @@ class ForumSeeder extends Seeder
             ]));
 
             // Create 3 forums
-            factory(App\Models\Forum\Forum::class, 'parent', 3)->create()->each(function ($f) {
+            factory(App\Models\Forum\Forum::class, 3)->states('parent')->create()->each(function ($f) {
                 for ($i = 0; $i < 4; $i++) {
                     // Subforums for each forum.
                     $f2 = $f->subforums()->save(factory(App\Models\Forum\Forum::class)->states('child')->make());

--- a/database/seeds/ModelSeeders/ForumSeeder.php
+++ b/database/seeds/ModelSeeders/ForumSeeder.php
@@ -32,12 +32,12 @@ class ForumSeeder extends Seeder
             $beatmapCount = App\Models\Beatmapset::count();
             if ($beatmapCount > 0) {
                 // Create beatmap threads
-                $f = factory(App\Models\Forum\Forum::class, 'parent')->create([
+                $f = factory(App\Models\Forum\Forum::class)->states('parent')->create([
                     'forum_name' => 'Beatmap Threads',
                     'forum_desc' => 'Beatmap thread info for beatmaps',
                 ]);
 
-                $f2 = $f->subforums()->save(factory(App\Models\Forum\Forum::class, 'child')->make([
+                $f2 = $f->subforums()->save(factory(App\Models\Forum\Forum::class)->states('child')->make([
                     'parent_id' => 1,
                     'forum_name' => 'Beatmap Threads',
                     'forum_desc' => 'Beatmap thread info for beatmaps',
@@ -69,12 +69,12 @@ class ForumSeeder extends Seeder
             }
 
             // Create userpage threads
-            $f = factory(App\Models\Forum\Forum::class, 'parent')->create([
+            $f = factory(App\Models\Forum\Forum::class)->states('parent')->create([
                 'forum_name' => 'User Pages',
                 'forum_desc' => 'Your user profile pages go here!',
             ]);
 
-            $f->subforums()->save(factory(App\Models\Forum\Forum::class, 'child')->make([
+            $f->subforums()->save(factory(App\Models\Forum\Forum::class)->states('child')->make([
                 'forum_id' => config('osu.user.user_page_forum_id'),
                 'parent_id' => $f->forum_id,
                 'forum_name' => 'User Pages',
@@ -84,7 +84,7 @@ class ForumSeeder extends Seeder
             factory(App\Models\Forum\Forum::class, 'parent', 3)->create()->each(function ($f) {
                 for ($i = 0; $i < 4; $i++) {
                     // Subforums for each forum.
-                    $f2 = $f->subforums()->save(factory(App\Models\Forum\Forum::class, 'child')->make());
+                    $f2 = $f->subforums()->save(factory(App\Models\Forum\Forum::class)->states('child')->make());
                     // Topics for each subforum
                     for ($j = 0; $j < 3; $j++) {
                         $topicUser = User::orderByRaw('RAND()')->first();

--- a/database/seeds/ModelSeeders/ProductSeeder.php
+++ b/database/seeds/ModelSeeders/ProductSeeder.php
@@ -23,8 +23,8 @@ class ProductSeeder extends Seeder
         $this->product_ids = [];
         $this->count = 0;
 
-        $master_tshirt = factory(App\Models\Store\Product::class, 'master_tshirt')->create();
-        $child_shirts = factory(App\Models\Store\Product::class, 'child_tshirt', 7)->create([
+        $master_tshirt = factory(App\Models\Store\Product::class)->states('master_tshirt')->create();
+        $child_shirts = factory(App\Models\Store\Product::class, 7)->states('child_tshirt')->create([
             'master_product_id' => $master_tshirt->product_id,
         ])->each(function ($s) {
             $this->product_ids[] = $s->product_id;
@@ -64,7 +64,7 @@ class ProductSeeder extends Seeder
         $countries = App\Models\Country::limit(6)->get()->toArray();
         $master_country = array_shift($countries);
 
-        $master = factory(App\Models\Store\Product::class, 'child_banners')->create([
+        $master = factory(App\Models\Store\Product::class)->states('child_banners')->create([
             'name' => "{$tournament->name} Support Banner ({$master_country['name']})",
             'description' => ':)',
             'header_description' => "# {$tournament->name} Support Banners\nYayifications",
@@ -80,7 +80,7 @@ class ProductSeeder extends Seeder
         ];
 
         foreach ($countries as $country) {
-            $product = factory(App\Models\Store\Product::class, 'child_banners')->create([
+            $product = factory(App\Models\Store\Product::class)->states('child_banners')->create([
                 'name' => "{$tournament->name} Support Banner ({$country['name']})",
                 'master_product_id' => $master->product_id,
             ]);

--- a/database/seeds/ModelSeeders/SpotlightSeeder.php
+++ b/database/seeds/ModelSeeders/SpotlightSeeder.php
@@ -39,7 +39,7 @@ class SpotlightSeeder extends Seeder
     {
         // note: this does result in spotlights with beatmaps from the future.
         DB::transaction(function () use ($date) {
-            $spotlight = factory(Spotlight::class, 'monthly')->make([
+            $spotlight = factory(Spotlight::class)->states('monthly')->make([
                 'chart_month' => $date,
             ]);
 
@@ -52,7 +52,7 @@ class SpotlightSeeder extends Seeder
     public function seedBestOf($date)
     {
         DB::transaction(function () use ($date) {
-            $spotlight = factory(Spotlight::class, 'bestof')->make([
+            $spotlight = factory(Spotlight::class)->states('bestof')->make([
                 'chart_month' => $date->copy()->endOfYear(),
             ]);
 

--- a/tests/Browser/BeatmapDiscussionPostsTest.php
+++ b/tests/Browser/BeatmapDiscussionPostsTest.php
@@ -112,12 +112,12 @@ class BeatmapDiscussionPostsTest extends DuskTestCase
         $this->beatmap = $this->beatmapset->beatmaps()->save(factory(Beatmap::class)->make([
             'user_id' => $this->mapper->getKey(),
         ]));
-        $this->beatmapDiscussion = factory(BeatmapDiscussion::class, 'timeline')->create([
+        $this->beatmapDiscussion = factory(BeatmapDiscussion::class)->states('timeline')->create([
             'beatmapset_id' => $this->beatmapset->getKey(),
             'beatmap_id' => $this->beatmap->getKey(),
             'user_id' => $this->user->getKey(),
         ]);
-        $post = factory(BeatmapDiscussionPost::class, 'timeline')->make([
+        $post = factory(BeatmapDiscussionPost::class)->states('timeline')->make([
             'user_id' => $this->user->getKey(),
         ]);
         $this->beatmapDiscussionPost = $this->beatmapDiscussion->beatmapDiscussionPosts()->save($post);

--- a/tests/Browser/SanityTest.php
+++ b/tests/Browser/SanityTest.php
@@ -102,27 +102,27 @@ class SanityTest extends DuskTestCase
         self::$scaffolding['artist'] = factory(\App\Models\Artist::class)->create();
 
         // factories for /store/*
-        self::$scaffolding['product'] = factory(\App\Models\Store\Product::class, 'master_tshirt')->create();
+        self::$scaffolding['product'] = factory(\App\Models\Store\Product::class)->states('master_tshirt')->create();
         self::$scaffolding['order'] = factory(\App\Models\Store\Order::class)->states('checkout')->create([
             'user_id' => self::$scaffolding['user']->getKey(),
         ]);
         self::$scaffolding['checkout'] = new ScaffoldDummy(self::$scaffolding['order']->getKey());
-        self::$scaffolding['invoice'] = factory(\App\Models\Store\Order::class, 'paid')->create([
+        self::$scaffolding['invoice'] = factory(\App\Models\Store\Order::class)->states('paid')->create([
             'user_id' => self::$scaffolding['user']->getKey(),
         ]);
 
         // factories for /community/forums/*
-        self::$scaffolding['forum_parent'] = factory(\App\Models\Forum\Forum::class, 'parent')->create();
-        self::$scaffolding['forum'] = factory(\App\Models\Forum\Forum::class, 'child')->create([
+        self::$scaffolding['forum_parent'] = factory(\App\Models\Forum\Forum::class)->states('parent')->create();
+        self::$scaffolding['forum'] = factory(\App\Models\Forum\Forum::class)->states('child')->create([
             'parent_id' => self::$scaffolding['forum_parent']->getKey(),
         ]);
         // satisfy group permissions required for posting in forum
         self::$scaffolding['_group'] = app('groups')->byIdentifier('default');
-        self::$scaffolding['_forum_acl_post'] = factory(\App\Models\Forum\Authorize::class, 'post')->create([
+        self::$scaffolding['_forum_acl_post'] = factory(\App\Models\Forum\Authorize::class)->states('post')->create([
             'forum_id' => self::$scaffolding['forum']->getKey(),
             'group_id' => self::$scaffolding['_group']->getKey(),
         ]);
-        self::$scaffolding['_forum_acl_reply'] = factory(\App\Models\Forum\Authorize::class, 'reply')->create([
+        self::$scaffolding['_forum_acl_reply'] = factory(\App\Models\Forum\Authorize::class)->states('reply')->create([
             'forum_id' => self::$scaffolding['forum']->getKey(),
             'group_id' => self::$scaffolding['_group']->getKey(),
         ]);

--- a/tests/Controllers/BeatmapDiscussionPostsControllerTest.php
+++ b/tests/Controllers/BeatmapDiscussionPostsControllerTest.php
@@ -393,7 +393,7 @@ class BeatmapDiscussionPostsControllerTest extends TestCase
     public function testPostUpdateWhenBeatmapsetDiscussionIsLocked()
     {
         $reply = $this->beatmapDiscussion->beatmapDiscussionPosts()->save(
-            factory(BeatmapDiscussionPost::class, 'timeline')->make([
+            factory(BeatmapDiscussionPost::class)->states('timeline')->make([
                 'user_id' => $this->user->getKey(),
             ])
         );
@@ -409,7 +409,7 @@ class BeatmapDiscussionPostsControllerTest extends TestCase
     {
         // reply made before resolve
         $reply1 = $this->beatmapDiscussion->beatmapDiscussionPosts()->save(
-            factory(BeatmapDiscussionPost::class, 'timeline')->make([
+            factory(BeatmapDiscussionPost::class)->states('timeline')->make([
                 'user_id' => $this->user->getKey(),
             ])
         );
@@ -419,7 +419,7 @@ class BeatmapDiscussionPostsControllerTest extends TestCase
 
         // reply made after resolve
         $reply2 = $this->beatmapDiscussion->beatmapDiscussionPosts()->save(
-            factory(BeatmapDiscussionPost::class, 'timeline')->make([
+            factory(BeatmapDiscussionPost::class)->states('timeline')->make([
                 'user_id' => $this->user->getKey(),
             ])
         );
@@ -435,7 +435,7 @@ class BeatmapDiscussionPostsControllerTest extends TestCase
     {
         // reply made before resolve
         $reply1 = $this->beatmapDiscussion->beatmapDiscussionPosts()->save(
-            factory(BeatmapDiscussionPost::class, 'timeline')->make([
+            factory(BeatmapDiscussionPost::class)->states('timeline')->make([
                 'user_id' => $this->user->getKey(),
             ])
         );
@@ -450,7 +450,7 @@ class BeatmapDiscussionPostsControllerTest extends TestCase
 
         // reply made after resolve
         $reply2 = $this->beatmapDiscussion->beatmapDiscussionPosts()->save(
-            factory(BeatmapDiscussionPost::class, 'timeline')->make([
+            factory(BeatmapDiscussionPost::class)->states('timeline')->make([
                 'user_id' => $this->user->getKey(),
             ])
         );
@@ -499,7 +499,7 @@ class BeatmapDiscussionPostsControllerTest extends TestCase
     public function testPostDestroy()
     {
         $reply = $this->beatmapDiscussion->beatmapDiscussionPosts()->save(
-            factory(BeatmapDiscussionPost::class, 'timeline')->make([
+            factory(BeatmapDiscussionPost::class)->states('timeline')->make([
                 'user_id' => $this->user->getKey(),
             ])
         );
@@ -511,7 +511,7 @@ class BeatmapDiscussionPostsControllerTest extends TestCase
     public function testPostDestroyNotLoggedIn()
     {
         $reply = $this->beatmapDiscussion->beatmapDiscussionPosts()->save(
-            factory(BeatmapDiscussionPost::class, 'timeline')->make([
+            factory(BeatmapDiscussionPost::class)->states('timeline')->make([
                 'user_id' => $this->user->getKey(),
             ])
         );
@@ -526,7 +526,7 @@ class BeatmapDiscussionPostsControllerTest extends TestCase
     public function testPostDestroyWhenBeatmapsetDiscussionIsLocked()
     {
         $reply = $this->beatmapDiscussion->beatmapDiscussionPosts()->save(
-            factory(BeatmapDiscussionPost::class, 'timeline')->make([
+            factory(BeatmapDiscussionPost::class)->states('timeline')->make([
                 'user_id' => $this->user->getKey(),
             ])
         );
@@ -541,7 +541,7 @@ class BeatmapDiscussionPostsControllerTest extends TestCase
     {
         // reply made before resolve
         $reply1 = $this->beatmapDiscussion->beatmapDiscussionPosts()->save(
-            factory(BeatmapDiscussionPost::class, 'timeline')->make([
+            factory(BeatmapDiscussionPost::class)->states('timeline')->make([
                 'user_id' => $this->user->getKey(),
             ])
         );
@@ -550,7 +550,7 @@ class BeatmapDiscussionPostsControllerTest extends TestCase
 
         // reply made after resolve
         $reply2 = $this->beatmapDiscussion->beatmapDiscussionPosts()->save(
-            factory(BeatmapDiscussionPost::class, 'timeline')->make([
+            factory(BeatmapDiscussionPost::class)->states('timeline')->make([
                 'user_id' => $this->user->getKey(),
             ])
         );
@@ -565,7 +565,7 @@ class BeatmapDiscussionPostsControllerTest extends TestCase
     {
         // reply made before resolve
         $reply1 = $this->beatmapDiscussion->beatmapDiscussionPosts()->save(
-            factory(BeatmapDiscussionPost::class, 'timeline')->make([
+            factory(BeatmapDiscussionPost::class)->states('timeline')->make([
                 'user_id' => $this->user->getKey(),
             ])
         );
@@ -579,7 +579,7 @@ class BeatmapDiscussionPostsControllerTest extends TestCase
 
         // reply made after resolve
         $reply2 = $this->beatmapDiscussion->beatmapDiscussionPosts()->save(
-            factory(BeatmapDiscussionPost::class, 'timeline')->make([
+            factory(BeatmapDiscussionPost::class)->states('timeline')->make([
                 'user_id' => $this->user->getKey(),
             ])
         );
@@ -798,12 +798,12 @@ class BeatmapDiscussionPostsControllerTest extends TestCase
         $this->beatmap = $this->beatmapset->beatmaps()->save(factory(Beatmap::class)->make([
             'user_id' => $this->mapper->getKey(),
         ]));
-        $this->beatmapDiscussion = factory(BeatmapDiscussion::class, 'timeline')->create([
+        $this->beatmapDiscussion = factory(BeatmapDiscussion::class)->states('timeline')->create([
             'beatmapset_id' => $this->beatmapset->getKey(),
             'beatmap_id' => $this->beatmap->getKey(),
             'user_id' => $this->user->getKey(),
         ]);
-        $post = factory(BeatmapDiscussionPost::class, 'timeline')->make([
+        $post = factory(BeatmapDiscussionPost::class)->states('timeline')->make([
             'user_id' => $this->user->getKey(),
         ]);
         $this->beatmapDiscussionPost = $this->beatmapDiscussion->beatmapDiscussionPosts()->save($post);

--- a/tests/Controllers/Chat/ChannelsControllerTest.php
+++ b/tests/Controllers/Chat/ChannelsControllerTest.php
@@ -98,7 +98,7 @@ class ChannelsControllerTest extends TestCase
      */
     public function testChannelJoin($type, $success)
     {
-        $channel = factory(Channel::class)->state($type)->create();
+        $channel = factory(Channel::class)->states($type)->create();
         $status = $success ? 200 : 403;
 
         $this->actAsScopedUser($this->user, ['*']);
@@ -290,7 +290,7 @@ class ChannelsControllerTest extends TestCase
      */
     public function testChannelLeave($type, $success)
     {
-        $channel = factory(Channel::class)->state($type)->create();
+        $channel = factory(Channel::class)->states($type)->create();
         $channel->addUser($this->user);
         $status = $success ? 204 : 403;
 
@@ -326,7 +326,7 @@ class ChannelsControllerTest extends TestCase
      */
     public function testChannelLeaveWhenNotJoined($type, $success)
     {
-        $channel = factory(Channel::class)->state($type)->create();
+        $channel = factory(Channel::class)->states($type)->create();
         $status = $success ? 204 : 403;
 
         $this->actAsScopedUser($this->user, ['*']);

--- a/tests/Controllers/ForumForumsControllerTest.php
+++ b/tests/Controllers/ForumForumsControllerTest.php
@@ -19,7 +19,7 @@ class ForumForumsControllerTest extends TestCase
 
     public function testShow()
     {
-        $forum = factory(Forum\Forum::class, 'parent')->create();
+        $forum = factory(Forum\Forum::class)->states('parent')->create();
 
         $this
             ->get(route('forum.forums.show', $forum->forum_id))

--- a/tests/Controllers/ForumPostsControllerTest.php
+++ b/tests/Controllers/ForumPostsControllerTest.php
@@ -13,7 +13,7 @@ class ForumPostsControllerTest extends TestCase
 {
     public function testDestroy()
     {
-        $forum = factory(Forum\Forum::class, 'child')->create();
+        $forum = factory(Forum\Forum::class)->states('child')->create();
         $topic = factory(Forum\Topic::class)->create([
             'forum_id' => $forum->forum_id,
         ]);
@@ -40,7 +40,7 @@ class ForumPostsControllerTest extends TestCase
 
     public function testDestroyFirstPost()
     {
-        $forum = factory(Forum\Forum::class, 'child')->create();
+        $forum = factory(Forum\Forum::class)->states('child')->create();
         $topic = factory(Forum\Topic::class)->create([
             'forum_id' => $forum->forum_id,
         ]);
@@ -66,7 +66,7 @@ class ForumPostsControllerTest extends TestCase
 
     public function testDestroyNotLastPost()
     {
-        $forum = factory(Forum\Forum::class, 'child')->create();
+        $forum = factory(Forum\Forum::class)->states('child')->create();
         $topic = factory(Forum\Topic::class)->create([
             'forum_id' => $forum->forum_id,
         ]);
@@ -94,7 +94,7 @@ class ForumPostsControllerTest extends TestCase
 
     public function testRestore()
     {
-        $forum = factory(Forum\Forum::class, 'child')->create();
+        $forum = factory(Forum\Forum::class)->states('child')->create();
         $topic = factory(Forum\Topic::class)->create([
             'forum_id' => $forum->forum_id,
         ]);

--- a/tests/Controllers/ForumTopicsControllerTest.php
+++ b/tests/Controllers/ForumTopicsControllerTest.php
@@ -14,7 +14,7 @@ class ForumTopicsControllerTest extends TestCase
 {
     public function testDestroy()
     {
-        $forum = factory(Forum\Forum::class, 'child')->create();
+        $forum = factory(Forum\Forum::class)->states('child')->create();
         $topic = factory(Forum\Topic::class)->create([
             'forum_id' => $forum->forum_id,
         ]);
@@ -61,7 +61,7 @@ class ForumTopicsControllerTest extends TestCase
 
     public function testPin()
     {
-        $forum = factory(Forum\Forum::class, 'child')->create();
+        $forum = factory(Forum\Forum::class)->states('child')->create();
         $topic = factory(Forum\Topic::class)->create([
             'forum_id' => $forum->getKey(),
             'topic_status' => Forum\Topic::TYPES['normal'],
@@ -82,7 +82,7 @@ class ForumTopicsControllerTest extends TestCase
 
     public function testReply()
     {
-        $forum = factory(Forum\Forum::class, 'child')->create();
+        $forum = factory(Forum\Forum::class)->states('child')->create();
         $topic = factory(Forum\Topic::class)->create([
             'forum_id' => $forum->forum_id,
         ]);
@@ -129,7 +129,7 @@ class ForumTopicsControllerTest extends TestCase
 
     public function testRestore()
     {
-        $forum = factory(Forum\Forum::class, 'child')->create();
+        $forum = factory(Forum\Forum::class)->states('child')->create();
         $topic = factory(Forum\Topic::class)->create([
             'forum_id' => $forum->forum_id,
         ]);
@@ -157,7 +157,7 @@ class ForumTopicsControllerTest extends TestCase
 
     public function testShow()
     {
-        $forum = factory(Forum\Forum::class, 'child')->create();
+        $forum = factory(Forum\Forum::class)->states('child')->create();
         $topic = factory(Forum\Topic::class)->create([
             'forum_id' => $forum->forum_id,
         ]);
@@ -173,7 +173,7 @@ class ForumTopicsControllerTest extends TestCase
 
     public function testShowNoMorePosts()
     {
-        $forum = factory(Forum\Forum::class, 'child')->create();
+        $forum = factory(Forum\Forum::class)->states('child')->create();
         $topic = factory(Forum\Topic::class)->create([
             'forum_id' => $forum->forum_id,
         ]);
@@ -191,7 +191,7 @@ class ForumTopicsControllerTest extends TestCase
 
     public function testShowNoMorePostsWithSkipLayout()
     {
-        $forum = factory(Forum\Forum::class, 'child')->create();
+        $forum = factory(Forum\Forum::class)->states('child')->create();
         $topic = factory(Forum\Topic::class)->create([
             'forum_id' => $forum->forum_id,
         ]);
@@ -210,7 +210,7 @@ class ForumTopicsControllerTest extends TestCase
 
     public function testShowMissingPosts()
     {
-        $forum = factory(Forum\Forum::class, 'child')->create();
+        $forum = factory(Forum\Forum::class)->states('child')->create();
         $topic = factory(Forum\Topic::class)->create([
             'forum_id' => $forum->forum_id,
         ]);
@@ -222,7 +222,7 @@ class ForumTopicsControllerTest extends TestCase
 
     public function testShowNewUser()
     {
-        $forum = factory(Forum\Forum::class, 'child')->create();
+        $forum = factory(Forum\Forum::class)->states('child')->create();
         $topic = factory(Forum\Topic::class)->create([
             'forum_id' => $forum->forum_id,
         ]);
@@ -240,7 +240,7 @@ class ForumTopicsControllerTest extends TestCase
 
     public function testStore()
     {
-        $forum = factory(Forum\Forum::class, 'child')->create();
+        $forum = factory(Forum\Forum::class)->states('child')->create();
         $user = factory(User::class)->create()->fresh();
         $group = app('groups')->byIdentifier('default');
         $user->setDefaultGroup($group);
@@ -292,7 +292,7 @@ class ForumTopicsControllerTest extends TestCase
 
     public function testUpdateTitle()
     {
-        $forum = factory(Forum\Forum::class, 'child')->create();
+        $forum = factory(Forum\Forum::class)->states('child')->create();
         $user = factory(User::class)->create();
         $group = app('groups')->byIdentifier('default');
         $user->setDefaultGroup($group);
@@ -319,7 +319,7 @@ class ForumTopicsControllerTest extends TestCase
 
     public function testUpdateTitleBlank()
     {
-        $forum = factory(Forum\Forum::class, 'child')->create();
+        $forum = factory(Forum\Forum::class)->states('child')->create();
         $user = factory(User::class)->create();
         $group = app('groups')->byIdentifier('default');
         $user->setDefaultGroup($group);

--- a/tests/Controllers/Payments/CentiliControllerTest.php
+++ b/tests/Controllers/Payments/CentiliControllerTest.php
@@ -28,7 +28,7 @@ class CentiliControllerTest extends TestCase
 
     public function testWhenPaymentIsInsufficient()
     {
-        $orderItem = factory(OrderItem::class, 'supporter_tag')->create(['order_id' => $this->order->order_id]);
+        $orderItem = factory(OrderItem::class)->states('supporter_tag')->create(['order_id' => $this->order->order_id]);
 
         $data = $this->getPostData(['enduserprice' => '479.000']);
 

--- a/tests/Controllers/Payments/ShopifyControllerTest.php
+++ b/tests/Controllers/Payments/ShopifyControllerTest.php
@@ -14,7 +14,7 @@ class ShopifyControllerTest extends TestCase
 {
     public function testWebhookOrdersCancelled()
     {
-        $order = factory(Order::class, 'paid')->states('shopify')->create();
+        $order = factory(Order::class)->states('paid')->states('shopify')->create();
         $payment = new Payment([
             'provider' => Order::PROVIDER_SHOPIFY,
             'transaction_id' => $order->getProviderReference(),

--- a/tests/Jobs/BeatmapsetDeleteTest.php
+++ b/tests/Jobs/BeatmapsetDeleteTest.php
@@ -19,7 +19,7 @@ class BeatmapsetDeleteTest extends TestCase
     public function testBeatmapsetDeletedByOwner()
     {
         $owner = factory(User::class)->create();
-        $forum = factory(Forum::class, 'parent')->create();
+        $forum = factory(Forum::class)->states('parent')->create();
         $topic = factory(Topic::class)->create([
             'forum_id' => $forum->getKey(),
         ]);
@@ -46,7 +46,7 @@ class BeatmapsetDeleteTest extends TestCase
     {
         $moderator = factory(User::class)->create();
         $owner = factory(User::class)->create();
-        $forum = factory(Forum::class, 'parent')->create();
+        $forum = factory(Forum::class)->states('parent')->create();
         $topic = factory(Topic::class)->create([
             'forum_id' => $forum->getKey(),
         ]);

--- a/tests/Jobs/UpdateUserForumTopicFollowsTest.php
+++ b/tests/Jobs/UpdateUserForumTopicFollowsTest.php
@@ -17,10 +17,10 @@ class UpdateUserForumTopicFollowsTest extends TestCase
 {
     public function testRemoveUserWithNoWatchPermission()
     {
-        $forum = factory(Forum::class, 'child')->create();
-        $adminForum = factory(Forum::class, 'child')->create(['forum_id' => config('osu.forum.admin_forum_id')]);
+        $forum = factory(Forum::class)->states('child')->create();
+        $adminForum = factory(Forum::class)->states('child')->create(['forum_id' => config('osu.forum.admin_forum_id')]);
         config()->set('osu.forum.admin_forum_id', $adminForum->getKey());
-        $anotherForum = factory(Forum::class, 'child')->create();
+        $anotherForum = factory(Forum::class)->states('child')->create();
         $topic = factory(Topic::class)->create(['forum_id' => $forum->getKey()]);
         $user = factory(User::class)->create();
 

--- a/tests/Jobs/UserNotificationDigestTest.php
+++ b/tests/Jobs/UserNotificationDigestTest.php
@@ -28,7 +28,7 @@ class UserNotificationDigestTest extends TestCase
             'details' => ['mail' => true],
         ]);
 
-        $forum = factory(Forum::class, 'parent')->create();
+        $forum = factory(Forum::class)->states('parent')->create();
         $topic = factory(Topic::class)->make();
         $forum->topics()->save($topic);
         $topic->refresh();

--- a/tests/Libraries/ChatTest.php
+++ b/tests/Libraries/ChatTest.php
@@ -21,7 +21,7 @@ class ChatTest extends TestCase
     public function testSendMessage(bool $verified, $expectedException)
     {
         $sender = factory(User::class)->create();
-        $channel = factory(Channel::class)->state('public')->create();
+        $channel = factory(Channel::class)->states('public')->create();
         $channel->addUser($sender);
 
         if ($verified) {

--- a/tests/Libraries/Fulfillments/BannerFulfillmentTest.php
+++ b/tests/Libraries/Fulfillments/BannerFulfillmentTest.php
@@ -99,7 +99,7 @@ class BannerFulfillmentTest extends TestCase
             'osu_subscriptionexpiry' => Carbon::now(),
         ]);
 
-        $this->order = factory(Order::class, 'paid')->create([
+        $this->order = factory(Order::class)->states('paid')->create([
             'user_id' => $this->user->user_id,
         ]);
 

--- a/tests/Libraries/Fulfillments/FulfillmentFactoryTest.php
+++ b/tests/Libraries/Fulfillments/FulfillmentFactoryTest.php
@@ -18,7 +18,7 @@ class FulfillmentFactoryTest extends TestCase
 {
     public function testCustomClassSupporterTag()
     {
-        $orderItem = factory(OrderItem::class, 'supporter_tag')->create();
+        $orderItem = factory(OrderItem::class)->states('supporter_tag')->create();
         $order = $orderItem->order;
 
         $fulfillers = FulfillmentFactory::createFulfillersFor($order);
@@ -28,7 +28,7 @@ class FulfillmentFactoryTest extends TestCase
 
     public function testCustomClassUsernameChange()
     {
-        $orderItem = factory(OrderItem::class, 'username_change')->create();
+        $orderItem = factory(OrderItem::class)->states('username_change')->create();
         $order = $orderItem->order;
 
         $fulfillers = FulfillmentFactory::createFulfillersFor($order);

--- a/tests/Libraries/Fulfillments/SupporterTagFulfillmentTest.php
+++ b/tests/Libraries/Fulfillments/SupporterTagFulfillmentTest.php
@@ -245,7 +245,7 @@ class SupporterTagFulfillmentTest extends TestCase
             'osu_subscriptionexpiry' => Carbon::today(),
         ]);
 
-        $this->order = factory(Order::class, 'paid')->create([
+        $this->order = factory(Order::class)->states('paid')->create([
             'user_id' => $this->user->user_id,
         ]);
     }
@@ -279,7 +279,7 @@ class SupporterTagFulfillmentTest extends TestCase
 
     private function createOrderItem($user, $duration, $amount)
     {
-        return factory(OrderItem::class, 'supporter_tag')->create([
+        return factory(OrderItem::class)->states('supporter_tag')->create([
             'order_id' => $this->order->order_id,
             'cost' => $amount,
             'extra_data' => [

--- a/tests/Libraries/Fulfillments/UsernameChangeFulfillmentTest.php
+++ b/tests/Libraries/Fulfillments/UsernameChangeFulfillmentTest.php
@@ -21,7 +21,7 @@ class UsernameChangeFulfillmentTest extends TestCase
     {
         $oldUsername = $this->user->username;
         $newUsername = 'new_username';
-        $orderItem = factory(OrderItem::class, 'username_change')->create([
+        $orderItem = factory(OrderItem::class)->states('username_change')->create([
             'order_id' => $this->order->order_id,
             'extra_info' => $newUsername,
         ]);
@@ -41,7 +41,7 @@ class UsernameChangeFulfillmentTest extends TestCase
 
         $oldUsername = $this->user->username_previous;
         $newUsername = $this->user->username;
-        $orderItem = factory(OrderItem::class, 'username_change')->create([
+        $orderItem = factory(OrderItem::class)->states('username_change')->create([
             'order_id' => $this->order->order_id,
             'extra_info' => $newUsername,
         ]);
@@ -56,7 +56,7 @@ class UsernameChangeFulfillmentTest extends TestCase
 
     public function testRevokeWhenNameDoesNotMatch()
     {
-        $orderItem = factory(OrderItem::class, 'username_change')->create([
+        $orderItem = factory(OrderItem::class)->states('username_change')->create([
             'order_id' => $this->order->order_id,
             'extra_info' => 'herpderp',
         ]);
@@ -69,7 +69,7 @@ class UsernameChangeFulfillmentTest extends TestCase
 
     public function testRevokeWhenPreviousUsernameIsNull()
     {
-        $orderItem = factory(OrderItem::class, 'username_change')->create([
+        $orderItem = factory(OrderItem::class)->states('username_change')->create([
             'order_id' => $this->order->order_id,
             'extra_info' => $this->user->username,
         ]);
@@ -82,7 +82,7 @@ class UsernameChangeFulfillmentTest extends TestCase
 
     public function testRunWhenInsuffientPaid()
     {
-        $orderItem = factory(OrderItem::class, 'username_change')->create([
+        $orderItem = factory(OrderItem::class)->states('username_change')->create([
             'order_id' => $this->order->order_id,
             'cost' => 1,
             'extra_info' => 'new_username',
@@ -108,7 +108,7 @@ class UsernameChangeFulfillmentTest extends TestCase
             'user_lastvisit' => time(),
         ]);
 
-        $orderItem = factory(OrderItem::class, 'username_change')->create([
+        $orderItem = factory(OrderItem::class)->states('username_change')->create([
             'order_id' => $this->order->order_id,
             'extra_info' => 'new_username',
         ]);
@@ -124,6 +124,6 @@ class UsernameChangeFulfillmentTest extends TestCase
         parent::setUp();
 
         $this->user = factory(User::class)->create(['osu_subscriptionexpiry' => Carbon::now()]);
-        $this->order = factory(Order::class, 'paid')->create(['user_id' => $this->user->user_id]);
+        $this->order = factory(Order::class)->states('paid')->create(['user_id' => $this->user->user_id]);
     }
 }

--- a/tests/Libraries/OrderCheckoutTest.php
+++ b/tests/Libraries/OrderCheckoutTest.php
@@ -141,7 +141,7 @@ class OrderCheckoutTest extends TestCase
     {
         $country = Country::inRandomOrder()->first() ?? factory(Country::class)->create();
 
-        $product = factory(Product::class, 'child_banners')->create([
+        $product = factory(Product::class)->states('child_banners')->create([
             'available_until' => $availableUntil,
             'name' => "{$tournament->name} Support Banner ({$country->name})",
         ]);

--- a/tests/Libraries/Payments/CentiliPaymentProcessorTest.php
+++ b/tests/Libraries/Payments/CentiliPaymentProcessorTest.php
@@ -67,7 +67,7 @@ class CentiliPaymentProcessorTest extends TestCase
 
     public function testWhenPaymentIsInsufficient()
     {
-        $orderItem = factory(OrderItem::class, 'supporter_tag')->create(['order_id' => $this->order->order_id]);
+        $orderItem = factory(OrderItem::class)->states('supporter_tag')->create(['order_id' => $this->order->order_id]);
 
         $params = $this->getTestParams(['enduserprice' => '479.000']);
         $subject = new CentiliPaymentProcessor($params, $this->validSignature());

--- a/tests/Libraries/Payments/XsollaPaymentProcessorTest.php
+++ b/tests/Libraries/Payments/XsollaPaymentProcessorTest.php
@@ -27,7 +27,7 @@ class XsollaPaymentProcessorTest extends TestCase
 
     public function testWhenPaymentIsInsufficient()
     {
-        $orderItem = factory(OrderItem::class, 'supporter_tag')->create(['order_id' => $this->order->order_id]);
+        $orderItem = factory(OrderItem::class)->states('supporter_tag')->create(['order_id' => $this->order->order_id]);
 
         $params = $this->getTestParams([
             'purchase' => [


### PR DESCRIPTION
Cleans up a bunch of things needed to work with latest non-class factory (before it got replaced with the class based one).

- remove `defineAs` (deprecated since forever)
- use `->states` instead of `->state` for creation
- fix beatmapset factory generating wrong `approved` attribute (`bool` when it should be `int`)

Seeders seem to still work so that's nice :ok_hand: 