### PR TITLE
Allow profile page for bot

### DIFF
--- a/app/Libraries/User/FindForProfilePage.php
+++ b/app/Libraries/User/FindForProfilePage.php
@@ -15,7 +15,7 @@ class FindForProfilePage
         $user = User::lookupWithHistory($id, $type, true);
         $request = request();
 
-        if ($user === null || $user->isBot() || !priv_check('UserShow', $user)->can()) {
+        if ($user === null || !priv_check('UserShow', $user)->can()) {
             throw new UserProfilePageLookupException(function () {
                 if (is_json_request()) {
                     abort(404);


### PR DESCRIPTION
Not sure if should put back the check for modding profile because it's kind of visible already from the overall listing page.