### PR TITLE
Remove test on PHP 7.4

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -27,7 +27,7 @@ jobs:
   tests:
     strategy:
       matrix:
-        php: ['7.4', '8.0']
+        php: ['8.0']
     name: Tests
     runs-on: ubuntu-latest
     services:


### PR DESCRIPTION
Live servers have been updated so no need to test on earlier version anymore. Keeping it as matrix because that seems convenient for future use.