### PR TITLE
Mark fonts and images as binary file in git

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,4 @@
 * text=auto
 *.sh eol=lf
+/public/images/** binary
+/resources/assets/fonts/** binary


### PR DESCRIPTION
Seems like a good thing to add to reduce noise on some `git grep`