### PR TITLE
Fix check to display comment owner badge

### DIFF
--- a/resources/assets/coffee/react/_components/comment.coffee
+++ b/resources/assets/coffee/react/_components/comment.coffee
@@ -254,7 +254,7 @@ export class Comment extends React.PureComponent
 
 
   renderOwnerBadge: (meta) =>
-    return null unless @props.comment.userId == meta.owner_id
+    return null unless meta.owner_id? && @props.comment.userId == meta.owner_id
 
     div className: 'comment__row-item',
       div className: 'comment__owner-badge', meta.owner_title


### PR DESCRIPTION
I think it's only a problem for old disqus comments with no user attached. random example https://osu.ppy.sh/comments/174156