### PR TITLE
Match user page with its preview

### DIFF
--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -630,7 +630,7 @@ class UsersController extends Controller
                 ]);
             }
 
-            return ['html' => $user->userPage->bodyHTML(['withoutImageDimensions' => true, 'modifiers' => ['profile-page']])];
+            return ['html' => $user->userPage->bodyHTML(['modifiers' => ['profile-page']])];
         } catch (ModelNotSavedException $e) {
             return error_popup($e->getMessage());
         }

--- a/app/Libraries/BBCodeFromDB.php
+++ b/app/Libraries/BBCodeFromDB.php
@@ -23,7 +23,6 @@ class BBCodeFromDB
         $defaultOptions = [
             'withGallery' => false,
             'ignoreLineHeight' => false,
-            'withoutImageDimensions' => false,
             'extraClasses' => '',
             'modifiers' => [],
         ];
@@ -151,12 +150,9 @@ class BBCodeFromDB
             $proxiedSrc = proxy_media(html_entity_decode_better($i['url']));
 
             $imageTag = $galleryAttributes = '';
+            $imageSize = fast_imagesize($proxiedSrc);
 
-            if (!$this->options['withoutImageDimensions']) {
-                $imageSize = fast_imagesize($proxiedSrc);
-            }
-
-            if (!$this->options['withoutImageDimensions'] && $imageSize !== null && $imageSize[0] !== 0) {
+            if ($imageSize !== null && $imageSize[0] !== 0) {
                 $heightPercentage = $imageSize[1] / $imageSize[0] * 100;
 
                 $topClass = 'proportional-container';

--- a/app/Transformers/UserCompactTransformer.php
+++ b/app/Transformers/UserCompactTransformer.php
@@ -280,7 +280,7 @@ class UserCompactTransformer extends TransformerAbstract
         return $this->item($user, function ($user) {
             if ($user->userPage !== null) {
                 return [
-                    'html' => $user->userPage->bodyHTML(['withoutImageDimensions' => true, 'modifiers' => ['profile-page']]),
+                    'html' => $user->userPage->bodyHTML(['modifiers' => ['profile-page']]),
                     'raw' => $user->userPage->bodyRaw,
                 ];
             } else {


### PR DESCRIPTION
Hopefully this doesn't break anything :eyes: 

An alternative is to match `withoutImageDimensions` option between preview and real.

Or just remove `withoutImageDimensions` option considering it's calculated during preview and everything goes through the proxy anyway...? &larr; now this (previously was matching `.bbcode img` and `.proportional-container` vertical-align css)

Resolves #7771.