### PR TITLE
Add osu!catch "hard rock offsets" to DA mod

### DIFF
--- a/app/Libraries/Multiplayer/Mod.php
+++ b/app/Libraries/Multiplayer/Mod.php
@@ -154,6 +154,7 @@ class Mod
             'approach_rate' => 'float',
             'extended_limits' => 'bool',
             'scroll_speed' => 'float',
+            'hard_rock_offsets' => 'bool',
         ],
         self::DOUBLETIME => [
             'speed_change' => 'float',


### PR DESCRIPTION
See: https://github.com/ppy/osu/pull/13629

Mod settings should really be validated per-ruleset. At the same time we'll need to figure out a path forward for acronym conflicts in the first place (which, I guess this could be treated as).

But the taiko setting is already in there so...