### PR TITLE
Fix contest upload

### DIFF
--- a/app/Http/Controllers/ContestEntriesController.php
+++ b/app/Http/Controllers/ContestEntriesController.php
@@ -61,7 +61,7 @@ class ContestEntriesController extends Controller
             abort(422);
         }
 
-        if (Request::file('entry')->getClientSize() > $maxFilesize) {
+        if (Request::file('entry')->getSize() > $maxFilesize) {
             abort(413);
         }
 

--- a/app/Models/UserContestEntry.php
+++ b/app/Models/UserContestEntry.php
@@ -43,7 +43,7 @@ class UserContestEntry extends Model
         DB::transaction(function () use ($entry, $file, $user, $contest) {
             $entry->save(); // get id
 
-            $entry->filesize = $file->getClientSize();
+            $entry->filesize = $file->getSize();
             $entry->original_filename = $file->getClientOriginalName();
             $entry->user()->associate($user);
             $entry->contest()->associate($contest);


### PR DESCRIPTION
`getClientSize()` was removed in an earlier version of Symfony; should be calling `getSize()` instead which is what `getClientSize()` was calling anyway