### PR TITLE
Add osu! logo to docs

### DIFF
--- a/config/scribe.php
+++ b/config/scribe.php
@@ -293,7 +293,7 @@ INTRO
      * - 'logo' => 'img/logo.png' // for `laravel` type
      *
      */
-    'logo' => false,
+    'logo' => 'https://osu.ppy.sh/images/layout/osu-logo-white.svg',
 
     /*
      * The router your API is using (Laravel or Dingo).

--- a/resources/views/vendor/scribe/index.blade.php
+++ b/resources/views/vendor/scribe/index.blade.php
@@ -26,6 +26,10 @@
         padding-top: 5px;
         padding-bottom: 5px;
     }
+    .logo {
+        max-width: 70%;
+        margin: auto;
+    }
 </style>
 
 @if($isInteractive)


### PR DESCRIPTION
This kinda requires the svg to stay in the same url forever (or updated together). It'll be rather problematic if we ever move to fully hashed assets although it could also be fixed by uploading a copy to somewhere more static like assets.ppy.sh.