### PR TITLE
Adding a missing space for day_ago and hours_ago

### DIFF
--- a/resources/lang/fr/common.php
+++ b/resources/lang/fr/common.php
@@ -144,8 +144,8 @@ return [
     ],
 
     'time' => [
-        'days_ago' => 'Il y à :count_delimited jour|Il y à:count_delimited jours',
-        'hours_ago' => 'Il y à:count_delimited heure|Il y à :count_delimited heures',
+        'days_ago' => 'Il y à :count_delimited jour|Il y à :count_delimited jours',
+        'hours_ago' => 'Il y à :count_delimited heure|Il y à :count_delimited heures',
         'now' => 'maintenant',
         'remaining' => 'Temps restant',
     ],


### PR DESCRIPTION
Hello,
there was a space missing for "days_ago" and "hours_ago" in the French translation so I added them!

![image](https://user-images.githubusercontent.com/36472830/124026257-b9a6e380-d9f1-11eb-9cb6-a81f6a279e27.png)
