### PR TITLE
Accept legacy "m" parameter for beatmap redirect mode

### DIFF
--- a/app/Http/Controllers/BeatmapsController.php
+++ b/app/Http/Controllers/BeatmapsController.php
@@ -32,13 +32,18 @@ class BeatmapsController extends Controller
             abort(404);
         }
 
-        $requestedMode = presence(request('mode'));
+        if ($beatmap->mode === 'osu') {
+            $params = get_params(request()->all(), null, [
+                'm:int', // legacy parameter
+                'mode:string',
+            ], ['null_missing' => true]);
 
-        if (Beatmap::isModeValid($requestedMode) && $beatmap->mode === 'osu') {
-            $mode = $requestedMode;
-        } else {
-            $mode = $beatmap->mode;
+            $mode = Beatmap::isModeValid($params['mode'])
+                ? $params['mode']
+                : Beatmap::modeStr($params['m']);
         }
+
+        $mode ??= $beatmap->mode;
 
         return ujs_redirect(route('beatmapsets.show', ['beatmapset' => $set->beatmapset_id]).'#'.$mode.'/'.$id);
     }


### PR DESCRIPTION
Mainly coming from user events (`App\Models\Event`).

Resolves #7739.