### PR TITLE
Prevent showing empty livestream listing on error

### DIFF
--- a/app/Models/LivestreamCollection.php
+++ b/app/Models/LivestreamCollection.php
@@ -27,9 +27,7 @@ class LivestreamCollection
             $this->streams = cache_remember_mutexed('livestreams:arr:v2', 300, [], function () {
                 $streams = $this->downloadStreams()['data'] ?? [];
 
-                return array_map(function ($stream) {
-                    return new Twitch\Stream($stream);
-                }, $streams);
+                return array_map(fn ($stream) => new Twitch\Stream($stream), $streams);
             });
         }
 

--- a/app/Models/LivestreamCollection.php
+++ b/app/Models/LivestreamCollection.php
@@ -24,7 +24,7 @@ class LivestreamCollection
     public function all()
     {
         if ($this->streams === null) {
-            $this->streams = Cache::remember('livestreams:arr:v2', 300, function () {
+            $this->streams = cache_remember_mutexed('livestreams:arr:v2', 300, [], function () {
                 $streams = $this->downloadStreams()['data'] ?? [];
 
                 return array_map(function ($stream) {


### PR DESCRIPTION
5 minutes outdated list is better than nothing.