### PR TITLE
Filter out fail scores by the pass flag instead of rank

### DIFF
--- a/app/Models/LegacyMatch/Score.php
+++ b/app/Models/LegacyMatch/Score.php
@@ -34,6 +34,9 @@ class Score extends Model
         getEnabledModsAttribute as private _getEnabledMods;
     }
 
+    protected $casts = [
+        'pass' => 'bool',
+    ];
     protected $table = 'game_scores';
     protected $primaryKeys = ['game_id', 'slot'];
     protected $hidden = ['frame', 'game_id'];

--- a/app/Models/Score/Best/Model.php
+++ b/app/Models/Score/Best/Model.php
@@ -328,7 +328,7 @@ abstract class Model extends BaseModel
      * Override parent scope with a noop as only passed scores go in here.
      * And the `pass` column doesn't exist.
      */
-    public function scopeIncludeFails($query, bool $include = false)
+    public function scopeIncludeFails($query, bool $include)
     {
         return $query;
     }

--- a/app/Models/Score/Best/Model.php
+++ b/app/Models/Score/Best/Model.php
@@ -324,6 +324,20 @@ abstract class Model extends BaseModel
         return $query->whereIn('user_id', $userIds);
     }
 
+    /**
+     * Override parent scope with a noop as only passed scores go in here.
+     * And the `pass` column doesn't exist.
+     */
+    public function scopeIncludeFails($query, bool $include = false)
+    {
+        return $query;
+    }
+
+    public function getPassAttribute(): bool
+    {
+        return true;
+    }
+
     public function replayViewCount()
     {
         $class = ReplayViewCount::class.'\\'.get_class_basename(static::class);

--- a/app/Models/Score/Model.php
+++ b/app/Models/Score/Model.php
@@ -23,8 +23,9 @@ abstract class Model extends BaseModel
     protected $primaryKey = 'score_id';
 
     protected $casts = [
-        'perfect' => 'boolean',
-        'replay' => 'boolean',
+        'pass' => 'bool',
+        'perfect' => 'bool',
+        'replay' => 'bool',
     ];
     protected $dates = ['date'];
 
@@ -73,28 +74,7 @@ abstract class Model extends BaseModel
             return $query;
         }
 
-        // FIXME: on mysql 8.0.22, character set (coercibility?) difference causes query error.
-        //
-        // The error itself doesn't manifest if only doing `Score\Osu::where('rank', '<>', 'F')`.
-        // It's when having more conditions like `Score\Osu::where('user_id', 1)->where('rank', '<>', 'F')`
-        // then mysql spits out error.
-        //
-        // One alternative is using CONVERT: `whereRaw('`rank` <> CONVERT(? USING latin1)', ['F'])`.
-        // The character set for CONVERT() doesn't actually matter - doing this at all allows
-        // mysql to coerce the value to the column's character set. Presumably. The writer of this
-        // comment isn't sure either why this works.
-        //
-        // Skipping variable binding altogether and using literal query also works (used here).
-        //
-        // Also note the error only happens when using prepared statement with binding value.
-        //
-        // Original error:
-        // General error: 1267 Illegal mix of collations (latin1_swedish_ci,IMPLICIT) and (utf8mb4_0900_ai_ci,COERCIBLE) for operation '<>'
-        //
-        // Maybe references:
-        // - https://dev.mysql.com/doc/relnotes/mysql/8.0/en/news-8-0-22.html#mysqld-8-0-22-optimizer
-        // - https://dev.mysql.com/doc/refman/8.0/en/type-conversion.html
-        return $query->whereRaw("`rank` <> 'F'");
+        return $query->where('pass', true);
     }
 
     public function scopeVisibleUsers($query)

--- a/app/Models/Score/Model.php
+++ b/app/Models/Score/Model.php
@@ -68,7 +68,7 @@ abstract class Model extends BaseModel
         return $query->where('user_id', $user->user_id);
     }
 
-    public function scopeIncludeFails($query, bool $include = false)
+    public function scopeIncludeFails($query, bool $include)
     {
         if ($include) {
             return $query;

--- a/app/Transformers/ScoreTransformer.php
+++ b/app/Transformers/ScoreTransformer.php
@@ -31,6 +31,7 @@ class ScoreTransformer extends TransformerAbstract
             'mods' => $score->enabled_mods,
             'score' => $score->score,
             'max_combo' => $score->maxcombo,
+            'passed' => $score->pass,
             'perfect' => $score->perfect,
             'statistics' => [
                 'count_50' => $score->count50,

--- a/resources/assets/lib/interfaces/score-json.ts
+++ b/resources/assets/lib/interfaces/score-json.ts
@@ -18,6 +18,7 @@ export default interface ScoreJson {
   mode?: GameMode;
   mode_int?: number;
   mods: string[];
+  passed: boolean;
   pp?: number;
   rank?: Rank;
   rank_country?: number;

--- a/resources/views/docs/_structures/score.md
+++ b/resources/views/docs/_structures/score.md
@@ -1,27 +1,28 @@
 ## Score
 
-Field                 | Type | Description
---------------------- | ---- | -----------
-id                    |      | |
-best_id               |      | |
-user_id               |      | |
-accuracy              |      | |
-mods                  |      | |
-score                 |      | |
-max_combo             |      | |
-perfect               |      | |
-statistics.count_50   |      | |
-statistics.count_100  |      | |
-statistics.count_300  |      | |
-statistics.count_geki |      | |
-statistics.count_katu |      | |
-statistics.count_miss |      | |
-pp                    |      | |
-rank                  |      | |
-created_at            |      | |
-mode                  |      | |
-mode_int              |      | |
-replay                |      | |
+Field                 | Type    | Description
+--------------------- | ------- | -----------
+id                    |         | |
+best_id               |         | |
+user_id               |         | |
+accuracy              |         | |
+mods                  |         | |
+score                 |         | |
+max_combo             |         | |
+perfect               |         | |
+statistics.count_50   |         | |
+statistics.count_100  |         | |
+statistics.count_300  |         | |
+statistics.count_geki |         | |
+statistics.count_katu |         | |
+statistics.count_miss |         | |
+passed                | boolean | |
+pp                    |         | |
+rank                  |         | |
+created_at            |         | |
+mode                  |         | |
+mode_int              |         | |
+replay                |         | |
 
 Optional attributes:
 


### PR DESCRIPTION
Lazer currently sends actual ongoing rank for non-passing scores instead of "F" so they're all shown in profile page.

Resolves #7847.