### PR TITLE
Fix sticky header component not available when mounting react

### DIFF
--- a/resources/assets/coffee/_classes/sticky-header.coffee
+++ b/resources/assets/coffee/_classes/sticky-header.coffee
@@ -11,8 +11,6 @@ class @StickyHeader
     @header = document.getElementsByClassName('js-pinned-header')
     @marker = document.getElementsByClassName('js-sticky-header')
     @pinnedSticky = document.getElementsByClassName('js-pinned-header-sticky')
-    @stickyBreadcrumbs = document.getElementsByClassName('js-sticky-header-breadcrumbs')
-    @stickyContent = document.getElementsByClassName('js-sticky-header-content')
 
     $(window).on 'scroll', @onScroll
     $(document).on 'turbolinks:load', @debouncedOnScroll
@@ -21,11 +19,11 @@ class @StickyHeader
 
 
   breadcrumbsElement: ->
-    @stickyBreadcrumbs[0]
+    newBody.querySelector('.js-sticky-header-breadcrumbs')
 
 
   contentElement: ->
-    @stickyContent[0]
+    newBody.querySelector('.js-sticky-header-content')
 
 
   headerHeight: ->


### PR DESCRIPTION
Mainly for beatmapset search page where it's used for the floating search box.

Resolves #7867.