### PR TITLE
Remove underscore identifier lint

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -193,7 +193,6 @@ module.exports = {
     'no-throw-literal': 'error',
     'no-trailing-spaces': 'error',
     'no-undef-init': 'error',
-    'no-underscore-dangle': 'error',
     'no-unsafe-finally': 'error',
     'object-shorthand': 'error',
     'one-var': ['error', 'never'],


### PR DESCRIPTION
Not really useful and just adding noise to fix the existing ones.

Typescript also already has `private` visibility for classes.