### PR TITLE
Increase user stats per-page limit to 100

### DIFF
--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -650,7 +650,7 @@ class UsersController extends Controller
 
     private function sanitizedLimitParam()
     {
-        return clamp(get_int(request('limit')) ?? 5, 1, 51);
+        return clamp(get_int(request('limit')) ?? 5, 1, 100);
     }
 
     private function getExtra($user, $page, $options, $perPage = 10, $offset = 0)


### PR DESCRIPTION
Resolves #7673.

I also noticed fetching beyond 100 isn't actually allowed in the first place.