### PR TITLE
Fix download score replay button

### DIFF
--- a/resources/assets/lib/scores-show/buttons.tsx
+++ b/resources/assets/lib/scores-show/buttons.tsx
@@ -17,7 +17,7 @@ export default function Buttons(props: Props) {
     <div className='score-buttons'>
       {props.score.replay && (
         <a
-          className='btn-osu-big btn-osu-big--rounded'
+          className='js-login-required--click btn-osu-big btn-osu-big--rounded'
           data-turbolinks={false}
           href={route('scores.download', { mode: props.score.mode, score: props.score.best_id })}
         >

--- a/resources/assets/lib/scores-show/buttons.tsx
+++ b/resources/assets/lib/scores-show/buttons.tsx
@@ -18,6 +18,7 @@ export default function Buttons(props: Props) {
       {props.score.replay && (
         <a
           className='btn-osu-big btn-osu-big--rounded'
+          data-turbolinks={false}
           href={route('scores.download', { mode: props.score.mode, score: props.score.best_id })}
         >
           {osu.trans('users.show.extra.top_ranks.download_replay')}


### PR DESCRIPTION
Resolves #7884.

The flow isn't quite right when downloading from logged out state for privileged user (it reloads the page after logging in to show the verification window). There isn't an easy fix for that apart of disabling verification for the download endpoint.