### PR TITLE
Fix (lazer) failed plays showing up in profile recent plays

### DIFF
--- a/app/Models/Solo/Score.php
+++ b/app/Models/Solo/Score.php
@@ -67,7 +67,7 @@ class Score extends Model
         // accept their scores.
         //
         // also, "F" rank is not a thing in lazer yet (and may never be?).
-        if (!$this->passed)
+        if ($this->passed == false)
             $this->rank = 'F';
 
         $this->save();
@@ -105,7 +105,7 @@ class Score extends Model
             'enabled_mods' => ModsHelper::toBitset(array_column($this->mods, 'acronym')),
             'maxcombo' => $this->max_combo,
             'pass' => $this->passed,
-            'perfect' => $this->rank != 'F' && $statistics['Miss'] + $statistics['LargeTickMiss'] === 0,
+            'perfect' => $this->rank !== 'F' && $statistics['Miss'] + $statistics['LargeTickMiss'] === 0,
             'rank' => $this->rank,
             'score' => $this->total_score,
             'scorechecksum' => "\0",

--- a/app/Models/Solo/Score.php
+++ b/app/Models/Solo/Score.php
@@ -106,7 +106,7 @@ class Score extends Model
             'enabled_mods' => ModsHelper::toBitset(array_column($this->mods, 'acronym')),
             'maxcombo' => $this->max_combo,
             'pass' => $this->passed,
-            'perfect' => !$this->passed && $statistics['Miss'] + $statistics['LargeTickMiss'] === 0,
+            'perfect' => $this->passed && $statistics['Miss'] + $statistics['LargeTickMiss'] === 0,
             'rank' => $this->rank,
             'score' => $this->total_score,
             'scorechecksum' => "\0",

--- a/app/Models/Solo/Score.php
+++ b/app/Models/Solo/Score.php
@@ -67,8 +67,7 @@ class Score extends Model
         // accept their scores.
         //
         // also, "F" rank is not a thing in lazer yet (and may never be?).
-        if ($this->passed !== true)
-        {
+        if ($this->passed !== true) {
             $this->rank = 'F';
         }
 

--- a/app/Models/Solo/Score.php
+++ b/app/Models/Solo/Score.php
@@ -67,8 +67,10 @@ class Score extends Model
         // accept their scores.
         //
         // also, "F" rank is not a thing in lazer yet (and may never be?).
-        if ($this->passed == false)
+        if ($this->passed !== true)
+        {
             $this->rank = 'F';
+        }
 
         $this->save();
     }

--- a/app/Models/Solo/Score.php
+++ b/app/Models/Solo/Score.php
@@ -67,7 +67,7 @@ class Score extends Model
         // accept their scores.
         //
         // also, "F" rank is not a thing in lazer yet (and may never be?).
-        if ($this->passed !== true) {
+        if (!$this->passed) {
             $this->rank = 'F';
         }
 
@@ -106,7 +106,7 @@ class Score extends Model
             'enabled_mods' => ModsHelper::toBitset(array_column($this->mods, 'acronym')),
             'maxcombo' => $this->max_combo,
             'pass' => $this->passed,
-            'perfect' => $this->rank !== 'F' && $statistics['Miss'] + $statistics['LargeTickMiss'] === 0,
+            'perfect' => !$this->passed && $statistics['Miss'] + $statistics['LargeTickMiss'] === 0,
             'rank' => $this->rank,
             'score' => $this->total_score,
             'scorechecksum' => "\0",

--- a/app/Models/Solo/Score.php
+++ b/app/Models/Solo/Score.php
@@ -62,6 +62,14 @@ class Score extends Model
 
         ScoreCheck::assertCompleted($this);
 
+        // this should potentially just be validation rather than applying this logic here, but
+        // older lazer builds potentially submit incorrect details here (and we still want to
+        // accept their scores.
+        //
+        // also, "F" rank is not a thing in lazer yet (and may never be?).
+        if (!$this->passed)
+            $this->rank = 'F';
+
         $this->save();
     }
 
@@ -89,6 +97,7 @@ class Score extends Model
         }
 
         $scoreClass = LegacyScore\Model::getClass($this->ruleset_id);
+
         $score = new $scoreClass([
             'beatmap_id' => $this->beatmap_id,
             'beatmapset_id' => optional($this->beatmap)->beatmapset_id ?? 0,
@@ -96,7 +105,7 @@ class Score extends Model
             'enabled_mods' => ModsHelper::toBitset(array_column($this->mods, 'acronym')),
             'maxcombo' => $this->max_combo,
             'pass' => $this->passed,
-            'perfect' => $statistics['Miss'] + $statistics['LargeTickMiss'] === 0,
+            'perfect' => $this->rank != 'F' && $statistics['Miss'] + $statistics['LargeTickMiss'] === 0,
             'rank' => $this->rank,
             'score' => $this->total_score,
             'scorechecksum' => "\0",
@@ -127,6 +136,7 @@ class Score extends Model
                 break;
         }
 
-        return $score->saveOrExplode();
+        $score->saveOrExplode();
+        return $score;
     }
 }

--- a/tests/Models/Solo/ScoreTest.php
+++ b/tests/Models/Solo/ScoreTest.php
@@ -19,6 +19,9 @@ class ScoreTest extends TestCase
         $this->expectException(InvariantException::class);
 
         $score->createLegacyEntry();
+
+        $this->assertFalse($score->passed);
+        $this->assertEquals($score->rank, 'F');
     }
 
     public function testModsPropertyType()

--- a/tests/Models/Solo/ScoreTest.php
+++ b/tests/Models/Solo/ScoreTest.php
@@ -38,7 +38,7 @@ class ScoreTest extends TestCase
             'max_combo' => 100,
             'statistics' => ['great' => 10],
             'accuracy' => 1,
-            'rank' => 'S', // lazer may send an incorrect rank for a failed score.
+            'rank' => 'S',
         ]);
 
         $this->assertTrue($score->passed);

--- a/tests/Models/Solo/ScoreTest.php
+++ b/tests/Models/Solo/ScoreTest.php
@@ -8,6 +8,7 @@ namespace Tests\Models\Solo;
 use App\Exceptions\InvariantException;
 use App\Models\Solo\Score;
 use stdClass;
+use Carbon\Carbon;
 use Tests\TestCase;
 
 class ScoreTest extends TestCase
@@ -19,9 +20,62 @@ class ScoreTest extends TestCase
         $this->expectException(InvariantException::class);
 
         $score->createLegacyEntry();
+    }
+
+    public function testLegacyPassScoreRetainsRank()
+    {
+        $score = new Score([
+            'mods' => [],
+            'user_id' => 1,
+            'beatmap_id' => 1,
+            'ruleset_id' => 1,
+        ]);
+
+        $score->complete([
+            'ended_at' => Carbon::now(),
+            'passed' => true,
+            'total_score' => 1000,
+            'max_combo' => 100,
+            'statistics' => ['great' => 10],
+            'accuracy' => 1,
+            'rank' => 'S', // lazer may send an incorrect rank for a failed score.
+        ]);
+
+        $this->assertTrue($score->passed);
+        $this->assertEquals($score->rank, 'S');
+
+        $legacy = $score->createLegacyEntry();
+
+        $this->assertTrue($legacy->perfect);
+        $this->assertEquals($legacy->rank, 'S');
+    }
+
+    public function testLegacyFailScoreIsRankF()
+    {
+        $score = new Score([
+            'mods' => [],
+            'user_id' => 1,
+            'beatmap_id' => 1,
+            'ruleset_id' => 1,
+        ]);
+
+        $score->complete([
+            'ended_at' => Carbon::now(),
+            'passed' => false,
+            'total_score' => 1000,
+            'max_combo' => 100,
+            'statistics' => ['great' => 10],
+            'accuracy' => 1,
+            'rank' => 'S', // lazer may send an incorrect rank for a failed score.
+        ]);
 
         $this->assertFalse($score->passed);
         $this->assertEquals($score->rank, 'F');
+
+        $legacy = $score->createLegacyEntry();
+
+        $this->assertFalse($legacy->perfect);
+        $this->assertEquals($legacy->rank, 'F');
     }
 
     public function testModsPropertyType()

--- a/tests/Models/Solo/ScoreTest.php
+++ b/tests/Models/Solo/ScoreTest.php
@@ -7,8 +7,8 @@ namespace Tests\Models\Solo;
 
 use App\Exceptions\InvariantException;
 use App\Models\Solo\Score;
-use stdClass;
 use Carbon\Carbon;
+use stdClass;
 use Tests\TestCase;
 
 class ScoreTest extends TestCase

--- a/tests/Models/Solo/ScoreTest.php
+++ b/tests/Models/Solo/ScoreTest.php
@@ -36,7 +36,7 @@ class ScoreTest extends TestCase
             'passed' => true,
             'total_score' => 1000,
             'max_combo' => 100,
-            'statistics' => ['great' => 10],
+            'statistics' => ['Great' => 10],
             'accuracy' => 1,
             'rank' => 'S',
         ]);

--- a/tests/Models/Solo/ScoreTest.php
+++ b/tests/Models/Solo/ScoreTest.php
@@ -64,7 +64,7 @@ class ScoreTest extends TestCase
             'passed' => false,
             'total_score' => 1000,
             'max_combo' => 100,
-            'statistics' => ['great' => 10],
+            'statistics' => ['Great' => 10],
             'accuracy' => 1,
             'rank' => 'S', // lazer may send an incorrect rank for a failed score.
         ]);


### PR DESCRIPTION
We are also applying a fix at the lazer end but it's probably best to have this. Could be converted to a validation rule (throw on incorrect values) if/when we support "F" ranks in lazer, but that's still up for discussion.

Closes https://github.com/ppy/osu/issues/13897. 
