### PR TITLE
Add settings and incompatibility rules for osu! target mod

### DIFF
--- a/app/Libraries/Multiplayer/Mod.php
+++ b/app/Libraries/Multiplayer/Mod.php
@@ -208,6 +208,9 @@ class Mod
             'scale' => 'float',
             'style' => 'int',
         ],
+        self::OSU_TARGET => [
+            'seed' => 'int',
+        ],
     ];
 
     public static function assertValidExclusivity($requiredIds, $allowedIds, $ruleset)
@@ -351,6 +354,10 @@ class Mod
                             self::OSU_SPININ,
                         ],
                         [
+                            self::OSU_APPROACH_DIFFERENT,
+                            self::OSU_TARGET,
+                        ],
+                        [
                             self::OSU_TRACEABLE,
                             self::OSU_DEFLATE,
                         ],
@@ -365,6 +372,10 @@ class Mod
                         [
                             self::OSU_TRACEABLE,
                             self::OSU_SPININ,
+                        ],
+                        [
+                            self::OSU_TRACEABLE,
+                            self::OSU_TARGET,
                         ],
                         [
                             self::OSU_SPININ,


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/13938.

[Reference for settings & incompatibility rules.](https://github.com/ppy/osu/blob/master/osu.Game.Rulesets.Osu/Mods/OsuModTarget.cs) (`OsuModApproachDifferent` and `OsuModTraceable` are the only two implementations of `IRequiresApproachCircles` game-side.)