### PR TITLE
Fix discussion url parser

### DIFF
--- a/resources/assets/coffee/_classes/beatmap-discussion-helper.coffee
+++ b/resources/assets/coffee/_classes/beatmap-discussion-helper.coffee
@@ -207,7 +207,7 @@ class @BeatmapDiscussionHelper
   @urlParse: (urlString, discussions, options = {}) =>
     options.forceDiscussionId ?= false
 
-    url = new URL(urlString ? document.location.href)
+    url = new URL(urlString ? window.newUrl ? document.location.href)
     [__, pathBeatmapsets, beatmapsetId, pathDiscussions, beatmapId, mode, filter] = url.pathname.split /\/+/
 
     return if pathBeatmapsets != 'beatmapsets' || pathDiscussions != 'discussion'

--- a/resources/assets/lib/globals.d.ts
+++ b/resources/assets/lib/globals.d.ts
@@ -3,6 +3,7 @@
 
 interface Window {
   newBody?: HTMLElement;
+  newUrl?: string;
 }
 
 // interfaces for using process.env

--- a/resources/assets/lib/react-turbolinks.ts
+++ b/resources/assets/lib/react-turbolinks.ts
@@ -71,6 +71,9 @@ export default class ReactTurbolinks {
 
   private handleBeforeRender = (e: JQuery.TriggeredEvent) => {
     window.newBody = (e.originalEvent as Event & { data: { newBody: HTMLElement }}).data.newBody;
+    window.newUrl = Turbolinks.controller.currentVisit?.redirectedToLocation?.absoluteURL
+      ?? Turbolinks.controller.currentVisit?.location.absoluteURL
+      ?? document.location.href;
     this.pageReady = true;
     this.loadScripts(false);
     this.boot();

--- a/resources/assets/lib/turbolinks.d.ts
+++ b/resources/assets/lib/turbolinks.d.ts
@@ -2,6 +2,15 @@
 // See the LICENCE file in the repository root for full licence text.
 
 declare module 'turbolinks' {
+  interface Controller {
+    currentVisit?: Visit;
+    advanceHistory(url: string): void;
+  }
+
+  interface Location {
+    absoluteURL: string;
+  }
+
   interface TurbolinksAction {
     action: 'advance' | 'replace' | 'restore';
   }
@@ -11,8 +20,13 @@ declare module 'turbolinks' {
     isHTML(): boolean;
   }
 
+  interface Visit {
+    location: Location;
+    redirectedToLocation?: Location;
+  }
+
   export default interface TurbolinksStatic {
-    controller: any;
+    controller: Controller;
     supported: boolean;
 
     clearCache(): void;


### PR DESCRIPTION
Doesn't work right when part of turbolinks render and using current url as the actual url hasn't been set yet.

Resolves #7892.