### PR TITLE
Add group url as osu-web url

### DIFF
--- a/resources/assets/lib/osu-url-helper.ts
+++ b/resources/assets/lib/osu-url-helper.ts
@@ -16,6 +16,7 @@ export default class OsuUrlHelper {
     'community',
     'help',
     'home',
+    'groups',
     'legal',
     'multiplayer',
     'notifications',


### PR DESCRIPTION
Currently causing plain browser navigation instead of turbolinks. I wonder if checking for external links instead is better now :thinking: 