### PR TITLE
Use rank D instead of F for failed plays

### DIFF
--- a/app/Models/Solo/Score.php
+++ b/app/Models/Solo/Score.php
@@ -65,10 +65,8 @@ class Score extends Model
         // this should potentially just be validation rather than applying this logic here, but
         // older lazer builds potentially submit incorrect details here (and we still want to
         // accept their scores.
-        //
-        // also, "F" rank is not a thing in lazer yet (and may never be?).
         if (!$this->passed) {
-            $this->rank = 'F';
+            $this->rank = 'D';
         }
 
         $this->save();

--- a/tests/Models/Solo/ScoreTest.php
+++ b/tests/Models/Solo/ScoreTest.php
@@ -50,7 +50,7 @@ class ScoreTest extends TestCase
         $this->assertEquals($legacy->rank, 'S');
     }
 
-    public function testLegacyFailScoreIsRankF()
+    public function testLegacyFailScoreIsRankD()
     {
         $score = new Score([
             'mods' => [],
@@ -70,12 +70,12 @@ class ScoreTest extends TestCase
         ]);
 
         $this->assertFalse($score->passed);
-        $this->assertEquals($score->rank, 'F');
+        $this->assertEquals($score->rank, 'D');
 
         $legacy = $score->createLegacyEntry();
 
         $this->assertFalse($legacy->perfect);
-        $this->assertEquals($legacy->rank, 'F');
+        $this->assertEquals($legacy->rank, 'D');
     }
 
     public function testModsPropertyType()


### PR DESCRIPTION
As it turns out, F causes errors with deserialisation at lazer's end.

This might not be the final case but just want to stop breakage for now.
