### PR TITLE
Fix profile page navigation scroll on Firefox

### DIFF
--- a/resources/assets/coffee/react/modding-profile/main.coffee
+++ b/resources/assets/coffee/react/modding-profile/main.coffee
@@ -13,6 +13,7 @@ import { ReviewEditorConfigContext } from 'beatmap-discussions/review-editor-con
 import { BlockButton } from 'block-button'
 import { deletedUser } from 'models/user'
 import { NotificationBanner } from 'notification-banner'
+import core from 'osu-core-singleton'
 import { Posts } from "./posts"
 import * as React from 'react'
 import { a, button, div, i, span } from 'react-dom-factories'
@@ -81,12 +82,15 @@ export class Main extends React.PureComponent
     @modeScrollUrl = currentLocation()
 
     if !@restoredState
-      Timeout.set 0, => @pageJump null, @initialPage
+      core.reactTurbolinks.runAfterPageLoad @eventId, =>
+        # The scroll is a bit off on Firefox if not using timeout.
+        Timeout.set 0, => @pageJump(null, @initialPage)
 
 
   componentWillUnmount: =>
     $.unsubscribe ".#{@eventId}"
     $(window).off ".#{@eventId}"
+    $(document).off ".#{@eventId}"
 
     $(window).stop()
     Timeout.clear @modeScrollTimeout

--- a/resources/assets/coffee/react/profile-page/main.coffee
+++ b/resources/assets/coffee/react/profile-page/main.coffee
@@ -13,6 +13,7 @@ import { TopRanks } from './top-ranks'
 import { UserPage } from './user-page'
 import { BlockButton } from 'block-button'
 import { NotificationBanner } from 'notification-banner'
+import core from 'osu-core-singleton'
 import * as React from 'react'
 import { a, button, div, i, li, span, ul } from 'react-dom-factories'
 import UserProfileContainer from 'user-profile-container'
@@ -110,12 +111,15 @@ export class Main extends React.PureComponent
     @modeScrollUrl = currentLocation()
 
     if !@restoredState
-      Timeout.set 0, => @pageJump null, @initialPage
+      core.reactTurbolinks.runAfterPageLoad @eventId, =>
+        # The scroll is a bit off on Firefox if not using timeout.
+        Timeout.set 0, => @pageJump(null, @initialPage)
 
 
   componentWillUnmount: =>
     $.unsubscribe ".#{@eventId}"
     $(window).off ".#{@eventId}"
+    $(document).off ".#{@eventId}"
 
     for sortable in [@pages, @tabs]
       $(sortable.current).sortable 'destroy'


### PR DESCRIPTION
Navigating to `/users/:user#:section` from another page doesn't correctly scroll on Firefox.