### PR TITLE
Fix session duration for non-guest user on octane

### DIFF
--- a/app/Libraries/Session/Store.php
+++ b/app/Libraries/Session/Store.php
@@ -245,8 +245,8 @@ class Store extends \Illuminate\Session\Store
     {
         $isGuest = $this->isGuestSession();
 
-        if ($isGuest && $this->handler instanceof CacheBasedSessionHandler) {
-            $this->handler->setMinutes(120);
+        if ($this->handler instanceof CacheBasedSessionHandler) {
+            $this->handler->setMinutes($isGuest ? 120 : config('session.lifetime'));
         }
 
         // Overriden to track user sessions in Redis


### PR DESCRIPTION
Session handler instance is persistent so the duration needs to be set before saving.