### PR TITLE
Adjust page and menu titles

### DIFF
--- a/resources/lang/en/layout.php
+++ b/resources/lang/en/layout.php
@@ -64,16 +64,16 @@ return [
         'beatmaps' => [
             '_' => 'beatmaps',
             'artists' => 'featured artists',
-            'index' => 'listing',
-            'packs' => 'packs',
+            'index' => 'beatmap listing',
+            'packs' => 'beatmap packs',
         ],
         'community' => [
             '_' => 'community',
             'chat' => 'chat',
             'contests' => 'contests',
             'dev' => 'development',
-            'forum-forums-index' => 'forums',
-            'getLive' => 'live',
+            'forum-forums-index' => 'forum',
+            'getLive' => 'live stream',
             'tournaments' => 'tournaments',
         ],
         'help' => [
@@ -104,7 +104,7 @@ return [
         'store' => [
             '_' => 'store',
             'cart-show' => 'cart',
-            'getListing' => 'listing',
+            'getListing' => 'products',
             'orders-index' => 'order history',
         ],
     ],

--- a/resources/lang/en/page_title.php
+++ b/resources/lang/en/page_title.php
@@ -111,13 +111,13 @@ return [
             '_' => 'password reset',
         ],
         'ranking_controller' => [
-            '_' => 'ranking',
+            '_' => 'rankings',
         ],
         'scores_controller' => [
             '_' => 'performance',
         ],
         'store_controller' => [
-            '_' => 'osu!store',
+            '_' => 'store',
         ],
         'tournaments_controller' => [
             '_' => 'tournaments',
@@ -127,16 +127,16 @@ return [
             'disabled' => 'notice',
         ],
         'wiki_controller' => [
-            '_' => 'knowledge base',
+            '_' => 'wiki',
         ],
     ],
     'multiplayer' => [
         'rooms_controller' => [
-            '_' => 'ranking',
+            '_' => 'rankings',
         ],
     ],
     'store' => [
-        '_' => 'osu!store',
+        '_' => 'store',
     ],
     'users' => [
         'modding_history_controller' => [


### PR DESCRIPTION
Simpler change compared to #7925 by just duplicating the translations. Changes for `page_title` on another locales have already applied :eyes: 