### PR TITLE
Add beatmap discussion message type typings

### DIFF
--- a/resources/assets/coffee/_classes/beatmap-discussion-helper.coffee
+++ b/resources/assets/coffee/_classes/beatmap-discussion-helper.coffee
@@ -73,16 +73,6 @@ class @BeatmapDiscussionHelper
         osu.link(_exported.OsuUrlHelper.openBeatmapEditor("#{m}:#{s}:#{ms}#{range ? ''}"), text, classNames: classNames)
 
 
-  @messageType:
-    icon:
-      hype: 'fas fa-bullhorn'
-      mapperNote: 'far fa-sticky-note'
-      praise: 'fas fa-heart'
-      problem: 'fas fa-exclamation-circle'
-      review: 'fas fa-tasks'
-      suggestion: 'far fa-circle'
-
-
   @nearbyDiscussions: (discussions, timestamp) =>
     return [] if !timestamp?
 

--- a/resources/assets/coffee/react/beatmap-discussions/discussion.coffee
+++ b/resources/assets/coffee/react/beatmap-discussions/discussion.coffee
@@ -319,7 +319,7 @@ export class Discussion extends React.PureComponent
             span
               className: "beatmap-discussion-message-type beatmap-discussion-message-type--#{_.kebabCase(@props.discussion.message_type)}"
               i
-                className: discussionTypeIcons[_.camelCase(@props.discussion.message_type)]
+                className: discussionTypeIcons[@props.discussion.message_type]
                 title: osu.trans "beatmaps.discussions.message_type.#{@props.discussion.message_type}"
 
           if @props.discussion.resolved

--- a/resources/assets/coffee/react/beatmap-discussions/discussion.coffee
+++ b/resources/assets/coffee/react/beatmap-discussions/discussion.coffee
@@ -5,6 +5,7 @@ import { NewReply } from './new-reply'
 import { Post } from './post'
 import { SystemPost } from './system-post'
 import { UserCard } from './user-card'
+import { discussionTypeIcons } from 'beatmap-discussions/discussion-type'
 import * as React from 'react'
 import { renderToStaticMarkup } from 'react-dom/server'
 import { button, div, i, span, a } from 'react-dom-factories'
@@ -318,7 +319,7 @@ export class Discussion extends React.PureComponent
             span
               className: "beatmap-discussion-message-type beatmap-discussion-message-type--#{_.kebabCase(@props.discussion.message_type)}"
               i
-                className: BeatmapDiscussionHelper.messageType.icon[_.camelCase(@props.discussion.message_type)]
+                className: discussionTypeIcons[_.camelCase(@props.discussion.message_type)]
                 title: osu.trans "beatmaps.discussions.message_type.#{@props.discussion.message_type}"
 
           if @props.discussion.resolved

--- a/resources/assets/coffee/react/beatmap-discussions/new-discussion.coffee
+++ b/resources/assets/coffee/react/beatmap-discussions/new-discussion.coffee
@@ -324,7 +324,7 @@ export class NewDiscussion extends React.PureComponent
 
     el BigButton,
       modifiers: ['beatmap-discussion-new']
-      icon: discussionTypeIcons[_.camelCase(type)]
+      icon: discussionTypeIcons[type]
       isBusy: @state.posting == type
       text: osu.trans("beatmaps.discussions.message_type.#{typeText}")
       key: type

--- a/resources/assets/coffee/react/beatmap-discussions/new-discussion.coffee
+++ b/resources/assets/coffee/react/beatmap-discussions/new-discussion.coffee
@@ -2,6 +2,7 @@
 # See the LICENCE file in the repository root for full licence text.
 
 import { MessageLengthCounter } from './message-length-counter'
+import { discussionTypeIcons } from 'beatmap-discussions/discussion-type'
 import { BigButton } from 'big-button'
 import * as React from 'react'
 import TextareaAutosize from 'react-autosize-textarea'
@@ -323,7 +324,7 @@ export class NewDiscussion extends React.PureComponent
 
     el BigButton,
       modifiers: ['beatmap-discussion-new']
-      icon: BeatmapDiscussionHelper.messageType.icon[_.camelCase(type)]
+      icon: discussionTypeIcons[_.camelCase(type)]
       isBusy: @state.posting == type
       text: osu.trans("beatmaps.discussions.message_type.#{typeText}")
       key: type

--- a/resources/assets/lib/beatmap-discussions/discussion-type.ts
+++ b/resources/assets/lib/beatmap-discussions/discussion-type.ts
@@ -1,13 +1,19 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
-const discussionTypes = ['hype', 'mapperNote', 'praise', 'problem', 'suggestion'] as const;
+const discussionTypes = ['hype', 'mapperNote', 'praise', 'problem', 'review', 'suggestion'] as const;
 export type DiscussionType = (typeof discussionTypes)[number];
+
+// TODO: we should probably have the type as all camelCase or all snake_case.
+const discussionTypesJson = ['hype', 'mapper_note', 'praise', 'problem', 'review', 'suggestion'] as const;
+export type DiscussionTypeJson = (typeof discussionTypesJson)[number];
+
 
 export const discussionTypeIcons: Record<DiscussionType, string> = {
   hype: 'fas fa-fw fa-bullhorn',
   mapperNote: 'far fa-fw fa-sticky-note',
   praise: 'fas fa-fw fa-heart',
   problem: 'fas fa-fw fa-exclamation-circle',
+  review: 'fas fa-fw fa-tasks',
   suggestion: 'far fa-fw fa-circle',
 };

--- a/resources/assets/lib/beatmap-discussions/discussion-type.ts
+++ b/resources/assets/lib/beatmap-discussions/discussion-type.ts
@@ -1,0 +1,13 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
+const discussionTypes = ['hype', 'mapperNote', 'praise', 'problem', 'suggestion'] as const;
+export type DiscussionType = (typeof discussionTypes)[number];
+
+export const discussionTypeIcons: Record<DiscussionType, string> = {
+  hype: 'fas fa-fw fa-bullhorn',
+  mapperNote: 'far fa-fw fa-sticky-note',
+  praise: 'fas fa-fw fa-heart',
+  problem: 'fas fa-fw fa-exclamation-circle',
+  suggestion: 'far fa-fw fa-circle',
+};

--- a/resources/assets/lib/beatmap-discussions/discussion-type.ts
+++ b/resources/assets/lib/beatmap-discussions/discussion-type.ts
@@ -1,17 +1,12 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
-const discussionTypes = ['hype', 'mapperNote', 'praise', 'problem', 'review', 'suggestion'] as const;
+const discussionTypes = ['hype', 'mapper_note', 'praise', 'problem', 'review', 'suggestion'] as const;
 export type DiscussionType = (typeof discussionTypes)[number];
-
-// TODO: we should probably have the type as all camelCase or all snake_case.
-const discussionTypesJson = ['hype', 'mapper_note', 'praise', 'problem', 'review', 'suggestion'] as const;
-export type DiscussionTypeJson = (typeof discussionTypesJson)[number];
-
 
 export const discussionTypeIcons: Record<DiscussionType, string> = {
   hype: 'fas fa-fw fa-bullhorn',
-  mapperNote: 'far fa-fw fa-sticky-note',
+  mapper_note: 'far fa-fw fa-sticky-note',
   praise: 'fas fa-fw fa-heart',
   problem: 'fas fa-fw fa-exclamation-circle',
   review: 'fas fa-fw fa-tasks',

--- a/resources/assets/lib/beatmap-discussions/discussion-type.ts
+++ b/resources/assets/lib/beatmap-discussions/discussion-type.ts
@@ -5,10 +5,10 @@ const discussionTypes = ['hype', 'mapper_note', 'praise', 'problem', 'review', '
 export type DiscussionType = (typeof discussionTypes)[number];
 
 export const discussionTypeIcons: Record<DiscussionType, string> = {
-  hype: 'fas fa-fw fa-bullhorn',
-  mapper_note: 'far fa-fw fa-sticky-note',
-  praise: 'fas fa-fw fa-heart',
-  problem: 'fas fa-fw fa-exclamation-circle',
-  review: 'fas fa-fw fa-tasks',
-  suggestion: 'far fa-fw fa-circle',
+  hype: 'fas fa-bullhorn',
+  mapper_note: 'far fa-sticky-note',
+  praise: 'fas fa-heart',
+  problem: 'fas fa-exclamation-circle',
+  review: 'fas fa-tasks',
+  suggestion: 'far fa-circle',
 };

--- a/resources/assets/lib/beatmap-discussions/editor-insertion-menu.tsx
+++ b/resources/assets/lib/beatmap-discussions/editor-insertion-menu.tsx
@@ -1,6 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+import { discussionTypeIcons } from 'beatmap-discussions/discussion-type';
 import BeatmapJsonExtended from 'interfaces/beatmap-json-extended';
 import { Cancelable, throttle } from 'lodash';
 import { Portal } from 'portal';
@@ -226,10 +227,10 @@ export class EditorInsertionMenu extends React.Component<Props> {
       case 'praise':
       case 'problem':
       case 'suggestion':
-        icon = BeatmapDiscussionHelper.messageType.icon[type];
+        icon = discussionTypeIcons[type];
         break;
       case 'paragraph':
-        icon = 'fas fa-indent';
+        icon = 'fas fa-fw fa-indent';
         break;
     }
 

--- a/resources/assets/lib/beatmap-discussions/editor-insertion-menu.tsx
+++ b/resources/assets/lib/beatmap-discussions/editor-insertion-menu.tsx
@@ -230,7 +230,7 @@ export class EditorInsertionMenu extends React.Component<Props> {
         icon = discussionTypeIcons[type];
         break;
       case 'paragraph':
-        icon = 'fas fa-fw fa-indent';
+        icon = 'fas fa-indent';
         break;
     }
 

--- a/resources/assets/lib/beatmap-discussions/editor-issue-type-selector.tsx
+++ b/resources/assets/lib/beatmap-discussions/editor-issue-type-selector.tsx
@@ -1,6 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+import { DiscussionType, discussionTypeIcons } from 'beatmap-discussions/discussion-type';
 import { BeatmapReviewDiscussionType } from 'interfaces/beatmap-discussion-review';
 import BeatmapJsonExtended from 'interfaces/beatmap-json-extended';
 import * as React from 'react';
@@ -9,18 +10,7 @@ import { ReactEditor } from 'slate-react';
 import IconDropdownMenu, { MenuItem } from './icon-dropdown-menu';
 import { SlateContext } from './slate-context';
 
-const discussionTypes = ['hype', 'mapperNote', 'praise', 'problem', 'suggestion'] as const;
-export type DiscussionType = (typeof discussionTypes)[number];
-
 const selectableTypes: DiscussionType[] = ['praise', 'problem', 'suggestion'];
-
-const discussionTypeIcons: Record<DiscussionType, string> = {
-  hype: 'fas fa-fw fa-bullhorn',
-  mapperNote: 'far fa-fw fa-sticky-note',
-  praise: 'fas fa-fw fa-heart',
-  problem: 'fas fa-fw fa-exclamation-circle',
-  suggestion: 'far fa-fw fa-circle',
-};
 
 interface Props {
   beatmaps: BeatmapJsonExtended[];

--- a/resources/assets/lib/beatmap-discussions/editor-issue-type-selector.tsx
+++ b/resources/assets/lib/beatmap-discussions/editor-issue-type-selector.tsx
@@ -9,9 +9,12 @@ import { ReactEditor } from 'slate-react';
 import IconDropdownMenu, { MenuItem } from './icon-dropdown-menu';
 import { SlateContext } from './slate-context';
 
-type DiscussionType = 'hype' | 'mapperNote' | 'praise' | 'problem' | 'suggestion';
+const discussionTypes = ['hype', 'mapperNote', 'praise', 'problem', 'suggestion'] as const;
+export type DiscussionType = (typeof discussionTypes)[number];
+
 const selectableTypes: DiscussionType[] = ['praise', 'problem', 'suggestion'];
-const discussionTypeIcons = {
+
+const discussionTypeIcons: Record<DiscussionType, string> = {
   hype: 'fas fa-fw fa-bullhorn',
   mapperNote: 'far fa-fw fa-sticky-note',
   praise: 'fas fa-fw fa-heart',

--- a/resources/assets/lib/beatmap-discussions/editor-issue-type-selector.tsx
+++ b/resources/assets/lib/beatmap-discussions/editor-issue-type-selector.tsx
@@ -24,7 +24,7 @@ export default class EditorIssueTypeSelector extends React.Component<Props> {
 
   render(): React.ReactNode {
     const menuOptions: MenuItem[] = selectableTypes.map((type) => ({
-      icon: <span className={`beatmap-discussion-message-type beatmap-discussion-message-type--${type}`}><i className={`${discussionTypeIcons[type]}`} /></span>,
+      icon: <span className={`beatmap-discussion-message-type beatmap-discussion-message-type--${type}`}><i className={discussionTypeIcons[type]} /></span>,
       id: type,
       label: osu.trans(`beatmaps.discussions.message_type.${type}`),
     }));

--- a/resources/assets/lib/beatmap-discussions/review-post-embed.tsx
+++ b/resources/assets/lib/beatmap-discussions/review-post-embed.tsx
@@ -2,12 +2,11 @@
 // See the LICENCE file in the repository root for full licence text.
 
 import { BeatmapIcon } from 'beatmap-icon';
-import { DiscussionType, discussionTypeIcons } from 'beatmap-discussions/discussion-type';
+import { discussionTypeIcons } from 'beatmap-discussions/discussion-type';
 import * as React from 'react';
 import { classWithModifiers } from 'utils/css';
 import { BeatmapsContext } from './beatmaps-context';
 import { DiscussionsContext } from './discussions-context';
-import { camelCase } from 'lodash';
 
 interface Props {
   data: {
@@ -49,7 +48,7 @@ export const ReviewPostEmbed = ({ data }: Props) => {
   }
 
   const messageTypeIcon = () => {
-    const type = camelCase(discussion.message_type) as DiscussionType;
+    const type = discussion.message_type;
     return (
       <div className={`beatmap-discussion-message-type beatmap-discussion-message-type--${type}`}><i className={discussionTypeIcons[type]} title={osu.trans(`beatmaps.discussions.message_type.${type}`)} /></div>
     );

--- a/resources/assets/lib/beatmap-discussions/review-post-embed.tsx
+++ b/resources/assets/lib/beatmap-discussions/review-post-embed.tsx
@@ -1,8 +1,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
-import { BeatmapIcon } from 'beatmap-icon';
 import { discussionTypeIcons } from 'beatmap-discussions/discussion-type';
+import { BeatmapIcon } from 'beatmap-icon';
 import * as React from 'react';
 import { classWithModifiers } from 'utils/css';
 import { BeatmapsContext } from './beatmaps-context';

--- a/resources/assets/lib/beatmap-discussions/review-post-embed.tsx
+++ b/resources/assets/lib/beatmap-discussions/review-post-embed.tsx
@@ -2,10 +2,12 @@
 // See the LICENCE file in the repository root for full licence text.
 
 import { BeatmapIcon } from 'beatmap-icon';
+import { DiscussionType, discussionTypeIcons } from 'beatmap-discussions/discussion-type';
 import * as React from 'react';
 import { classWithModifiers } from 'utils/css';
 import { BeatmapsContext } from './beatmaps-context';
 import { DiscussionsContext } from './discussions-context';
+import { camelCase } from 'lodash';
 
 interface Props {
   data: {
@@ -47,9 +49,9 @@ export const ReviewPostEmbed = ({ data }: Props) => {
   }
 
   const messageTypeIcon = () => {
-    const type = discussion.message_type;
+    const type = camelCase(discussion.message_type) as DiscussionType;
     return (
-      <div className={`beatmap-discussion-message-type beatmap-discussion-message-type--${type}`}><i className={BeatmapDiscussionHelper.messageType.icon[type]} title={osu.trans(`beatmaps.discussions.message_type.${type}`)} /></div>
+      <div className={`beatmap-discussion-message-type beatmap-discussion-message-type--${type}`}><i className={discussionTypeIcons[type]} title={osu.trans(`beatmaps.discussions.message_type.${type}`)} /></div>
     );
   };
 

--- a/resources/assets/lib/globals.d.ts
+++ b/resources/assets/lib/globals.d.ts
@@ -133,7 +133,7 @@ interface BeatmapsetDiscussionJson {
   beatmapset_id: number;
   deleted_at: string | null;
   id: number;
-  message_type: import('beatmap-discussions/discussion-type').DiscussionTypeJson;
+  message_type: import('beatmap-discussions/discussion-type').DiscussionType;
   parent_id: number | null;
   posts: BeatmapsetDiscussionPostJson[];
   resolved: boolean;

--- a/resources/assets/lib/globals.d.ts
+++ b/resources/assets/lib/globals.d.ts
@@ -38,12 +38,7 @@ interface Comment {
   id: number;
 }
 
-interface DiscussionMessageType {
-  icon: {[key: string]: string};
-}
-
 interface BeatmapDiscussionHelperClass {
-  messageType: DiscussionMessageType;
   TIMESTAMP_REGEX: RegExp;
   format(text: string, options?: any): string;
   formatTimestamp(value: number | null): string | undefined;
@@ -138,7 +133,7 @@ interface BeatmapsetDiscussionJson {
   beatmapset_id: number;
   deleted_at: string | null;
   id: number;
-  message_type: string;
+  message_type: import('beatmap-discussions/discussion-type').DiscussionTypeJson;
   parent_id: number | null;
   posts: BeatmapsetDiscussionPostJson[];
   resolved: boolean;


### PR DESCRIPTION
Noticed while reviewing stuff, also removed the roundabout camelCasing.

There's still the usage of `mapperNotes` in coffeescript for handling the grouping in some places, but I left that for now.