### PR TITLE
Add muted mod

### DIFF
--- a/app/Libraries/Multiplayer/Mod.php
+++ b/app/Libraries/Multiplayer/Mod.php
@@ -27,6 +27,7 @@ class Mod
     const WIND_DOWN = 'WD';
     const RANDOM = 'RD';
     const MIRROR = 'MR';
+    const MUTED = 'MU';
 
     // osu-specific
     const OSU_AUTOPILOT = 'AP';
@@ -87,6 +88,7 @@ class Mod
         self::SUDDENDEATH,
         self::WIND_DOWN,
         self::WIND_UP,
+        self::MUTED,
     ];
 
     // Defines mutual-exclusivity for groups of mods, i.e. only one mod within each group can be active at a time
@@ -213,6 +215,9 @@ class Mod
         ],
         self::MIRROR => [
             'reflection' => 'int',
+        ],
+        self::MUTED => [
+            'enable_metronome' => 'bool',
         ],
     ];
 

--- a/app/Libraries/Multiplayer/Mod.php
+++ b/app/Libraries/Multiplayer/Mod.php
@@ -218,6 +218,9 @@ class Mod
         ],
         self::MUTED => [
             'enable_metronome' => 'bool',
+            'mute_combo_count' => 'int',
+            'inverse_muting' => 'bool',
+            'affects_hit_sounds' => 'bool',
         ],
     ];
 


### PR DESCRIPTION
Reference: https://github.com/ppy/osu/pull/14041

Valid for all rulesets, no incompatibility rules (yet?). Metronome setting being persisted server-side makes _some_ sense as it makes things a bit easier.

<personal_opinion>Playtesting that this works with multi was quite dreadful gameplay-wise. Never touching this mod with a ten foot pole again...</personal_opinion>