### PR TITLE
Remove country flags drop shadow

### DIFF
--- a/resources/assets/less/bem/flag-country.less
+++ b/resources/assets/less/bem/flag-country.less
@@ -12,7 +12,7 @@
   background-repeat: no-repeat;
   border-radius: 3px;
   position: relative;
-  filter: saturate(1.1) drop-shadow(0 1px @box-shadow-radius @box-shadow-color);
+  filter: saturate(1.1);
 
   &::after {
     .full-size();

--- a/resources/assets/less/bem/ranking-page-table.less
+++ b/resources/assets/less/bem/ranking-page-table.less
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 .ranking-page-table {
+  .own-layer();
   width: 100%;
   min-width: 650px;
   white-space: nowrap;


### PR DESCRIPTION
Apparently the shadow causes lag for some people. It was done that way because some flags are shaped differently.

People affected should check if this test page is actually smoother: https://osunext.dev.myconan.net/rankings/osu/performance