### PR TITLE
Fix typo and wrong index data for converted mania maps

### DIFF
--- a/app/Models/Beatmap.php
+++ b/app/Models/Beatmap.php
@@ -158,7 +158,7 @@ class Beatmap extends Model
          * Matches client implementation.
          * all round()s here use PHP_ROUND_HALF_EVEN to match C# default Math.Round.
          * References:
-         * - (implmentation) https://github.com/ppy/osu/blob/6bbc23c831cd73bf126b31edb0bb4fa729f947d1/osu.Game.Rulesets.Mania/Beatmaps/ManiaBeatmapConverter.cs#L40
+         * - (implementation) https://github.com/ppy/osu/blob/6bbc23c831cd73bf126b31edb0bb4fa729f947d1/osu.Game.Rulesets.Mania/Beatmaps/ManiaBeatmapConverter.cs#L40
          * - (rounding) https://msdn.microsoft.com/en-us/library/wyk4d9cy(v=vs.110).aspx
          */
         if ($this->mode === 'mania') {

--- a/app/Models/Beatmap.php
+++ b/app/Models/Beatmap.php
@@ -158,7 +158,7 @@ class Beatmap extends Model
          * Matches client implementation.
          * all round()s here use PHP_ROUND_HALF_EVEN to match C# default Math.Round.
          * References:
-         * - (implmentation) https://github.com/ppy/osu/blob/c9276ce2b8b2eb728b1e5fc74f5f7ef81b0c6e09/osu.Game.Rulesets.Mania/Beatmaps/ManiaBeatmapConverter.cs#L36
+         * - (implmentation) https://github.com/ppy/osu/blob/6bbc23c831cd73bf126b31edb0bb4fa729f947d1/osu.Game.Rulesets.Mania/Beatmaps/ManiaBeatmapConverter.cs#L40
          * - (rounding) https://msdn.microsoft.com/en-us/library/wyk4d9cy(v=vs.110).aspx
          */
         if ($this->mode === 'mania') {
@@ -174,7 +174,7 @@ class Beatmap extends Model
                 if ($percentSliderOrSpinner < 0.2) {
                     return 7;
                 } elseif ($percentSliderOrSpinner < 0.3 || $roundedValue >= 5) {
-                    return $accuracy > 5 ? 7 : 5;
+                    return $accuracy > 5 ? 7 : 6;
                 } elseif ($percentSliderOrSpinner > 0.6) {
                     return $accuracy > 4 ? 5 : 4;
                 } else {

--- a/app/Models/Elasticsearch/BeatmapsetTrait.php
+++ b/app/Models/Elasticsearch/BeatmapsetTrait.php
@@ -70,10 +70,9 @@ trait BeatmapsetTrait
         foreach ($this->beatmaps as $beatmap) {
             $beatmapValues = [];
             foreach ($mappings as $field => $mapping) {
-                $beatmapValues[$field] = $beatmap[$field];
+                $beatmapValues[$field] = $beatmap->$field;
             }
 
-            $beatmapValues['convert'] = false;
             $values[] = $beatmapValues;
 
             if ($beatmap->playmode === Beatmap::MODES['osu']) {
@@ -82,11 +81,13 @@ trait BeatmapsetTrait
                         continue;
                     }
 
-                    $diff = $beatmap->baseDifficultyRatings?->firstWhere('mode', $modeInt);
-                    $convertValues = $beatmapValues; // is an array, so automatically a copy.
-                    $convertValues['convert'] = true;
-                    $convertValues['difficultyrating'] = $diff?->diff_unified ?? $beatmap->difficultyrating;
-                    $convertValues['playmode'] = $modeInt;
+                    $convert = clone $beatmap;
+                    $convert->playmode = $modeInt;
+                    $convert->convert = true;
+                    $convertValues = [];
+                    foreach ($mappings as $field => $mapping) {
+                        $convertValues[$field] = $convert->$field;
+                    }
 
                     $values[] = $convertValues;
                 }


### PR DESCRIPTION
Resolves #7846.

A full reindex is needed for correct search result.