### PR TITLE
Remove invalid usage of shared view variables

### DIFF
--- a/app/Exceptions/Handler.php
+++ b/app/Exceptions/Handler.php
@@ -189,8 +189,6 @@ class Handler extends ExceptionHandler
             $scope->setTag('http_code', (string) static::statusCode($e));
         });
 
-        $ref = app('sentry')->captureException($e);
-
-        view()->share('ref', $ref);
+        request()->attributes->set('ref', app('sentry')->captureException($e));
     }
 }

--- a/app/Http/Controllers/FollowsController.php
+++ b/app/Http/Controllers/FollowsController.php
@@ -64,7 +64,7 @@ class FollowsController extends Controller
 
     public function store()
     {
-        $params = $this->getParams();
+        $params = $this->getStoreParams();
         $follow = new Follow($params);
 
         try {
@@ -86,7 +86,7 @@ class FollowsController extends Controller
         return response([], 204);
     }
 
-    private function getParams()
+    private function getStoreParams()
     {
         $params = get_params(request()->all(), 'follow', ['notifiable_type:string', 'notifiable_id:int', 'subtype:string']);
         $params['user_id'] = auth()->user()->getKey();

--- a/app/Http/Controllers/FollowsController.php
+++ b/app/Http/Controllers/FollowsController.php
@@ -50,23 +50,23 @@ class FollowsController extends Controller
 
     public function index($subtype = null)
     {
-        if (!present($subtype)) {
-            return ujs_redirect(route('follows.index', ['subtype' => Follow::DEFAULT_SUBTYPE]));
-        }
-
         $this->user = auth()->user();
 
-        [$view, $vars] = match ($subtype) {
+        $viewArgs = match ($subtype) {
             'comment' => $this->indexComment(),
             'forum_topic' => $this->indexForumTopic(),
             'mapping' => $this->indexMapping(),
             'modding' => $this->indexModding(),
-            default => throw new InvariantException('invalid subtype parameter'),
+            default => null,
         };
 
-        $vars['subtype'] = $subtype;
+        if ($viewArgs === null) {
+            return ujs_redirect(route('follows.index', ['subtype' => Follow::DEFAULT_SUBTYPE]));
+        }
 
-        return ext_view($view, $vars);
+        $viewArgs[1]['subtype'] = $subtype;
+
+        return ext_view(...$viewArgs);
     }
 
     public function store()

--- a/app/Http/Controllers/FollowsController.php
+++ b/app/Http/Controllers/FollowsController.php
@@ -5,7 +5,6 @@
 
 namespace App\Http\Controllers;
 
-use App\Exceptions\InvariantException;
 use App\Exceptions\ModelNotSavedException;
 use App\Jobs\UpdateUserMappingFollowerCountCache;
 use App\Models\BeatmapDiscussion;

--- a/app/Http/Controllers/FollowsController.php
+++ b/app/Http/Controllers/FollowsController.php
@@ -71,7 +71,7 @@ class FollowsController extends Controller
 
     public function store()
     {
-        $params = $this->getStoreParams();
+        $params = $this->getParams();
         $follow = new Follow($params);
 
         try {
@@ -93,7 +93,7 @@ class FollowsController extends Controller
         return response([], 204);
     }
 
-    private function getStoreParams()
+    private function getParams()
     {
         $params = get_params(request()->all(), 'follow', ['notifiable_type:string', 'notifiable_id:int', 'subtype:string']);
         $params['user_id'] = auth()->user()->getKey();

--- a/app/Http/Controllers/RankingController.php
+++ b/app/Http/Controllers/RankingController.php
@@ -20,6 +20,7 @@ class RankingController extends Controller
 {
     private $country;
     private $countryStats;
+    private array $defaultViewVars;
     private $params;
     private $friendsOnly;
 
@@ -52,9 +53,11 @@ class RankingController extends Controller
             $this->friendsOnly = auth()->check() && $this->params['filter'] === 'friends';
             $this->setVariantParam();
 
-            view()->share('hasPager', !in_array($type, static::SPOTLIGHT_TYPES, true));
-            view()->share('spotlight', null); // so variable capture in selector function doesn't die when spotlight is null.
-            view()->share($this->params); // won't set null values
+            $this->defaultViewVars = array_merge([
+                'hasPager' => !in_array($type, static::SPOTLIGHT_TYPES, true),
+                // so variable capture in selector function doesn't die when spotlight is null.
+                'spotlight' => null,
+            ], $this->params);
 
             if ($mode === null) {
                 return ujs_redirect(route('rankings', ['mode' => default_mode(), 'type' => 'performance']));
@@ -85,7 +88,7 @@ class RankingController extends Controller
                 $this->country = $this->countryStats->country;
             }
 
-            view()->share('country', $this->country);
+            $this->defaultViewVars['country'] = $this->country;
 
             return $next($request);
         });
@@ -209,7 +212,7 @@ class RankingController extends Controller
 
         $countries = json_collection($this->getCountries($mode), 'Country', ['display']);
 
-        return ext_view("rankings.{$type}", compact('countries', 'scores'));
+        return ext_view("rankings.{$type}", array_merge($this->defaultViewVars, compact('countries', 'scores')));
     }
 
     public function spotlight($mode)
@@ -264,7 +267,13 @@ class RankingController extends Controller
 
         return ext_view(
             'rankings.charts',
-            compact('scores', 'scoreCount', 'selectOptions', 'spotlight', 'beatmapsets')
+            array_merge($this->defaultViewVars, compact(
+                'beatmapsets',
+                'scoreCount',
+                'scores',
+                'selectOptions',
+                'spotlight',
+            ))
         );
     }
 

--- a/app/Http/Controllers/Store/Controller.php
+++ b/app/Http/Controllers/Store/Controller.php
@@ -11,19 +11,8 @@ use Auth;
 
 abstract class Controller extends BaseController
 {
-    protected $pendingCheckout;
-
     public function __construct()
     {
-        $this->middleware(function ($request, $next) {
-            if (Auth::check()) {
-                $pendingCheckouts = Order::where('user_id', Auth::user()->getKey())->processing();
-                view()->share('pendingCheckout', $pendingCheckouts->first());
-            }
-
-            return $next($request);
-        });
-
         parent::__construct();
     }
 

--- a/app/Models/Store/Order.php
+++ b/app/Models/Store/Order.php
@@ -12,6 +12,7 @@ use App\Models\SupporterTag;
 use App\Models\User;
 use Carbon\Carbon;
 use DB;
+use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\SoftDeletes;
 
 /**
@@ -74,6 +75,15 @@ class Order extends Model
     protected static function splitTransactionId($value)
     {
         return explode('-', $value, 2);
+    }
+
+    public static function pendingForUser(?User $user): ?Builder
+    {
+        if ($user === null) {
+            return null;
+        }
+
+        return static::where('user_id', $user->getKey())->processing();
     }
 
     public function items()

--- a/resources/views/layout/error.blade.php
+++ b/resources/views/layout/error.blade.php
@@ -24,7 +24,10 @@
         ]) !!}
     </p>
 
-    @if (isset($ref))
+    @php
+        $ref = request()->attributes->get('ref');
+    @endphp
+    @if ($ref !== null)
         <h4>{{ osu_trans('layout.errors.reference') }}<br><small>{{ $ref }}</small></h4>
     @endif
 </div>

--- a/resources/views/store/header.blade.php
+++ b/resources/views/store/header.blade.php
@@ -41,6 +41,10 @@
             'url' => route('store.orders.index'),
         ],
     ];
+
+    $showPendingCheckout = $currentNav !== 'cart'
+        && App\Models\Store\Order::pendingForUser(auth()->user())?->exists()
+        ?? false;
 @endphp
 
 @component('layout._page_header_v4', ['params' => [
@@ -86,7 +90,7 @@
 
     {{-- TODO: make nicer --}}
     {{-- Show message if there is a pending checkout and not currently on a checkout page --}}
-    @if(isset($pendingCheckout) && optional(request()->route())->getName() !== 'store.checkout.show')
+    @if($showPendingCheckout)
         @php
             $pendingCheckoutLink = Html::link(
                 route('store.orders.index', ['type' => 'processing']),


### PR DESCRIPTION
As it turned out it's not intended as per-request global variable store for view but just global per app and to be set during application start. And thus it's not reset by octane between requests.

Resolves #7952.