### PR TITLE
Add footnote support for wiki markdown

### DIFF
--- a/app/Libraries/Markdown/Indexing/Extension.php
+++ b/app/Libraries/Markdown/Indexing/Extension.php
@@ -9,6 +9,7 @@ use App\Libraries\Markdown\StyleBlock\Element as StyleBlock;
 use League\CommonMark\Block\Element as Block;
 use League\CommonMark\ConfigurableEnvironmentInterface;
 use League\CommonMark\Extension\ExtensionInterface;
+use League\CommonMark\Extension\Footnote\Node as FootnoteExtension;
 use League\CommonMark\Extension\Table as TableExtension;
 use League\CommonMark\Inline\Element as Inline;
 
@@ -38,6 +39,8 @@ class Extension implements ExtensionInterface
             Block\ListItem::class => new Renderers\ListItemRenderer(),
             Block\Paragraph::class => new Renderers\BlockRenderer(),
             Block\ThematicBreak::class => new Renderers\BlockRenderer(),
+            FootnoteExtension\Footnote::class => new Renderers\NoopRenderer(),
+            FootnoteExtension\FootnoteContainer::class => new Renderers\NoopRenderer(),
             StyleBlock::class => new Renderers\BlockRenderer(),
             TableExtension\Table::class => new Renderers\TableRenderer(),
             TableExtension\TableCaption::class => new Renderers\NoopRenderer(),
@@ -50,6 +53,8 @@ class Extension implements ExtensionInterface
     private function inlineRenderers()
     {
         return [
+            FootnoteExtension\FootnoteBackref::class => new Renderers\NoopRenderer(),
+            FootnoteExtension\FootnoteRef::class => new Renderers\NoopRenderer(),
             Inline\Code::class => new Renderers\InlineRenderer(),
             Inline\Emphasis::class => new Renderers\InlineRenderer(),
             Inline\HtmlInline::class => new Renderers\NoopRenderer(),

--- a/app/Libraries/Markdown/Osu/DocumentProcessor.php
+++ b/app/Libraries/Markdown/Osu/DocumentProcessor.php
@@ -119,6 +119,9 @@ class DocumentProcessor
             case Block\Paragraph::class:
                 $class = "{$blockClass}__paragraph";
                 break;
+            case FootnoteExtension\Footnote::class:
+                $class = "{$blockClass}__list-item";
+                break;
             case FootnoteExtension\FootnoteContainer::class:
                 $class = "{$blockClass}__list {$blockClass}__list--ordered";
                 break;

--- a/app/Libraries/Markdown/Osu/DocumentProcessor.php
+++ b/app/Libraries/Markdown/Osu/DocumentProcessor.php
@@ -12,6 +12,7 @@ use League\CommonMark\Block\Element as Block;
 use League\CommonMark\EnvironmentInterface;
 use League\CommonMark\Event\DocumentParsedEvent;
 use League\CommonMark\Extension\Table as TableExtension;
+use League\CommonMark\Extension\Footnote\Node as FootnoteExtension;
 use League\CommonMark\Inline\Element as Inline;
 
 class DocumentProcessor
@@ -117,6 +118,9 @@ class DocumentProcessor
                 break;
             case Block\Paragraph::class:
                 $class = "{$blockClass}__paragraph";
+                break;
+            case FootnoteExtension\FootnoteContainer::class:
+                $class = "{$blockClass}__list {$blockClass}__list--ordered";
                 break;
             case Inline\Image::class:
                 $class = "{$blockClass}__image";

--- a/app/Libraries/Markdown/Osu/DocumentProcessor.php
+++ b/app/Libraries/Markdown/Osu/DocumentProcessor.php
@@ -123,7 +123,7 @@ class DocumentProcessor
                 $class = "{$blockClass}__list-item";
                 break;
             case FootnoteExtension\FootnoteContainer::class:
-                $class = "{$blockClass}__list {$blockClass}__list--ordered";
+                $class = "{$blockClass}__list {$blockClass}__list--ordered {$blockClass}__list--footnote";
                 break;
             case Inline\Image::class:
                 $class = "{$blockClass}__image";
@@ -157,11 +157,6 @@ class DocumentProcessor
 
     private function addListStartAsVariable()
     {
-        if ($this->node instanceof FootnoteExtension\FootnoteContainer) {
-            $this->node->data['attributes']['style'] = '--list-start: 0';
-            return;
-        }
-
         if (!$this->node instanceof Block\ListBlock || !$this->event->isEntering()) {
             return;
         }

--- a/app/Libraries/Markdown/Osu/DocumentProcessor.php
+++ b/app/Libraries/Markdown/Osu/DocumentProcessor.php
@@ -11,8 +11,8 @@ use App\Libraries\OsuWiki;
 use League\CommonMark\Block\Element as Block;
 use League\CommonMark\EnvironmentInterface;
 use League\CommonMark\Event\DocumentParsedEvent;
-use League\CommonMark\Extension\Table as TableExtension;
 use League\CommonMark\Extension\Footnote\Node as FootnoteExtension;
+use League\CommonMark\Extension\Table as TableExtension;
 use League\CommonMark\Inline\Element as Inline;
 
 class DocumentProcessor

--- a/app/Libraries/Markdown/Osu/DocumentProcessor.php
+++ b/app/Libraries/Markdown/Osu/DocumentProcessor.php
@@ -157,6 +157,11 @@ class DocumentProcessor
 
     private function addListStartAsVariable()
     {
+        if ($this->node instanceof FootnoteExtension\FootnoteContainer) {
+            $this->node->data['attributes']['style'] = '--list-start: 0';
+            return;
+        }
+
         if (!$this->node instanceof Block\ListBlock || !$this->event->isEntering()) {
             return;
         }

--- a/app/Libraries/Markdown/Osu/Extension.php
+++ b/app/Libraries/Markdown/Osu/Extension.php
@@ -29,6 +29,7 @@ class Extension implements ExtensionInterface
             ->addBlockRenderer(FootnoteExtension\FootnoteContainer::class, new Renderers\FootnoteContainerRenderer(), 10)
             ->addBlockRenderer(FootnoteExtension\Footnote::class, new Renderers\FootnoteListItemRenderer(), 10)
             ->addInlineRenderer(FootnoteExtension\FootnoteRef::class, new Renderers\FootnoteRefRenderer(), 10)
+            ->addInlineRenderer(FootnoteExtension\FootnoteBackref::class, new Renderers\FootnoteBackrefRenderer(), 10)
             ->addEventListener(DocumentParsedEvent::class, $this->processor);
     }
 }

--- a/app/Libraries/Markdown/Osu/Extension.php
+++ b/app/Libraries/Markdown/Osu/Extension.php
@@ -27,6 +27,7 @@ class Extension implements ExtensionInterface
             ->addBlockRenderer(ListItem::class, new Renderers\ListItemRenderer(), 10)
             ->addBlockRenderer(Table::class, new Renderers\TableRenderer(), 10)
             ->addBlockRenderer(FootnoteExtension\FootnoteContainer::class, new Renderers\FootnoteContainerRenderer(), 10)
+            ->addBlockRenderer(FootnoteExtension\Footnote::class, new Renderers\FootnoteListItemRenderer(), 10)
             ->addEventListener(DocumentParsedEvent::class, $this->processor);
     }
 }

--- a/app/Libraries/Markdown/Osu/Extension.php
+++ b/app/Libraries/Markdown/Osu/Extension.php
@@ -28,6 +28,7 @@ class Extension implements ExtensionInterface
             ->addBlockRenderer(Table::class, new Renderers\TableRenderer(), 10)
             ->addBlockRenderer(FootnoteExtension\FootnoteContainer::class, new Renderers\FootnoteContainerRenderer(), 10)
             ->addBlockRenderer(FootnoteExtension\Footnote::class, new Renderers\FootnoteListItemRenderer(), 10)
+            ->addInlineRenderer(FootnoteExtension\FootnoteRef::class, new Renderers\FootnoteRefRenderer(), 10)
             ->addEventListener(DocumentParsedEvent::class, $this->processor);
     }
 }

--- a/app/Libraries/Markdown/Osu/Extension.php
+++ b/app/Libraries/Markdown/Osu/Extension.php
@@ -9,6 +9,7 @@ use League\CommonMark\Block\Element\ListItem;
 use League\CommonMark\ConfigurableEnvironmentInterface;
 use League\CommonMark\Event\DocumentParsedEvent;
 use League\CommonMark\Extension\ExtensionInterface;
+use League\CommonMark\Extension\Footnote\Node as FootnoteExtension;
 use League\CommonMark\Extension\Table\Table;
 
 class Extension implements ExtensionInterface
@@ -25,6 +26,7 @@ class Extension implements ExtensionInterface
         $environment
             ->addBlockRenderer(ListItem::class, new Renderers\ListItemRenderer(), 10)
             ->addBlockRenderer(Table::class, new Renderers\TableRenderer(), 10)
+            ->addBlockRenderer(FootnoteExtension\FootnoteContainer::class, new Renderers\FootnoteContainerRenderer(), 10)
             ->addEventListener(DocumentParsedEvent::class, $this->processor);
     }
 }

--- a/app/Libraries/Markdown/Osu/Renderers/FootnoteBackrefRenderer.php
+++ b/app/Libraries/Markdown/Osu/Renderers/FootnoteBackrefRenderer.php
@@ -22,16 +22,16 @@ class FootnoteBackrefRenderer implements InlineRendererInterface, ConfigurationA
     public function render(AbstractInline $inline, ElementRendererInterface $htmlRenderer)
     {
         if (!($inline instanceof FootnoteBackref)) {
-            throw new InvalidArgumentException('Incompatible inline type: ' . \get_class($inline));
+            throw new InvalidArgumentException('Incompatible inline type: '.\get_class($inline));
         }
 
         $attrs = $inline->getData('attributes', []);
-        $attrs['class'] = $this->blockName . '__link';
+        $attrs['class'] = $this->blockName.'__link';
         $attrs['data-backref'] = 'true';
         $attrs['href'] = \mb_strtolower($inline->getReference()->getDestination());
         $attrs['title'] = osu_trans('wiki.show.back');
 
-        return '&nbsp;' . new HtmlElement('a', $attrs, '&#8593;', true);
+        return '&nbsp;'.new HtmlElement('a', $attrs, '&#8593;', true);
     }
 
     public function setConfiguration(ConfigurationInterface $configuration)

--- a/app/Libraries/Markdown/Osu/Renderers/FootnoteBackrefRenderer.php
+++ b/app/Libraries/Markdown/Osu/Renderers/FootnoteBackrefRenderer.php
@@ -1,0 +1,39 @@
+<?php
+
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
+namespace App\Libraries\Markdown\Osu\Renderers;
+
+use App\Libraries\Markdown\OsuMarkdown;
+use InvalidArgumentException;
+use League\CommonMark\ElementRendererInterface;
+use League\CommonMark\Extension\Footnote\Node\FootnoteBackref;
+use League\CommonMark\HtmlElement;
+use League\CommonMark\Inline\Element\AbstractInline;
+use League\CommonMark\Inline\Renderer\InlineRendererInterface;
+use League\CommonMark\Util\ConfigurationAwareInterface;
+use League\CommonMark\Util\ConfigurationInterface;
+
+class FootnoteBackrefRenderer implements InlineRendererInterface, ConfigurationAwareInterface
+{
+    private string $blockName;
+
+    public function render(AbstractInline $inline, ElementRendererInterface $htmlRenderer)
+    {
+        if (!($inline instanceof FootnoteBackref)) {
+            throw new InvalidArgumentException('Incompatible inline type: ' . \get_class($inline));
+        }
+
+        $attrs = $inline->getData('attributes', []);
+        $attrs['class'] = $this->blockName . '__link';
+        $attrs['href'] = \mb_strtolower($inline->getReference()->getDestination());
+
+        return '&nbsp;' . new HtmlElement('a', $attrs, '&#8593;', true);
+    }
+
+    public function setConfiguration(ConfigurationInterface $configuration)
+    {
+        $this->blockName = $configuration->get('block_name', OsuMarkdown::DEFAULT_CONFIG['block_name']);
+    }
+}

--- a/app/Libraries/Markdown/Osu/Renderers/FootnoteBackrefRenderer.php
+++ b/app/Libraries/Markdown/Osu/Renderers/FootnoteBackrefRenderer.php
@@ -28,6 +28,7 @@ class FootnoteBackrefRenderer implements InlineRendererInterface, ConfigurationA
         $attrs = $inline->getData('attributes', []);
         $attrs['class'] = $this->blockName . '__link';
         $attrs['href'] = \mb_strtolower($inline->getReference()->getDestination());
+        $attrs['title'] = osu_trans('wiki.show.back');
 
         return '&nbsp;' . new HtmlElement('a', $attrs, '&#8593;', true);
     }

--- a/app/Libraries/Markdown/Osu/Renderers/FootnoteBackrefRenderer.php
+++ b/app/Libraries/Markdown/Osu/Renderers/FootnoteBackrefRenderer.php
@@ -27,6 +27,7 @@ class FootnoteBackrefRenderer implements InlineRendererInterface, ConfigurationA
 
         $attrs = $inline->getData('attributes', []);
         $attrs['class'] = $this->blockName . '__link';
+        $attrs['data-backref'] = 'true';
         $attrs['href'] = \mb_strtolower($inline->getReference()->getDestination());
         $attrs['title'] = osu_trans('wiki.show.back');
 

--- a/app/Libraries/Markdown/Osu/Renderers/FootnoteContainerRenderer.php
+++ b/app/Libraries/Markdown/Osu/Renderers/FootnoteContainerRenderer.php
@@ -1,0 +1,27 @@
+<?php
+
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
+namespace App\Libraries\Markdown\Osu\Renderers;
+
+use InvalidArgumentException;
+use League\CommonMark\Block\Element\AbstractBlock;
+use League\CommonMark\Block\Renderer\BlockRendererInterface;
+use League\CommonMark\ElementRendererInterface;
+use League\CommonMark\Extension\Footnote\Node\FootnoteContainer;
+use League\CommonMark\HtmlElement;
+
+class FootnoteContainerRenderer implements BlockRendererInterface
+{
+    public function render(AbstractBlock $block, ElementRendererInterface $htmlRenderer, bool $inTightList = false)
+    {
+        if (!($block instanceof FootnoteContainer)) {
+            throw new InvalidArgumentException('Incompatible block type: '.\get_class($block));
+        }
+
+        $attrs = $block->getData('attributes', []);
+
+        return new HtmlElement('ol', $attrs, $htmlRenderer->renderBlocks($block->children()));
+    }
+}

--- a/app/Libraries/Markdown/Osu/Renderers/FootnoteListItemRenderer.php
+++ b/app/Libraries/Markdown/Osu/Renderers/FootnoteListItemRenderer.php
@@ -1,0 +1,34 @@
+<?php
+
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
+namespace App\Libraries\Markdown\Osu\Renderers;
+
+use InvalidArgumentException;
+use League\CommonMark\Block\Element\AbstractBlock;
+use League\CommonMark\Block\Renderer\BlockRendererInterface;
+use League\CommonMark\ElementRendererInterface;
+use League\CommonMark\Extension\Footnote\Node\Footnote;
+use League\CommonMark\HtmlElement;
+
+class FootnoteListItemRenderer implements BlockRendererInterface
+{
+    public function render(AbstractBlock $block, ElementRendererInterface $htmlRenderer, bool $inTightList = false)
+    {
+        if (!($block instanceof Footnote)) {
+            throw new InvalidArgumentException('Incompatible block type: '.\get_class($block));
+        }
+
+        $attrs = $block->getData('attributes', []);
+        $attrs['id'] = 'fn:'.\mb_strtolower($block->getReference()->getLabel());
+
+        foreach ($block->getBackrefs() as $backref) {
+            $block->lastChild()->appendChild($backref);
+        }
+
+        $content = new HtmlElement('div', [], $htmlRenderer->renderInlines($block->firstChild()->children()));
+
+        return new HtmlElement('li', $attrs, $content, true);
+    }
+}

--- a/app/Libraries/Markdown/Osu/Renderers/FootnoteRefRenderer.php
+++ b/app/Libraries/Markdown/Osu/Renderers/FootnoteRefRenderer.php
@@ -27,6 +27,7 @@ class FootnoteRefRenderer implements InlineRendererInterface, ConfigurationAware
 
         $attrs = $inline->getData('attributes', []);
         $attrs['id'] = 'fnref:' . \mb_strtolower($inline->getReference()->getLabel());
+        $attrs['class'] = $this->blockName . '__superscript';
 
         return new HtmlElement(
             'sup',

--- a/app/Libraries/Markdown/Osu/Renderers/FootnoteRefRenderer.php
+++ b/app/Libraries/Markdown/Osu/Renderers/FootnoteRefRenderer.php
@@ -29,14 +29,17 @@ class FootnoteRefRenderer implements InlineRendererInterface, ConfigurationAware
         $attrs['id'] = 'fnref:' . \mb_strtolower($inline->getReference()->getLabel());
         $attrs['class'] = $this->blockName . '__superscript';
 
+        $target = \mb_strtolower($inline->getReference()->getDestination());
+
         return new HtmlElement(
             'sup',
             $attrs,
             new HtmlElement(
                 'a',
                 [
-                    'class' => $this->blockName . '__link',
-                    'href' => \mb_strtolower($inline->getReference()->getDestination())
+                    'class' => $this->blockName . '__link' . ' js-reference-link',
+                    'data-target' => $target,
+                    'href' => $target,
                 ],
                 '[' . $inline->getReference()->getTitle() . ']',
             ),

--- a/app/Libraries/Markdown/Osu/Renderers/FootnoteRefRenderer.php
+++ b/app/Libraries/Markdown/Osu/Renderers/FootnoteRefRenderer.php
@@ -1,0 +1,49 @@
+<?php
+
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
+namespace App\Libraries\Markdown\Osu\Renderers;
+
+use App\Libraries\Markdown\OsuMarkdown;
+use InvalidArgumentException;
+use League\CommonMark\ElementRendererInterface;
+use League\CommonMark\Extension\Footnote\Node\FootnoteRef;
+use League\CommonMark\HtmlElement;
+use League\CommonMark\Inline\Element\AbstractInline;
+use League\CommonMark\Inline\Renderer\InlineRendererInterface;
+use League\CommonMark\Util\ConfigurationAwareInterface;
+use League\CommonMark\Util\ConfigurationInterface;
+
+class FootnoteRefRenderer implements InlineRendererInterface, ConfigurationAwareInterface
+{
+    private string $blockName;
+
+    public function render(AbstractInline $inline, ElementRendererInterface $htmlRenderer)
+    {
+        if (!($inline instanceof FootnoteRef)) {
+            throw new InvalidArgumentException('Incompatible inline type: ' . \get_class($inline));
+        }
+
+        $attrs = $inline->getData('attributes', []);
+        $attrs['id'] = 'fnref:' . \mb_strtolower($inline->getReference()->getLabel());
+
+        return new HtmlElement(
+            'sup',
+            $attrs,
+            new HtmlElement(
+                'a',
+                [
+                    'class' => $this->blockName . '__link',
+                    'href' => \mb_strtolower($inline->getReference()->getDestination())
+                ],
+                $inline->getReference()->getTitle(),
+            ),
+        );
+    }
+
+    public function setConfiguration(ConfigurationInterface $configuration)
+    {
+        $this->blockName = $configuration->get('block_name', OsuMarkdown::DEFAULT_CONFIG['block_name']);
+    }
+}

--- a/app/Libraries/Markdown/Osu/Renderers/FootnoteRefRenderer.php
+++ b/app/Libraries/Markdown/Osu/Renderers/FootnoteRefRenderer.php
@@ -38,7 +38,7 @@ class FootnoteRefRenderer implements InlineRendererInterface, ConfigurationAware
                     'class' => $this->blockName . '__link',
                     'href' => \mb_strtolower($inline->getReference()->getDestination())
                 ],
-                $inline->getReference()->getTitle(),
+                '[' . $inline->getReference()->getTitle() . ']',
             ),
         );
     }

--- a/app/Libraries/Markdown/Osu/Renderers/FootnoteRefRenderer.php
+++ b/app/Libraries/Markdown/Osu/Renderers/FootnoteRefRenderer.php
@@ -22,12 +22,12 @@ class FootnoteRefRenderer implements InlineRendererInterface, ConfigurationAware
     public function render(AbstractInline $inline, ElementRendererInterface $htmlRenderer)
     {
         if (!($inline instanceof FootnoteRef)) {
-            throw new InvalidArgumentException('Incompatible inline type: ' . \get_class($inline));
+            throw new InvalidArgumentException('Incompatible inline type: '.\get_class($inline));
         }
 
         $attrs = $inline->getData('attributes', []);
-        $attrs['id'] = 'fnref:' . \mb_strtolower($inline->getReference()->getLabel());
-        $attrs['class'] = $this->blockName . '__superscript';
+        $attrs['id'] = 'fnref:'.\mb_strtolower($inline->getReference()->getLabel());
+        $attrs['class'] = $this->blockName.'__superscript';
 
         $target = \mb_strtolower($inline->getReference()->getDestination());
 
@@ -37,11 +37,11 @@ class FootnoteRefRenderer implements InlineRendererInterface, ConfigurationAware
             new HtmlElement(
                 'a',
                 [
-                    'class' => $this->blockName . '__link' . ' js-reference-link',
+                    'class' => $this->blockName.'__link'.' js-reference-link',
                     'data-target' => $target,
                     'href' => $target,
                 ],
-                '[' . $inline->getReference()->getTitle() . ']',
+                '['.$inline->getReference()->getTitle().']',
             ),
         );
     }

--- a/app/Libraries/Markdown/OsuMarkdown.php
+++ b/app/Libraries/Markdown/OsuMarkdown.php
@@ -219,6 +219,13 @@ class OsuMarkdown
 
         if ($this->config['parse_footnote']) {
             $environment->addExtension(new FootnoteExtension());
+            $environment->mergeConfig([
+                'footnote' => [
+                    'backref_class' => 'osu-md__link',
+                    'backref_symbol' => '&#8593;',
+                    'ref_class' => 'osu-md__link',
+                ],
+            ]);
         }
 
         if ($this->config['style_block_allowed_classes'] !== null) {

--- a/app/Libraries/Markdown/OsuMarkdown.php
+++ b/app/Libraries/Markdown/OsuMarkdown.php
@@ -219,13 +219,6 @@ class OsuMarkdown
 
         if ($this->config['parse_footnote']) {
             $environment->addExtension(new FootnoteExtension());
-            $environment->mergeConfig([
-                'footnote' => [
-                    'backref_class' => 'osu-md__link',
-                    'backref_symbol' => '&#8593;',
-                    'ref_class' => 'osu-md__link',
-                ],
-            ]);
         }
 
         if ($this->config['style_block_allowed_classes'] !== null) {

--- a/app/Libraries/Markdown/OsuMarkdown.php
+++ b/app/Libraries/Markdown/OsuMarkdown.php
@@ -11,6 +11,7 @@ use League\CommonMark\Environment;
 use League\CommonMark\Event\DocumentParsedEvent;
 use League\CommonMark\Extension\Attributes\AttributesExtension;
 use League\CommonMark\Extension\Autolink\AutolinkExtension;
+use League\CommonMark\Extension\Footnote\FootnoteExtension;
 use League\CommonMark\Extension\Table\TableExtension;
 use League\CommonMark\MarkdownConverter;
 use Symfony\Component\Yaml\Exception\ParseException as YamlParseException;
@@ -34,6 +35,7 @@ class OsuMarkdown
         'block_name' => 'osu-md',
         'generate_toc' => false,
         'parse_attribute_id' => false,
+        'parse_footnote' => false,
         'parse_yaml_header' => true,
         'record_first_image' => false,
         'relative_url_root' => null,
@@ -73,6 +75,7 @@ class OsuMarkdown
             'block_modifiers' => ['wiki'],
             'generate_toc' => true,
             'parse_attribute_id' => true,
+            'parse_footnote' => true,
             'style_block_allowed_classes' => ['infobox'],
             'title_from_document' => true,
         ],
@@ -212,6 +215,10 @@ class OsuMarkdown
         if ($this->config['parse_attribute_id']) {
             $environment->addEventListener(DocumentParsedEvent::class, new Attributes\AttributesOnlyIdListener());
             $environment->addExtension(new AttributesExtension());
+        }
+
+        if ($this->config['parse_footnote']) {
+            $environment->addExtension(new FootnoteExtension());
         }
 
         if ($this->config['style_block_allowed_classes'] !== null) {

--- a/resources/assets/less/bem/osu-md.less
+++ b/resources/assets/less/bem/osu-md.less
@@ -277,6 +277,8 @@
   }
 
   &__superscript {
+    .fragment-target-fn(10px);
+    position: relative;
     font-size: @font-size--small;
   }
 

--- a/resources/assets/less/bem/osu-md.less
+++ b/resources/assets/less/bem/osu-md.less
@@ -230,6 +230,10 @@
   &__list {
     padding-left: 20px;
 
+    &--footnote {
+      --list-start: 0;
+    }
+
     &--ordered {
       list-style: none;
       padding-left: 0;

--- a/resources/assets/less/bem/osu-md.less
+++ b/resources/assets/less/bem/osu-md.less
@@ -276,6 +276,10 @@
     }
   }
 
+  &__superscript {
+    font-size: @font-size--small;
+  }
+
   // not actual table but its container
   &__table {
     overflow-x: auto;

--- a/resources/assets/less/bem/osu-md.less
+++ b/resources/assets/less/bem/osu-md.less
@@ -239,6 +239,7 @@
 
   &__list-item {
     margin: 5px 0;
+    .fragment-target-fn();
 
     .@{_top}--store & {
       margin-left: 10px;

--- a/resources/assets/lib/osu-core.ts
+++ b/resources/assets/lib/osu-core.ts
@@ -25,6 +25,7 @@ import UserLogin from 'user-login';
 import UserLoginObserver from 'user-login-observer';
 import UserPreferences from 'user-preferences';
 import UserVerification from 'user-verification';
+import ReferenceLink from 'wiki/reference-link';
 import WindowFocusObserver from 'window-focus-observer';
 import WindowSize from 'window-size';
 
@@ -52,6 +53,7 @@ export default class OsuCore {
   readonly osuAudio: OsuAudio;
   readonly osuLayzr = new OsuLayzr();
   readonly reactTurbolinks: ReactTurbolinks;
+  readonly referenceLink = new ReferenceLink();
   socketWorker: SocketWorker;
   readonly timeago = new Timeago();
   readonly turbolinksReload = new TurbolinksReload();

--- a/resources/assets/lib/osu-core.ts
+++ b/resources/assets/lib/osu-core.ts
@@ -25,7 +25,7 @@ import UserLogin from 'user-login';
 import UserLoginObserver from 'user-login-observer';
 import UserPreferences from 'user-preferences';
 import UserVerification from 'user-verification';
-import ReferenceLink from 'wiki/reference-link';
+import ReferenceLinkTooltip from 'wiki/reference-link-tooltip';
 import WindowFocusObserver from 'window-focus-observer';
 import WindowSize from 'window-size';
 
@@ -53,7 +53,7 @@ export default class OsuCore {
   readonly osuAudio: OsuAudio;
   readonly osuLayzr = new OsuLayzr();
   readonly reactTurbolinks: ReactTurbolinks;
-  readonly referenceLink = new ReferenceLink();
+  readonly referenceLinkTooltip = new ReferenceLinkTooltip();
   socketWorker: SocketWorker;
   readonly timeago = new Timeago();
   readonly turbolinksReload = new TurbolinksReload();

--- a/resources/assets/lib/wiki/reference-link-tooltip.ts
+++ b/resources/assets/lib/wiki/reference-link-tooltip.ts
@@ -1,7 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
-export default class ReferenceLink {
+export default class ReferenceLinkTooltip {
   constructor() {
     $(document).on('mouseover', '.js-reference-link', this.showTitle);
   }

--- a/resources/assets/lib/wiki/reference-link-tooltip.ts
+++ b/resources/assets/lib/wiki/reference-link-tooltip.ts
@@ -51,8 +51,6 @@ export default class ReferenceLinkTooltip {
       tooltipContent.removeChild(backRefLink);
     }
 
-    if (el._tooltip == null) {
-      this.createTooltip(el, tooltipContent);
-    }
+    this.createTooltip(el, tooltipContent);
   };
 }

--- a/resources/assets/lib/wiki/reference-link.ts
+++ b/resources/assets/lib/wiki/reference-link.ts
@@ -12,6 +12,8 @@ export default class ReferenceLink {
         text: content,
       },
       hide: {
+        delay: 200,
+        effect: $(content).fadeTo(110, 0),
         fixed: true,
       },
       position: {
@@ -20,6 +22,8 @@ export default class ReferenceLink {
         viewport: $(window),
       },
       show: {
+        delay: 200,
+        effect: $(content).fadeTo(110, 1),
         ready: true,
       },
       style: {

--- a/resources/assets/lib/wiki/reference-link.ts
+++ b/resources/assets/lib/wiki/reference-link.ts
@@ -1,0 +1,54 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
+export default class ReferenceLink {
+  constructor() {
+    $(document).on('mouseover', '.js-reference-link', this.showTitle);
+  }
+
+  createTooltip = (element: HTMLElement, content: HTMLElement) => {
+    $(element).qtip({
+      content: {
+        text: content,
+      },
+      hide: {
+        fixed: true,
+      },
+      position: {
+        at: 'top center',
+        my: 'bottom center',
+        viewport: $(window),
+      },
+      show: {
+        ready: true,
+      },
+      style: {
+        classes: 'tooltip-default tooltip-default--interactable',
+      },
+    });
+  };
+
+  showTitle = (event: JQueryEventObject) => {
+    if (!(event.currentTarget instanceof HTMLAnchorElement)) return;
+
+    const el = event.currentTarget;
+    const target = el.dataset.target;
+
+    if (target == null) return;
+
+    const elTarget = document.querySelector(target.replace(':', '\\:')); // querySelector not working if ID contains colon
+
+    if (!(elTarget?.firstElementChild instanceof HTMLDivElement)) return;
+
+    const tooltipContent = $(elTarget.firstElementChild).clone()[0];
+    const backRefLink = tooltipContent.querySelector('[data-backref="true"]');
+
+    if (backRefLink instanceof HTMLAnchorElement) {
+      tooltipContent.removeChild(backRefLink);
+    }
+
+    if (el._tooltip == null) {
+      this.createTooltip(el, tooltipContent);
+    }
+  };
+}

--- a/resources/lang/en/wiki.php
+++ b/resources/lang/en/wiki.php
@@ -5,6 +5,7 @@
 
 return [
     'show' => [
+        'back' => 'Go back',
         'fallback_translation' => 'Requested page is not yet translated to the selected language (:language). Showing English version.',
         'incomplete_or_outdated' => 'The content on this page is incomplete or outdated. If you are able to help out, please consider updating the article!',
         'missing' => 'Requested page ":keyword" could not be found.',

--- a/tests/Libraries/Markdown/ProcessorTest.php
+++ b/tests/Libraries/Markdown/ProcessorTest.php
@@ -51,6 +51,7 @@ class ProcessorTest extends TestCase
         return [
             (new OsuMarkdown('default', [
                 'parse_attribute_id' => true,
+                'parse_footnote' => true,
                 'style_block_allowed_classes' => ['class-name'],
             ]))->load(file_get_contents($mdFilePath)),
             file_get_contents($textFilePath),

--- a/tests/Libraries/Markdown/html_markdown_examples/footnote.html
+++ b/tests/Libraries/Markdown/html_markdown_examples/footnote.html
@@ -1,0 +1,10 @@
+<p class="osu-md__paragraph">
+Footnote<sup id="fnref:1"><a class="osu-md__link" href="#fn:1" role="doc-noteref">1</a></sup>
+</p>
+
+<ol class="osu-md__list osu-md__list--ordered">
+  <li class="osu-md__list-item" id="fn:1">
+    <div>Simple reference&nbsp;<a class="osu-md__link" rev="footnote" href="#fnref:1" role="doc-backlink">&#8617;</a>
+    </div>
+  </li>
+</ol>

--- a/tests/Libraries/Markdown/html_markdown_examples/footnote.html
+++ b/tests/Libraries/Markdown/html_markdown_examples/footnote.html
@@ -1,10 +1,11 @@
 <p class="osu-md__paragraph">
-Footnote<sup id="fnref:1"><a class="osu-md__link" href="#fn:1" role="doc-noteref">1</a></sup>
+Footnote<sup id="fnref:1"><a class="osu-md__link" href="#fn:1">1</a></sup>
 </p>
 
 <ol class="osu-md__list osu-md__list--ordered">
   <li class="osu-md__list-item" id="fn:1">
-    <div>Simple reference&nbsp;<a class="osu-md__link" rev="footnote" href="#fnref:1" role="doc-backlink">&#8617;</a>
+    <div>
+Simple reference&nbsp;<a class="footnote-backref" rev="footnote" href="#fnref:1" role="doc-backlink">&#8617;</a>
     </div>
   </li>
 </ol>

--- a/tests/Libraries/Markdown/html_markdown_examples/footnote.html
+++ b/tests/Libraries/Markdown/html_markdown_examples/footnote.html
@@ -1,10 +1,18 @@
 <p class="osu-md__paragraph">
-Footnote<sup id="fnref:1" class="osu-md__superscript"><a class="osu-md__link js-reference-link" data-target="#fn:1" href="#fn:1">[1]</a></sup>
+First<sup id="fnref:1" class="osu-md__superscript"><a class="osu-md__link js-reference-link" data-target="#fn:1" href="#fn:1">[1]</a></sup>
+</p>
+
+<p class="osu-md__paragraph">
+Second<sup id="fnref:custom" class="osu-md__superscript"><a class="osu-md__link js-reference-link" data-target="#fn:custom" href="#fn:custom">[2]</a></sup>
 </p>
 
 <ol style="--list-start: 0" class="osu-md__list osu-md__list--ordered">
   <li class="osu-md__list-item" id="fn:1">
     <div>Simple reference&nbsp;<a class="osu-md__link" data-backref="true" href="#fnref:1" title="Go back">&#8593;</a>
     </div>
+  </li>
+
+  <li class="osu-md__list-item" id="fn:custom">
+    <div>Custom reference&nbsp;<a class="osu-md__link" data-backref="true" href="#fnref:custom" title="Go back">&#8593;</a></div>
   </li>
 </ol>

--- a/tests/Libraries/Markdown/html_markdown_examples/footnote.html
+++ b/tests/Libraries/Markdown/html_markdown_examples/footnote.html
@@ -1,9 +1,10 @@
 <p class="osu-md__paragraph">
-Footnote<sup id="fnref:1"><a class="osu-md__link" href="#fn:1">1</a></sup>
+Footnote<sup id="fnref:1" class="osu-md__superscript"><a class="osu-md__link js-reference-link" data-target="#fn:1" href="#fn:1">[1]</a></sup>
 </p>
 
-<ol class="osu-md__list osu-md__list--ordered">
+<ol style="--list-start: 0" class="osu-md__list osu-md__list--ordered">
   <li class="osu-md__list-item" id="fn:1">
-    <div>Simple reference&nbsp;<a class="osu-md__link" href="#fnref:1">&#8593;</a></div>
+    <div>Simple reference&nbsp;<a class="osu-md__link" data-backref="true" href="#fnref:1" title="Go back">&#8593;</a>
+    </div>
   </li>
 </ol>

--- a/tests/Libraries/Markdown/html_markdown_examples/footnote.html
+++ b/tests/Libraries/Markdown/html_markdown_examples/footnote.html
@@ -4,8 +4,6 @@ Footnote<sup id="fnref:1"><a class="osu-md__link" href="#fn:1">1</a></sup>
 
 <ol class="osu-md__list osu-md__list--ordered">
   <li class="osu-md__list-item" id="fn:1">
-    <div>
-Simple reference&nbsp;<a class="footnote-backref" rev="footnote" href="#fnref:1" role="doc-backlink">&#8617;</a>
-    </div>
+    <div>Simple reference&nbsp;<a class="osu-md__link" href="#fnref:1">&#8593;</a></div>
   </li>
 </ol>

--- a/tests/Libraries/Markdown/html_markdown_examples/footnote.html
+++ b/tests/Libraries/Markdown/html_markdown_examples/footnote.html
@@ -6,7 +6,7 @@ First<sup id="fnref:1" class="osu-md__superscript"><a class="osu-md__link js-ref
 Second<sup id="fnref:custom" class="osu-md__superscript"><a class="osu-md__link js-reference-link" data-target="#fn:custom" href="#fn:custom">[2]</a></sup>
 </p>
 
-<ol style="--list-start: 0" class="osu-md__list osu-md__list--ordered">
+<ol class="osu-md__list osu-md__list--ordered osu-md__list--footnote">
   <li class="osu-md__list-item" id="fn:1">
     <div>Simple reference&nbsp;<a class="osu-md__link" data-backref="true" href="#fnref:1" title="Go back">&#8593;</a>
     </div>

--- a/tests/Libraries/Markdown/html_markdown_examples/footnote.md
+++ b/tests/Libraries/Markdown/html_markdown_examples/footnote.md
@@ -1,0 +1,3 @@
+Footnote[^1]
+
+[^1]: Simple reference

--- a/tests/Libraries/Markdown/html_markdown_examples/footnote.md
+++ b/tests/Libraries/Markdown/html_markdown_examples/footnote.md
@@ -1,3 +1,6 @@
-Footnote[^1]
+First[^1]
+
+Second[^custom]
 
 [^1]: Simple reference
+[^custom]: Custom reference

--- a/tests/Libraries/Markdown/html_markdown_examples/footnote_custom.html
+++ b/tests/Libraries/Markdown/html_markdown_examples/footnote_custom.html
@@ -1,0 +1,9 @@
+<p class="osu-md__paragraph">
+Footnote<sup id="fnref:custom" class="osu-md__superscript"><a class="osu-md__link js-reference-link" data-target="#fn:custom" href="#fn:custom">[1]</a></sup>
+</p>
+
+<ol style="--list-start: 0" class="osu-md__list osu-md__list--ordered">
+  <li class="osu-md__list-item" id="fn:custom">
+    <div>Custom reference&nbsp;<a class="osu-md__link" data-backref="true" href="#fnref:custom" title="Go back">&#8593;</a></div>
+  </li>
+</ol>

--- a/tests/Libraries/Markdown/html_markdown_examples/footnote_custom.html
+++ b/tests/Libraries/Markdown/html_markdown_examples/footnote_custom.html
@@ -1,9 +1,0 @@
-<p class="osu-md__paragraph">
-Footnote<sup id="fnref:custom" class="osu-md__superscript"><a class="osu-md__link js-reference-link" data-target="#fn:custom" href="#fn:custom">[1]</a></sup>
-</p>
-
-<ol style="--list-start: 0" class="osu-md__list osu-md__list--ordered">
-  <li class="osu-md__list-item" id="fn:custom">
-    <div>Custom reference&nbsp;<a class="osu-md__link" data-backref="true" href="#fnref:custom" title="Go back">&#8593;</a></div>
-  </li>
-</ol>

--- a/tests/Libraries/Markdown/html_markdown_examples/footnote_custom.md
+++ b/tests/Libraries/Markdown/html_markdown_examples/footnote_custom.md
@@ -1,0 +1,3 @@
+Footnote[^custom]
+
+[^custom]: Custom reference

--- a/tests/Libraries/Markdown/html_markdown_examples/footnote_custom.md
+++ b/tests/Libraries/Markdown/html_markdown_examples/footnote_custom.md
@@ -1,3 +1,0 @@
-Footnote[^custom]
-
-[^custom]: Custom reference

--- a/tests/Libraries/Markdown/html_markdown_examples/footnote_invalid_duplicate.html
+++ b/tests/Libraries/Markdown/html_markdown_examples/footnote_invalid_duplicate.html
@@ -10,7 +10,7 @@ Second<sup id="fnref:test__2" class="osu-md__superscript"><a class="osu-md__link
   <div>Invalid&nbsp;<a class="osu-md__link" data-backref="true" href="#fnref:test" title="Go back">&#8593;</a>&nbsp;<a class="osu-md__link" data-backref="true" href="#fnref:test__2" title="Go back">&#8593;</a></div>
 </li>
 
-<ol style="--list-start: 0" class="osu-md__list osu-md__list--ordered">
+<ol class="osu-md__list osu-md__list--ordered osu-md__list--footnote">
   <li class="osu-md__list-item" id="fn:test">
     <div>Valid&nbsp;<a class="osu-md__link" data-backref="true" href="#fnref:test" title="Go back">&#8593;</a>&nbsp;<a class="osu-md__link" data-backref="true" href="#fnref:test__2" title="Go back">&#8593;</a></div>
   </li>

--- a/tests/Libraries/Markdown/html_markdown_examples/footnote_invalid_duplicate.html
+++ b/tests/Libraries/Markdown/html_markdown_examples/footnote_invalid_duplicate.html
@@ -1,0 +1,17 @@
+<p class="osu-md__paragraph">
+First<sup id="fnref:test" class="osu-md__superscript"><a class="osu-md__link js-reference-link" data-target="#fn:test" href="#fn:test">[1]</a></sup>
+</p>
+
+<p class="osu-md__paragraph">
+Second<sup id="fnref:test__2" class="osu-md__superscript"><a class="osu-md__link js-reference-link" data-target="#fn:test" href="#fn:test">[1]</a></sup>
+</p>
+
+<li class="osu-md__list-item" id="fn:test">
+  <div>Invalid&nbsp;<a class="osu-md__link" data-backref="true" href="#fnref:test" title="Go back">&#8593;</a>&nbsp;<a class="osu-md__link" data-backref="true" href="#fnref:test__2" title="Go back">&#8593;</a></div>
+</li>
+
+<ol style="--list-start: 0" class="osu-md__list osu-md__list--ordered">
+  <li class="osu-md__list-item" id="fn:test">
+    <div>Valid&nbsp;<a class="osu-md__link" data-backref="true" href="#fnref:test" title="Go back">&#8593;</a>&nbsp;<a class="osu-md__link" data-backref="true" href="#fnref:test__2" title="Go back">&#8593;</a></div>
+  </li>
+</ol>

--- a/tests/Libraries/Markdown/html_markdown_examples/footnote_invalid_duplicate.md
+++ b/tests/Libraries/Markdown/html_markdown_examples/footnote_invalid_duplicate.md
@@ -1,0 +1,6 @@
+First[^test]
+
+Second[^test]
+
+[^test]: Invalid
+[^test]: Valid

--- a/tests/Libraries/Markdown/html_markdown_examples/footnote_invalid_spacing.html
+++ b/tests/Libraries/Markdown/html_markdown_examples/footnote_invalid_spacing.html
@@ -1,0 +1,13 @@
+<p class="osu-md__paragraph">
+osu! <sup id="fnref:space" class="osu-md__superscript"><a class="osu-md__link js-reference-link" data-target="#fn:space" href="#fn:space">[1]</a></sup>
+</p>
+<p class="osu-md__paragraph">osu![^nospace]</p>
+
+<ol style="--list-start: 0" class="osu-md__list osu-md__list--ordered">
+  <li class="osu-md__list-item" id="fn:nospace">
+    <div>Without space</div>
+  </li>
+  <li class="osu-md__list-item" id="fn:space">
+    <div>With space&nbsp;<a class="osu-md__link" data-backref="true" href="#fnref:space" title="Go back">&#8593;</a></div>
+  </li>
+</ol>

--- a/tests/Libraries/Markdown/html_markdown_examples/footnote_invalid_spacing.html
+++ b/tests/Libraries/Markdown/html_markdown_examples/footnote_invalid_spacing.html
@@ -3,7 +3,7 @@ osu! <sup id="fnref:space" class="osu-md__superscript"><a class="osu-md__link js
 </p>
 <p class="osu-md__paragraph">osu![^nospace]</p>
 
-<ol style="--list-start: 0" class="osu-md__list osu-md__list--ordered">
+<ol class="osu-md__list osu-md__list--ordered osu-md__list--footnote">
   <li class="osu-md__list-item" id="fn:nospace">
     <div>Without space</div>
   </li>

--- a/tests/Libraries/Markdown/html_markdown_examples/footnote_invalid_spacing.md
+++ b/tests/Libraries/Markdown/html_markdown_examples/footnote_invalid_spacing.md
@@ -1,0 +1,6 @@
+osu! [^space]
+
+osu![^nospace]
+
+[^space]: With space
+[^nospace]: Without space

--- a/tests/Libraries/Markdown/html_markdown_examples/footnote_mixed.html
+++ b/tests/Libraries/Markdown/html_markdown_examples/footnote_mixed.html
@@ -1,0 +1,29 @@
+<p class="osu-md__paragraph">
+Footnote<sup id="fnref:1" class="osu-md__superscript"><a class="osu-md__link js-reference-link" data-target="#fn:1" href="#fn:1">[1]</a></sup> mixed<sup id="fnref:custom" class="osu-md__superscript"><a class="osu-md__link js-reference-link" data-target="#fn:custom" href="#fn:custom">[2]</a></sup>.
+</p>
+<p class="osu-md__paragraph">
+Hello<sup id="fnref:2" class="osu-md__superscript"><a class="osu-md__link js-reference-link" data-target="#fn:2" href="#fn:2">[3]</a></sup> world<sup id="fnref:world" class="osu-md__superscript"><a class="osu-md__link js-reference-link" data-target="#fn:world" href="#fn:world">[4]</a></sup>
+</p>
+
+<ol style="--list-start: 0" class="osu-md__list osu-md__list--ordered">
+  <li class="osu-md__list-item" id="fn:1">
+    <div>
+      <em>Reference 1</em>&nbsp;<a class="osu-md__link" data-backref="true" href="#fnref:1" title="Go back">&#8593;</a>
+    </div>
+  </li>
+  <li class="osu-md__list-item" id="fn:custom">
+    <div>
+      <strong>Custom reference</strong>&nbsp;<a class="osu-md__link" data-backref="true" href="#fnref:custom" title="Go back">&#8593;</a>
+    </div>
+  </li>
+  <li class="osu-md__list-item" id="fn:2">
+    <div>
+      <a class="osu-md__link" href="https://osu.ppy.sh">osu!</a>&nbsp;<a class="osu-md__link" data-backref="true" href="#fnref:2" title="Go back">&#8593;</a>
+    </div>
+  </li>
+  <li class="osu-md__list-item" id="fn:world">
+    <div>
+      <em><strong>World domination</strong></em>&nbsp;<a class="osu-md__link" data-backref="true" href="#fnref:world" title="Go back">&#8593;</a>
+    </div>
+  </li>
+</ol>

--- a/tests/Libraries/Markdown/html_markdown_examples/footnote_mixed.html
+++ b/tests/Libraries/Markdown/html_markdown_examples/footnote_mixed.html
@@ -5,7 +5,7 @@ Footnote<sup id="fnref:1" class="osu-md__superscript"><a class="osu-md__link js-
 Hello<sup id="fnref:2" class="osu-md__superscript"><a class="osu-md__link js-reference-link" data-target="#fn:2" href="#fn:2">[3]</a></sup> world<sup id="fnref:world" class="osu-md__superscript"><a class="osu-md__link js-reference-link" data-target="#fn:world" href="#fn:world">[4]</a></sup>
 </p>
 
-<ol style="--list-start: 0" class="osu-md__list osu-md__list--ordered">
+<ol class="osu-md__list osu-md__list--ordered osu-md__list--footnote">
   <li class="osu-md__list-item" id="fn:1">
     <div>
       <em>Reference 1</em>&nbsp;<a class="osu-md__link" data-backref="true" href="#fnref:1" title="Go back">&#8593;</a>

--- a/tests/Libraries/Markdown/html_markdown_examples/footnote_mixed.md
+++ b/tests/Libraries/Markdown/html_markdown_examples/footnote_mixed.md
@@ -1,0 +1,8 @@
+Footnote[^1] mixed[^custom].
+
+Hello[^2] world[^world]
+
+[^1]: *Reference 1*
+[^custom]: **Custom reference**
+[^2]: [osu!](https://osu.ppy.sh)
+[^world]: ***World domination***

--- a/tests/Libraries/Markdown/html_markdown_examples/footnote_order.html
+++ b/tests/Libraries/Markdown/html_markdown_examples/footnote_order.html
@@ -6,7 +6,7 @@ First<sup id="fnref:ref1" class="osu-md__superscript"><a class="osu-md__link js-
 Second<sup id="fnref:ref2" class="osu-md__superscript"><a class="osu-md__link js-reference-link" data-target="#fn:ref2" href="#fn:ref2">[2]</a></sup>
 </p>
 
-<ol style="--list-start: 0" class="osu-md__list osu-md__list--ordered">
+<ol class="osu-md__list osu-md__list--ordered osu-md__list--footnote">
   <li class="osu-md__list-item" id="fn:ref1">
     <div>Reference 1&nbsp;<a class="osu-md__link" data-backref="true" href="#fnref:ref1" title="Go back">&#8593;</a>
     </div>

--- a/tests/Libraries/Markdown/html_markdown_examples/footnote_order.html
+++ b/tests/Libraries/Markdown/html_markdown_examples/footnote_order.html
@@ -1,0 +1,18 @@
+<p class="osu-md__paragraph">
+First<sup id="fnref:ref1" class="osu-md__superscript"><a class="osu-md__link js-reference-link" data-target="#fn:ref1" href="#fn:ref1">[1]</a></sup>
+</p>
+
+<p class="osu-md__paragraph">
+Second<sup id="fnref:ref2" class="osu-md__superscript"><a class="osu-md__link js-reference-link" data-target="#fn:ref2" href="#fn:ref2">[2]</a></sup>
+</p>
+
+<ol style="--list-start: 0" class="osu-md__list osu-md__list--ordered">
+  <li class="osu-md__list-item" id="fn:ref1">
+    <div>Reference 1&nbsp;<a class="osu-md__link" data-backref="true" href="#fnref:ref1" title="Go back">&#8593;</a>
+    </div>
+  </li>
+  <li class="osu-md__list-item" id="fn:ref2">
+    <div>Reference 2&nbsp;<a class="osu-md__link" data-backref="true" href="#fnref:ref2" title="Go back">&#8593;</a>
+    </div>
+  </li>
+</ol>

--- a/tests/Libraries/Markdown/html_markdown_examples/footnote_order.md
+++ b/tests/Libraries/Markdown/html_markdown_examples/footnote_order.md
@@ -1,0 +1,6 @@
+First[^ref1]
+
+Second[^ref2]
+
+[^ref2]: Reference 2
+[^ref1]: Reference 1


### PR DESCRIPTION
- Closes #7316 
- [ ] Depends on #7980

## How to use

Basic syntax:

```markdown
Footnote[^ref]

[^ref]: Reference here
```

And will automatically assign number and render something like this:

Footnote<sup><a href="#">[1]</a></sup>

1. Reference here <a href="#">↑</a>

[1] link will target to the reference list item and ↑ link will go back to [1].

### Some caveats

**Be careful of exclamation**

Valid:

```markdown
osu! [^ref]

[^ref]: https://osu.ppy.sh
```

Invalid:

```markdown
osu![^ref]

[^ref]: https://osu.ppy.sh
```

**Be careful of duplicate reference key**

Valid:

```markdown
First[^ref]

Second[^ref]

[^ref]: Valid shared reference
```

Invalid:

```markdown
First[^ref]

Second[^ref]

[^ref]: This become invalid
[^ref]: Valid shared reference
```

## Demo

*[This file](https://raw.githubusercontent.com/gagahpangeran/osu-wiki/test-footnote/wiki/Welcome/en.md) is used for this demo*


https://user-images.githubusercontent.com/4964985/128446811-68b89d64-6305-4e38-8c30-d1f1646380b7.mp4


