### PR TITLE
Use original BeatmapsetEvent timestamp for BeatmapsetNomination migration

### DIFF
--- a/app/Console/Commands/BeatmapsetNominationSyncCommand.php
+++ b/app/Console/Commands/BeatmapsetNominationSyncCommand.php
@@ -32,6 +32,7 @@ class BeatmapsetNominationSyncCommand extends Command
                                 Log::debug('nominate', ['beatmapset_id' => $event->beatmapset_id, 'user_id' => $event->user_id]);
                                 BeatmapsetNomination::create([
                                     'beatmapset_id' => $event->beatmapset_id,
+                                    'created_at' => $event->created_at,
                                     'event_id' => $event->getKey(),
                                     'modes' => $event->comment['modes'] ?? null,
                                     'user_id' => $event->user_id,


### PR DESCRIPTION
`User::beatmapsetNominationsToday()` was relying on `created_at` so the date should be preserved

Missing from #7983 found while checking #7861 again