### PR TITLE
Fix chat input autosize height

### DIFF
--- a/resources/assets/less/bem/chat-input.less
+++ b/resources/assets/less/bem/chat-input.less
@@ -2,7 +2,9 @@
 // See the LICENCE file in the repository root for full licence text.
 
 .chat-input {
-  padding: 10px 30px 10px 50px;
+  @_height: 80px;
+  @_vertical-padding: 10px;
+
   color: white;
   position: absolute;
   bottom: 0;
@@ -10,7 +12,8 @@
 
   background: linear-gradient(to bottom, hsla(var(--hsl-b4), 0), hsla(var(--hsl-b4), 0.95) 40%, hsla(var(--hsl-b4), 0.95) 100%);
   width: calc(100% - 20px); // this prevents the gradient drawing over the browser's scroll-bar
-  height: 80px;
+  height: @_height;
+  padding: @_vertical-padding 30px @_vertical-padding 50px;
 
   align-items: center;
   display: flex;
@@ -18,13 +21,15 @@
   @media @mobile {
     position: fixed;
     font-size: 16px;
-    padding: 10px 0px 10px 20px;
+    padding-right: 0;
+    padding-left: 20px
   }
 
   &__box {
     .reset-input();
     .default-border-radius();
     .default-box-shadow();
+    max-height: @_height - @_vertical-padding * 2;
     max-width: 100%;
     min-width: 0;
     background: @osu-colour-b6;

--- a/resources/assets/less/bem/chat-input.less
+++ b/resources/assets/less/bem/chat-input.less
@@ -2,9 +2,6 @@
 // See the LICENCE file in the repository root for full licence text.
 
 .chat-input {
-  @_height: 80px;
-  @_vertical-padding: 10px;
-
   color: white;
   position: absolute;
   bottom: 0;
@@ -12,8 +9,8 @@
 
   background: linear-gradient(to bottom, hsla(var(--hsl-b4), 0), hsla(var(--hsl-b4), 0.95) 40%, hsla(var(--hsl-b4), 0.95) 100%);
   width: calc(100% - 20px); // this prevents the gradient drawing over the browser's scroll-bar
-  height: @_height;
-  padding: @_vertical-padding 30px @_vertical-padding 50px;
+  height: 80px;
+  padding: 10px 30px 10px 50px;
 
   align-items: center;
   display: flex;
@@ -29,7 +26,7 @@
     .reset-input();
     .default-border-radius();
     .default-box-shadow();
-    max-height: @_height - @_vertical-padding * 2;
+    max-height: 100%;
     max-width: 100%;
     min-width: 0;
     background: @osu-colour-b6;


### PR DESCRIPTION
closes #7918

Manually apply `max-height` via css.
Likely due to #7798 causing the line height calculation to be `NaN` on first render when arriving via turbolinks navigation.
Can't just call `updateLineHeight` on `TextareaAutosize` after mounting as it's a `forwardRef`.