### PR TITLE
Fix eslint import order settings

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -180,7 +180,7 @@ module.exports = {
       'undefined',
     ],
     'id-match': 'error',
-    'import/order': 'error',
+    'import/order': ['error', { alphabetize: { order: 'asc' } }],
     'jsdoc/check-alignment': 'error',
     'jsdoc/check-indentation': 'error',
     'jsdoc/newline-after-description': 'error',

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,8 +1,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
-const path = require('path');
 const { spawnSync } = require('child_process');
+const path = require('path');
 const Watchpack = require('watchpack');
 const spawnOptions = { stdio: 'inherit' };
 

--- a/webpack.unmix.js
+++ b/webpack.unmix.js
@@ -7,23 +7,16 @@
 const fs = require('fs');
 const path = require('path');
 
-// #region plugin imports
 const Autoprefixer = require('autoprefixer');
-const CopyPlugin = require('copy-webpack-plugin');
 const { CleanWebpackPlugin } = require('clean-webpack-plugin');
-const MiniCssExtractPlugin = require('mini-css-extract-plugin');
-const SentryPlugin = require('webpack-sentry-plugin');
-const TsconfigPathsPlugin = require('tsconfig-paths-webpack-plugin');
-const TerserPlugin = require('terser-webpack-plugin');
+const CopyPlugin = require('copy-webpack-plugin');
 const CssMinimizerPlugin = require('css-minimizer-webpack-plugin');
-
-// #endregion
-
-// #region non-plugin imports
 const dotenv = require('dotenv');
+const MiniCssExtractPlugin = require('mini-css-extract-plugin');
+const TerserPlugin = require('terser-webpack-plugin');
+const TsconfigPathsPlugin = require('tsconfig-paths-webpack-plugin');
 const webpack = require('webpack');
-
-// #endregion
+const SentryPlugin = require('webpack-sentry-plugin');
 
 // #region env
 const env = process.env.NODE_ENV || 'development';


### PR DESCRIPTION
The default order is `ignore` :thinking: 

Side effect is it also sorts `require`.