### PR TITLE
Add interop endpoint for disqualifying or reseting nominations

### DIFF
--- a/app/Http/Controllers/InterOp/BeatmapsetsController.php
+++ b/app/Http/Controllers/InterOp/BeatmapsetsController.php
@@ -8,6 +8,8 @@ namespace App\Http\Controllers\InterOp;
 use App\Http\Controllers\Controller;
 use App\Jobs\BeatmapsetDelete;
 use App\Jobs\Notifications\UserBeatmapsetNew;
+use App\Models\BeatmapDiscussion;
+use App\Models\BeatmapDiscussionPost;
 use App\Models\Beatmapset;
 use App\Models\User;
 
@@ -30,5 +32,35 @@ class BeatmapsetsController extends Controller
         (new BeatmapsetDelete($beatmapset, $user))->handle();
 
         return response(null, 204);
+    }
+
+    public function disqualify($id)
+    {
+        $beatmapset = Beatmapset::findOrFail($id);
+        $user = User::findOrFail(config('osu.legacy.bancho_bot_user_id'));
+
+        $message = request('message') ?? null;
+
+        $discussion = new BeatmapDiscussion([
+            'beatmapset_id' => $beatmapset->getKey(),
+            'message_type' => 'problem',
+            'user_id' => $user->getKey(),
+            'resolved' => false,
+        ]);
+
+        $post = new BeatmapDiscussionPost([
+            'message' => $message,
+            'user_id' => $user->getKey(),
+        ]);
+
+        $discussion->getConnection()->transaction(function () use ($discussion, $post, $user) {
+            $discussion->saveOrExplode();
+            $post->beatmap_discussion_id = $discussion->getKey();
+            $post->saveOrExplode();
+
+            $discussion->beatmapset->disqualifyOrResetNominations($user, $discussion);
+        });
+
+        $beatmapset->disqualifyOrResetNominations($user, $discussion);
     }
 }

--- a/app/Http/Controllers/InterOp/BeatmapsetsController.php
+++ b/app/Http/Controllers/InterOp/BeatmapsetsController.php
@@ -61,6 +61,6 @@ class BeatmapsetsController extends Controller
             $discussion->beatmapset->disqualifyOrResetNominations($user, $discussion);
         });
 
-        $beatmapset->disqualifyOrResetNominations($user, $discussion);
+        return ['beatmapset_discussion_id' => $discussion->getKey()];
     }
 }

--- a/routes/web.php
+++ b/routes/web.php
@@ -529,6 +529,7 @@ Route::group(['prefix' => '_lio', 'middleware' => 'lio', 'as' => 'interop.'], fu
     Route::group(['namespace' => 'InterOp'], function () {
         Route::resource('beatmapsets', 'BeatmapsetsController', ['only' => ['destroy']]);
         Route::post('beatmapsets/{beatmapset}/broadcast-new', 'BeatmapsetsController@broadcastNew');
+        Route::post('beatmapsets/{beatmapset}/disqualify', 'BeatmapsetsController@disqualify');
 
         Route::group(['as' => 'indexing.', 'prefix' => 'indexing'], function () {
             Route::apiResource('bulk', 'Indexing\BulkController', ['only' => ['store']]);

--- a/routes/web.php
+++ b/routes/web.php
@@ -529,7 +529,7 @@ Route::group(['prefix' => '_lio', 'middleware' => 'lio', 'as' => 'interop.'], fu
     Route::group(['namespace' => 'InterOp'], function () {
         Route::resource('beatmapsets', 'BeatmapsetsController', ['only' => ['destroy']]);
         Route::post('beatmapsets/{beatmapset}/broadcast-new', 'BeatmapsetsController@broadcastNew');
-        Route::post('beatmapsets/{beatmapset}/disqualify', 'BeatmapsetsController@disqualify');
+        Route::post('beatmapsets/{beatmapset}/disqualify', 'BeatmapsetsController@disqualify')->name('beatmapsets.disqualify');
 
         Route::group(['as' => 'indexing.', 'prefix' => 'indexing'], function () {
             Route::apiResource('bulk', 'Indexing\BulkController', ['only' => ['store']]);

--- a/routes/web.php
+++ b/routes/web.php
@@ -528,8 +528,11 @@ Route::group(['prefix' => '_lio', 'middleware' => 'lio', 'as' => 'interop.'], fu
 
     Route::group(['namespace' => 'InterOp'], function () {
         Route::resource('beatmapsets', 'BeatmapsetsController', ['only' => ['destroy']]);
-        Route::post('beatmapsets/{beatmapset}/broadcast-new', 'BeatmapsetsController@broadcastNew');
-        Route::post('beatmapsets/{beatmapset}/disqualify', 'BeatmapsetsController@disqualify')->name('beatmapsets.disqualify');
+
+        Route::group(['as' => 'beatmapsets.', 'prefix' => 'beatmapsets/{beatmapset}'], function () {
+            Route::post('broadcast-new', 'BeatmapsetsController@broadcastNew');
+            Route::post('disqualify', 'BeatmapsetsController@disqualify')->name('disqualify');
+        });
 
         Route::group(['as' => 'indexing.', 'prefix' => 'indexing'], function () {
             Route::apiResource('bulk', 'Indexing\BulkController', ['only' => ['store']]);

--- a/tests/BeatmapsetEventNominationResetTest.php
+++ b/tests/BeatmapsetEventNominationResetTest.php
@@ -7,6 +7,7 @@ namespace Tests;
 
 use App\Jobs\Notifications\BeatmapsetDisqualify;
 use App\Jobs\Notifications\BeatmapsetResetNominations;
+use App\Models\BeatmapDiscussion;
 use App\Models\Beatmapset;
 use App\Models\BeatmapsetEvent;
 use App\Models\BeatmapsetNomination;
@@ -57,6 +58,46 @@ class BeatmapsetEventNominationResetTest extends TestCase
         $this->assertEqualsCanonicalizing(array_pluck($this->nominators, 'user_id'), BeatmapsetEvent::nominationResetReceiveds()->pluck('user_id')->all());
     }
     #endregion
+
+    // FIXME: disqualification tests could probably do with some reorganization.
+    public function testInterOpDisqualify()
+    {
+        $this->createBeatmapsetWithNominators('qualified');
+        $banchoBotUser = factory(User::class)->create([
+            'user_id' => config('osu.legacy.bancho_bot_user_id'),
+        ]);
+
+        $disqualifyCount = BeatmapsetEvent::disqualifications()->count();
+        $nominationResetReceivedCount = BeatmapsetEvent::nominationResetReceiveds()->count();
+
+        $url = route('interop.beatmapsets.disqualify', [
+            'beatmapset' => $this->beatmapset->getKey(),
+            'timestamp' => time(),
+        ]);
+
+        $response = $this
+            ->withInterOpHeader($url)
+            ->post($url, ['message' => 'hello'])
+            ->assertStatus(200);
+
+        Queue::assertPushed(BeatmapsetDisqualify::class);
+        Queue::assertNotPushed(BeatmapsetResetNominations::class);
+
+        $this->beatmapset->refresh();
+
+        $discussionId = json_decode($response->getContent(), true)['beatmapset_discussion_id'] ?? null;
+
+        $this->assertNotEmpty($discussionId);
+
+        $discussion = BeatmapDiscussion::find($discussionId);
+        $this->assertTrue($banchoBotUser->is($discussion->user));
+        $this->assertSame('hello', $discussion->startingPost->message);
+
+        $this->assertSame($this->beatmapset->status(), 'pending');
+        $this->assertSame($disqualifyCount + 1, BeatmapsetEvent::disqualifications()->count());
+        $this->assertSame($nominationResetReceivedCount + count($this->nominators), BeatmapsetEvent::nominationResetReceiveds()->count());
+        $this->assertEqualsCanonicalizing(array_pluck($this->nominators, 'user_id'), BeatmapsetEvent::nominationResetReceiveds()->pluck('user_id')->all());
+    }
 
     protected function setUp(): void
     {


### PR DESCRIPTION
post to `/_lio/beatmapsets/${beatmapsetId}/disqualify` with `{ message: "post message" }` to disqualify or reset nomination.
Returns the discussion id in the response.