### PR TITLE
Strip trailing slash when generating wiki url

### DIFF
--- a/app/helpers.php
+++ b/app/helpers.php
@@ -886,7 +886,7 @@ function wiki_url($path = null, $locale = null, $api = null, $fullUrl = true)
         }
     }
 
-    return str_replace($params['path'], $path, route($route, $params, $fullUrl));
+    return rtrim(str_replace($params['path'], $path, route($route, $params, $fullUrl)), '/');
 }
 
 function bbcode($text, $uid, $options = [])


### PR DESCRIPTION
For legal index page, path being empty results in `/en/WIKI_PATH` get replaced with `/en/` instead of just `/en`.

Resolves #8016.