### PR TITLE
Don't escape '#' character for wiki url

### DIFF
--- a/app/helpers.php
+++ b/app/helpers.php
@@ -864,7 +864,7 @@ function post_url($topicId, $postId, $jumpHash = true, $tail = false)
 
 function wiki_url($path = null, $locale = null, $api = null, $fullUrl = true)
 {
-    $path = $path === null ? 'Main_Page' : str_replace('%2F', '/', rawurlencode($path));
+    $path = $path === null ? 'Main_Page' : str_replace(['%2F', '%23'], ['/', '#'], rawurlencode($path));
 
     $params = [
         'path' => 'WIKI_PATH',


### PR DESCRIPTION
Fixes redirect. This assumes there won't be page which contain '#' in its name.

Resolves #8030.