### PR TITLE
Reduce queries for user profile page

### DIFF
--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -720,7 +720,7 @@ class UsersController extends Controller
                 case 'scoresBest':
                     $transformer = 'Score';
                     $includes = ['beatmap', 'beatmapset', 'weight', 'user'];
-                    $collection = $user->beatmapBestScores($options['mode'], $perPage, $offset, ['beatmap', 'beatmap.beatmapset', 'user']);
+                    $collection = $user->beatmapBestScores($options['mode'], $perPage, $offset, ['beatmap', 'beatmap.beatmapset']);
                     break;
                 case 'scoresFirsts':
                     $transformer = 'Score';

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -755,6 +755,11 @@ class User extends Model implements AfterCommit, AuthenticatableContract, HasLoc
         $this->attributes['osu_subscriptionexpiry'] = optional($value)->startOfDay();
     }
 
+    public function getUserRankAttribute($value)
+    {
+        return $value === 0 ? null : $value;
+    }
+
     /*
     |--------------------------------------------------------------------------
     | Permission Checker Functions

--- a/app/Models/UserScoreable.php
+++ b/app/Models/UserScoreable.php
@@ -92,10 +92,12 @@ trait UserScoreable
         $results = $clazz::whereIn('score_id', $ids)->orderByField('score_id', $ids)->with($with)->get();
 
         // fill in positions for weighting
+        // also preload the user relation
         $position = $offset;
         foreach ($results as $result) {
             $result->position = $position;
             $result->weight = pow(0.95, $position);
+            $result->setRelation('user', $this);
             $position++;
         }
 

--- a/app/Transformers/UserCompactTransformer.php
+++ b/app/Transformers/UserCompactTransformer.php
@@ -335,7 +335,8 @@ class UserCompactTransformer extends TransformerAbstract
     {
         $rankHistoryData = $user->rankHistories()
             ->where('mode', Beatmap::modeInt($this->mode))
-            ->first();
+            ->first()
+            ->setRelation('user', $user);
 
         return $rankHistoryData === null
             ? $this->primitive(null)


### PR DESCRIPTION
Noticed these when checking for the queries.

Additionally, the deprecated user includes (`rankHistory`, `ranked_and_approved_beatmapset_count`, and `unranked_beatmapset_count`) causes extra queries (not removed here).