### PR TITLE
Accept moment instance for TimeWithTooltip

### DIFF
--- a/resources/assets/lib/time-with-tooltip.tsx
+++ b/resources/assets/lib/time-with-tooltip.tsx
@@ -5,19 +5,30 @@ import * as moment from 'moment';
 import * as React from 'react';
 
 interface Props {
-  dateTime: string;
+  dateTime: string | moment.Moment;
   format?: string;
   key?: string;
   relative?: boolean;
 }
 
 export default function TimeWithTooltip(props: Props) {
-  const { format = 'll', relative = false, ...otherProps } = props;
+  const { dateTime, format = 'll', relative = false, ...otherProps } = props;
   const className = relative ? 'js-timeago' : 'js-tooltip-time';
 
+  let dateTimeAttr: string;
+  let dateTimeMoment: moment.Moment;
+
+  if (typeof dateTime === 'string') {
+    dateTimeAttr = dateTime;
+    dateTimeMoment = moment(dateTime);
+  } else {
+    dateTimeAttr = dateTime.format();
+    dateTimeMoment = dateTime;
+  }
+
   return (
-    <time className={className} title={props.dateTime} {...otherProps}>
-      {moment(props.dateTime).format(format)}
+    <time className={className} dateTime={dateTimeAttr} title={dateTimeAttr} {...otherProps}>
+      {dateTimeMoment.format(format)}
     </time>
   );
 }

--- a/resources/assets/lib/time-with-tooltip.tsx
+++ b/resources/assets/lib/time-with-tooltip.tsx
@@ -7,7 +7,6 @@ import * as React from 'react';
 interface Props {
   dateTime: string | moment.Moment;
   format?: string;
-  key?: string;
   relative?: boolean;
 }
 

--- a/resources/assets/lib/time-with-tooltip.tsx
+++ b/resources/assets/lib/time-with-tooltip.tsx
@@ -12,23 +12,25 @@ interface Props {
 }
 
 export default function TimeWithTooltip(props: Props) {
-  const { dateTime, format = 'll', relative = false, ...otherProps } = props;
-  const className = relative ? 'js-timeago' : 'js-tooltip-time';
+  const { dateTime, format, relative = false, ...otherProps } = props;
 
-  let dateTimeAttr: string;
-  let dateTimeMoment: moment.Moment;
+  const dateTimeAttr = typeof dateTime === 'string' ? dateTime : dateTime.format();
 
-  if (typeof dateTime === 'string') {
-    dateTimeAttr = dateTime;
-    dateTimeMoment = moment(dateTime);
+  let className: string;
+  let label = dateTimeAttr;
+
+  if (relative) {
+    className = 'js-timeago';
   } else {
-    dateTimeAttr = dateTime.format();
-    dateTimeMoment = dateTime;
+    className = 'js-tooltip-time';
+
+    const dateTimeMoment = typeof dateTime === 'string' ? moment(dateTime) : dateTime;
+    label = dateTimeMoment.format(format ?? 'll');
   }
 
   return (
     <time className={className} dateTime={dateTimeAttr} title={dateTimeAttr} {...otherProps}>
-      {dateTimeMoment.format(format)}
+      {label}
     </time>
   );
 }


### PR DESCRIPTION
To be used in profile page AccountStanding to skip casting moment object back and forth.

Also skip creating moment object altogether if not needed (relative time display).