### PR TITLE
Add support for new style block syntax

### DIFF
--- a/app/Libraries/Markdown/StyleBlock/Element.php
+++ b/app/Libraries/Markdown/StyleBlock/Element.php
@@ -15,14 +15,12 @@ class Element extends AbstractBlock
      */
     protected $class;
 
-    /**
-     * @var static[]
-     */
-    protected $containedStyleBlocks = [];
+    private string $fenceChar;
 
-    public function __construct(string $class)
+    public function __construct(string $class, string $fenceChar)
     {
         $this->class = $class;
+        $this->fenceChar = $fenceChar;
     }
 
     public function getClass(): string
@@ -32,10 +30,6 @@ class Element extends AbstractBlock
 
     public function canContain(AbstractBlock $block): bool
     {
-        if ($block instanceof static) {
-            $this->containedStyleBlocks[] = $block;
-        }
-
         return true;
     }
 
@@ -46,25 +40,17 @@ class Element extends AbstractBlock
 
     public function matchesNextLine(Cursor $cursor): bool
     {
-        // Make sure the most nested open StyleBlock tries to handle this first
-        if ($cursor->getRemainder() === '}}}' && !$this->containsOpenStyleBlock()) {
+        $currentLine = $cursor->getRemainder();
+
+        if (
+            ($currentLine === '}}}' && $this->fenceChar === '{') ||
+            ($currentLine === ':::' && $this->fenceChar === ':')
+        ) {
             $cursor->advanceToEnd();
 
             return false;
         }
 
         return true;
-    }
-
-    private function containsOpenStyleBlock(): bool
-    {
-        // Assumes that these StyleBlocks are never removed from descendant tree
-        foreach ($this->containedStyleBlocks as $styleBlock) {
-            if ($styleBlock->isOpen()) {
-                return true;
-            }
-        }
-
-        return false;
     }
 }

--- a/app/Libraries/Markdown/StyleBlock/Parser.php
+++ b/app/Libraries/Markdown/StyleBlock/Parser.php
@@ -13,16 +13,20 @@ class Parser implements BlockParserInterface
 {
     public function parse(ContextInterface $context, Cursor $cursor): bool
     {
-        if (!starts_with($cursor->getRemainder(), '{{{')) {
+        $currentLine = $cursor->getRemainder();
+
+        if (!starts_with($currentLine, '{{{') && !starts_with($currentLine, ':::')) {
             return false;
         }
 
-        $cursor->advanceBy(3);
+        $class = mb_strtolower(str_replace(' ', '-', trim($currentLine, ' {:')));
 
-        $class = mb_strtolower(str_replace(' ', '-', trim($cursor->getRemainder())));
+        if (!present($class)) {
+            return false;
+        }
 
         $cursor->advanceToEnd();
-        $context->addBlock(new Element($class));
+        $context->addBlock(new Element($class, $currentLine[0]));
 
         return true;
     }

--- a/tests/Libraries/Markdown/html_markdown_examples/new_style_block.html
+++ b/tests/Libraries/Markdown/html_markdown_examples/new_style_block.html
@@ -1,0 +1,6 @@
+<div class="osu-md__class-name">
+<h2 class="osu-md__header osu-md__header--2">Other blocks</h2>
+</div>
+
+<div class="osu-md__class-name">
+</div>

--- a/tests/Libraries/Markdown/html_markdown_examples/new_style_block.md
+++ b/tests/Libraries/Markdown/html_markdown_examples/new_style_block.md
@@ -1,0 +1,9 @@
+::: Class Name
+
+## Other blocks
+
+:::
+
+:::class name
+
+:::

--- a/tests/Libraries/Markdown/html_markdown_examples/new_style_block_invalid_class.html
+++ b/tests/Libraries/Markdown/html_markdown_examples/new_style_block_invalid_class.html
@@ -1,0 +1,1 @@
+<p class="osu-md__paragraph">paragraph</p>

--- a/tests/Libraries/Markdown/html_markdown_examples/new_style_block_invalid_class.md
+++ b/tests/Libraries/Markdown/html_markdown_examples/new_style_block_invalid_class.md
@@ -1,0 +1,5 @@
+::: Invalid Class
+
+paragraph
+
+:::

--- a/tests/Libraries/Markdown/html_markdown_examples/new_style_block_invalid_space.html
+++ b/tests/Libraries/Markdown/html_markdown_examples/new_style_block_invalid_space.html
@@ -1,0 +1,8 @@
+<p class="osu-md__paragraph">::: Class Name</p>
+<p class="osu-md__paragraph">paragraph</p>
+<p class="osu-md__paragraph">:::</p>
+
+<div class="osu-md__class-name">
+  <p class="osu-md__paragraph">:::</p>
+  <p class="osu-md__paragraph">still inside class-name</p>
+</div>

--- a/tests/Libraries/Markdown/html_markdown_examples/new_style_block_invalid_space.md
+++ b/tests/Libraries/Markdown/html_markdown_examples/new_style_block_invalid_space.md
@@ -1,0 +1,11 @@
+  ::: Class Name
+
+paragraph
+
+:::
+
+::: Class Name
+
+  :::
+
+still inside class-name

--- a/tests/Libraries/Markdown/html_markdown_examples/new_style_block_unclosed.html
+++ b/tests/Libraries/Markdown/html_markdown_examples/new_style_block_unclosed.html
@@ -1,0 +1,3 @@
+<div class="osu-md__class-name">
+<p class="osu-md__paragraph">paragraph</p>
+</div>

--- a/tests/Libraries/Markdown/html_markdown_examples/new_style_block_unclosed.md
+++ b/tests/Libraries/Markdown/html_markdown_examples/new_style_block_unclosed.md
@@ -1,0 +1,3 @@
+::: Class Name
+
+paragraph

--- a/tests/Libraries/Markdown/html_markdown_examples/style_block_nested.html
+++ b/tests/Libraries/Markdown/html_markdown_examples/style_block_nested.html
@@ -1,4 +1,0 @@
-<div class="osu-md__class-name">
-<div class="osu-md__class-name">
-</div>
-</div>

--- a/tests/Libraries/Markdown/html_markdown_examples/style_block_nested.md
+++ b/tests/Libraries/Markdown/html_markdown_examples/style_block_nested.md
@@ -1,7 +1,0 @@
-{{{ Class Name
-
-{{{ Class Name
-
-}}}
-
-}}}

--- a/tests/Libraries/Markdown/indexable_markdown_examples/new_style_block.md
+++ b/tests/Libraries/Markdown/indexable_markdown_examples/new_style_block.md
@@ -1,0 +1,5 @@
+::: Class Name
+
+paragraph
+
+:::

--- a/tests/Libraries/Markdown/indexable_markdown_examples/new_style_block.txt
+++ b/tests/Libraries/Markdown/indexable_markdown_examples/new_style_block.txt
@@ -1,0 +1,3 @@
+paragraph
+
+


### PR DESCRIPTION
As mentioned in https://github.com/ppy/osu-web/pull/8087#issuecomment-913779554, this PR add support for new `:::` syntax and old `{{{` as intermediate step until wiki migrate to new syntax (https://github.com/ppy/osu-wiki/pull/6067) and old syntax will be drop in https://github.com/ppy/osu-web/pull/8087.

Also drop support for nested `StyleBlock` for simplicity. Can be added back until there's such need from wiki-side.