### PR TITLE
Fix cover-editor being below page-extra-tabs

### DIFF
--- a/resources/assets/less/variables.less
+++ b/resources/assets/less/variables.less
@@ -92,10 +92,10 @@
 @z-index--wiki-search: 1;
 
 @z-index--beatmaps-panel: 4;
-@z-index--profile-page-cover-selector: 100; // must be at least 1 more than @z-index--page-extra-tabs
 @z-index--profile-previous-usernames: 10;
 @z-index--profile-tournament-banner: 11;
 @z-index--page-extra-tabs: 99;
+@z-index--profile-page-cover-selector: 100; // must be at least 1 more than @z-index--page-extra-tabs
 @z-index--beatmap-discussion-editor-insertion-menu: 100;
 @z-index--simple-menu: 101;
 @z-index--simple-menu-hover-object: 102;

--- a/resources/assets/less/variables.less
+++ b/resources/assets/less/variables.less
@@ -92,7 +92,7 @@
 @z-index--wiki-search: 1;
 
 @z-index--beatmaps-panel: 4;
-@z-index--profile-page-cover-selector: 5;
+@z-index--profile-page-cover-selector: 100; // must be at least 1 more than @z-index--page-extra-tabs
 @z-index--profile-previous-usernames: 10;
 @z-index--profile-tournament-banner: 11;
 @z-index--page-extra-tabs: 99;


### PR DESCRIPTION
#7909 increased the z-index to prevent beatmap-card borders to be above the extra tabs, however this lead to the cover selector being below them now.

![image](https://user-images.githubusercontent.com/35633093/133179396-a7543b5a-b40a-4d37-b306-228292eeccf7.png)

Increased the editors index and left a note that it must be at least 1 higher than extra-tabs
