### PR TITLE
Add gallery support in wiki

### DIFF
--- a/app/Libraries/Markdown/Osu/DocumentProcessor.php
+++ b/app/Libraries/Markdown/Osu/DocumentProcessor.php
@@ -250,7 +250,7 @@ class DocumentProcessor
         $width = isset($imageSize[0]) ? "{$imageSize[0]}" : '';
         $height = isset($imageSize[1]) ? "{$imageSize[1]}" : '';
 
-        $this->node->data->append('attributes/class', 'js-gallery');
+        $this->node->data->append('attributes/class', "{$imageClass}--gallery js-gallery");
         $this->node->data->set('attributes/data-width', $width);
         $this->node->data->set('attributes/data-height', $height);
         $this->node->data->set('attributes/data-gallery-id', $this->relativeUrlRoot);

--- a/app/Libraries/Markdown/Osu/Extension.php
+++ b/app/Libraries/Markdown/Osu/Extension.php
@@ -31,6 +31,7 @@ class Extension implements ConfigurableExtensionInterface
             'style_block_allowed_classes' => Expect::array()->nullable(),
             'title_from_document' => Expect::bool(),
             'wiki_locale' => Expect::string()->nullable(),
+            'with_gallery' => Expect::bool(),
         ]));
     }
 

--- a/app/Libraries/Markdown/OsuMarkdown.php
+++ b/app/Libraries/Markdown/OsuMarkdown.php
@@ -47,6 +47,7 @@ class OsuMarkdown
         'style_block_allowed_classes' => null,
         'title_from_document' => false,
         'wiki_locale' => null,
+        'with_gallery' => false,
     ];
 
     // this config is only used in this class
@@ -113,6 +114,7 @@ class OsuMarkdown
                 'generate_toc' => true,
                 'style_block_allowed_classes' => ['infobox'],
                 'title_from_document' => true,
+                'with_gallery' => true,
             ],
             'osu_markdown' => [
                 'block_modifiers' => ['wiki'],

--- a/resources/assets/less/bem/osu-md.less
+++ b/resources/assets/less/bem/osu-md.less
@@ -90,6 +90,10 @@
     display: block;
     margin: 0 auto;
 
+    &--gallery {
+      cursor: pointer;
+    }
+
     .@{_top}--comment & {
       margin: 0;
     }


### PR DESCRIPTION
closes #4257

Currently only use figure image (image with class `osu-md__figure-image`) for simplicity.

![gallery1](https://user-images.githubusercontent.com/4964985/133726678-a67fea72-f519-4347-940f-3e93e6b21de4.gif)

![gallery2](https://user-images.githubusercontent.com/4964985/133726693-15880153-e133-411d-bf90-a7967c43d7ee.gif)

![gallery3](https://user-images.githubusercontent.com/4964985/133726704-e176471f-1d15-4ba9-bbd6-b3e7e45fed0d.gif)
