### PR TITLE
Remove unused analyzer from schemas

### DIFF
--- a/config/schemas/beatmaps.json
+++ b/config/schemas/beatmaps.json
@@ -237,9 +237,6 @@
     "index": {
       "analysis": {
         "analyzer": {
-          "lowercase": {
-            "tokenizer": "lowercase"
-          },
           "prefix": {
             "filter": [
               "lowercase"

--- a/config/schemas/wiki_page.json
+++ b/config/schemas/wiki_page.json
@@ -93,9 +93,6 @@
     "index": {
       "analysis": {
         "analyzer": {
-          "lowercase": {
-            "tokenizer": "lowercase"
-          },
           "autocomplete": {
             "filter": [
               "lowercase"


### PR DESCRIPTION
Wasn't needed since `standard` analyzer already applies a lowercase filter