### PR TITLE
Increase max blocked users to double the previous amount

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -1325,7 +1325,7 @@ class User extends Model implements AfterCommit, AuthenticatableContract, HasLoc
 
     public function maxBlocks()
     {
-        return ceil($this->maxFriends() / 10);
+        return max(5, ceil($this->maxFriends() / 5));
     }
 
     public function maxFriends()

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -1325,7 +1325,7 @@ class User extends Model implements AfterCommit, AuthenticatableContract, HasLoc
 
     public function maxBlocks()
     {
-        return max(5, ceil($this->maxFriends() / 5));
+        return (int)ceil($this->maxFriends() / 5);
     }
 
     public function maxFriends()


### PR DESCRIPTION
Received a request to increase this via email, and it does seem like it could do with a bit of a bump. I've also added a hard minimum because it is feasible that a user with no friends still wants to block at least a few users.

Previously, non-supporter could block up to 25 users, supporter up to 50 (based on friend count div 10). Numbers are now double that, with a minimum of 5 entries.