### PR TITLE
Label routes requiring a user in API docs

### DIFF
--- a/app/Libraries/ApidocRouteHelper.php
+++ b/app/Libraries/ApidocRouteHelper.php
@@ -71,8 +71,15 @@ class ApidocRouteHelper
                 $route['scopes'] = [];
             }
 
+            $route['auth'] = in_array('auth', $route['middlewares'], true);
+
             $this->routeScopes[static::keyFor($route['methods'], $route['uri'])] = $route;
         }
+    }
+
+    public function getAuth(array $methods, string $uri)
+    {
+        return $this->routeScopes[static::keyFor($methods, $uri)]['auth'];
     }
 
     public function getScopeTags(array $methods, string $uri)

--- a/resources/views/docs/info.blade.php
+++ b/resources/views/docs/info.blade.php
@@ -261,6 +261,8 @@ For [Authorization Code Grant](#authorization-code-grant) tokens, the Resource O
 
 [Client Credentials Grant](#client-credentials-grant) tokens do not have a Resource Owner (i.e. is a guest user), unless they have been granted the {{ ApidocRouteHelper::scopeBadge('delegate') }} scope. The Resource Owner of tokens with the {{ ApidocRouteHelper::scopeBadge('delegate') }} scope is the owner of the OAuth Application that was granted the token.
 
+Routes marked with <span class='badge badge-scope badge-user'>requires user</span> require the use of tokens that have a Resource Owner.
+
 
 ## Client Credentials Delegation
 

--- a/resources/views/vendor/scribe/index.blade.php
+++ b/resources/views/vendor/scribe/index.blade.php
@@ -19,6 +19,9 @@
     .badge.badge-scope-oauth {
         background: #3a87ad;
     }
+    .badge.badge-user {
+        background: #ad2a66;
+    }
     .content table tr:nth-child(2n+1) > td {
         background: rgba(0, 0, 0, 0.02);
     }

--- a/resources/views/vendor/scribe/partials/endpoint.blade.php
+++ b/resources/views/vendor/scribe/partials/endpoint.blade.php
@@ -23,8 +23,7 @@
 
 <p>
     @if($helper->getAuth($methods, $uri))
-        @component('scribe::components.badges.base', ['colour' => 'darkred', 'text' => 'requires user'])
-        @endcomponent
+        <a href='#resource-owner' class='badge badge-scope badge-user'>requires user</a>
     @endif
 
     @foreach($helper->getScopeTags($methods, $uri) as $scope)

--- a/resources/views/vendor/scribe/partials/endpoint.blade.php
+++ b/resources/views/vendor/scribe/partials/endpoint.blade.php
@@ -19,12 +19,14 @@
 @endphp
 ## {{ $route['metadata']['title'] ?: $displayUri }}
 
-@component('scribe::components.badges.auth', ['authenticated' => $route['metadata']['authenticated']])
-@endcomponent
-
 {!! $topDescription !!}
 
 <p>
+    @if($helper->getAuth($methods, $uri))
+        @component('scribe::components.badges.base', ['colour' => 'darkred', 'text' => 'requires user'])
+        @endcomponent
+    @endif
+
     @foreach($helper->getScopeTags($methods, $uri) as $scope)
         {{ ApidocRouteHelper::scopeBadge($scope) }}
     @endforeach


### PR DESCRIPTION
closes #8116

Badge colour `#ad2a66` is just a complement of `#87ad3a`