### PR TITLE
Convert json helpers to typescript

### DIFF
--- a/app/Http/Controllers/RankingController.php
+++ b/app/Http/Controllers/RankingController.php
@@ -89,6 +89,9 @@ class RankingController extends Controller
             }
 
             $this->defaultViewVars['country'] = $this->country;
+            if ($type === 'performance') {
+                $this->defaultViewVars['countries'] = json_collection($this->getCountries($mode), 'Country', ['display']);
+            }
 
             return $next($request);
         });
@@ -210,9 +213,7 @@ class RankingController extends Controller
             ])]
         );
 
-        $countries = json_collection($this->getCountries($mode), 'Country', ['display']);
-
-        return ext_view("rankings.{$type}", array_merge($this->defaultViewVars, compact('countries', 'scores')));
+        return ext_view("rankings.{$type}", array_merge($this->defaultViewVars, compact('scores')));
     }
 
     public function spotlight($mode)

--- a/resources/assets/coffee/_classes/changelog-chart.coffee
+++ b/resources/assets/coffee/_classes/changelog-chart.coffee
@@ -57,7 +57,7 @@ class @ChangelogChart
 
 
   loadData: ->
-    @config = osu.parseJson 'json-chart-config'
+    @config = _exported.parseJson 'json-chart-config'
 
     {data, hasData} = @normalizeData @config.build_history
 

--- a/resources/assets/coffee/_classes/fancy-chart.coffee
+++ b/resources/assets/coffee/_classes/fancy-chart.coffee
@@ -46,7 +46,7 @@ class @FancyChart
       .attr 'data-visibility', 'hidden'
       .attr 'r', 2
 
-    data = osu.parseJson area.dataset.src
+    data = osu.parseJsonNullable area.dataset.src
     @loadData data
 
 

--- a/resources/assets/coffee/_classes/fancy-chart.coffee
+++ b/resources/assets/coffee/_classes/fancy-chart.coffee
@@ -46,7 +46,7 @@ class @FancyChart
       .attr 'data-visibility', 'hidden'
       .attr 'r', 2
 
-    data = osu.parseJsonNullable area.dataset.src
+    data = _exported.parseJsonNullable area.dataset.src
     @loadData data
 
 

--- a/resources/assets/coffee/_classes/landing-user-stats.coffee
+++ b/resources/assets/coffee/_classes/landing-user-stats.coffee
@@ -64,7 +64,7 @@ class @LandingUserStats
 
 
   loadData: =>
-    @data = osu.parseJson('json-stats')
+    @data = _exported.parseJson('json-stats')
 
     return if _.isEmpty(@data)
 

--- a/resources/assets/coffee/osu_common.coffee
+++ b/resources/assets/coffee/osu_common.coffee
@@ -44,37 +44,6 @@
       $(element).trigger 'ajax:error', [xhr, status, error]
 
 
-  parseJson: (id, remove = false) ->
-    element = window.newBody?.querySelector("##{id}")
-    return unless element?
-
-    json = JSON.parse element.text
-    element.remove() if remove
-
-    json
-
-
-  storeJson: (id, object) ->
-    json = JSON.stringify object
-    element = document.getElementById(id)
-
-    if !element?
-      element = document.createElement 'script'
-      element.id = id
-      element.type = 'application/json'
-      document.body.appendChild element
-
-    element.text = json
-
-
-  # make a clone of json-like object (object with simple values)
-  jsonClone: (object) ->
-    if object?
-      JSON.parse JSON.stringify(object)
-    else
-      object
-
-
   isInputElement: (el) ->
     el.tagName in ['INPUT', 'SELECT', 'TEXTAREA'] || el.isContentEditable
 

--- a/resources/assets/coffee/react/_components/comments-manager.coffee
+++ b/resources/assets/coffee/react/_components/comments-manager.coffee
@@ -19,12 +19,12 @@ export class CommentsManager extends React.PureComponent
 
     if props.commentableType? && props.commentableId?
       # FIXME no initialization from component?
-      json = osu.parseJson("json-comments-#{props.commentableType}-#{props.commentableId}", true)
+      json = osu.parseJsonNullable("json-comments-#{props.commentableType}-#{props.commentableId}", true)
       if json?
         core.dataStore.updateWithCommentBundleJson(json)
         uiState.initializeWithCommentBundleJson(json)
 
-      state = osu.parseJson @jsonStorageId()
+      state = osu.parseJsonNullable(@jsonStorageId())
       uiState.importCommentsUIState(state) if state?
 
     @id = "comments-#{nextVal()}"

--- a/resources/assets/coffee/react/_components/comments-manager.coffee
+++ b/resources/assets/coffee/react/_components/comments-manager.coffee
@@ -4,6 +4,7 @@
 import { runInAction } from 'mobx'
 import { Observer } from 'mobx-react'
 import core from 'osu-core-singleton'
+import { parseJsonNullable, storeJson } from 'utils/json'
 import { nextVal } from 'utils/seq'
 
 uiState = core.dataStore.uiState
@@ -19,12 +20,12 @@ export class CommentsManager extends React.PureComponent
 
     if props.commentableType? && props.commentableId?
       # FIXME no initialization from component?
-      json = osu.parseJsonNullable("json-comments-#{props.commentableType}-#{props.commentableId}", true)
+      json = parseJsonNullable("json-comments-#{props.commentableType}-#{props.commentableId}", true)
       if json?
         core.dataStore.updateWithCommentBundleJson(json)
         uiState.initializeWithCommentBundleJson(json)
 
-      state = osu.parseJsonNullable(@jsonStorageId())
+      state = parseJsonNullable(@jsonStorageId())
       uiState.importCommentsUIState(state) if state?
 
     @id = "comments-#{nextVal()}"
@@ -78,7 +79,7 @@ export class CommentsManager extends React.PureComponent
 
   saveState: =>
     if @props.commentableType? && @props.commentableId?
-      osu.storeJson @jsonStorageId(), uiState.exportCommentsUIState()
+      storeJson @jsonStorageId(), uiState.exportCommentsUIState()
 
 
   toggleFollow: =>

--- a/resources/assets/coffee/react/admin/contest.coffee
+++ b/resources/assets/coffee/react/admin/contest.coffee
@@ -3,10 +3,11 @@
 
 import core from 'osu-core-singleton'
 import { createElement } from 'react'
+import { parseJson } from 'utils/json'
 import { UserEntryList } from './contest/user-entry-list'
 
 core.reactTurbolinks.register 'admin-contest-user-entry-list', (container) ->
   createElement UserEntryList,
     container: container
-    contest: osu.parseJson('json-contest')
-    entries: osu.parseJson('json-contest-entries')
+    contest: parseJson('json-contest')
+    entries: parseJson('json-contest-entries')

--- a/resources/assets/coffee/react/artist-page.coffee
+++ b/resources/assets/coffee/react/artist-page.coffee
@@ -4,6 +4,7 @@
 import core from 'osu-core-singleton'
 import { createElement } from 'react'
 import { Tracklist } from 'tracklist'
+import { parseJson } from 'utils/json'
 
 core.reactTurbolinks.register 'artistTracklist', (container) ->
-  createElement Tracklist, tracks: osu.parseJson(container.dataset.src)
+  createElement Tracklist, tracks: parseJson(container.dataset.src)

--- a/resources/assets/coffee/react/beatmap-discussions-history.coffee
+++ b/resources/assets/coffee/react/beatmap-discussions-history.coffee
@@ -3,10 +3,11 @@
 
 import core from 'osu-core-singleton'
 import { createElement } from 'react'
+import { parseJson } from 'utils/json'
 import { Main } from './beatmap-discussions-history/main'
 
 core.reactTurbolinks.register 'beatmap-discussions-history', (container) ->
-  bundle = osu.parseJson 'json-index'
+  bundle = parseJson 'json-index'
 
   # TODO: rename props to match
   createElement Main,

--- a/resources/assets/coffee/react/beatmap-discussions.coffee
+++ b/resources/assets/coffee/react/beatmap-discussions.coffee
@@ -3,9 +3,10 @@
 
 import core from 'osu-core-singleton'
 import { createElement } from 'react'
+import { parseJson } from 'utils/json'
 import { Main } from './beatmap-discussions/main'
 
 core.reactTurbolinks.register 'beatmap-discussions', (container) ->
   createElement Main,
-    initial: osu.parseJson 'json-beatmapset-discussion'
+    initial: parseJson 'json-beatmapset-discussion'
     container: container

--- a/resources/assets/coffee/react/beatmap-discussions/discussions.coffee
+++ b/resources/assets/coffee/react/beatmap-discussions/discussions.coffee
@@ -5,6 +5,7 @@ import { Discussion } from './discussion'
 import { IconExpand } from 'icon-expand'
 import * as React from 'react'
 import { a, button, div, i, p, span } from 'react-dom-factories'
+import { jsonClone } from 'utils/json'
 import { nextVal } from 'utils/seq'
 el = React.createElement
 
@@ -195,7 +196,7 @@ export class Discussions extends React.PureComponent
 
     return if targetPreset == @currentSort()
 
-    sort = osu.jsonClone @state.sort
+    sort = jsonClone @state.sort
     sort[@props.mode] = targetPreset
 
     @setState {sort}

--- a/resources/assets/coffee/react/beatmapset-page.coffee
+++ b/resources/assets/coffee/react/beatmapset-page.coffee
@@ -3,9 +3,10 @@
 
 import core from 'osu-core-singleton'
 import { createElement } from 'react'
+import { parseJson } from 'utils/json'
 import { Main } from './beatmapset-page/main'
 
 core.reactTurbolinks.register 'beatmapset-page', (container) ->
   createElement Main,
-    beatmapset: osu.parseJson('json-beatmapset')
+    beatmapset: parseJson('json-beatmapset')
     container: container

--- a/resources/assets/coffee/react/changelog-build.coffee
+++ b/resources/assets/coffee/react/changelog-build.coffee
@@ -3,10 +3,11 @@
 
 import core from 'osu-core-singleton'
 import { createElement } from 'react'
+import { parseJson } from 'utils/json'
 import { Main } from './changelog-build/main'
 
 core.reactTurbolinks.register 'changelog-build', (container) ->
   createElement Main,
     container: container
-    updateStreams: osu.parseJson('json-update-streams')
-    build: osu.parseJson('json-build')
+    updateStreams: parseJson('json-update-streams')
+    build: parseJson('json-build')

--- a/resources/assets/coffee/react/changelog-index.coffee
+++ b/resources/assets/coffee/react/changelog-index.coffee
@@ -3,10 +3,11 @@
 
 import core from 'osu-core-singleton'
 import { createElement } from 'react'
+import { parseJson } from 'utils/json'
 import { Main } from './changelog-index/main'
 
 core.reactTurbolinks.register 'changelog-index', (container) ->
   createElement Main,
     container: container
-    updateStreams: osu.parseJson('json-update-streams')
-    data: osu.parseJson('json-index')
+    updateStreams: parseJson('json-update-streams')
+    data: parseJson('json-index')

--- a/resources/assets/coffee/react/changelog-index/main.coffee
+++ b/resources/assets/coffee/react/changelog-index/main.coffee
@@ -7,6 +7,7 @@ import HeaderV4 from 'header-v4'
 import * as React from 'react'
 import { button, div, h1, p, span } from 'react-dom-factories'
 import ShowMoreLink from 'show-more-link'
+import { jsonClone } from 'utils/json'
 el = React.createElement
 
 groupChangelogBuilds = (builds) ->
@@ -72,7 +73,7 @@ export class Main extends React.PureComponent
   showMore: =>
     return if !@state.hasMore
 
-    search = osu.jsonClone @props.data.search
+    search = jsonClone @props.data.search
     search.max_id = _.last(@state.builds).id - 1
     @setState loading: true
 

--- a/resources/assets/coffee/react/comments-index.coffee
+++ b/resources/assets/coffee/react/comments-index.coffee
@@ -4,10 +4,11 @@
 import { CommentsManager } from 'comments-manager'
 import core from 'osu-core-singleton'
 import { createElement } from 'react'
+import { parseJson } from 'utils/json'
 import { Main } from './comments-index/main'
 
 core.reactTurbolinks.register 'comments-index', ->
-  commentBundle = osu.parseJson('json-index')
+  commentBundle = parseJson('json-index')
   core.dataStore.updateWithCommentBundleJson(commentBundle)
   core.dataStore.uiState.initializeWithCommentBundleJson(commentBundle)
 

--- a/resources/assets/coffee/react/comments-show.coffee
+++ b/resources/assets/coffee/react/comments-show.coffee
@@ -4,10 +4,11 @@
 import { CommentsManager } from 'comments-manager'
 import core from 'osu-core-singleton'
 import { createElement } from 'react'
+import { parseJson } from 'utils/json'
 import { Main } from './comments-show/main'
 
 core.reactTurbolinks.register 'comments-show', ->
-  commentBundle = osu.parseJson('json-show')
+  commentBundle = parseJson('json-show')
   core.dataStore.updateWithCommentBundleJson(commentBundle)
   core.dataStore.uiState.initializeWithCommentBundleJson(commentBundle)
 

--- a/resources/assets/coffee/react/contest-entry.coffee
+++ b/resources/assets/coffee/react/contest-entry.coffee
@@ -3,11 +3,12 @@
 
 import core from 'osu-core-singleton'
 import { createElement } from 'react'
+import { parseJson } from 'utils/json'
 import { UserEntryList } from './contest-entry/user-entry-list'
 
 core.reactTurbolinks.register 'userContestEntry', ->
-  data = osu.parseJson('json-contest')
-  userEntries = osu.parseJson('json-userEntries')
+  data = parseJson('json-contest')
+  userEntries = parseJson('json-userEntries')
 
   createElement UserEntryList,
     contest: data.contest

--- a/resources/assets/coffee/react/contest-voting.coffee
+++ b/resources/assets/coffee/react/contest-voting.coffee
@@ -3,11 +3,12 @@
 
 import core from 'osu-core-singleton'
 import { createElement } from 'react'
+import { parseJson } from 'utils/json'
 import { ArtEntryList } from './contest-voting/art-entry-list'
 import { EntryList } from './contest-voting/entry-list'
 
 propsFunction = (container) ->
-  data = osu.parseJson container.dataset.src
+  data = parseJson container.dataset.src
 
   return {
     contest: data.contest

--- a/resources/assets/coffee/react/modding-profile.coffee
+++ b/resources/assets/coffee/react/modding-profile.coffee
@@ -3,18 +3,19 @@
 
 import core from 'osu-core-singleton'
 import { createElement } from 'react'
+import { parseJson } from 'utils/json'
 import { Main } from './modding-profile/main'
 
 core.reactTurbolinks.register 'modding-profile', (container) ->
   createElement Main,
-    beatmaps: osu.parseJson('json-beatmaps')
+    beatmaps: parseJson('json-beatmaps')
     container: container
-    discussions: osu.parseJson('json-discussions')
-    events: osu.parseJson('json-events')
-    extras: osu.parseJson('json-extras')
-    perPage: osu.parseJson('json-perPage')
-    posts: osu.parseJson('json-posts')
-    reviewsConfig: osu.parseJson('json-reviewsConfig')
-    user: osu.parseJson('json-user')
-    users: osu.parseJson('json-users')
-    votes: osu.parseJson('json-votes')
+    discussions: parseJson('json-discussions')
+    events: parseJson('json-events')
+    extras: parseJson('json-extras')
+    perPage: parseJson('json-perPage')
+    posts: parseJson('json-posts')
+    reviewsConfig: parseJson('json-reviewsConfig')
+    user: parseJson('json-user')
+    users: parseJson('json-users')
+    votes: parseJson('json-votes')

--- a/resources/assets/coffee/react/modding-profile/detail-bar.coffee
+++ b/resources/assets/coffee/react/modding-profile/detail-bar.coffee
@@ -7,6 +7,7 @@ import { FriendButton } from 'friend-button'
 import * as React from 'react'
 import { a, button, div, i, span } from 'react-dom-factories'
 import { ReportReportable } from 'report-reportable'
+import { jsonClone } from 'utils/json'
 import { nextVal } from 'utils/seq'
 el = React.createElement
 
@@ -19,7 +20,7 @@ export class DetailBar extends React.PureComponent
     super props
 
     @eventId = "profile-page-#{nextVal()}"
-    @state = currentUser: osu.jsonClone(currentUser)
+    @state = currentUser: jsonClone(currentUser)
 
 
   componentDidMount: =>
@@ -103,4 +104,4 @@ export class DetailBar extends React.PureComponent
   updateCurrentUser: (_e, user) =>
     return unless @state.currentUser.id == user.id
 
-    @setState currentUser: osu.jsonClone(user)
+    @setState currentUser: jsonClone(user)

--- a/resources/assets/coffee/react/mp-history.coffee
+++ b/resources/assets/coffee/react/mp-history.coffee
@@ -3,7 +3,8 @@
 
 import core from 'osu-core-singleton'
 import { createElement } from 'react'
+import { parseJson } from 'utils/json'
 import { Main } from './mp-history/main'
 
 core.reactTurbolinks.register 'mp-history', ->
-  createElement(Main, events: osu.parseJson('json-events'))
+  createElement(Main, events: parseJson('json-events'))

--- a/resources/assets/coffee/react/profile-page.coffee
+++ b/resources/assets/coffee/react/profile-page.coffee
@@ -3,18 +3,19 @@
 
 import core from 'osu-core-singleton'
 import { createElement } from 'react'
+import { parseJson } from 'utils/json'
 import { Main } from './profile-page/main'
 
 core.reactTurbolinks.register 'profile-page', (container) ->
-  user = osu.parseJson('json-user')
+  user = parseJson('json-user')
 
   createElement Main,
     user: user
     userPage: user.page
     userAchievements: user.user_achievements
-    currentMode: osu.parseJson('json-currentMode')
+    currentMode: parseJson('json-currentMode')
     withEdit: user.id == window.currentUser.id
-    achievements: _.keyBy osu.parseJson('json-achievements'), 'id'
-    perPage: osu.parseJson('json-perPage')
-    extras: osu.parseJson('json-extras')
+    achievements: _.keyBy parseJson('json-achievements'), 'id'
+    perPage: parseJson('json-perPage')
+    extras: parseJson('json-extras')
     container: container

--- a/resources/assets/lib/account-edit.tsx
+++ b/resources/assets/lib/account-edit.tsx
@@ -1,13 +1,16 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+import { ClientJson } from 'interfaces/client-json';
+import { OwnClientJson } from 'interfaces/own-client-json';
 import { AuthorizedClients } from 'oauth/authorized-clients';
 import { OwnClients } from 'oauth/own-clients';
 import core from 'osu-core-singleton';
 import * as React from 'react';
+import { parseJson } from 'utils/json';
 
 core.reactTurbolinks.register('authorized-clients', () => {
-  const json = osu.parseJson('json-authorized-clients', true);
+  const json = parseJson<ClientJson[]>('json-authorized-clients', true);
   if (json != null) {
     core.dataStore.clientStore.initialize(json);
   }
@@ -16,7 +19,7 @@ core.reactTurbolinks.register('authorized-clients', () => {
 });
 
 core.reactTurbolinks.register('own-clients', () => {
-  const json = osu.parseJson('json-own-clients', true);
+  const json = parseJson<OwnClientJson[]>('json-own-clients', true);
   if (json != null) {
     core.dataStore.ownClientStore.initialize(json);
   }

--- a/resources/assets/lib/account-edit.tsx
+++ b/resources/assets/lib/account-edit.tsx
@@ -7,10 +7,10 @@ import { AuthorizedClients } from 'oauth/authorized-clients';
 import { OwnClients } from 'oauth/own-clients';
 import core from 'osu-core-singleton';
 import * as React from 'react';
-import { parseJson } from 'utils/json';
+import { parseJsonNullable } from 'utils/json';
 
 core.reactTurbolinks.register('authorized-clients', () => {
-  const json = parseJson<ClientJson[]>('json-authorized-clients', true);
+  const json = parseJsonNullable<ClientJson[]>('json-authorized-clients', true);
   if (json != null) {
     core.dataStore.clientStore.initialize(json);
   }
@@ -19,7 +19,7 @@ core.reactTurbolinks.register('authorized-clients', () => {
 });
 
 core.reactTurbolinks.register('own-clients', () => {
-  const json = parseJson<OwnClientJson[]>('json-own-clients', true);
+  const json = parseJsonNullable<OwnClientJson[]>('json-own-clients', true);
   if (json != null) {
     core.dataStore.ownClientStore.initialize(json);
   }

--- a/resources/assets/lib/beatmaps.tsx
+++ b/resources/assets/lib/beatmaps.tsx
@@ -1,12 +1,14 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+import { SearchResponse } from 'beatmaps/beatmapset-search';
 import { Main } from 'beatmaps/main';
 import core from 'osu-core-singleton';
 import * as React from 'react';
+import { parseJson } from 'utils/json';
 
 core.reactTurbolinks.register('beatmaps', (container: HTMLElement) => {
-  const beatmapsets = osu.parseJson('json-beatmaps', true);
+  const beatmapsets = parseJson<SearchResponse>('json-beatmaps', true);
   if (beatmapsets != null) {
     core.beatmapsetSearchController.initialize(beatmapsets);
   }
@@ -15,5 +17,5 @@ core.reactTurbolinks.register('beatmaps', (container: HTMLElement) => {
   // includes an initial search to load the pre-initialized data properly.
   core.beatmapsetSearchController.restoreTurbolinks();
 
-  return <Main availableFilters={osu.parseJson('json-filters')} />;
+  return <Main availableFilters={parseJson('json-filters')} />;
 });

--- a/resources/assets/lib/beatmaps.tsx
+++ b/resources/assets/lib/beatmaps.tsx
@@ -5,10 +5,10 @@ import { SearchResponse } from 'beatmaps/beatmapset-search';
 import { Main } from 'beatmaps/main';
 import core from 'osu-core-singleton';
 import * as React from 'react';
-import { parseJson } from 'utils/json';
+import { parseJson, parseJsonNullable } from 'utils/json';
 
 core.reactTurbolinks.register('beatmaps', (container: HTMLElement) => {
-  const beatmapsets = parseJson<SearchResponse>('json-beatmaps', true);
+  const beatmapsets = parseJsonNullable<SearchResponse>('json-beatmaps', true);
   if (beatmapsets != null) {
     core.beatmapsetSearchController.initialize(beatmapsets);
   }

--- a/resources/assets/lib/beatmapsets-show/metadata-editor.tsx
+++ b/resources/assets/lib/beatmapsets-show/metadata-editor.tsx
@@ -6,6 +6,7 @@ import GenreJson from 'interfaces/genre-json';
 import LanguageJson from 'interfaces/language-json';
 import { route } from 'laroute';
 import * as React from 'react';
+import { parseJson } from 'utils/json';
 
 interface Props {
   beatmapset: BeatmapsetJson;
@@ -20,8 +21,8 @@ interface State {
 }
 
 export default class MetadataEditor extends React.PureComponent<Props, State> {
-  private genres = osu.parseJson<GenreJson[]>('json-genres');
-  private languages = osu.parseJson<LanguageJson[]>('json-languages');
+  private genres = parseJson<GenreJson[]>('json-genres');
+  private languages = parseJson<LanguageJson[]>('json-languages');
 
   constructor(props: Props) {
     super(props);

--- a/resources/assets/lib/chat.tsx
+++ b/resources/assets/lib/chat.tsx
@@ -8,7 +8,7 @@ import { action } from 'mobx';
 import Channel from 'models/chat/channel';
 import core from 'osu-core-singleton';
 import * as React from 'react';
-import { parseJson } from 'utils/json';
+import { parseJsonNullable } from 'utils/json';
 import { currentUrlParams } from 'utils/turbolinks';
 
 interface ChatInitialJson {
@@ -25,7 +25,7 @@ interface SendToJson {
 
 core.reactTurbolinks.register('chat', action(() => {
   const dataStore = core.dataStore;
-  const initial = parseJson<ChatInitialJson | null>('json-chat-initial', true);
+  const initial = parseJsonNullable<ChatInitialJson>('json-chat-initial', true);
 
   if (initial != null) {
     if (Array.isArray(initial.presence)) {

--- a/resources/assets/lib/chat.tsx
+++ b/resources/assets/lib/chat.tsx
@@ -8,6 +8,7 @@ import { action } from 'mobx';
 import Channel from 'models/chat/channel';
 import core from 'osu-core-singleton';
 import * as React from 'react';
+import { parseJson } from 'utils/json';
 import { currentUrlParams } from 'utils/turbolinks';
 
 interface ChatInitialJson {
@@ -24,7 +25,7 @@ interface SendToJson {
 
 core.reactTurbolinks.register('chat', action(() => {
   const dataStore = core.dataStore;
-  const initial = osu.parseJson<ChatInitialJson | null>('json-chat-initial', true);
+  const initial = parseJson<ChatInitialJson | null>('json-chat-initial', true);
 
   if (initial != null) {
     if (Array.isArray(initial.presence)) {

--- a/resources/assets/lib/follows-comment.tsx
+++ b/resources/assets/lib/follows-comment.tsx
@@ -4,7 +4,8 @@
 import Main from 'follows-comment/main';
 import core from 'osu-core-singleton';
 import * as React from 'react';
+import { parseJson } from 'utils/json';
 
 core.reactTurbolinks.register('follows-comment', () => (
-  <Main follows={osu.parseJson('json-follows-comment')} />
+  <Main follows={parseJson('json-follows-comment')} />
 ));

--- a/resources/assets/lib/follows-mapping.tsx
+++ b/resources/assets/lib/follows-mapping.tsx
@@ -4,7 +4,8 @@
 import Main from 'follows-mapping/main';
 import core from 'osu-core-singleton';
 import * as React from 'react';
+import { parseJson } from 'utils/json';
 
 core.reactTurbolinks.register('follows-mapping', () => (
-  <Main follows={osu.parseJson('json-follows-mapping')} />
+  <Main follows={parseJson('json-follows-mapping')} />
 ));

--- a/resources/assets/lib/friends-index.tsx
+++ b/resources/assets/lib/friends-index.tsx
@@ -4,7 +4,8 @@
 import { Main } from 'friends-index/main';
 import core from 'osu-core-singleton';
 import * as React from 'react';
+import { parseJson } from 'utils/json';
 
 core.reactTurbolinks.register('friends-index', () => (
-  <Main friends={osu.parseJson('json-users')} />
+  <Main friends={parseJson('json-users')} />
 ));

--- a/resources/assets/lib/globals.d.ts
+++ b/resources/assets/lib/globals.d.ts
@@ -76,7 +76,6 @@ interface OsuCommon {
   link: (url: string, text: string, options?: OsuLinkOptions) => string;
   linkify: (text: string, newWindow?: boolean) => string;
   navigate: (url: string, keepScroll?: boolean, action?: Partial<Record<string, unknown>>) => void;
-  parseJson<T = any>(id: string, remove?: boolean): T;
   popup: (message: string, type: string) => void;
   popupShowing: () => boolean;
   presence: (str?: string | null) => string | null;

--- a/resources/assets/lib/globals.d.ts
+++ b/resources/assets/lib/globals.d.ts
@@ -72,7 +72,6 @@ interface OsuCommon {
   formatNumber(num: number, precision?: number, options?: Intl.NumberFormatOptions, locale?: string): string;
   groupColour: (group?: import('interfaces/group-json').default) => React.CSSProperties;
   isClickable: (el: HTMLElement) => boolean;
-  jsonClone<T>(obj: T): T;
   link: (url: string, text: string, options?: OsuLinkOptions) => string;
   linkify: (text: string, newWindow?: boolean) => string;
   navigate: (url: string, keepScroll?: boolean, action?: Partial<Record<string, unknown>>) => void;

--- a/resources/assets/lib/groups-show.tsx
+++ b/resources/assets/lib/groups-show.tsx
@@ -4,7 +4,8 @@
 import { Main } from 'groups-show/main';
 import core from 'osu-core-singleton';
 import * as React from 'react';
+import { parseJson } from 'utils/json';
 
 core.reactTurbolinks.register('groups-show', () => (
-  <Main group={osu.parseJson('json-group')} users={osu.parseJson('json-users')} />
+  <Main group={parseJson('json-group')} users={parseJson('json-users')} />
 ));

--- a/resources/assets/lib/header-v4.tsx
+++ b/resources/assets/lib/header-v4.tsx
@@ -5,7 +5,7 @@ import HeaderLink from 'interfaces/header-link';
 import * as React from 'react';
 import { Spinner } from 'spinner';
 import { classWithModifiers } from 'utils/css';
-import { parseJson } from 'utils/json';
+import { parseJsonNullable } from 'utils/json';
 
 interface Props {
   backgroundImage?: string | null;
@@ -181,7 +181,7 @@ export default class HeaderV4 extends React.Component<Props> {
   }
 
   private title() {
-    const routeSection: RouteSection | null = parseJson('json-route-section');
+    const routeSection = parseJsonNullable<RouteSection>('json-route-section');
 
     if (routeSection != null) {
       const keys = [

--- a/resources/assets/lib/header-v4.tsx
+++ b/resources/assets/lib/header-v4.tsx
@@ -5,6 +5,7 @@ import HeaderLink from 'interfaces/header-link';
 import * as React from 'react';
 import { Spinner } from 'spinner';
 import { classWithModifiers } from 'utils/css';
+import { parseJson } from 'utils/json';
 
 interface Props {
   backgroundImage?: string | null;
@@ -180,7 +181,7 @@ export default class HeaderV4 extends React.Component<Props> {
   }
 
   private title() {
-    const routeSection: RouteSection | null = osu.parseJson('json-route-section');
+    const routeSection: RouteSection | null = parseJson('json-route-section');
 
     if (routeSection != null) {
       const keys = [

--- a/resources/assets/lib/import-shims.coffee
+++ b/resources/assets/lib/import-shims.coffee
@@ -39,6 +39,8 @@ window._exported = {
   make2x
   pageChange
   pageChangeImmediate
+  parseJson
+  parseJsonNullable
 }
 
 # FIXME: remove once everything imports instead of using global
@@ -52,6 +54,3 @@ window._styles =
     heightMobile: 50 # @navbar-height
 
 window.StoreCheckout = StoreCheckout
-
-window.osu.parseJson = parseJson
-window.osu.parseJsonNullable = parseJsonNullable

--- a/resources/assets/lib/import-shims.coffee
+++ b/resources/assets/lib/import-shims.coffee
@@ -13,7 +13,7 @@ import { classWithModifiers } from 'utils/css'
 import { discussionLinkify } from 'utils/beatmapset-discussion-helper'
 import { fadeIn, fadeOut, fadeToggle } from 'utils/fade'
 import { make2x } from 'utils/html'
-import { jsonClone, parseJson, storeJson } from 'utils/json'
+import { jsonClone, parseJson, parseJsonNullable, storeJson } from 'utils/json'
 import { pageChange, pageChangeImmediate } from 'utils/page-change'
 import { currentUrl } from 'utils/turbolinks'
 import * as OsuUrlHelper from 'utils/url'
@@ -55,4 +55,5 @@ window.StoreCheckout = StoreCheckout
 
 window.osu.jsonClone = jsonClone
 window.osu.parseJson = parseJson
+window.osu.parseJsonNullable = parseJsonNullable
 window.osu.storeJson = storeJson

--- a/resources/assets/lib/import-shims.coffee
+++ b/resources/assets/lib/import-shims.coffee
@@ -56,4 +56,3 @@ window.StoreCheckout = StoreCheckout
 window.osu.jsonClone = jsonClone
 window.osu.parseJson = parseJson
 window.osu.parseJsonNullable = parseJsonNullable
-window.osu.storeJson = storeJson

--- a/resources/assets/lib/import-shims.coffee
+++ b/resources/assets/lib/import-shims.coffee
@@ -53,6 +53,5 @@ window._styles =
 
 window.StoreCheckout = StoreCheckout
 
-window.osu.jsonClone = jsonClone
 window.osu.parseJson = parseJson
 window.osu.parseJsonNullable = parseJsonNullable

--- a/resources/assets/lib/import-shims.coffee
+++ b/resources/assets/lib/import-shims.coffee
@@ -13,6 +13,7 @@ import { classWithModifiers } from 'utils/css'
 import { discussionLinkify } from 'utils/beatmapset-discussion-helper'
 import { fadeIn, fadeOut, fadeToggle } from 'utils/fade'
 import { make2x } from 'utils/html'
+import { jsonClone, parseJson, storeJson } from 'utils/json'
 import { pageChange, pageChangeImmediate } from 'utils/page-change'
 import { currentUrl } from 'utils/turbolinks'
 import * as OsuUrlHelper from 'utils/url'
@@ -51,3 +52,7 @@ window._styles =
     heightMobile: 50 # @navbar-height
 
 window.StoreCheckout = StoreCheckout
+
+window.osu.jsonClone = jsonClone
+window.osu.parseJson = parseJson
+window.osu.storeJson = storeJson

--- a/resources/assets/lib/news-index/main.tsx
+++ b/resources/assets/lib/news-index/main.tsx
@@ -12,6 +12,7 @@ import NewsHeader from 'news-header';
 import NewsSidebar from 'news-sidebar/main';
 import * as React from 'react';
 import ShowMoreLink from 'show-more-link';
+import { jsonClone } from 'utils/json';
 import PostItem from './post-item';
 
 interface NewsSearch {
@@ -33,7 +34,7 @@ interface Props {
 
 @observer
 export default class Main extends React.Component<Props> {
-  @observable private data = osu.jsonClone(this.props.data);
+  @observable private data = jsonClone(this.props.data);
   @observable private loadingXhr?: JQuery.jqXHR | null = null;
 
   constructor(props: Props) {

--- a/resources/assets/lib/news-show.tsx
+++ b/resources/assets/lib/news-show.tsx
@@ -4,11 +4,12 @@
 import Main from 'news-show/main';
 import core from 'osu-core-singleton';
 import * as React from 'react';
+import { parseJson } from 'utils/json';
 
 core.reactTurbolinks.register('news-show', (container: HTMLElement) => (
   <Main
     container={container}
-    post={osu.parseJson('json-show')}
-    sidebarMeta={osu.parseJson('json-sidebar')}
+    post={parseJson('json-show')}
+    sidebarMeta={parseJson('json-sidebar')}
   />
 ));

--- a/resources/assets/lib/notifications-index.tsx
+++ b/resources/assets/lib/notifications-index.tsx
@@ -7,9 +7,10 @@ import { Main } from 'notifications-index/main';
 import { NotificationEventMoreLoaded } from 'notifications/notification-events';
 import core from 'osu-core-singleton';
 import * as React from 'react';
+import { parseJson } from 'utils/json';
 
 core.reactTurbolinks.register('notifications-index', (container: HTMLElement) => {
-  const bundle = osu.parseJson<NotificationBundleJson>('json-notifications');
+  const bundle = parseJson<NotificationBundleJson>('json-notifications');
   dispatch(new NotificationEventMoreLoaded(bundle, { isWidget: false }));
 
   return <Main />;

--- a/resources/assets/lib/notifications-index.tsx
+++ b/resources/assets/lib/notifications-index.tsx
@@ -2,7 +2,6 @@
 // See the LICENCE file in the repository root for full licence text.
 
 import { dispatch } from 'app-dispatcher';
-import { NotificationBundleJson } from 'interfaces/notification-json';
 import { Main } from 'notifications-index/main';
 import { NotificationEventMoreLoaded } from 'notifications/notification-events';
 import core from 'osu-core-singleton';
@@ -10,8 +9,7 @@ import * as React from 'react';
 import { parseJson } from 'utils/json';
 
 core.reactTurbolinks.register('notifications-index', (container: HTMLElement) => {
-  const bundle = parseJson<NotificationBundleJson>('json-notifications');
-  dispatch(new NotificationEventMoreLoaded(bundle, { isWidget: false }));
+  dispatch(new NotificationEventMoreLoaded(parseJson('json-notifications'), { isWidget: false }));
 
   return <Main />;
 });

--- a/resources/assets/lib/register-components.coffee
+++ b/resources/assets/lib/register-components.coffee
@@ -31,6 +31,7 @@ import { UserCards } from 'user-cards'
 import { WikiSearch } from 'wiki-search'
 import core from 'osu-core-singleton'
 import { createElement } from 'react'
+import { parseJson } from 'utils/json'
 
 # Globally init countdown timers
 core.reactTurbolinks.register 'countdownTimer', (container) ->
@@ -50,13 +51,13 @@ core.reactTurbolinks.register 'blockButton', (container) ->
 
 core.reactTurbolinks.register 'beatmap-discussion-events', (container) ->
   props = {
-    events: osu.parseJson('json-events')
+    events: parseJson('json-events')
     mode: 'list'
-    posts: osu.parseJson('json-posts')
+    posts: parseJson('json-posts')
   }
 
   # TODO: move to store?
-  users = osu.parseJson('json-users')
+  users = parseJson('json-users')
   props.users = _.keyBy(users, 'id')
   props.users[null] = props.users[undefined] = deletedUser.toJson()
 
@@ -69,10 +70,10 @@ core.reactTurbolinks.register 'beatmapset-panel', (container) ->
 core.reactTurbolinks.register 'forum-post-report', -> createElement(ForumPostReport)
 
 core.reactTurbolinks.register 'spotlight-select-options', ->
-  createElement SpotlightSelectOptions, osu.parseJson('json-spotlight-select-options')
+  createElement SpotlightSelectOptions, parseJson('json-spotlight-select-options')
 
 core.reactTurbolinks.register 'multiplayer-select-options', ->
-  createElement MultiplayerSelectOptions, osu.parseJson('json-multiplayer-select-options')
+  createElement MultiplayerSelectOptions, parseJson('json-multiplayer-select-options')
 
 core.reactTurbolinks.register 'comments', (container) ->
   props = JSON.parse(container.dataset.props)
@@ -98,7 +99,7 @@ core.reactTurbolinks.register 'quick-search-button', ->
 
 core.reactTurbolinks.register 'ranking-filter', (container) ->
   createElement RankingFilter,
-    countries: osu.parseJson 'json-countries'
+    countries: parseJson 'json-countries'
     gameMode: container.dataset.gameMode
     type: container.dataset.type
     variants: try JSON.parse(container.dataset.variants)
@@ -125,4 +126,4 @@ core.reactTurbolinks.register 'user-cards', (container) ->
 core.reactTurbolinks.register 'wiki-search', -> createElement(WikiSearch)
 
 core.reactTurbolinks.register 'landing-news', ->
-  createElement LandingNews, posts: osu.parseJson('json-posts')
+  createElement LandingNews, posts: parseJson('json-posts')

--- a/resources/assets/lib/register-components.coffee
+++ b/resources/assets/lib/register-components.coffee
@@ -31,7 +31,7 @@ import { UserCards } from 'user-cards'
 import { WikiSearch } from 'wiki-search'
 import core from 'osu-core-singleton'
 import { createElement } from 'react'
-import { parseJson } from 'utils/json'
+import { parseJson, parseJsonNullable } from 'utils/json'
 
 # Globally init countdown timers
 core.reactTurbolinks.register 'countdownTimer', (container) ->
@@ -99,7 +99,7 @@ core.reactTurbolinks.register 'quick-search-button', ->
 
 core.reactTurbolinks.register 'ranking-filter', (container) ->
   createElement RankingFilter,
-    countries: parseJson 'json-countries'
+    countries: parseJsonNullable 'json-countries'
     gameMode: container.dataset.gameMode
     type: container.dataset.type
     variants: try JSON.parse(container.dataset.variants)

--- a/resources/assets/lib/scores-show.tsx
+++ b/resources/assets/lib/scores-show.tsx
@@ -4,7 +4,8 @@
 import core from 'osu-core-singleton';
 import * as React from 'react';
 import Main from 'scores-show/main';
+import { parseJson } from 'utils/json';
 
 core.reactTurbolinks.register('scores-show', () => (
-  <Main score={osu.parseJson('json-show')} />
+  <Main score={parseJson('json-show')} />
 ));

--- a/resources/assets/lib/user-multiplayer-index.tsx
+++ b/resources/assets/lib/user-multiplayer-index.tsx
@@ -1,7 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
-import UserMultiplayerHistoryJson from 'interfaces/user-multiplayer-history-json';
 import core from 'osu-core-singleton';
 import * as React from 'react';
 import UserMultiplayerHistoryContext, { makeStore, updateStore } from 'user-multiplayer-history-context';
@@ -9,9 +8,8 @@ import Main from 'user-multiplayer-index/main';
 import { parseJson } from 'utils/json';
 
 core.reactTurbolinks.register('user-multiplayer-index', () => {
-  const json = parseJson<UserMultiplayerHistoryJson>('json-user-multiplayer-index');
   const store = makeStore();
-  updateStore(store, json);
+  updateStore(store, parseJson('json-user-multiplayer-index'));
 
   return (
     <UserMultiplayerHistoryContext.Provider value={store}>

--- a/resources/assets/lib/user-multiplayer-index.tsx
+++ b/resources/assets/lib/user-multiplayer-index.tsx
@@ -1,22 +1,21 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
-import UserExtendedJson from 'interfaces/user-extended-json';
 import UserMultiplayerHistoryJson from 'interfaces/user-multiplayer-history-json';
 import core from 'osu-core-singleton';
 import * as React from 'react';
 import UserMultiplayerHistoryContext, { makeStore, updateStore } from 'user-multiplayer-history-context';
 import Main from 'user-multiplayer-index/main';
+import { parseJson } from 'utils/json';
 
 core.reactTurbolinks.register('user-multiplayer-index', () => {
-  const jsonUser = osu.parseJson<UserExtendedJson>('json-user');
-  const json = osu.parseJson<UserMultiplayerHistoryJson>('json-user-multiplayer-index');
+  const json = parseJson<UserMultiplayerHistoryJson>('json-user-multiplayer-index');
   const store = makeStore();
   updateStore(store, json);
 
   return (
     <UserMultiplayerHistoryContext.Provider value={store}>
-      <Main user={jsonUser} />
+      <Main user={parseJson('json-user')} />
     </UserMultiplayerHistoryContext.Provider>
   );
 });

--- a/resources/assets/lib/utils/beatmap-helper.ts
+++ b/resources/assets/lib/utils/beatmap-helper.ts
@@ -159,7 +159,7 @@ let userRecommendedDifficultyCache: Partial<Record<GameMode, number>> | null = n
 
 function userRecommendedDifficulty(mode: GameMode) {
   if (userRecommendedDifficultyCache == null) {
-    userRecommendedDifficultyCache = parseJson<Record<GameMode, number> | null>('json-recommended-star-difficulty-all') ?? {};
+    userRecommendedDifficultyCache = parseJson('json-recommended-star-difficulty-all') ?? {};
     $(document).one('turbolinks:before-cache', () => {
       userRecommendedDifficultyCache = null;
     });

--- a/resources/assets/lib/utils/beatmap-helper.ts
+++ b/resources/assets/lib/utils/beatmap-helper.ts
@@ -8,6 +8,7 @@ import BeatmapsetJson from 'interfaces/beatmapset-json';
 import GameMode from 'interfaces/game-mode';
 import * as _ from 'lodash';
 import core from 'osu-core-singleton';
+import { parseJson } from 'utils/json';
 
 export const modes: GameMode[] = ['osu', 'taiko', 'fruits', 'mania'];
 
@@ -158,7 +159,7 @@ let userRecommendedDifficultyCache: Partial<Record<GameMode, number>> | null = n
 
 function userRecommendedDifficulty(mode: GameMode) {
   if (userRecommendedDifficultyCache == null) {
-    userRecommendedDifficultyCache = osu.parseJson<Record<GameMode, number> | null>('json-recommended-star-difficulty-all') ?? {};
+    userRecommendedDifficultyCache = parseJson<Record<GameMode, number> | null>('json-recommended-star-difficulty-all') ?? {};
     $(document).one('turbolinks:before-cache', () => {
       userRecommendedDifficultyCache = null;
     });

--- a/resources/assets/lib/utils/json.ts
+++ b/resources/assets/lib/utils/json.ts
@@ -1,8 +1,9 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
-export function jsonClone<T = string|number|Record<string, unknown>>(obj: T) {
-  return JSON.parse(JSON.stringify(obj)) as T;
+// TODO: stop supporting null/undefined?
+export function jsonClone<T>(obj: T) {
+  return obj != null ? JSON.parse(JSON.stringify(obj)) as T : obj;
 }
 
 export function parseJson<T>(id: string): T {

--- a/resources/assets/lib/utils/json.ts
+++ b/resources/assets/lib/utils/json.ts
@@ -1,10 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
-function isScriptElement(ele: HTMLElement | null): ele is HTMLScriptElement {
-  return ele?.localName === 'script';
-}
-
 export function jsonClone<T = string|number|Record<string, unknown>>(obj: T) {
   return JSON.parse(JSON.stringify(obj)) as T;
 }
@@ -32,20 +28,19 @@ export function parseJsonNullable<T>(id: string, remove = false): T | undefined 
 
 export function storeJson(id: string, object: Record<string, unknown>) {
   const json = JSON.stringify(object);
-  let element = document.getElementById(id);
+  const maybeElement = document.getElementById(id);
 
-  // TODO: typingggggg???
-  if (element == null) {
+  let element: HTMLScriptElement;
+  if (maybeElement == null) {
     element = document.createElement('script');
     element.id = id;
+    element.type = 'application/json';
     document.body.appendChild(element);
+  } else if (maybeElement instanceof HTMLScriptElement) {
+    element = maybeElement;
+  } else {
+    throw new Error(`existing ${id} is not a script element.`);
   }
 
-  if (!isScriptElement(element)) {
-    throw new Error();
-  }
-
-  element.id = id;
-  element.type = 'application/json';
   element.text = json;
 }

--- a/resources/assets/lib/utils/json.ts
+++ b/resources/assets/lib/utils/json.ts
@@ -1,0 +1,42 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
+function isScriptElement(ele: HTMLElement | null): ele is HTMLScriptElement {
+  return ele?.localName === 'script';
+}
+
+export function jsonClone<T = string|number|Record<string, unknown>>(obj: T) {
+  return JSON.parse(JSON.stringify(obj)) as T;
+}
+
+export function parseJson<T = any>(id: string, remove = false) {
+  const element = window.newBody?.querySelector(`#${id}`);
+  if (!(element instanceof HTMLScriptElement)) return undefined;
+  const json = JSON.parse(element.text) as T;
+
+  if (remove) {
+    element.remove();
+  }
+
+  return json;
+}
+
+export function storeJson(id: string, object: Record<string, unknown>) {
+  const json = JSON.stringify(object);
+  let element = document.getElementById(id);
+
+  // TODO: typingggggg???
+  if (element == null) {
+    element = document.createElement('script');
+    element.id = id;
+    document.body.appendChild(element);
+  }
+
+  if (!isScriptElement(element)) {
+    throw new Error();
+  }
+
+  element.id = id;
+  element.type = 'application/json';
+  element.text = json;
+}

--- a/resources/assets/lib/utils/json.ts
+++ b/resources/assets/lib/utils/json.ts
@@ -9,7 +9,16 @@ export function jsonClone<T = string|number|Record<string, unknown>>(obj: T) {
   return JSON.parse(JSON.stringify(obj)) as T;
 }
 
-export function parseJson<T = any>(id: string, remove = false) {
+export function parseJson<T>(id: string): T {
+  const json = parseJsonNullable<T>(id);
+  if (json == null) {
+    throw new Error(`missing script element ${id}`);
+  }
+
+  return json;
+}
+
+export function parseJsonNullable<T>(id: string, remove = false): T | undefined {
   const element = window.newBody?.querySelector(`#${id}`);
   if (!(element instanceof HTMLScriptElement)) return undefined;
   const json = JSON.parse(element.text) as T;

--- a/resources/views/rankings/charts.blade.php
+++ b/resources/views/rankings/charts.blade.php
@@ -2,7 +2,7 @@
     Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
     See the LICENCE file in the repository root for full licence text.
 --}}
-@extends('rankings.index')
+@extends('rankings.index', ['hasFilter' => false])
 
 @section('ranking-header')
     <div

--- a/tests/karma/osu_common.spec.ts
+++ b/tests/karma/osu_common.spec.ts
@@ -3,6 +3,7 @@
 
 import GroupJson from 'interfaces/group-json';
 import * as React from 'react';
+import { jsonClone } from 'utils/json';
 
 describe('osu_common', () => {
   describe('locale file loaded in test runner', () => {
@@ -45,7 +46,7 @@ describe('osu_common', () => {
   describe('jsonClone', () => {
     it('clone object with different reference', () => {
       const obj = { test: '1234' };
-      const result = osu.jsonClone(obj);
+      const result = jsonClone(obj);
 
       expect(result).toEqual(obj);
       expect(result).not.toBe(obj);
@@ -53,18 +54,18 @@ describe('osu_common', () => {
 
     it('clone nested object with different reference', () => {
       const obj = { test: { inner: '1234' } };
-      const result = osu.jsonClone(obj);
+      const result = jsonClone(obj);
 
       expect(result.test).toEqual(obj.test);
       expect(result.test).not.toBe(obj.test);
     });
 
     it('clone null', () => {
-      expect(osu.jsonClone(null)).toBe(null);
+      expect(jsonClone(null)).toBe(null);
     });
 
     it('clone undefined', () => {
-      expect(osu.jsonClone(undefined)).toBe(undefined);
+      expect(jsonClone(undefined)).toBe(undefined);
     });
   });
 


### PR DESCRIPTION
extracted from #7915 as a base

`parseJson` is split into nullable and non-nullable versions so it's simpler to do type inference in code like `<Main follows={parseJson('json-follows-comment')} />` where the element is always expected to exist.