### PR TITLE
Add bottom line for wiki and news header

### DIFF
--- a/resources/assets/less/bem/osu-md.less
+++ b/resources/assets/less/bem/osu-md.less
@@ -127,6 +127,8 @@
       .@{_top}--wiki & {
         margin-right: 0;
         margin-bottom: 10px;
+        padding-bottom: 5px;
+        border-bottom: 1px solid hsl(var(--hsl-b3));
       }
     }
 
@@ -141,6 +143,13 @@
 
       .@{_top}--news & {
         font-size: @font-size--title;
+        padding-bottom: 5px;
+        border-bottom: 1px solid hsl(var(--hsl-b3));
+      }
+
+      .@{_top}--wiki & {
+        padding-bottom: 5px;
+        border-bottom: 1px solid hsl(var(--hsl-b3));
       }
     }
 


### PR DESCRIPTION
Part of #5529

Just small changes compare to other wiki PR.

After asking in `osu-wiki` discord channel, looks like this is an okay changes for both news and wiki. Only applied for h1 and h2 like in markdown github.