### PR TITLE
Add login error hint to OAuth authorisation failure

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -32,6 +32,7 @@ use Illuminate\Contracts\Auth\Authenticatable as AuthenticatableContract;
 use Illuminate\Contracts\Translation\HasLocalePreference;
 use Illuminate\Database\QueryException;
 use Laravel\Passport\HasApiTokens;
+use League\OAuth2\Server\Exception\OAuthServerException;
 use Request;
 
 /**
@@ -1881,7 +1882,13 @@ class User extends Model implements AfterCommit, AuthenticatableContract, HasLoc
 
     public function validateForPassportPasswordGrant($password)
     {
-        return static::attemptLogin($this, $password) === null;
+        $authError = static::attemptLogin($this, $password);
+
+        if ($authError === null) {
+            return true;
+        }
+
+        throw OAuthServerException::invalidGrant($authError);
     }
 
     public function playCount()

--- a/composer.json
+++ b/composer.json
@@ -33,6 +33,7 @@
     "league/commonmark": "^2.0",
     "league/flysystem-aws-s3-v3": "*",
     "league/fractal": "*",
+    "league/oauth2-server": "^8.3",
     "maennchen/zipstream-php": "^2.1",
     "mariuzzo/laravel-js-localization": "*",
     "paypal/paypal-checkout-sdk": "*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2d6f8c99aa5a89f13f2cc55db09e75f9",
+    "content-hash": "17aea4718b799997a86ec57125dd6f55",
     "packages": [
         {
             "name": "anhskohbo/no-captcha",
@@ -4421,16 +4421,16 @@
         },
         {
             "name": "league/oauth2-server",
-            "version": "8.2.4",
+            "version": "8.3.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/oauth2-server.git",
-                "reference": "622eaa1f28eb4a2dea0cfc7e4f5280fac794e83c"
+                "reference": "0809487d33dd8a2c8c8c04e4a599ba4aadba1ae6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/oauth2-server/zipball/622eaa1f28eb4a2dea0cfc7e4f5280fac794e83c",
-                "reference": "622eaa1f28eb4a2dea0cfc7e4f5280fac794e83c",
+                "url": "https://api.github.com/repos/thephpleague/oauth2-server/zipball/0809487d33dd8a2c8c8c04e4a599ba4aadba1ae6",
+                "reference": "0809487d33dd8a2c8c8c04e4a599ba4aadba1ae6",
                 "shasum": ""
             },
             "require": {
@@ -4496,7 +4496,7 @@
             ],
             "support": {
                 "issues": "https://github.com/thephpleague/oauth2-server/issues",
-                "source": "https://github.com/thephpleague/oauth2-server/tree/8.2.4"
+                "source": "https://github.com/thephpleague/oauth2-server/tree/8.3.2"
             },
             "funding": [
                 {
@@ -4504,7 +4504,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2020-12-10T11:35:44+00:00"
+            "time": "2021-07-27T08:17:08+00:00"
         },
         {
             "name": "maennchen/zipstream-php",


### PR DESCRIPTION
Returning in `hint` field same message as the one on osu-web login box.

```json
{
    "error": "invalid_grant",
    "error_description": "The provided authorization grant (e.g., authorization code, resource owner credentials) or refresh token is invalid, expired, revoked, does not match the redirection URI used in the authorization request, or was issued to another client.",
    "hint": "your IP address is locked. Please wait a few minutes.",
    "message": "The provided authorization grant (e.g., authorization code, resource owner credentials) or refresh token is invalid, expired, revoked, does not match the redirection URI used in the authorization request, or was issued to another client."
}
```