### PR TITLE
Convert Beatmap Factory to be class based

### DIFF
--- a/database/factories/BeatmapFactory.php
+++ b/database/factories/BeatmapFactory.php
@@ -3,65 +3,56 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+namespace Database\Factories;
+
 use App\Models\Beatmap;
 use App\Models\Beatmapset;
+use Illuminate\Database\Eloquent\Factories\Factory;
 
-/*
-|--------------------------------------------------------------------------
-| Model Factories
-|--------------------------------------------------------------------------
-|
-| Here you may define all of your model factories. Model factories give
-| you a convenient way to create models for testing and seeding your
-| database. Just tell the factory how a default model should look.
-|
-*/
+class BeatmapFactory extends Factory
+{
+    protected $model = Beatmap::class;
 
-$factory->define(Beatmap::class, function (Faker\Generator $faker) {
-    $name = $faker->sentence(3);
-    $length = rand(30, 200);
-    $hits = rand(100, 2000);
-    $hitsSpinner = rand(0, 5);
-    $hitsNormal = round(($hits - $hitsSpinner) * 0.9);
-    $hitsSlider = $hits - $hitsSpinner - $hitsNormal;
-    $playCount = rand(0, 50000);
+    public function definition(): array
+    {
+        return [
+            'filename' => fn () => $this->faker->sentence(3),
+            'checksum' => str_repeat('0', 32),
+            'version' => fn () => $this->faker->domainWord(),
+            'total_length' => rand(30, 200),
+            'hit_length' => fn (array $attr) => $attr['total_length'] - rand(0, 20),
+            'countSpinner' => rand(0, 5),
+            'countNormal' => rand(100, 2000),
+            'bpm' => rand(100, 200),
+            'diff_drain' => rand(0, 10),
+            'diff_size' => rand(0, 10),
+            'diff_overall' => rand(0, 10),
+            'diff_approach' => rand(0, 10),
+            'playmode' => array_rand_val(Beatmap::MODES),
+            'approved' => array_rand_val(Beatmapset::STATES),
+            'difficultyrating' => rand(0, 5000) / 1000,
+            'playcount' => rand(0, 50000),
 
-    return [
-        'filename' => $name,
-        'checksum' => str_repeat('0', 32),
-        'version' => $faker->domainWord,
-        'total_length' => $length,
-        'hit_length' => $length - rand(0, 20),
-        'countNormal' => $hitsNormal,
-        'countSlider' => $hitsSlider,
-        'countSpinner' => $hitsSpinner,
-        'bpm' => rand(100, 200),
-        'diff_drain' => rand(0, 10),
-        'diff_size' => rand(0, 10),
-        'diff_overall' => rand(0, 10),
-        'diff_approach' => rand(0, 10),
-        'playmode' => array_rand_val(Beatmap::MODES),
-        'approved' => rand(-2, 4),
-        'difficultyrating' => rand(0, 5000) / 1000,
-        'playcount' => $playCount,
-        'passcount' => round($playCount * 0.7),
-    ];
-});
+            // depends on countNormal
+            'countSlider' => fn (array $attr) => round($attr['countNormal'] / 9),
 
-$factory->state(Beatmap::class, 'approved', function (Faker\Generator $faker) {
-    return [
-        'approved' => 3,
-    ];
-});
+            // depends on playcount
+            'passcount' => fn (array $attr) => round($attr['playcount'] * 0.7),
+        ];
+    }
 
-$factory->state(Beatmap::class, 'wip', function (Faker\Generator $faker) {
-    return [
-        'approved' => Beatmapset::STATES['wip'],
-    ];
-});
+    public function qualified()
+    {
+        return $this->state(['approved' => Beatmapset::STATES['qualified']]);
+    }
 
-$factory->state(Beatmap::class, 'ranked', function (Faker\Generator $faker) {
-    return [
-        'approved' => Beatmapset::STATES['ranked'],
-    ];
-});
+    public function ranked()
+    {
+        return $this->state(['approved' => Beatmapset::STATES['ranked']]);
+    }
+
+    public function wip()
+    {
+        return $this->state(['approved' => Beatmapset::STATES['wip']]);
+    }
+}

--- a/database/factories/BeatmapsetFactory.php
+++ b/database/factories/BeatmapsetFactory.php
@@ -78,7 +78,7 @@ $factory->state(Beatmapset::class, 'qualified', function () {
 $factory->afterCreatingState(Beatmapset::class, 'with_discussion', function (App\Models\Beatmapset $beatmapset) {
     if (
         !$beatmapset->beatmaps()->save(
-            factory(App\Models\Beatmap::class)->make()
+            App\Models\Beatmap::factory()->make()
         )
     ) {
         throw new Exception();

--- a/database/factories/Multiplayer/PlaylistItemFactory.php
+++ b/database/factories/Multiplayer/PlaylistItemFactory.php
@@ -6,7 +6,7 @@
 $factory->define(App\Models\Multiplayer\PlaylistItem::class, function (Faker\Generator $faker) {
     return [
         'beatmap_id' => function () {
-            return factory(App\Models\Beatmap::class)->create()->getKey();
+            return App\Models\Beatmap::factory()->create()->getKey();
         },
         'room_id' => function () {
             return factory(App\Models\Multiplayer\Room::class)->create()->getKey();

--- a/database/factories/ScoreBestFactory.php
+++ b/database/factories/ScoreBestFactory.php
@@ -11,7 +11,7 @@ foreach (Beatmap::MODES as $modeStr => $modeInt) {
     $class = ScoreBest::class.'\\'.studly_case($modeStr);
 
     $factory->define($class, function (Faker\Generator $faker) use ($modeInt) {
-        $beatmap = factory(Beatmap::class)->create([
+        $beatmap = Beatmap::factory()->create([
             'playmode' => $modeInt, // force playmode to match score type
         ]);
         $maxCombo = rand(1, $beatmap->countNormal);

--- a/tests/Browser/BeatmapDiscussionPostsTest.php
+++ b/tests/Browser/BeatmapDiscussionPostsTest.php
@@ -109,7 +109,7 @@ class BeatmapDiscussionPostsTest extends DuskTestCase
         $this->beatmapset = factory(Beatmapset::class)->create([
             'user_id' => $this->mapper->getKey(),
         ]);
-        $this->beatmap = $this->beatmapset->beatmaps()->save(factory(Beatmap::class)->make([
+        $this->beatmap = $this->beatmapset->beatmaps()->save(Beatmap::factory()->make([
             'user_id' => $this->mapper->getKey(),
         ]));
         $this->beatmapDiscussion = factory(BeatmapDiscussion::class)->states('timeline')->create([

--- a/tests/Browser/SanityTest.php
+++ b/tests/Browser/SanityTest.php
@@ -83,7 +83,7 @@ class SanityTest extends DuskTestCase
             'language_id' => self::$scaffolding['language']->language_id,
             'user_id' => self::$scaffolding['user']->getKey(),
         ]);
-        self::$scaffolding['beatmap'] = factory(\App\Models\Beatmap::class)->create([
+        self::$scaffolding['beatmap'] = \App\Models\Beatmap::factory()->create([
             'beatmapset_id' => self::$scaffolding['beatmapset']->getKey(),
         ]);
         self::$scaffolding['beatmap_discussion'] = factory(\App\Models\BeatmapDiscussion::class)->create([

--- a/tests/Controllers/BeatmapDiscussionPostsControllerTest.php
+++ b/tests/Controllers/BeatmapDiscussionPostsControllerTest.php
@@ -913,7 +913,7 @@ class BeatmapDiscussionPostsControllerTest extends TestCase
         $this->beatmapset = factory(Beatmapset::class)->create([
             'user_id' => $this->mapper->getKey(),
         ]);
-        $this->beatmap = $this->beatmapset->beatmaps()->save(factory(Beatmap::class)->make([
+        $this->beatmap = $this->beatmapset->beatmaps()->save(Beatmap::factory()->make([
             'user_id' => $this->mapper->getKey(),
         ]));
         $this->beatmapDiscussion = factory(BeatmapDiscussion::class)->states('timeline')->create([
@@ -927,7 +927,7 @@ class BeatmapDiscussionPostsControllerTest extends TestCase
         $this->beatmapDiscussionPost = $this->beatmapDiscussion->beatmapDiscussionPosts()->save($post);
 
         $this->otherBeatmapset = factory(Beatmapset::class)->states('no_discussion')->create();
-        $this->otherBeatmapset->beatmaps()->save(factory(Beatmap::class)->make());
+        $this->otherBeatmapset->beatmaps()->save(Beatmap::factory()->make());
     }
 
     private function deletePost(BeatmapDiscussionPost $post, ?User $user = null)

--- a/tests/Controllers/BeatmapDiscussionsControllerTest.php
+++ b/tests/Controllers/BeatmapDiscussionsControllerTest.php
@@ -266,7 +266,7 @@ class BeatmapDiscussionsControllerTest extends TestCase
             'discussion_enabled' => true,
             'approved' => Beatmapset::STATES['pending'],
         ]);
-        $this->beatmap = $this->beatmapset->beatmaps()->save(factory(Beatmap::class)->make([
+        $this->beatmap = $this->beatmapset->beatmaps()->save(Beatmap::factory()->make([
             'user_id' => $this->mapper->user_id,
         ]));
         $this->discussion = BeatmapDiscussion::create([

--- a/tests/Controllers/BeatmapsControllerTest.php
+++ b/tests/Controllers/BeatmapsControllerTest.php
@@ -172,6 +172,6 @@ class BeatmapsControllerTest extends TestCase
         parent::setUp();
 
         $this->user = factory(User::class)->create();
-        $this->beatmap = factory(Beatmap::class)->states('approved')->create();
+        $this->beatmap = Beatmap::factory()->qualified()->create();
     }
 }

--- a/tests/Controllers/BeatmapsetsControllerTest.php
+++ b/tests/Controllers/BeatmapsetsControllerTest.php
@@ -35,7 +35,7 @@ class BeatmapsetsControllerTest extends TestCase
         $beatmapset = factory(Beatmapset::class)->create([
             'approved' => Beatmapset::STATES['pending'],
         ]);
-        $beatmap = factory(Beatmap::class)->create(['beatmapset_id' => $beatmapset->getKey()]);
+        $beatmap = Beatmap::factory()->create(['beatmapset_id' => $beatmapset->getKey()]);
         $nominator = $this->createUserWithGroupPlaymodes('bng', [$beatmap->mode]);
 
         $this->actingAsVerified($nominator)
@@ -50,7 +50,7 @@ class BeatmapsetsControllerTest extends TestCase
         $beatmapset = factory(Beatmapset::class)->create([
             'approved' => Beatmapset::STATES['pending'],
         ]);
-        $beatmap = factory(Beatmap::class)->create(['beatmapset_id' => $beatmapset->getKey()]);
+        $beatmap = Beatmap::factory()->create(['beatmapset_id' => $beatmapset->getKey()]);
         $nominator = $this->createUserWithGroupPlaymodes('bng', [$beatmap->mode]);
 
         $beatmapset->update(['user_id' => $nominator->getKey()]);
@@ -67,7 +67,7 @@ class BeatmapsetsControllerTest extends TestCase
         $beatmapset = factory(Beatmapset::class)->create([
             'approved' => Beatmapset::STATES['pending'],
         ]);
-        $beatmap = factory(Beatmap::class)->create(['beatmapset_id' => $beatmapset->getKey()]);
+        $beatmap = Beatmap::factory()->create(['beatmapset_id' => $beatmapset->getKey()]);
         $nominator = $this->createUserWithGroupPlaymodes('bng', [$beatmap->mode]);
 
         $beatmap->update(['user_id' => $nominator->getKey()]);

--- a/tests/Controllers/Multiplayer/RoomsControllerTest.php
+++ b/tests/Controllers/Multiplayer/RoomsControllerTest.php
@@ -151,7 +151,7 @@ class RoomsControllerTest extends TestCase
     {
         $token = factory(Token::class)->create(['scopes' => ['*']]);
         $beatmapset = factory(Beatmapset::class)->create();
-        $beatmap = factory(Beatmap::class)->create(['beatmapset_id' => $beatmapset->getKey()]);
+        $beatmap = Beatmap::factory()->create(['beatmapset_id' => $beatmapset->getKey()]);
 
         $roomsCountInitial = Room::count();
         $playlistItemsCountInitial = PlaylistItem::count();
@@ -302,7 +302,7 @@ class RoomsControllerTest extends TestCase
     private function createBasicStoreParams()
     {
         $beatmapset = factory(Beatmapset::class)->create();
-        $beatmap = factory(Beatmap::class)->create(['beatmapset_id' => $beatmapset->getKey()]);
+        $beatmap = Beatmap::factory()->create(['beatmapset_id' => $beatmapset->getKey()]);
 
         return [
             'name' => 'test room '.rand(),

--- a/tests/Controllers/Solo/ScoreTokensControllerTest.php
+++ b/tests/Controllers/Solo/ScoreTokensControllerTest.php
@@ -19,7 +19,7 @@ class ScoreTokensControllerTest extends TestCase
     public function testStore($beatmapState, $passRulesetId, $hashParam, $status)
     {
         $user = factory(User::class)->create();
-        $beatmap = factory(Beatmap::class)->states($beatmapState)->create();
+        $beatmap = Beatmap::factory()->$beatmapState()->create();
         $build = Build::factory()->create(['allow_ranking' => true]);
         $initialScoreTokenCount = ScoreToken::count();
 

--- a/tests/Controllers/Solo/ScoresControllerTest.php
+++ b/tests/Controllers/Solo/ScoresControllerTest.php
@@ -17,7 +17,7 @@ class ScoresControllerTest extends TestCase
     public function testStore()
     {
         $user = factory(User::class)->create();
-        $beatmap = factory(Beatmap::class)->states('ranked')->create();
+        $beatmap = Beatmap::factory()->ranked()->create();
         $scoreToken = ScoreToken::create([
             'beatmap_id' => $beatmap->getKey(),
             'ruleset_id' => $beatmap->playmode,
@@ -55,7 +55,7 @@ class ScoresControllerTest extends TestCase
     public function testStoreCompleted()
     {
         $user = factory(User::class)->create();
-        $beatmap = factory(Beatmap::class)->states('ranked')->create();
+        $beatmap = Beatmap::factory()->ranked()->create();
         // TODO: create factory
         $score = Score::createFromJsonOrExplode([
             'accuracy' => 1,
@@ -104,7 +104,7 @@ class ScoresControllerTest extends TestCase
     public function testStoreMissingData()
     {
         $user = factory(User::class)->create();
-        $beatmap = factory(Beatmap::class)->states('ranked')->create();
+        $beatmap = Beatmap::factory()->ranked()->create();
         $scoreToken = ScoreToken::create([
             'beatmap_id' => $beatmap->getKey(),
             'ruleset_id' => $beatmap->playmode,
@@ -133,7 +133,7 @@ class ScoresControllerTest extends TestCase
     {
         $user = factory(User::class)->create();
         $otherUser = factory(User::class)->create();
-        $beatmap = factory(Beatmap::class)->states('ranked')->create();
+        $beatmap = Beatmap::factory()->ranked()->create();
         $scoreToken = ScoreToken::create([
             'beatmap_id' => $beatmap->getKey(),
             'ruleset_id' => $beatmap->playmode,

--- a/tests/Libraries/BeatmapsetDiscussionReviewTest.php
+++ b/tests/Libraries/BeatmapsetDiscussionReviewTest.php
@@ -244,7 +244,7 @@ class BeatmapsetDiscussionReviewTest extends TestCase
     {
         $gmtUser = factory(User::class)->states('gmt')->create();
         $beatmapset = factory(Beatmapset::class)->states('qualified')->create();
-        $beatmapset->beatmaps()->save(factory(Beatmap::class)->make());
+        $beatmapset->beatmaps()->save(Beatmap::factory()->make());
         $watchingUser = factory(User::class)->create();
         $beatmapset->watches()->create(['user_id' => $watchingUser->getKey()]);
 
@@ -280,7 +280,7 @@ class BeatmapsetDiscussionReviewTest extends TestCase
             'discussion_enabled' => true,
             'approved' => Beatmapset::STATES['pending'],
         ]);
-        $beatmapset->beatmaps()->save(factory(Beatmap::class)->make());
+        $beatmapset->beatmaps()->save(Beatmap::factory()->make());
 
         $playmode = $beatmapset->playmodesStr()[0];
         $natUser = $this->createUserWithGroupPlaymodes('nat', [$playmode]);
@@ -328,7 +328,7 @@ class BeatmapsetDiscussionReviewTest extends TestCase
     {
         $gmtUser = factory(User::class)->states('gmt')->create();
         $beatmapset = factory(Beatmapset::class)->states($state)->create();
-        $beatmapset->beatmaps()->save(factory(Beatmap::class)->make(['playmode' => 0]));
+        $beatmapset->beatmaps()->save(Beatmap::factory()->make(['playmode' => 0]));
 
         $notificationOption = $gmtUser->notificationOptions()->firstOrCreate([
             'name' => Notification::BEATMAPSET_DISCUSSION_QUALIFIED_PROBLEM,
@@ -565,7 +565,7 @@ class BeatmapsetDiscussionReviewTest extends TestCase
     {
         $gmtUser = factory(User::class)->states('gmt')->create();
         $beatmapset = factory(Beatmapset::class)->states('qualified')->create();
-        $beatmapset->beatmaps()->save(factory(Beatmap::class)->make());
+        $beatmapset->beatmaps()->save(Beatmap::factory()->make());
         $review = $this->setUpPraiseOnlyReview($beatmapset, $gmtUser);
 
         // ensure qualified beatmap is qualified
@@ -601,7 +601,7 @@ class BeatmapsetDiscussionReviewTest extends TestCase
             'discussion_enabled' => true,
             'approved' => Beatmapset::STATES['pending'],
         ]);
-        $beatmapset->beatmaps()->save(factory(Beatmap::class)->make());
+        $beatmapset->beatmaps()->save(Beatmap::factory()->make());
 
         $playmode = $beatmapset->playmodesStr()[0];
         $natUser = $this->createUserWithGroupPlaymodes('nat', [$playmode]);
@@ -647,7 +647,7 @@ class BeatmapsetDiscussionReviewTest extends TestCase
     {
         $gmtUser = factory(User::class)->states('gmt')->create();
         $beatmapset = factory(Beatmapset::class)->states($state)->create();
-        $beatmapset->beatmaps()->save(factory(Beatmap::class)->make(['playmode' => 0]));
+        $beatmapset->beatmaps()->save(Beatmap::factory()->make(['playmode' => 0]));
 
         $notificationOption = $gmtUser->notificationOptions()->firstOrCreate([
             'name' => Notification::BEATMAPSET_DISCUSSION_QUALIFIED_PROBLEM,
@@ -737,7 +737,7 @@ class BeatmapsetDiscussionReviewTest extends TestCase
             'discussion_enabled' => true,
             'approved' => Beatmapset::STATES['pending'],
         ]);
-        $this->beatmap = $this->beatmapset->beatmaps()->save(factory(Beatmap::class)->make());
+        $this->beatmap = $this->beatmapset->beatmaps()->save(Beatmap::factory()->make());
     }
 
     protected function setUpReview($beatmapset = null): BeatmapDiscussion

--- a/tests/Models/BeatmapDiscussionPostTest.php
+++ b/tests/Models/BeatmapDiscussionPostTest.php
@@ -20,7 +20,7 @@ class BeatmapDiscussionPostTest extends TestCase
     public function testMessageCharacterLimitGeneralAll()
     {
         $beatmapset = factory(Beatmapset::class)->create(['discussion_enabled' => true]);
-        $beatmap = $beatmapset->beatmaps()->save(factory(Beatmap::class)->make());
+        $beatmap = $beatmapset->beatmaps()->save(Beatmap::factory()->make());
         $user = factory(User::class)->create();
         $discussion = BeatmapDiscussion::create([
             'beatmapset_id' => $beatmapset->getKey(),
@@ -39,7 +39,7 @@ class BeatmapDiscussionPostTest extends TestCase
     public function testMessageCharacterLimitGeneral()
     {
         $beatmapset = factory(Beatmapset::class)->create(['discussion_enabled' => true]);
-        $beatmap = $beatmapset->beatmaps()->save(factory(Beatmap::class)->make());
+        $beatmap = $beatmapset->beatmaps()->save(Beatmap::factory()->make());
         $user = factory(User::class)->create();
         $discussion = BeatmapDiscussion::create([
             'beatmapset_id' => $beatmapset->getKey(),
@@ -59,7 +59,7 @@ class BeatmapDiscussionPostTest extends TestCase
     public function testMessageCharacterLimitTimeline()
     {
         $beatmapset = factory(Beatmapset::class)->create(['discussion_enabled' => true]);
-        $beatmap = $beatmapset->beatmaps()->save(factory(Beatmap::class)->make());
+        $beatmap = $beatmapset->beatmaps()->save(Beatmap::factory()->make());
         $user = factory(User::class)->create();
         $discussion = BeatmapDiscussion::create([
             'beatmapset_id' => $beatmapset->getKey(),
@@ -84,7 +84,7 @@ class BeatmapDiscussionPostTest extends TestCase
     public function testScopeOpenProblems()
     {
         $beatmapset = factory(Beatmapset::class)->create(['discussion_enabled' => true]);
-        $beatmap = $beatmapset->beatmaps()->save(factory(Beatmap::class)->make());
+        $beatmap = $beatmapset->beatmaps()->save(Beatmap::factory()->make());
         $user = factory(User::class)->create();
         $discussion = BeatmapDiscussion::create([
             'beatmapset_id' => $beatmapset->getKey(),
@@ -107,7 +107,7 @@ class BeatmapDiscussionPostTest extends TestCase
     public function testScopeByTypes()
     {
         $beatmapset = factory(Beatmapset::class)->create(['discussion_enabled' => true]);
-        $beatmap = $beatmapset->beatmaps()->save(factory(Beatmap::class)->make());
+        $beatmap = $beatmapset->beatmaps()->save(Beatmap::factory()->make());
         $user = factory(User::class)->create();
         $discussion = BeatmapDiscussion::create([
             'beatmapset_id' => $beatmapset->getKey(),
@@ -151,7 +151,7 @@ class BeatmapDiscussionPostTest extends TestCase
     public function testSoftDeleteOrExplode()
     {
         $beatmapset = factory(Beatmapset::class)->create(['discussion_enabled' => true]);
-        $beatmap = $beatmapset->beatmaps()->save(factory(Beatmap::class)->make());
+        $beatmap = $beatmapset->beatmaps()->save(Beatmap::factory()->make());
         $user = factory(User::class)->create();
         $discussion = BeatmapDiscussion::create([
             'beatmapset_id' => $beatmapset->getKey(),

--- a/tests/Models/BeatmapDiscussionTest.php
+++ b/tests/Models/BeatmapDiscussionTest.php
@@ -31,7 +31,7 @@ class BeatmapDiscussionTest extends TestCase
             'discussion_enabled' => true,
             'user_id' => $mapper->getKey(),
         ]);
-        $beatmap = $beatmapset->beatmaps()->save(factory(Beatmap::class)->make());
+        $beatmap = $beatmapset->beatmaps()->save(Beatmap::factory()->make());
 
         $discussion = $this->newDiscussion($beatmapset);
         $discussion->fill([
@@ -64,7 +64,7 @@ class BeatmapDiscussionTest extends TestCase
             'discussion_enabled' => true,
             'user_id' => $mapper->getKey(),
         ]);
-        $beatmap = $beatmapset->beatmaps()->save(factory(Beatmap::class)->make());
+        $beatmap = $beatmapset->beatmaps()->save(Beatmap::factory()->make());
         $modder = factory(User::class)->create();
 
         $discussion = $this->newDiscussion($beatmapset);
@@ -99,10 +99,10 @@ class BeatmapDiscussionTest extends TestCase
     public function testIsValid()
     {
         $beatmapset = factory(Beatmapset::class)->create(['discussion_enabled' => true]);
-        $beatmap = $beatmapset->beatmaps()->save(factory(Beatmap::class)->make());
+        $beatmap = $beatmapset->beatmaps()->save(Beatmap::factory()->make());
 
         $otherBeatmapset = factory(Beatmapset::class)->create();
-        $otherBeatmap = $otherBeatmapset->beatmaps()->save(factory(Beatmap::class)->make());
+        $otherBeatmap = $otherBeatmapset->beatmaps()->save(Beatmap::factory()->make());
 
         $validTimestamp = ($beatmap->total_length + 10) * 1000;
         $invalidTimestamp = $validTimestamp + 1;
@@ -153,7 +153,7 @@ class BeatmapDiscussionTest extends TestCase
     public function testSoftDeleteOrExplode()
     {
         $beatmapset = factory(Beatmapset::class)->create(['discussion_enabled' => true]);
-        $beatmap = $beatmapset->beatmaps()->save(factory(Beatmap::class)->make());
+        $beatmap = $beatmapset->beatmaps()->save(Beatmap::factory()->make());
         $user = factory(User::class)->create();
         $discussion = BeatmapDiscussion::create([
             'beatmapset_id' => $beatmapset->getKey(),

--- a/tests/Models/BeatmapsetTest.php
+++ b/tests/Models/BeatmapsetTest.php
@@ -425,7 +425,7 @@ class BeatmapsetTest extends TestCase
         }
 
         $beatmapset = factory(Beatmapset::class)->create(array_merge($defaultParams, $params));
-        $beatmapset->beatmaps()->save(factory(Beatmap::class)->make());
+        $beatmapset->beatmaps()->save(Beatmap::factory()->make());
         factory(BeatmapMirror::class)->states('default')->create();
 
         return $beatmapset;
@@ -450,7 +450,7 @@ class BeatmapsetTest extends TestCase
         $beatmapset = factory(Beatmapset::class)->create(array_merge($defaultParams, $params));
 
         foreach ($playmodes as $playmode) {
-            $beatmapset->beatmaps()->save(factory(Beatmap::class)->make(['playmode' => Beatmap::modeInt($playmode)]));
+            $beatmapset->beatmaps()->save(Beatmap::factory()->make(['playmode' => Beatmap::modeInt($playmode)]));
         }
         factory(BeatmapMirror::class)->states('default')->create();
 

--- a/tests/Models/Multiplayer/RoomTest.php
+++ b/tests/Models/Multiplayer/RoomTest.php
@@ -17,7 +17,7 @@ class RoomTest extends TestCase
 {
     public function testStartGameWithBeatmap()
     {
-        $beatmap = factory(Beatmap::class)->create();
+        $beatmap = Beatmap::factory()->create();
         $user = factory(User::class)->create();
 
         $params = [
@@ -37,7 +37,7 @@ class RoomTest extends TestCase
 
     public function testStartGameWithDeletedBeatmap()
     {
-        $beatmap = factory(Beatmap::class)->create(['deleted_at' => now()]);
+        $beatmap = Beatmap::factory()->create(['deleted_at' => now()]);
         $user = factory(User::class)->create();
 
         $params = [


### PR DESCRIPTION
One model at a time. This includes changing `approved` state to its correct name, `qualified`.