### PR TITLE
Add missing headers in docs example

### DIFF
--- a/resources/views/docs/info.blade.php
+++ b/resources/views/docs/info.blade.php
@@ -105,7 +105,7 @@ Restricted users can grant authorization like anyone else. If your client should
         'boundUri' => $uri,
         'cleanBodyParameters' => [],
         'fileParameters' => [],
-        'headers' => $defaultHeaders,
+        'headers' => [],
         'metadata' => ['authenticated' => false, 'description' => $description],
         'methods' => ['GET'],
         'nestedBodyParameters' => [],


### PR DESCRIPTION
I was hoping I could get away without specifying this :eyes: 

Resolves #8231