### PR TITLE
Rename star difficulty to star rating on beatmap info page

### DIFF
--- a/resources/lang/en/beatmapsets.php
+++ b/resources/lang/en/beatmapsets.php
@@ -181,7 +181,7 @@ return [
             'drain' => 'HP Drain',
             'accuracy' => 'Accuracy',
             'ar' => 'Approach Rate',
-            'stars' => 'Star Difficulty',
+            'stars' => 'Star Rating',
             'total_length' => 'Length (Drain length: :hit_length)',
             'bpm' => 'BPM',
             'count_circles' => 'Circle Count',


### PR DESCRIPTION
"Star rating" seems like the correct and well-known term:
- Wiki: https://osu.ppy.sh/wiki/en/Beatmapping/Star_rating
- Tournament client beatmap display:
	<img width="189" alt="Screen Shot 2021-10-25 at 10 03 51 PM" src="https://user-images.githubusercontent.com/35318437/138812082-65829a7a-3271-4486-9519-57dbde5d2492.png">

	