### PR TITLE
Add "only fade approach circles" setting to hidden mod

### DIFF
--- a/app/Libraries/Multiplayer/Mod.php
+++ b/app/Libraries/Multiplayer/Mod.php
@@ -232,6 +232,9 @@ class Mod
         self::OSU_NO_SCOPE => [
             'hidden_combo_count' => 'int',
         ],
+        self::HIDDEN => [
+            'only_fade_approach_circles' => 'bool',
+        ],
     ];
 
     public static function assertValidExclusivity($requiredIds, $allowedIds, $ruleset)


### PR DESCRIPTION
Reference: https://github.com/ppy/osu/pull/15284

While the setting is only valid for osu! (the ruleset) there is precedent for adding ruleset-specific settings to the global dictionary of permissible settings (namely, [mirror](https://github.com/ppy/osu-web/pull/7941) and [difficulty adjust](https://github.com/ppy/osu-web/pull/7779)).