### PR TITLE
Handle replay download with missing beatmap or user

### DIFF
--- a/app/Http/Controllers/ScoresController.php
+++ b/app/Http/Controllers/ScoresController.php
@@ -49,12 +49,10 @@ class ScoresController extends Controller
             abort(404);
         }
 
-        $file = implode([
-            $replayFile->headerChunk(),
-            pack('i', strlen($body)),
-            $body,
-            $replayFile->endChunk(),
-        ]);
+        $file = $replayFile->headerChunk()
+            .pack('i', strlen($body))
+            .$body
+            .$replayFile->endChunk();
 
         return response()->streamDownload(fn () => echo $file, $filename, ['Content-Type' => 'application/x-osu-replay']);
     }

--- a/app/Http/Controllers/ScoresController.php
+++ b/app/Http/Controllers/ScoresController.php
@@ -54,7 +54,9 @@ class ScoresController extends Controller
             .$body
             .$replayFile->endChunk();
 
-        return response()->streamDownload(fn () => echo $file, $filename, ['Content-Type' => 'application/x-osu-replay']);
+        return response()->streamDownload(function () use ($file) {
+            echo $file;
+        }, $filename, ['Content-Type' => 'application/x-osu-replay']);
     }
 
     public function show($mode, $id)

--- a/app/Http/Controllers/ScoresController.php
+++ b/app/Http/Controllers/ScoresController.php
@@ -49,18 +49,14 @@ class ScoresController extends Controller
             abort(404);
         }
 
-        $file = [
+        $file = implode([
             $replayFile->headerChunk(),
             pack('i', strlen($body)),
             $body,
             $replayFile->endChunk(),
-        ];
+        ]);
 
-        return response()->streamDownload(function () use ($file) {
-            foreach ($file as $f) {
-                echo $f;
-            }
-        }, $filename, ['Content-Type' => 'application/x-osu-replay']);
+        return response()->streamDownload(fn () => echo $file, $filename, ['Content-Type' => 'application/x-osu-replay']);
     }
 
     public function show($mode, $id)

--- a/app/Libraries/ReplayFile.php
+++ b/app/Libraries/ReplayFile.php
@@ -5,6 +5,7 @@
 
 namespace App\Libraries;
 
+use App\Exceptions\InvariantException;
 use App\Models\Beatmap;
 use Storage;
 
@@ -62,9 +63,18 @@ class ReplayFile
     public function headerChunk(): string
     {
         $score = $this->score;
-        $beatmap = $score->beatmap;
+        $beatmap = $score->beatmap()->withTrashed()->first();
+
+        if ($beatmap === null) {
+            throw new InvariantException('score is missing beatmap');
+        }
+
         $mode = Beatmap::MODES[$score->getMode()];
         $user = $score->user;
+
+        if ($user === null) {
+            throw new InvariantException('score is missing user');
+        }
 
         $md5 = md5("{$score->maxcombo}osu{$user->username}{$beatmap->checksum}{$score->score}{$score->rank}");
         $ticks = $score->date->timestamp * 10000000 + 621355968000000000; // Conversion to dotnet DateTime.Ticks.

--- a/database/factories/BeatmapFactory.php
+++ b/database/factories/BeatmapFactory.php
@@ -16,6 +16,7 @@ class BeatmapFactory extends Factory
     public function definition(): array
     {
         return [
+            'beatmapset_id' => fn () => Beatmapset::factory(),
             'filename' => fn () => $this->faker->sentence(3),
             'checksum' => str_repeat('0', 32),
             'version' => fn () => $this->faker->domainWord(),

--- a/tests/Controllers/ScoresControllerTest.php
+++ b/tests/Controllers/ScoresControllerTest.php
@@ -28,6 +28,39 @@ class ScoresControllerTest extends TestCase
             ->assertSuccessful();
     }
 
+    public function testDownloadDeletedBeatmap()
+    {
+        $this->score->beatmap->delete();
+
+        $this
+            ->actingAs($this->user)
+            ->withHeaders(['HTTP_REFERER' => config('app.url').'/'])
+            ->get(route('scores.download', $this->params()))
+            ->assertSuccessful();
+    }
+
+    public function testDownloadMissingBeatmap()
+    {
+        $this->score->beatmap->forceDelete();
+
+        $this
+            ->actingAs($this->user)
+            ->withHeaders(['HTTP_REFERER' => config('app.url').'/'])
+            ->get(route('scores.download', $this->params()))
+            ->assertStatus(422);
+    }
+
+    public function testDownloadMissingUser()
+    {
+        $this->score->user->delete();
+
+        $this
+            ->actingAs($this->user)
+            ->withHeaders(['HTTP_REFERER' => config('app.url').'/'])
+            ->get(route('scores.download', $this->params()))
+            ->assertStatus(422);
+    }
+
     public function testDownloadInvalidReferer()
     {
         $this

--- a/tests/Libraries/ReplayFileTest.php
+++ b/tests/Libraries/ReplayFileTest.php
@@ -54,10 +54,18 @@ class ReplayFileTest extends TestCase
 
     private function knownScore($hasReplayRecord = true, ?int $version = 20180822)
     {
+        $beatmapId = 1103293;
+        $beatmap = Beatmap::find($beatmapId) ?? Beatmap::factory()->create(['beatmap_id' => $beatmapId]);
+        $beatmap->fill(['checksum' => '9256b75a0df345bbb279e35480729f14'])->saveOrExplode();
+
+        $userId = 6258604;
+        $user = User::find($userId) ?? User::factory()->create(['user_id' => $userId]);
+        $user->fill(['username' => 'I.R.Real'])->saveOrExplode(['skipValidations' => true]);
+
         $score = Best\Osu::make([
             'score_id' => 2493013207,
-            'beatmap_id' => 1103293,
-            'user_id' => 6258604,
+            'beatmap_id' => $beatmapId,
+            'user_id' => $userId,
             'score' => 2068825,
             'maxcombo' => 326,
             'rank' => 'SH',
@@ -74,14 +82,6 @@ class ReplayFileTest extends TestCase
             'replay' => true,
             'hidden' => 0,
             'country_acronym' => 'DE',
-            'user' => User::make([
-                'user_id' => 6258604,
-                'username' => 'I.R.Real',
-            ]),
-            'beatmap' => Beatmap::make([
-                'beatmap_id' => 1103293,
-                'checksum' => '9256b75a0df345bbb279e35480729f14',
-            ]),
         ]);
 
         if ($hasReplayRecord) {


### PR DESCRIPTION
`headerChunk` throwing error is too late to abort once streamDownload runs.