### PR TITLE
Fix artist track search's enter to submit on Safari

### DIFF
--- a/resources/assets/less/utilities.less
+++ b/resources/assets/less/utilities.less
@@ -53,6 +53,12 @@
   pointer-events: auto;
 }
 
+.u-invisible {
+  opacity: 0;
+  position: absolute;
+  pointer-events: none;
+}
+
 .u-nav-float {
   z-index: @z-index--nav-float !important;
 }

--- a/resources/assets/lib/artist-tracks-index/search-form.tsx
+++ b/resources/assets/lib/artist-tracks-index/search-form.tsx
@@ -89,7 +89,7 @@ export default class SearchForm extends React.Component<Props> {
   render() {
     return (
       <form className='artist-track-search-form' onSubmit={this.handleSubmit}>
-        <input className='hidden' type='submit' />
+        <input className='u-invisible' type='submit' />
         <div className='artist-track-search-form__content'>
           <input
             className='artist-track-search-form__big-input'


### PR DESCRIPTION
`display: none` is no-go but `opacity: 0; pointer-events: none` is a-ok it seems :ok_hand: 

Wanted to add `enterkeyhint` as well for fancy blue button but our current React version is too old and doesn't support it yet.

Resolves #8261.