### PR TITLE
Throw validation error when failing to save factory user

### DIFF
--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -28,6 +28,10 @@ class UserFactory extends Factory
     public function configure()
     {
         return $this->afterCreating(function (User $user) {
+            if (!$user->exists) {
+                throw new \Exception($user->validationErrors()->toSentence());
+            }
+
             $user->addToGroup(app('groups')->byId($user->group_id));
         });
     }


### PR DESCRIPTION
Sometimes the user generated by the factory fails to save but we can't see what the exact error is.