### PR TITLE
Update Lang.js initialisation

### DIFF
--- a/resources/assets/app.ts
+++ b/resources/assets/app.ts
@@ -69,7 +69,6 @@ import 'ujs-common.coffee';
 import 'bootstrap-modal.coffee';
 import 'shared.coffee';
 import 'turbolinks-overrides.coffee';
-import 'lang-overrides';
 
 import 'import-shims';  // shim imports to window
 import 'osu-core-singleton';

--- a/resources/assets/coffee/main.coffee
+++ b/resources/assets/coffee/main.coffee
@@ -6,7 +6,6 @@ window.polyfills ?= new Polyfills
 Turbolinks.start()
 Turbolinks.setProgressBarDelay(0)
 
-Lang.setLocale(window.currentLocale)
 moment.relativeTimeThreshold('ss', 44)
 moment.relativeTimeThreshold('s', 120)
 moment.relativeTimeThreshold('m', 120)

--- a/resources/assets/lib/app-deps.ts
+++ b/resources/assets/lib/app-deps.ts
@@ -13,6 +13,7 @@ import 'jquery-ui/ui/widgets/slider.js';
 import 'jquery-ui/ui/widgets/sortable.js';
 import 'blueimp-file-upload/js/jquery.fileupload.js';
 
+import { patchPluralHandler } from 'lang-overrides';
 import Lang from 'lang.js';
 import { configure as mobxConfigure } from 'mobx';
 import * as moment from 'moment';
@@ -21,6 +22,8 @@ import Turbolinks from 'turbolinks';
 declare global {
   interface Window {
     $: any;
+    currentLocale: string;
+    fallbackLocale: string;
     jQuery: any;
     Lang: Lang;
     LangMessages: unknown;
@@ -32,7 +35,11 @@ declare global {
 window.$ = $;
 window.jQuery = $;
 window.LangMessages ??= {};
-window.Lang = new Lang({ messages: window.LangMessages });
+window.Lang = patchPluralHandler(new Lang({
+  fallback: window.fallbackLocale,
+  locale: window.currentLocale,
+  messages: window.LangMessages,
+}));
 window.moment = moment;
 window.Turbolinks = Turbolinks;
 

--- a/resources/assets/lib/globals.d.ts
+++ b/resources/assets/lib/globals.d.ts
@@ -144,12 +144,6 @@ interface BeatmapsetDiscussionPostJson {
   message: string;
 }
 
-interface LangClass {
-  _getPluralForm: (count: number, locale: string) => number;
-  _origGetPluralForm: (count: number, locale: string) => number;
-  has(key: string): boolean;
-}
-
 interface TooltipDefault {
   remove: (el: HTMLElement) => void;
 }

--- a/resources/assets/lib/lang-overrides.ts
+++ b/resources/assets/lib/lang-overrides.ts
@@ -1,14 +1,26 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
-Lang._origGetPluralForm = Lang._getPluralForm;
+import Lang from 'lang.js';
 
 // pt-br isn't in original getPluralForm so the locale needs to be
 // temporarily changed to pt for the function to return correct form.
-Lang._getPluralForm = (count, locale) => {
+function getPluralForm(count: number, locale: string) {
   if (locale === 'pt-br') {
     locale = 'pt';
   }
 
-  return Lang._origGetPluralForm(count, locale);
-};
+  return this._origGetPluralForm(count, locale); // eslint-disable-line
+}
+
+export function patchPluralHandler(lang: Lang) {
+  /* eslint-disable */
+  // Monkey patches original class
+  // @ts-ignore
+  lang._origGetPluralForm = lang._getPluralForm;
+  // @ts-ignore
+  lang._getPluralForm = getPluralForm;
+  /* eslint-enable */
+
+  return lang;
+}

--- a/tests/karma/osu_common.spec.ts
+++ b/tests/karma/osu_common.spec.ts
@@ -7,7 +7,7 @@ import * as React from 'react';
 describe('osu_common', () => {
   describe('locale file loaded in test runner', () => {
     it('should be loaded', () => {
-      expect(Lang.has('common.confirmation')).toBe(true);
+      expect(window.Lang.has('common.confirmation')).toBe(true);
     });
   });
 


### PR DESCRIPTION
Make the patch a function instead of global and set locale on initialisation.

Currently with `Lang.setLocale` set quite late, `model/user`'s `deletedUser` (and potentially others?) isn't translated correctly on `pt-br` due to its locale being set as `pt-BR` (as per html lang tag) instead of `pt-br`.

This isn't related to the coffeescript module thingy change but has been a thing for quite a while (if not forever). I think.

Can be cleaned up further by moving translation related functions as its own utils but I'm not quite sure on the exact method yet.