### PR TITLE
Fix custom popup menu causing error

### DIFF
--- a/resources/assets/lib/popup-menu.coffee
+++ b/resources/assets/lib/popup-menu.coffee
@@ -126,7 +126,7 @@ export class PopupMenu extends PureComponent
     @portal ?= document.createElement('div')
 
     if @props.customRender
-      @props.customRender createPortal(@props.children(@dismiss), @portal), @button, @toggle
+      @props.customRender createPortal(@renderMenu(), @portal), @button, @toggle
     else
       div
         className: 'popup-menu'


### PR DESCRIPTION
Always use existing popup menu wrapper to simplify handling menu ref.

Resolves #8312.