### PR TITLE
Fix styling for discussion review selector menu

### DIFF
--- a/resources/assets/lib/beatmap-discussions/icon-dropdown-menu.tsx
+++ b/resources/assets/lib/beatmap-discussions/icon-dropdown-menu.tsx
@@ -28,7 +28,7 @@ export default class IconDropdownMenu extends React.Component<Props> {
     return (
       <PopupMenu customRender={this.renderButton}>
         {() => (
-          <div className='simple-menu'>
+          <div className='simple-menu simple-menu--popup-menu-compact'>
             {this.props.menuOptions.map(this.renderMenuItem)}
           </div>
         )}


### PR DESCRIPTION
I didn't see the additional styling when removing the class :eyes: 

I think the menu can also use a custom anchor positioning option...

- [x] doesn't actually depend on #8314 but the menu is broken without it