### PR TITLE
Enable no scope mod for osu!catch

### DIFF
--- a/app/Libraries/Multiplayer/Mod.php
+++ b/app/Libraries/Multiplayer/Mod.php
@@ -28,6 +28,7 @@ class Mod
     const RANDOM = 'RD';
     const MIRROR = 'MR';
     const MUTED = 'MU';
+    const NO_SCOPE = 'NS';
 
     // osu-specific
     const OSU_AUTOPILOT = 'AP';
@@ -43,7 +44,6 @@ class Mod
     const OSU_CLASSIC = 'CL';
     const OSU_BARRELROLL = 'BR';
     const OSU_APPROACH_DIFFERENT = 'AD';
-    const OSU_NO_SCOPE = 'NS';
 
     // mania-specific
     const MANIA_KEY1 = '1K';
@@ -229,7 +229,7 @@ class Mod
         self::PERFECT => [
             'restart' => 'bool',
         ],
-        self::OSU_NO_SCOPE => [
+        self::NO_SCOPE => [
             'hidden_combo_count' => 'int',
         ],
         self::HIDDEN => [
@@ -308,7 +308,7 @@ class Mod
                         self::RANDOM,
                         self::OSU_APPROACH_DIFFERENT,
                         self::MIRROR,
-                        self::OSU_NO_SCOPE,
+                        self::NO_SCOPE,
                     ]
                 ),
 
@@ -325,6 +325,7 @@ class Mod
                     [
                         self::CATCH_FLOATINGFRUIT,
                         self::MIRROR,
+                        self::NO_SCOPE,
                     ]
                 ),
 


### PR DESCRIPTION
Reference: https://github.com/ppy/osu/pull/15540

No new settings. Tested multiplayer & solo submission both with the new catch mod as well as the existing osu! mod, both work on my local setup (game + spectator server + web).

I believe that due to method of storage renaming the constant (while keeping its value the same) should be safe. Similar things have been done in the past, too (62929f1c).