### PR TITLE
Cast BeatmapsetEvent search type param to string

### DIFF
--- a/app/Models/BeatmapsetEvent.php
+++ b/app/Models/BeatmapsetEvent.php
@@ -161,7 +161,7 @@ class BeatmapsetEvent extends Model
 
         $params['types'] = [];
 
-        if (isset($rawParams['type'])) {
+        if (get_string($rawParams['type'] ?? null) !== null) {
             $params['types'][] = $rawParams['type'];
         }
 


### PR DESCRIPTION
Was `type` a convenience param or something? 🤔 
`type` should be `string` or `null` instead of something weird like `array`