### PR TITLE
Fix displayed channel messages being reset when opening new PM

### DIFF
--- a/app/Http/Controllers/ChatController.php
+++ b/app/Http/Controllers/ChatController.php
@@ -31,9 +31,8 @@ class ChatController extends Controller
         $user = auth()->user();
         Chat::ack($user);
 
-        $targetId = get_params(request()->all(), null, ['sendto:int'], ['null_missing' => true])['sendto'];
         // rejoin any existing channel first, otherwise it'll be missing from the preload later.
-        $targetUser = $targetId !== null ? User::lookup($targetId, 'id') : null;
+        $targetUser = User::lookup(get_int(request('sendto')), 'id');
         if ($targetUser !== null) {
             $channel = Channel::findPM($targetUser, $user);
             $channel?->addUser($user);

--- a/app/Http/Controllers/ChatController.php
+++ b/app/Http/Controllers/ChatController.php
@@ -10,7 +10,6 @@ use App\Libraries\UserChannelList;
 use App\Models\Chat\Channel;
 use App\Models\Chat\Message;
 use App\Models\User;
-use Request;
 
 class ChatController extends Controller
 {

--- a/app/Models/Chat/Channel.php
+++ b/app/Models/Chat/Channel.php
@@ -401,21 +401,14 @@ class Channel extends Model
     {
         $userChannel = $this->userChannelFor($user);
 
-        if ($userChannel) {
-            // already in channel, just broadcast event.
-            if (!$userChannel->isHidden()) {
-                event(new ChatChannelEvent($userChannel->channel, $user, 'join'));
-
-                return;
-            }
-
-            $userChannel->update(['hidden' => false]);
-        } else {
+        if ($userChannel === null) {
             $userChannel = new UserChannel();
             $userChannel->user()->associate($user);
             $userChannel->channel()->associate($this);
             $userChannel->save();
             $this->resetMemoized();
+        } elseif ($userChannel->isHidden()) {
+            $userChannel->update(['hidden' => false]);
         }
 
         event(new ChatChannelEvent($userChannel->channel, $user, 'join'));

--- a/resources/assets/lib/chat/channel-join-event.ts
+++ b/resources/assets/lib/chat/channel-join-event.ts
@@ -2,10 +2,10 @@
 // See the LICENCE file in the repository root for full licence text.
 
 import DispatcherAction from 'actions/dispatcher-action';
-import Channel from 'models/chat/channel';
+import ChannelJson from 'interfaces/chat/channel-json';
 
 export default class ChannelJoinEvent extends DispatcherAction {
-  constructor(readonly channel: Channel) {
+  constructor(readonly json: ChannelJson) {
     super();
   }
 }

--- a/resources/assets/lib/chat/chat-state-store.ts
+++ b/resources/assets/lib/chat/chat-state-store.ts
@@ -133,7 +133,7 @@ export default class ChatStateStore implements DispatchListener {
 
   @action
   private handleChatChannelJoinEvent(event: ChannelJoinEvent) {
-    this.channelStore.channels.set(event.channel.channelId, event.channel);
+    this.channelStore.getOrCreate(event.json.channel_id).updateWithJson(event.json);
   }
 
   @action

--- a/resources/assets/lib/chat/chat-worker.ts
+++ b/resources/assets/lib/chat/chat-worker.ts
@@ -6,7 +6,6 @@ import { dispatch, dispatchListener } from 'app-dispatcher';
 import DispatchListener from 'dispatch-listener';
 import { isChannelEvent } from 'interfaces/chat/channel-event-json';
 import { isMessageNewEvent } from 'interfaces/chat/messages-new-event-json';
-import Channel from 'models/chat/channel';
 import SocketMessageEvent, { SocketEventData } from 'socket-message-event';
 import ChannelJoinEvent from './channel-join-event';
 import ChannelPartEvent from './channel-part-event';
@@ -18,9 +17,7 @@ function newDispatchActionFromJson(json: SocketEventData) {
   } else if (isChannelEvent(json)) {
     switch (json.event) {
       case 'chat.channel.join': {
-        const channel = new Channel(json.data.channel_id);
-        channel.updateWithJson(json.data);
-        return new ChannelJoinEvent(channel);
+        return new ChannelJoinEvent(json.data);
       }
       case 'chat.channel.part':
         return new ChannelPartEvent(json.data.channel_id);


### PR DESCRIPTION
Opening chat with `?sendto=$userId` causes other tabs with chat open to have that channel's display reset.

Also fixes another issue with the user preloading order when rejoining channels (causes other chat tabs to die because details in the socket event are missing)