### PR TITLE
Add missing makeObservable calls

### DIFF
--- a/resources/assets/lib/beatmaps/beatmapset-card-size-selector.tsx
+++ b/resources/assets/lib/beatmaps/beatmapset-card-size-selector.tsx
@@ -2,7 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 import { BeatmapsetCardSize } from 'beatmapset-panel';
-import { computed } from 'mobx';
+import { computed, makeObservable } from 'mobx';
 import { observer } from 'mobx-react';
 import core from 'osu-core-singleton';
 import * as React from 'react';
@@ -23,6 +23,12 @@ export default class BeatmapsetCardViewSelector extends React.Component<Props> {
   @computed
   private get isActive() {
     return this.props.size === core.userPreferences.get('beatmapset_card_size');
+  }
+
+  constructor(props: Props) {
+    super(props);
+
+    makeObservable(this);
   }
 
   render() {

--- a/resources/assets/lib/chat-icon.tsx
+++ b/resources/assets/lib/chat-icon.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
-import { computed } from 'mobx';
+import { computed, makeObservable } from 'mobx';
 import { observer } from 'mobx-react';
 import NotificationIcon from 'notification-icon';
 import core from 'osu-core-singleton';
@@ -16,6 +16,12 @@ export default class ChatIcon extends React.Component<Props> {
   @computed
   private get unreadCount() {
     return core.dataStore.notificationStore.unreadStacks.getOrCreateType({ objectType: 'channel' }).total;
+  }
+
+  constructor(props: Props) {
+    super(props);
+
+    makeObservable(this);
   }
 
   render() {

--- a/resources/assets/lib/chat/main-view.tsx
+++ b/resources/assets/lib/chat/main-view.tsx
@@ -3,7 +3,7 @@
 
 import HeaderV4 from 'header-v4';
 import Img2x from 'img2x';
-import { action, makeObservable } from 'mobx';
+import { action, makeObservable, runInAction } from 'mobx';
 import { observer, Provider } from 'mobx-react';
 import * as React from 'react';
 import RootDataStore from 'stores/root-data-store';
@@ -29,10 +29,12 @@ export default class MainView extends React.Component<Props> {
     this.props.dataStore.chatState.isChatMounted = true;
   }
 
-  @action
   componentWillUnmount() {
     $('html').removeClass('osu-layout--mobile-app');
-    this.props.dataStore.chatState.isChatMounted = false;
+
+    runInAction(() => {
+      this.props.dataStore.chatState.isChatMounted = false;
+    });
   }
 
   render(): React.ReactNode {

--- a/resources/assets/lib/chat/main-view.tsx
+++ b/resources/assets/lib/chat/main-view.tsx
@@ -3,7 +3,7 @@
 
 import HeaderV4 from 'header-v4';
 import Img2x from 'img2x';
-import { action } from 'mobx';
+import { action, makeObservable } from 'mobx';
 import { observer, Provider } from 'mobx-react';
 import * as React from 'react';
 import RootDataStore from 'stores/root-data-store';
@@ -17,6 +17,12 @@ interface Props {
 
 @observer
 export default class MainView extends React.Component<Props> {
+  constructor(props: Props) {
+    super(props);
+
+    makeObservable(this);
+  }
+
   @action
   componentDidMount() {
     $('html').addClass('osu-layout--mobile-app');

--- a/resources/assets/lib/main-notification-icon.tsx
+++ b/resources/assets/lib/main-notification-icon.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
-import { computed } from 'mobx';
+import { computed, makeObservable } from 'mobx';
 import { observer } from 'mobx-react';
 import { typeNames } from 'models/notification-type';
 import NotificationIcon from 'notification-icon';
@@ -23,6 +23,12 @@ export default class MainNotificationIcon extends React.Component<Props> {
 
   private get unreadLegacyPmCount() {
     return core.currentUser?.unread_pm_count ?? 0;
+  }
+
+  constructor(props: Props) {
+    super(props);
+
+    makeObservable(this);
   }
 
   render() {

--- a/resources/assets/lib/notification-widget/main.tsx
+++ b/resources/assets/lib/notification-widget/main.tsx
@@ -2,7 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 import { route } from 'laroute';
-import { computed } from 'mobx';
+import { computed, makeObservable } from 'mobx';
 import { observer } from 'mobx-react';
 import { Name, typeNames } from 'models/notification-type';
 import { NotificationContext } from 'notifications-context';
@@ -50,6 +50,12 @@ export default class Main extends React.Component<Props, State> {
   @computed
   get links() {
     return this.typeNames.map((type) => ({ title: osu.trans(`notifications.filters.${type ?? '_'}`), type }));
+  }
+
+  constructor(props: Props) {
+    super(props);
+
+    makeObservable(this);
   }
 
   static getDerivedStateFromError(error: Error) {

--- a/resources/assets/lib/notifications-index/main.tsx
+++ b/resources/assets/lib/notifications-index/main.tsx
@@ -4,7 +4,7 @@
 import HeaderV4 from 'header-v4';
 import HeaderLink from 'interfaces/header-link';
 import { route } from 'laroute';
-import { computed } from 'mobx';
+import { computed, makeObservable } from 'mobx';
 import { observer } from 'mobx-react';
 import { Name as NotificationTypeName, typeNames } from 'models/notification-type';
 import Stack from 'notification-widget/stack';
@@ -38,6 +38,8 @@ export class Main extends React.Component {
     super(props);
 
     this.controller = new NotificationController(core.dataStore.notificationStore, context);
+
+    makeObservable(this);
   }
 
   render() {

--- a/resources/assets/lib/oauth/client-details.tsx
+++ b/resources/assets/lib/oauth/client-details.tsx
@@ -2,7 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 import { FormErrors } from 'form-errors';
-import { action } from 'mobx';
+import { action, makeObservable } from 'mobx';
 import { observer } from 'mobx-react';
 import { OwnClient as Client } from 'models/oauth/own-client';
 import core from 'osu-core-singleton';
@@ -31,6 +31,12 @@ export class ClientDetails extends React.Component<Props, State> {
   };
 
   private errors = new FormErrors();
+
+  constructor(props: Props) {
+    super(props);
+
+    makeObservable(this);
+  }
 
   @action
   handleClose = () => {

--- a/resources/assets/lib/oauth/new-client.tsx
+++ b/resources/assets/lib/oauth/new-client.tsx
@@ -4,7 +4,7 @@
 import { FormErrors } from 'form-errors';
 import { OwnClientJson } from 'interfaces/own-client-json';
 import { route } from 'laroute';
-import { action } from 'mobx';
+import { action, makeObservable } from 'mobx';
 import { observer } from 'mobx-react';
 import core from 'osu-core-singleton';
 import * as React from 'react';
@@ -20,6 +20,12 @@ export class NewClient extends React.Component {
   private static readonly inputFields = ['name', 'redirect'];
 
   private errors = new FormErrors();
+
+  constructor(props: Record<string, never>) {
+    super(props);
+
+    makeObservable(this);
+  }
 
   handleCancel = () => {
     uiState.account.newClientVisible = false;

--- a/resources/assets/lib/oauth/own-clients.tsx
+++ b/resources/assets/lib/oauth/own-clients.tsx
@@ -2,7 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 import BigButton from 'big-button';
-import { action } from 'mobx';
+import { action, makeObservable } from 'mobx';
 import { observer } from 'mobx-react';
 import { Modal } from 'modal';
 import { ClientDetails } from 'oauth/client-details';
@@ -16,6 +16,12 @@ const uiState = core.dataStore.uiState;
 
 @observer
 export class OwnClients extends React.Component {
+  constructor(props: Record<string, never>) {
+    super(props);
+
+    makeObservable(this);
+  }
+
   @action
   handleModalClose = () => {
     uiState.account.client = null;

--- a/resources/assets/lib/user-multiplayer-index/room.tsx
+++ b/resources/assets/lib/user-multiplayer-index/room.tsx
@@ -6,7 +6,7 @@ import Img2x from 'img2x';
 import RoomJson from 'interfaces/room-json';
 import { route } from 'laroute';
 import { maxBy, minBy } from 'lodash';
-import { computed } from 'mobx';
+import { computed, makeObservable } from 'mobx';
 import { observer } from 'mobx-react';
 import * as moment from 'moment';
 import * as React from 'react';
@@ -57,6 +57,12 @@ export default class Room extends React.Component<Props> {
     if (beatmapset == null) return undefined;
 
     return beatmapset.covers.cover;
+  }
+
+  constructor(props: Props) {
+    super(props);
+
+    makeObservable(this);
   }
 
   render() {

--- a/resources/assets/lib/user-profile-container.tsx
+++ b/resources/assets/lib/user-profile-container.tsx
@@ -3,7 +3,7 @@
 
 import BlockButton from 'components/block-button';
 import UserJson from 'interfaces/user-json';
-import { computed } from 'mobx';
+import { computed, makeObservable } from 'mobx';
 import { observer } from 'mobx-react';
 import { NotificationBanner } from 'notification-banner';
 import * as React from 'react';
@@ -26,6 +26,12 @@ export default class UserProfileContainer extends React.Component<Props, State> 
   @computed
   get isBlocked() {
     return isBlocked(this.props.user);
+  }
+
+  constructor(props: Props) {
+    super(props);
+
+    makeObservable(this);
   }
 
   render() {


### PR DESCRIPTION
As it turned out there are quite a lot of mobx-decorated classes missing `makeObservable` call in their constructor, rendering the decorations useless :eyes: 