### PR TITLE
Add gameplay_order column to playlist items

### DIFF
--- a/app/Models/Multiplayer/PlaylistItem.php
+++ b/app/Models/Multiplayer/PlaylistItem.php
@@ -27,6 +27,7 @@ use App\Models\User;
  * @property \Illuminate\Database\Eloquent\Collection $scores Score
  * @property \Carbon\Carbon|null $updated_at
  * @property bool expired
+ * @property int $gameplay_order
  */
 class PlaylistItem extends Model
 {

--- a/app/Transformers/Multiplayer/PlaylistItemTransformer.php
+++ b/app/Transformers/Multiplayer/PlaylistItemTransformer.php
@@ -26,6 +26,7 @@ class PlaylistItemTransformer extends TransformerAbstract
             'required_mods' => $item->required_mods,
             'expired' => $item->expired,
             'owner_id' => $item->owner_id,
+            'gameplay_order' => $item->gameplay_order
         ];
     }
 

--- a/app/Transformers/Multiplayer/PlaylistItemTransformer.php
+++ b/app/Transformers/Multiplayer/PlaylistItemTransformer.php
@@ -26,7 +26,7 @@ class PlaylistItemTransformer extends TransformerAbstract
             'required_mods' => $item->required_mods,
             'expired' => $item->expired,
             'owner_id' => $item->owner_id,
-            'gameplay_order' => $item->gameplay_order
+            'gameplay_order' => $item->gameplay_order,
         ];
     }
 

--- a/database/migrations/2021_12_02_134937_add_gameplay_order_to_playlist_items.php
+++ b/database/migrations/2021_12_02_134937_add_gameplay_order_to_playlist_items.php
@@ -1,0 +1,35 @@
+<?php
+
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddGameplayOrderToPlaylistItems extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('multiplayer_playlist_items', function (Blueprint $table) {
+            $table->integer('gameplay_order')->default(0);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('multiplayer_playlist_items', function (Blueprint $table) {
+            $table->dropColumn('gameplay_order');
+        });
+    }
+}


### PR DESCRIPTION
Updated by osu-server-spectator to contain the order in which the items will be played in the room. Changes based on the room's queue mode.