### PR TITLE
Fix looking up beatmap with multiple parameters

### DIFF
--- a/app/Http/Controllers/BeatmapsController.php
+++ b/app/Http/Controllers/BeatmapsController.php
@@ -106,7 +106,7 @@ class BeatmapsController extends Controller
         foreach ($params as $key => $value) {
             $beatmap = Beatmap::whereHas('beatmapset')->firstWhere($keyMap[$key], $value);
 
-            if ($beatmap === null) {
+            if ($beatmap !== null) {
                 break;
             }
         }

--- a/tests/Controllers/BeatmapsControllerTest.php
+++ b/tests/Controllers/BeatmapsControllerTest.php
@@ -71,6 +71,25 @@ class BeatmapsControllerTest extends TestCase
     }
 
     /**
+     * Make sure the lookup stops when finding beatmap from one of the parameters
+     */
+    public function testLookupMultipleParamsForApi(): void
+    {
+        $beatmap = Beatmap::factory()->create();
+
+        $this->actAsScopedUser(User::factory()->create(), ['*']);
+
+        $this
+            ->get(route('api.beatmaps.lookup', [
+                'checksum' => '',
+                'id' => (string) $beatmap->getKey(),
+                'filename' => '',
+            ]))
+            ->assertSuccessful()
+            ->assertJsonPath('id', $beatmap->getKey());
+    }
+
+    /**
      * Checks whether HTTP 403 is thrown when a logged out
      * user tries to access the non-general (country or friend ranking)
      * scoreboards.


### PR DESCRIPTION
It should stop on not null, not the other way... :raised_eyebrow: 

Closes https://github.com/ppy/osu/issues/15912.