### PR TITLE
Fix new chat PM may not be correctly showing if you can't send a message

### DIFF
--- a/app/Http/Controllers/ChatController.php
+++ b/app/Http/Controllers/ChatController.php
@@ -38,7 +38,7 @@ class ChatController extends Controller
             $channel?->addUser($user);
 
             $sendToJson = [
-                'can_message' => $channel?->canMessage($user) ?? priv_check('ChatPmStart', $targetUser),
+                'can_message' => $channel?->canMessage($user) ?? priv_check('ChatPmStart', $targetUser)->can(),
                 'channel_id' => $channel?->getKey(),
                 'target' => json_item($targetUser, 'UserCompact'),
             ];
@@ -50,11 +50,7 @@ class ChatController extends Controller
         ];
 
         if (isset($sendToJson)) {
-            $json['send_to'] = [
-                'can_message' => $channel?->canMessage($user) ?? priv_check('ChatPmStart', $targetUser),
-                'channel_id' => $channel?->getKey(),
-                'target' => json_item($targetUser, 'UserCompact'),
-            ];
+            $json['send_to'] = $sendToJson;
         }
 
         return ext_view('chat.index', compact('json'));


### PR DESCRIPTION
Actually return a json `boolean` instead of `{}` in those cases where there was no previous channel.
...and fix a `git stash pop`ping fail 🤨 