### PR TITLE
Fix score weight transformer include

### DIFF
--- a/app/Models/Score/Best/Model.php
+++ b/app/Models/Score/Best/Model.php
@@ -26,7 +26,7 @@ abstract class Model extends BaseModel
     use Traits\Reportable, Traits\WithDbCursorHelper;
 
     public $position = null;
-    public $weight = null;
+    public ?float $weight = null;
 
     protected $macros = [
         'accurateRankCounts',
@@ -71,7 +71,7 @@ abstract class Model extends BaseModel
         return null;
     }
 
-    public function weightedPp()
+    public function weightedPp(): ?float
     {
         return $this->weight === null ? null : $this->weight * $this->pp;
     }

--- a/app/Models/Score/Best/Model.php
+++ b/app/Models/Score/Best/Model.php
@@ -73,7 +73,7 @@ abstract class Model extends BaseModel
 
     public function weightedPp()
     {
-        return $this->weight * $this->pp;
+        return $this->weight === null ? null : $this->weight * $this->pp;
     }
 
     public function macroForListing()

--- a/app/Transformers/ScoreTransformer.php
+++ b/app/Transformers/ScoreTransformer.php
@@ -109,16 +109,12 @@ class ScoreTransformer extends TransformerAbstract
 
     public function includeWeight($score)
     {
-        if (($score instanceof ScoreBest) === false) {
-            return;
-        }
-
-        return $this->item($score, function ($score) {
-            return [
+        if ($score instanceof ScoreBest && $score->weight !== null) {
+            return $this->primitive([
                 'percentage' => $score->weight * 100,
                 'pp' => $score->weightedPp(),
-            ];
-        });
+            ]);
+        }
     }
 
     public function includeUser($score)


### PR DESCRIPTION
Fix `weightedPp` value return and prevent returning invalid value when weight data is not loaded.

This was initially to make weight part of score includes for user profile but looking again it shouldn't be used as such and only explicitly include it for best scores.

...so it ended up being just an unrelated clean up.