### PR TITLE
Fix PM not being displayed after leaving a channel

### DIFF
--- a/app/Models/Chat/Channel.php
+++ b/app/Models/Chat/Channel.php
@@ -381,7 +381,11 @@ class Channel extends Model
         MessageTask::dispatch($message);
 
         if ($this->isPM()) {
-            $this->unhide();
+            if ($this->unhide()) {
+                // assume a join event has to be sent if any channels need to need to be unhidden.
+                event(new ChatChannelEvent($this, $this->pmTargetFor($sender), 'join'));
+            }
+
             (new ChannelMessage($message, $sender))->dispatch();
         }
 
@@ -468,7 +472,7 @@ class Channel extends Model
             return;
         }
 
-        UserChannel::where([
+        return UserChannel::where([
             'channel_id' => $this->channel_id,
             'hidden' => true,
         ])->update([


### PR DESCRIPTION
channel `join` event should also be sent to the recipient of the PM if they left the channel.