### PR TITLE
Don't return Builder from UserChannel::last_read_id

### DIFF
--- a/app/Models/Chat/UserChannel.php
+++ b/app/Models/Chat/UserChannel.php
@@ -9,6 +9,7 @@ use App\Libraries\Notification\BatchIdentities;
 use App\Models\User;
 use App\Models\UserNotification;
 use DB;
+use Illuminate\Database\Query\Expression;
 
 /**
  * @property Channel $channel
@@ -27,8 +28,8 @@ class UserChannel extends Model
 
     public function getLastReadIdAttribute($value): ?int
     {
-        // return the value we tried to set it to, not the builder.
-        return $this->lastReadIdToSet ?? $value;
+        // return the value we tried to set it to, not the query expression.
+        return $value instanceof Expression ? $this->lastReadIdToSet : $value;
     }
 
     public function user()

--- a/app/Models/Chat/UserChannel.php
+++ b/app/Models/Chat/UserChannel.php
@@ -23,6 +23,14 @@ class UserChannel extends Model
 {
     protected $primaryKeys = ['user_id', 'channel_id'];
 
+    private ?int $lastReadIdToSet;
+
+    public function getLastReadIdAttribute($value): ?int
+    {
+        // return the value we tried to set it to, not the builder.
+        return $this->lastReadIdToSet ?? $value;
+    }
+
     public function user()
     {
         return $this->belongsTo(User::class, 'user_id');
@@ -46,14 +54,14 @@ class UserChannel extends Model
 
     public function markAsRead($messageId = null)
     {
-        $maxId = get_int($messageId ?? Message::where('channel_id', $this->channel_id)->max('message_id'));
+        $this->lastReadIdToSet = get_int($messageId ?? Message::where('channel_id', $this->channel_id)->max('message_id'));
 
-        if ($maxId === null) {
+        if ($this->lastReadIdToSet === null) {
             return;
         }
 
         // this prevents the read marker from going backwards
-        $this->update(['last_read_id' => DB::raw("GREATEST(COALESCE(last_read_id, 0), $maxId)")]);
+        $this->update(['last_read_id' => DB::raw("GREATEST(COALESCE(last_read_id, 0), $this->lastReadIdToSet)")]);
 
         UserNotification::batchMarkAsRead($this->user, BatchIdentities::fromParams([
             'identities' => [


### PR DESCRIPTION
extracted from #8418

While looking at making the chat event broadcast dispatch after the transactions are committed instead of during the transactions, came across this issue again where `last_read_id` is a query `Expression` instance when it gets read after it's updated
