### PR TITLE
Extend line chart hover area

### DIFF
--- a/resources/assets/less/bem/line-chart.less
+++ b/resources/assets/less/bem/line-chart.less
@@ -15,12 +15,13 @@
   }
 
   &__hover {
-    .full-size();
     pointer-events: none;
+    position: relative;
   }
 
   &__hover-area {
     position: absolute;
+    display: grid;
   }
 
   &__hover-circle {


### PR DESCRIPTION
Trying to show tooltip on either edge of the chart is pretty difficult at the moment.

This should make it easier

![](https://s.myconan.net/2021-12/firefox_2021-12-16_13-54-47.png)