### PR TITLE
Move translation key of updated beatmap pack instruction

### DIFF
--- a/resources/lang/en/beatmappacks.php
+++ b/resources/lang/en/beatmappacks.php
@@ -11,9 +11,7 @@ return [
 
         'blurb' => [
             'important' => 'READ THIS BEFORE DOWNLOADING',
-            'instruction' => [
-                '_' => 'Installation: Once a pack has been downloaded, extract the contents of the pack into your osu! Songs directory and osu! will do the rest.',
-            ],
+            'install_instruction' => 'Installation: Once a pack has been downloaded, extract the contents of the pack into your osu! Songs directory and osu! will do the rest.',
             'note' => [
                 '_' => 'Also note that it is highly recommended to :scary, since older maps are generally of much lower quality than more recent maps.',
                 'scary' => 'download the packs from latest to earliest',

--- a/resources/views/packs/_header.blade.php
+++ b/resources/views/packs/_header.blade.php
@@ -26,14 +26,12 @@
 
 <div class="osu-page">
     <div class="beatmap-packs-header">
-        @php
-            $scaryTexts = [
-                tag('span', ['class' => 'beatmap-packs-header__scary'], osu_trans('beatmappacks.index.blurb.instruction.scary')),
-                tag('span', ['class' => 'beatmap-packs-header__scary'], osu_trans('beatmappacks.index.blurb.note.scary')),
-            ];
-        @endphp
         <p class="beatmap-packs-header__important">{{ osu_trans('beatmappacks.index.blurb.important') }}</p>
-        <p>{!! osu_trans('beatmappacks.index.blurb.instruction._', ['scary' => $scaryTexts[0]]) !!}</p>
-        <p>{!! osu_trans('beatmappacks.index.blurb.note._', ['scary' => $scaryTexts[1]]) !!}</p>
+        <p>{{ osu_trans('beatmappacks.index.blurb.install_instruction') }}</p>
+        <p>{!! osu_trans('beatmappacks.index.blurb.note._', ['scary' => tag(
+            'span',
+            ['class' => 'beatmap-packs-header__scary'],
+            osu_trans('beatmappacks.index.blurb.note.scary')
+        )]) !!}</p>
     </div>
 </div>


### PR DESCRIPTION
Prevents old one with removed `:scary` key from being used on other languages.