### PR TITLE
Always use UTC time for historical chart labels

### DIFF
--- a/resources/assets/lib/profile-page/historical.tsx
+++ b/resources/assets/lib/profile-page/historical.tsx
@@ -213,9 +213,9 @@ export default class Historical extends React.PureComponent<Props> {
       const options = makeOptionsDate({
         circleLine: true,
         curve: curveLinear,
-        formatX: (d: Date) => moment(d).format(osu.trans('common.datetime.year_month_short.moment')),
+        formatX: (d: Date) => moment.utc(d).format(osu.trans('common.datetime.year_month_short.moment')),
         formatY: (d: number) => osu.formatNumber(d),
-        infoBoxFormatX: (d: Date) => moment(d).format(osu.trans('common.datetime.year_month.moment')),
+        infoBoxFormatX: (d: Date) => moment.utc(d).format(osu.trans('common.datetime.year_month.moment')),
         infoBoxFormatY: (d: number) => `<strong>${osu.trans(`users.show.extra.historical.${attribute}.count_label`)}</strong> ${escape(osu.formatNumber(d))}`,
         marginRight: 60, // more spacing for x axis label
         modifiers: 'profile-page',


### PR DESCRIPTION
Resolves #8450.

So the reason is difference on how moment and native Date parses timezone-less date:

```
>> moment('2021-01-01').toString()
"Fri Jan 01 2021 00:00:00 GMT-0800"
>> (new Date('2021-01-01')).toString()
"Thu Dec 31 2020 16:00:00 GMT-0800 (Pacific Standard Time)"
```