### PR TITLE
Fix error when parsing non-array markdown yaml header

### DIFF
--- a/app/Libraries/Markdown/OsuMarkdown.php
+++ b/app/Libraries/Markdown/OsuMarkdown.php
@@ -152,16 +152,20 @@ class OsuMarkdown
             try {
                 $header = Yaml::parse($matches['header']);
             } catch (YamlParseException $_e) {
-                $header = [];
+                // ignores error
+            }
+
+            if (!is_array($header ?? null)) {
+                $header = null;
             }
 
             $document = $matches['document'];
-        } else {
-            $header = [];
-            $document = $input;
         }
 
-        return compact('header', 'document');
+        return [
+            'document' => $document ?? $input,
+            'header' => $header ?? [],
+        ];
     }
 
     public function __construct(


### PR DESCRIPTION
The new page from ppy/osu-wiki#6512 causes unexpected error as the page yaml header is parsed as string.