### PR TITLE
Allow required plugin on composer install

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -4,6 +4,7 @@ set -u
 set -e
 
 export COMPOSER_ALLOW_SUPERUSER=1
+export COMPOSER_NO_INTERACTION=1
 
 # The user when provisioning is different than the user running actual php workers (in production).
 if [ -z "${OSU_SKIP_CACHE_PERMISSION_OVERRIDE:-}" ]; then

--- a/composer.json
+++ b/composer.json
@@ -90,6 +90,10 @@
     "optimize-autoloader": true,
     "platform": {
       "php": "8.0.0"
+    },
+    "allow-plugins": {
+      "composer/package-versions-deprecated": true,
+      "dealerdirect/phpcodesniffer-composer-installer": true
     }
   },
   "extra": {


### PR DESCRIPTION
Recent composer update switched installation method to disallow code execution by default.

Also added flag to disable prompt on build scripts.