### PR TITLE
Add endpoint to reindex artist tracks

### DIFF
--- a/app/Http/Controllers/InterOp/ArtistTracksController.php
+++ b/app/Http/Controllers/InterOp/ArtistTracksController.php
@@ -13,6 +13,7 @@ class ArtistTracksController extends Controller
     public function reindexAll()
     {
         Artisan::call('es:index-documents', [
+            '--cleanup' => get_bool(request('cleanup')) ?? true,
             '--inplace' => get_bool(request('inplace')) ?? true,
             '--types' => 'artist_tracks',
             '--yes' => true,

--- a/app/Http/Controllers/InterOp/ArtistTracksController.php
+++ b/app/Http/Controllers/InterOp/ArtistTracksController.php
@@ -1,0 +1,23 @@
+<?php
+
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
+namespace App\Http\Controllers\InterOp;
+
+use App\Http\Controllers\Controller;
+use Artisan;
+
+class ArtistTracksController extends Controller
+{
+    public function reindexAll()
+    {
+        Artisan::call('es:index-documents', [
+            '--inplace' => get_bool(request('inplace')) ?? true,
+            '--types' => 'artist_tracks',
+            '--yes' => true,
+        ]);
+
+        return response()->noContent();
+    }
+}

--- a/app/Http/Controllers/InterOp/ArtistTracksController.php
+++ b/app/Http/Controllers/InterOp/ArtistTracksController.php
@@ -12,9 +12,14 @@ class ArtistTracksController extends Controller
 {
     public function reindexAll()
     {
+        $params = get_params(request()->all(), null, [
+            'cleanup:bool',
+            'inplace:bool',
+        ]);
+
         Artisan::call('es:index-documents', [
-            '--cleanup' => get_bool(request('cleanup')) ?? true,
-            '--inplace' => get_bool(request('inplace')) ?? true,
+            '--cleanup' => $params['cleanup'] ?? true,
+            '--inplace' => $params['inplace'] ?? true,
             '--types' => 'artist_tracks',
             '--yes' => true,
         ]);

--- a/app/Http/Controllers/InterOp/ArtistTracksController.php
+++ b/app/Http/Controllers/InterOp/ArtistTracksController.php
@@ -17,7 +17,7 @@ class ArtistTracksController extends Controller
             'inplace:bool',
         ]);
 
-        Artisan::call('es:index-documents', [
+        Artisan::queue('es:index-documents', [
             '--cleanup' => $params['cleanup'] ?? true,
             '--inplace' => $params['inplace'] ?? true,
             '--types' => 'artist_tracks',

--- a/routes/web.php
+++ b/routes/web.php
@@ -526,7 +526,7 @@ Route::group(['prefix' => '_lio', 'middleware' => 'lio', 'as' => 'interop.'], fu
     Route::apiResource('users', 'InterOp\UsersController', ['only' => ['store']]);
 
     Route::group(['namespace' => 'InterOp'], function () {
-        route::post('artist-tracks/reindex-all', 'ArtistTracksController@reindexAll');
+        Route::post('artist-tracks/reindex-all', 'ArtistTracksController@reindexAll');
 
         Route::group(['as' => 'beatmapsets.', 'prefix' => 'beatmapsets'], function () {
             Route::group(['prefix' => '{beatmapset}'], function () {

--- a/routes/web.php
+++ b/routes/web.php
@@ -526,6 +526,8 @@ Route::group(['prefix' => '_lio', 'middleware' => 'lio', 'as' => 'interop.'], fu
     Route::apiResource('users', 'InterOp\UsersController', ['only' => ['store']]);
 
     Route::group(['namespace' => 'InterOp'], function () {
+        route::post('artist-tracks/reindex-all', 'ArtistTracksController@reindexAll');
+
         Route::group(['as' => 'beatmapsets.', 'prefix' => 'beatmapsets'], function () {
             Route::group(['prefix' => '{beatmapset}'], function () {
                 Route::post('broadcast-new', 'BeatmapsetsController@broadcastNew')->name('broadcast-new');


### PR DESCRIPTION
This should be hit whenever artist related tables (`artists`, `artist_albums`, `artist_tracks`) are updated. This does full reindex but at current number of tracks it's simpler to do that instead of trying to figure out which tracks to update.

Inplace reindex doesn't delete deleted tracks so a new index will need to be created (by passing `inplace=false` parameter) although I don't think it's a common case at the moment? Old index (the one previously used) will be removed by default unless `cleanup=false` is specified.