### PR TITLE
Fix incorrect nullable specification in migration

### DIFF
--- a/database/migrations/2021_10_14_094706_add_build_id_to_solo_score_tokens.php
+++ b/database/migrations/2021_10_14_094706_add_build_id_to_solo_score_tokens.php
@@ -17,7 +17,7 @@ class AddBuildIdToSoloScoreTokens extends Migration
     public function up()
     {
         Schema::table('solo_score_tokens', function (Blueprint $table) {
-            $table->unsignedMediumInteger('build_id')->null(true)->after('ruleset_id');
+            $table->unsignedMediumInteger('build_id')->nullable()->after('ruleset_id');
         });
     }
 


### PR DESCRIPTION
Can't find any docs for `null()` in https://laravel.com/docs/8.x/migrations.

The code is written with the intention of supporting nulls (notice the null propagating `?` operator): https://github.com/ppy/osu-web/blob/37551ebb2f38ec9ef95451f0bd11903666ed1e34/app/Http/Controllers/Solo/ScoreTokensController.php#L31-L36

Finally, this is the only usage of `null(true)` in migrations.