### PR TITLE
Update default beatmaps bpm

### DIFF
--- a/database/migrations/2022_01_17_104933_update_default_beatmaps_bpm.php
+++ b/database/migrations/2022_01_17_104933_update_default_beatmaps_bpm.php
@@ -1,0 +1,34 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class UpdateDefaultBeatmapsBpm extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        DB::table('osu_beatmaps')->whereNull('bpm')->update(['bpm' => -60]);
+
+        Schema::table('osu_beatmaps', function (Blueprint $table) {
+            $table->float('bpm')->default(60)->nullable(false)->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('osu_beatmaps', function (Blueprint $table) {
+            $table->float('bpm')->default(null)->nullable()->change();
+        });
+    }
+}

--- a/database/migrations/2022_01_17_104933_update_default_beatmaps_bpm.php
+++ b/database/migrations/2022_01_17_104933_update_default_beatmaps_bpm.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;


### PR DESCRIPTION
Recently added to live system...

...except it's currently missing `NOT NULL` constraint 🤔 

@peppy please confirm whether or not the constraint is needed.

Also the migration entry will be `2022_01_17_104933_update_default_beatmaps_bpm`.