### PR TITLE
Remove composer package from development Dockerfile

### DIFF
--- a/Dockerfile.development
+++ b/Dockerfile.development
@@ -8,7 +8,6 @@ RUN add-apt-repository ppa:ondrej/php
 RUN apt-get update
 RUN DEBIAN_FRONTEND=noninteractive apt-get install -y \
     build-essential \
-    composer \
     curl \
     git \
     gosu \


### PR DESCRIPTION
composer's already installed from its website later in file, and this was breaking `composer install` by making a php8.1 installation without the right extensions