### PR TITLE
Disable autolink extension in wiki

### DIFF
--- a/app/Libraries/Markdown/OsuMarkdown.php
+++ b/app/Libraries/Markdown/OsuMarkdown.php
@@ -55,6 +55,7 @@ class OsuMarkdown
     // this config is only used in this class
     const DEFAULT_OSU_MARKDOWN_CONFIG = [
         'block_modifiers' => [],
+        'enable_autolink' => false,
         'enable_footnote' => false,
         'parse_attribute_id' => false,
         'parse_yaml_header' => true,
@@ -72,6 +73,7 @@ class OsuMarkdown
         'comment' => [
             'osu_markdown' => [
                 'block_modifiers' => ['comment'],
+                'enable_autolink' => true,
             ],
         ],
         'contest' => [
@@ -316,6 +318,10 @@ class OsuMarkdown
 
         if ($this->osuMarkdownConfig['enable_footnote']) {
             $environment->addExtension(new FootnoteExtension());
+        }
+
+        if ($this->osuMarkdownConfig['enable_autolink']) {
+            $environment->addExtension(new AutolinkExtension());
         }
 
         return $environment;

--- a/app/Libraries/Markdown/OsuMarkdown.php
+++ b/app/Libraries/Markdown/OsuMarkdown.php
@@ -302,7 +302,6 @@ class OsuMarkdown
 
         $environment = new Environment($config);
         $environment->addExtension(new CommonMarkCoreExtension());
-        $environment->addExtension(new AutolinkExtension());
         $environment->addExtension(new TableExtension());
         $environment->addExtension(new StrikethroughExtension());
 


### PR DESCRIPTION
closes #8570

Apparently we don't actually use this feature in wiki pages and a cursory glance through the wiki pages seems to confirm this. It ends up causing issues in the link markdown as `UrlAutolinkParser` starts replacing anything that it thinks is a link (even just ` www `) with a link node before the closing elements of the `[]()` markdown has been parsed.
`[label](link)` and `<link>` still work as usual.

It may be useful for comments so it's left enabled for them 🤷 