### PR TITLE
Fix 24h osu!catch scores from lazer missing count50 values

### DIFF
--- a/app/Models/Solo/Score.php
+++ b/app/Models/Solo/Score.php
@@ -150,6 +150,7 @@ class Score extends Model
                 $score['count300'] = $statistics->Great;
                 $score['count100'] = $statistics->LargeTickHit;
                 $score['countkatu'] = $statistics->SmallTickMiss;
+                $score['count50'] = $statistics->SmallTickHit;
                 break;
             case 'mania':
                 $score['countgeki'] = $statistics->Perfect;

--- a/app/Models/Solo/Score.php
+++ b/app/Models/Solo/Score.php
@@ -112,6 +112,7 @@ class Score extends Model
             'Miss',
             'Ok',
             'Perfect',
+            'SmallTickHit',
             'SmallTickMiss',
         ];
         $statistics = $this->data->statistics;


### PR DESCRIPTION
Found this as I'm reading through the new infrastructure planning.