### PR TITLE
Clean up user list page styling

### DIFF
--- a/resources/assets/less/bem/user-card-brick.less
+++ b/resources/assets/less/bem/user-card-brick.less
@@ -11,7 +11,7 @@
   margin: var(--item-margin);
   width: min-content;
   max-width: 100%;
-  background-color: hsla(var(--hsl-b4), 0.8);
+  background-color: hsla(var(--hsl-b2), 0.8);
   border: 2px solid transparent;
   border-radius: @border-radius-large;
   display: flex;

--- a/resources/assets/less/bem/user-list.less
+++ b/resources/assets/less/bem/user-list.less
@@ -3,6 +3,7 @@
 
 .user-list {
   padding: 0 0 20px;
+  background-color: hsl(var(--hsl-b4));
   color: @osu-colour-c1;
 
   &__description {

--- a/resources/assets/lib/friends-index/main.tsx
+++ b/resources/assets/lib/friends-index/main.tsx
@@ -17,19 +17,19 @@ interface Props {
 export class Main extends React.PureComponent<Props> {
   render() {
     return (
-      <div className='osu-layout osu-layout--full'>
+      <>
         <HeaderV4
           backgroundImage={this.props.user.cover.url}
           links={homeLinks('friends.index')}
           theme='friends'
         />
 
-        <div className='osu-page osu-page--users'>
+        <div className='osu-page osu-page--generic-compact'>
           <UserCardTypeContext.Provider value={{isFriendsPage: true}}>
             <UserList users={this.props.friends} />
           </UserCardTypeContext.Provider>
         </div>
-      </div>
+      </>
     );
   }
 }

--- a/resources/assets/lib/groups-show/main.tsx
+++ b/resources/assets/lib/groups-show/main.tsx
@@ -15,10 +15,10 @@ interface Props {
 export class Main extends React.PureComponent<Props> {
   render() {
     return (
-      <div className='osu-layout osu-layout--full'>
+      <>
         <HeaderV4 theme='friends' />
 
-        <div className='osu-page osu-page--users'>
+        <div className='osu-page osu-page--generic-compact'>
           <UserList
             descriptionHtml={this.props.group.description?.html}
             playmodeFilter={this.props.group.has_playmodes}
@@ -27,7 +27,7 @@ export class Main extends React.PureComponent<Props> {
             users={this.props.users}
           />
         </div>
-      </div>
+      </>
     );
   }
 }

--- a/resources/views/friends/index.blade.php
+++ b/resources/views/friends/index.blade.php
@@ -5,7 +5,7 @@
 @extends('master', ['titlePrepend' => osu_trans('friends.title_compact')])
 
 @section('content')
-    <div class="js-react--friends-index osu-layout osu-layout--full"></div>
+    <div class="js-react--friends-index"></div>
 @endsection
 
 @section("script")

--- a/resources/views/groups/show.blade.php
+++ b/resources/views/groups/show.blade.php
@@ -5,7 +5,7 @@
 @extends('master', ['titlePrepend' => $groupJson['name']])
 
 @section('content')
-    <div class="js-react--groups-show osu-layout osu-layout--full"></div>
+    <div class="js-react--groups-show"></div>
 @endsection
 
 @section("script")


### PR DESCRIPTION
margin-bottom of `osu-page--users` removed in #8557 accidentally also affects user listing page (friends, groups) and removed the space between content and footer. Fixed this by using different modifier and adding specific background through user list container class. Also removed some wrapper classes while at it.

Also made the background `b4` for added bonus of making hover effect of sort buttons visible.