### PR TITLE
Fix infinite inline container parsing

### DIFF
--- a/app/Libraries/Markdown/CustomContainerInline/Element.php
+++ b/app/Libraries/Markdown/CustomContainerInline/Element.php
@@ -12,11 +12,11 @@ class Element extends AbstractInline implements DelimitedInterface
 {
     public function getOpeningDelimiter(): string
     {
-        return ':';
+        return '::';
     }
 
     public function getClosingDelimiter(): string
     {
-        return ':';
+        return '::';
     }
 }

--- a/app/Libraries/Markdown/CustomContainerInline/Parser.php
+++ b/app/Libraries/Markdown/CustomContainerInline/Parser.php
@@ -28,7 +28,11 @@ class Parser implements DelimiterProcessorInterface
 
     public function getDelimiterUse(DelimiterInterface $opener, DelimiterInterface $closer): int
     {
-        return 2;
+        if ($opener->getLength() >= 2 && $closer->getLength() >= 2) {
+            return 2;
+        }
+
+        return 0;
     }
 
     public function process(AbstractStringContainer $opener, AbstractStringContainer $closer, int $delimiterUse): void

--- a/app/Libraries/Markdown/OsuMarkdown.php
+++ b/app/Libraries/Markdown/OsuMarkdown.php
@@ -120,7 +120,7 @@ class OsuMarkdown
         'wiki' => [
             'osu_extension' => [
                 'attributes_allowed' => ['flag', 'id'],
-                //'custom_container_inline' => true,
+                'custom_container_inline' => true,
                 'fix_wiki_url' => true,
                 'generate_toc' => true,
                 'style_block_allowed_classes' => ['infobox'],


### PR DESCRIPTION
fixes #8594

`getDelimiterUse` isn't quite clear on implementation and apparently the processor can go into negative lengths and keep going ಠ_ಠ