### PR TITLE
More discussion-related test cleanups

### DIFF
--- a/tests/Controllers/BeatmapDiscussionsControllerTest.php
+++ b/tests/Controllers/BeatmapDiscussionsControllerTest.php
@@ -81,9 +81,9 @@ class BeatmapDiscussionsControllerTest extends TestCase
     }
 
     /**
-     * @dataProvider putVoteChangeDataProvider
+     * @dataProvider putVoteChangeToDownDataProvider
      */
-    public function testPutVoteChange(?string $group, int $status, int $scoreChange)
+    public function testPutVoteChangeToDown(?string $group, int $status, int $scoreChange)
     {
         $user = User::factory()->withGroup($group)->create();
 
@@ -219,19 +219,19 @@ class BeatmapDiscussionsControllerTest extends TestCase
         ];
     }
 
-    public function putVoteChangeDataProvider()
+    public function putVoteChangeToDownDataProvider()
     {
         return [
-            'bng can change existing score' => ['bng', 200, -2],
-            'regular user cannot change existing score' => [null, 403, 0],
+            'bng can change to down vote' => ['bng', 200, -2],
+            'regular user cannot change to down vote' => [null, 403, 0],
         ];
     }
 
     public function putVoteDownDataProvider()
     {
         return [
-            'bng can downvote' => ['bng', 200, 1, -1],
-            'regular user cannot downvote' => [null, 403, 0, 0],
+            'bng can down vote' => ['bng', 200, 1, -1],
+            'regular user cannot down vote' => [null, 403, 0, 0],
         ];
     }
 

--- a/tests/Controllers/BeatmapDiscussionsControllerTest.php
+++ b/tests/Controllers/BeatmapDiscussionsControllerTest.php
@@ -117,8 +117,8 @@ class BeatmapDiscussionsControllerTest extends TestCase
             ->putVote($user, '-1')
             ->assertStatus($status);
 
-            $this->assertSame($currentVotes + $voteChange, BeatmapDiscussionVote::count());
-            $this->assertSame($currentScore + $scoreChange, $this->currentScore());
+        $this->assertSame($currentVotes + $voteChange, BeatmapDiscussionVote::count());
+        $this->assertSame($currentScore + $scoreChange, $this->currentScore());
     }
 
     // posting reviews - fail scenarios ----

--- a/tests/Controllers/BeatmapDiscussionsControllerTest.php
+++ b/tests/Controllers/BeatmapDiscussionsControllerTest.php
@@ -241,14 +241,9 @@ class BeatmapDiscussionsControllerTest extends TestCase
 
         $mapper = User::factory()->create();
         $user = User::factory()->create();
-        $beatmapset = Beatmapset::factory()->create([
-            'user_id' => $mapper,
-            'discussion_enabled' => true,
-            'approved' => Beatmapset::STATES['pending'],
-        ]);
-        $beatmap = $beatmapset->beatmaps()->save(Beatmap::factory()->make([
-            'user_id' => $mapper,
-        ]));
+        $beatmapset = Beatmapset::factory()->pending()->owner($mapper)->create();
+        // TODO: adding beatmap to beatmapset should probably copy come attributes.
+        $beatmap = $beatmapset->beatmaps()->save(Beatmap::factory()->make(['user_id' => $mapper]));
         $this->discussion = BeatmapDiscussion::factory()->timeline()->create([
             'beatmapset_id' => $beatmapset,
             'beatmap_id' => $beatmap,

--- a/tests/Controllers/BeatmapDiscussionsControllerTest.php
+++ b/tests/Controllers/BeatmapDiscussionsControllerTest.php
@@ -46,8 +46,10 @@ class BeatmapDiscussionsControllerTest extends TestCase
         $this->assertSame($currentScore + $change, $this->currentScore());
     }
 
-    // voting again has no effect
-    public function testPutVoteAgain()
+    /**
+     * @dataProvider putVoteAgainDataProvider
+     */
+    public function testPutVoteAgain(string $score, int $change)
     {
         $user = User::factory()->create();
 
@@ -59,11 +61,11 @@ class BeatmapDiscussionsControllerTest extends TestCase
         $currentVotes = BeatmapDiscussionVote::count();
         $currentScore = $this->currentScore();
 
-        $this->putVote($user, '1')
+        $this->putVote($user, $score)
             ->assertStatus(200);
 
-        $this->assertSame($currentVotes, BeatmapDiscussionVote::count());
-        $this->assertSame($currentScore, $this->currentScore());
+        $this->assertSame($currentVotes + $change, BeatmapDiscussionVote::count());
+        $this->assertSame($currentScore + $change, $this->currentScore());
     }
 
     // can not vote as discussion starter
@@ -78,26 +80,6 @@ class BeatmapDiscussionsControllerTest extends TestCase
 
         $this->assertSame($currentVotes, BeatmapDiscussionVote::count());
         $this->assertSame($currentScore, $this->currentScore());
-    }
-
-    // voting 0 will remove the vote
-    public function testPutVoteRemove()
-    {
-        $user = User::factory()->create();
-
-        $this->discussion->vote([
-            'score' => 1,
-            'user_id' => $user->getKey(),
-        ]);
-
-        $currentVotes = BeatmapDiscussionVote::count();
-        $currentScore = $this->currentScore();
-
-        $this->putVote($user, '0')
-            ->assertStatus(200);
-
-        $this->assertSame($currentVotes - 1, BeatmapDiscussionVote::count());
-        $this->assertSame($currentScore - 1, $this->currentScore());
     }
 
     /**
@@ -227,6 +209,14 @@ class BeatmapDiscussionsControllerTest extends TestCase
             ['approved', 403, 0],
             // TODO: qualified; factory the beatmapset with the correct state instead of using update.
             ['loved', 403, 0],
+        ];
+    }
+
+    public function putVoteAgainDataProvider()
+    {
+        return [
+            'voting again has no effect' => ['1', 0],
+            'voting 0 will remove the vote' => ['0', -1],
         ];
     }
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -106,7 +106,7 @@ class TestCase extends BaseTestCase
         $this->actAsUserWithToken($token, $driver);
     }
 
-    protected function actAsUser(?User $user, ?bool $verified = null, $driver = null)
+    protected function actAsUser(?User $user, bool $verified = false, $driver = null)
     {
         if ($user === null) {
             return;
@@ -114,9 +114,7 @@ class TestCase extends BaseTestCase
 
         $this->be($user, $driver);
 
-        if ($verified !== null) {
-            $this->withSession(['verified' => $verified]);
-        }
+        $this->withSession(['verified' => $verified]);
     }
 
     /**


### PR DESCRIPTION
continuing from #8591, more discussion-related test cleaning up, with more usage of data providers.

Also fix `TestCase::actAsUser` incorrectly preserving the previous verified status (we shouldn't be calling as multiple users in the same test case, anyway).