### PR TITLE
Move beatmapset events listing to components directory

### DIFF
--- a/resources/assets/coffee/react/beatmap-discussions/events.coffee
+++ b/resources/assets/coffee/react/beatmap-discussions/events.coffee
@@ -1,7 +1,7 @@
 # Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 # See the LICENCE file in the repository root for full licence text.
 
-import Event from 'beatmap-discussions/event'
+import BeatmapsetEvent from 'components/beatmapset-event'
 import * as React from 'react'
 import { a, div, li, span, ul } from 'react-dom-factories'
 el = React.createElement
@@ -32,7 +32,7 @@ export class Events extends React.PureComponent
                   key: "date-#{lastCreatedAtString}"
                   className: 'beatmapset-events__title'
                   lastCreatedAtString
-              el Event,
+              el BeatmapsetEvent,
                 key: event.id
                 event: event
                 discussions: @props.discussions

--- a/resources/assets/coffee/react/modding-profile/events.coffee
+++ b/resources/assets/coffee/react/modding-profile/events.coffee
@@ -17,7 +17,7 @@ export class Events extends React.Component
           div className: 'modding-profile-list__empty', osu.trans('users.show.extra.none')
         else
           el React.Fragment, null,
-            el DiscussionEvents,
+            el BeatmapsetEvents,
               events: @props.events
               mode: 'profile'
               users: @props.users

--- a/resources/assets/coffee/react/modding-profile/events.coffee
+++ b/resources/assets/coffee/react/modding-profile/events.coffee
@@ -1,7 +1,7 @@
 # Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 # See the LICENCE file in the repository root for full licence text.
 
-import DiscussionEvents from 'beatmap-discussions/events'
+import BeatmapsetEvents from 'components/beatmapset-events'
 import { route } from 'laroute'
 import * as React from 'react'
 import { div, h2, a, img } from 'react-dom-factories'

--- a/resources/assets/lib/components/beatmapset-event.tsx
+++ b/resources/assets/lib/components/beatmapset-event.tsx
@@ -47,7 +47,7 @@ interface Props {
   users: Partial<Record<string, UserJson>>;
 }
 
-export default class Event extends React.PureComponent<Props> {
+export default class BeatmapsetEvent extends React.PureComponent<Props> {
   private get beatmapsetId(): number | undefined {
     return this.props.event.beatmapset?.id;
   }

--- a/resources/assets/lib/components/beatmapset-events.tsx
+++ b/resources/assets/lib/components/beatmapset-events.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
-import Event, { EventViewMode } from 'beatmap-discussions/event';
+import BeatmapsetEvent, { EventViewMode } from 'components/beatmapset-event';
 import BeatmapsetEventJson from 'interfaces/beatmapset-event-json';
 import UserJson from 'interfaces/user-json';
 import * as React from 'react';
@@ -14,6 +14,6 @@ interface Props {
 
 export default class BeatmapsetEvents extends React.PureComponent<Props> {
   render() {
-    return this.props.events.map((event) => <Event key={event.id} event={event} mode={this.props.mode} users={this.props.users} />);
+    return this.props.events.map((event) => <BeatmapsetEvent key={event.id} event={event} mode={this.props.mode} users={this.props.users} />);
   }
 }

--- a/resources/assets/lib/components/beatmapset-events.tsx
+++ b/resources/assets/lib/components/beatmapset-events.tsx
@@ -1,10 +1,10 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+import Event, { EventViewMode } from 'beatmap-discussions/event';
 import BeatmapsetEventJson from 'interfaces/beatmapset-event-json';
 import UserJson from 'interfaces/user-json';
 import * as React from 'react';
-import Event, { EventViewMode } from './event';
 
 interface Props {
   events: BeatmapsetEventJson[];
@@ -12,7 +12,7 @@ interface Props {
   users: Partial<Record<string, UserJson>>;
 }
 
-export default class Events extends React.PureComponent<Props> {
+export default class BeatmapsetEvents extends React.PureComponent<Props> {
   render() {
     return this.props.events.map((event) => <Event key={event.id} event={event} mode={this.props.mode} users={this.props.users} />);
   }

--- a/resources/assets/lib/register-components.coffee
+++ b/resources/assets/lib/register-components.coffee
@@ -1,7 +1,7 @@
 # Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 # See the LICENCE file in the repository root for full licence text.
 
-import Events from 'beatmap-discussions/events'
+import BeatmapsetEvents from 'components/beatmapset-events'
 import BeatmapsetPanel from 'components/beatmapset-panel'
 import BlockButton from 'components/block-button'
 import ChatIcon from 'components/chat-icon'
@@ -52,7 +52,7 @@ core.reactTurbolinks.register 'beatmap-discussion-events', (container) ->
   props.users = _.keyBy(users, 'id')
   props.users[null] = props.users[undefined] = deletedUser.toJson()
 
-  createElement Events, props
+  createElement BeatmapsetEvents, props
 
 
 core.reactTurbolinks.register 'beatmapset-panel', (container) ->


### PR DESCRIPTION
Not only conflicts with the one in coffeescript but the component isn't used by the beatmap-discussions itself.