### PR TITLE
Don't count before indexing objects

### DIFF
--- a/app/Console/Commands/EsIndexDocuments.php
+++ b/app/Console/Commands/EsIndexDocuments.php
@@ -103,8 +103,7 @@ class EsIndexDocuments extends Command
         $pretext = $this->inplace ? 'In-place indexing' : 'Indexing';
 
         foreach ($types as $type) {
-            $count = $type::esIndexingQuery()->count();
-            $bar = $this->output->createProgressBar($count);
+            $bar = $this->output->createProgressBar();
 
             $this->info("{$pretext} {$type} into {$indexName}");
 


### PR DESCRIPTION
The operation may take *a bit* longer than expected in some cases (or at least on my dev db).