### PR TITLE
Add query parameter to get converted beatmaps from API v2

### DIFF
--- a/app/Http/Controllers/BeatmapsController.php
+++ b/app/Http/Controllers/BeatmapsController.php
@@ -160,8 +160,7 @@ class BeatmapsController extends Controller
 
         if (is_api_request()) {
             if ($beatmap->mode != $mode) {
-                $beatmap->convert = true;
-                $beatmap->playmode = Beatmap::modeInt($mode);
+                $beatmap->convertTo($mode);
             }
 
             return json_item($beatmap, new BeatmapTransformer(), static::DEFAULT_API_INCLUDES);

--- a/app/Models/Beatmap.php
+++ b/app/Models/Beatmap.php
@@ -339,4 +339,12 @@ class Beatmap extends Model
 
         return $this->hasMany("{$modelPath}\\{$mode}");
     }
+
+    public function convertTo(?string $mode)
+    {
+        if ($this->mode === 'osu' && static::isModeValid($mode)) {
+            $this->convert = true;
+            $this->playmode = static::modeInt($mode);
+        }
+    }
 }


### PR DESCRIPTION
As mentioned in #6572, we can't get converts from Get Beatmap endpoint, so I added a `mode` query parameter to convert the beatmap to specified gamemode