### PR TITLE
Fix popup hover area

### DIFF
--- a/resources/assets/less/layout.less
+++ b/resources/assets/less/layout.less
@@ -104,10 +104,12 @@ body {
   width: 100%;
   top: 155px;
   z-index: 9999;
+  pointer-events: none;
 
   .alert {
-    border: none;
     .default-box-shadow();
+    border: none;
+    pointer-events: auto;
   }
 
   .popup-text {


### PR DESCRIPTION
Stop it from blocking outer part of the actual popup. It's only noticeable on `info` popups because the other types also have full page blackout overlay blocking everything.

![](https://s.myconan.net/2022-02/firefox_2022-02-22_19-49-17.png)