### PR TITLE
Change password reset emails to not urge the user to reply

### DIFF
--- a/resources/lang/en/mail.php
+++ b/resources/lang/en/mail.php
@@ -15,6 +15,7 @@ return [
         'closing' => 'Regards,',
         'hello' => 'Hi :user,',
         'report' => 'Please reply to this email IMMEDIATELY if you did not request this change.',
+        'ignore' => 'If you did not request this, you can safely ignore this email.',
     ],
 
     'donation_thanks' => [

--- a/resources/views/emails/password_reset.blade.php
+++ b/resources/views/emails/password_reset.blade.php
@@ -8,6 +8,6 @@
 
 {!! osu_trans('mail.password_reset.code') !!} {{ $key }}
 
-{!! osu_trans('mail.common.report') !!}
+{!! osu_trans('mail.common.ignore') !!}
 
 @include('emails._signature')


### PR DESCRIPTION
There's no real reason for the user to reply in these cases as there's not much we can do, and not much room for actually compromising accounts using such a request.