### PR TITLE
Fix positioning of previous usernames popup

### DIFF
--- a/resources/assets/less/bem/profile-info.less
+++ b/resources/assets/less/bem/profile-info.less
@@ -193,6 +193,7 @@
       transform: translateY(0);
       position: absolute;
       left: 100%;
+      top: -16px;
 
       &:hover {
         z-index: @z-index--profile-previous-usernames;


### PR DESCRIPTION
Otherwise the icon on normal state floats up too high when there are many usernames.