### PR TITLE
Use custom cast for user preferences

### DIFF
--- a/app/Casts/UserPreferences.php
+++ b/app/Casts/UserPreferences.php
@@ -1,0 +1,112 @@
+<?php
+
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
+declare(strict_types=1);
+
+namespace App\Casts;
+
+use App\Models\Comment;
+use Illuminate\Contracts\Database\Eloquent\CastsAttributes;
+
+class UserPreferences implements CastsAttributes
+{
+    const BEATMAPSET_CARD_SIZES = ['normal', 'extra'];
+
+    const BEATMAPSET_DOWNLOAD = ['all', 'no_video', 'direct'];
+
+    const USER_LIST = [
+        'filters' => ['all' => ['all', 'online', 'offline'], 'default' => 'all'],
+        'sorts' => ['all' => ['last_visit', 'rank', 'username'], 'default' => 'last_visit'],
+        'views' => ['all' => ['card', 'list', 'brick'], 'default' => 'card'],
+    ];
+
+    public static function attributes()
+    {
+        static $ret;
+
+        if ($ret === null) {
+            $ret = [
+                'audio_autoplay' => [
+                    'cast' => 'get_bool',
+                    'default' => false,
+                ],
+                'audio_muted' => [
+                    'cast' => 'get_bool',
+                    'default' => false,
+                ],
+                'audio_volume' => [
+                    'cast' => 'get_float',
+                    'default' => 0.45,
+                ],
+                'beatmapset_card_size' => [
+                    'cast' => fn ($v) => is_string($v) && in_array($v, static::BEATMAPSET_CARD_SIZES, true) ? $v : null,
+                    'default' => static::BEATMAPSET_CARD_SIZES[0],
+                ],
+                'beatmapset_download' => [
+                    'cast' => fn ($v) => is_string($v) && in_array($v, static::BEATMAPSET_DOWNLOAD, true) ? $v : null,
+                    'default' => static::BEATMAPSET_DOWNLOAD[0],
+                ],
+                'beatmapset_show_nsfw' => [
+                    'cast' => 'get_bool',
+                    'default' => false,
+                ],
+                'beatmapset_title_show_original' => [
+                    'cast' => 'get_bool',
+                    'default' => false,
+                ],
+                'comments_show_deleted' => [
+                    'cast' => 'get_bool',
+                    'default' => false,
+                ],
+                'comments_sort' => [
+                    'cast' => fn ($v) => is_string($v) && array_key_exists($v, Comment::SORTS) ? $v : null,
+                    'default' => Comment::DEFAULT_SORT,
+                ],
+                'forum_posts_show_deleted' => [
+                    'cast' => 'get_bool',
+                    'default' => true,
+                ],
+                'user_list_filter' => [
+                    'cast' => fn ($v) => is_string($v) && in_array($v, static::USER_LIST['filters']['all'], true) ? $v : null,
+                    'default' => static::USER_LIST['filters']['default'],
+                ],
+                'user_list_sort' => [
+                    'cast' => fn ($v) => is_string($v) && in_array($v, static::USER_LIST['sorts']['all'], true) ? $v : null,
+                    'default' => static::USER_LIST['sorts']['default'],
+                ],
+                'user_list_view' => [
+                    'cast' => fn ($v) => is_string($v) && in_array($v, static::USER_LIST['views']['all'], true) ? $v : null,
+                    'default' => static::USER_LIST['views']['default'],
+                ],
+                'profile_cover_expanded' => [
+                    'cast' => 'get_bool',
+                    'default' => true,
+                ],
+            ];
+        }
+
+        return $ret;
+    }
+
+    public function get($model, string $key, $value, array $attributes)
+    {
+        return $model->options[$key] ?? static::attributes()[$key]['default'];
+    }
+
+    public function set($model, string $key, $value, array $attributes): array
+    {
+        $model->options ??= [];
+        $castedValue = static::attributes()[$key]['cast']($value);
+        if ($castedValue === null) {
+            if ($model->options->offsetExists($key)) {
+                unset($model->options[$key]);
+            }
+        } else {
+            $model->options[$key] = $castedValue;
+        }
+
+        return [];
+    }
+}

--- a/app/Casts/UserPreferences.php
+++ b/app/Casts/UserPreferences.php
@@ -29,59 +29,65 @@ class UserPreferences implements CastsAttributes
         if ($ret === null) {
             $ret = [
                 'audio_autoplay' => [
-                    'cast' => 'get_bool',
+                    'type' => 'bool',
                     'default' => false,
                 ],
                 'audio_muted' => [
-                    'cast' => 'get_bool',
+                    'type' => 'bool',
                     'default' => false,
                 ],
                 'audio_volume' => [
-                    'cast' => 'get_float',
+                    'type' => 'float',
                     'default' => 0.45,
                 ],
                 'beatmapset_card_size' => [
-                    'cast' => fn ($v) => is_string($v) && in_array($v, static::BEATMAPSET_CARD_SIZES, true) ? $v : null,
+                    'type' => 'string',
+                    'validator' => fn ($v) => is_string($v) && in_array($v, static::BEATMAPSET_CARD_SIZES, true),
                     'default' => static::BEATMAPSET_CARD_SIZES[0],
                 ],
                 'beatmapset_download' => [
-                    'cast' => fn ($v) => is_string($v) && in_array($v, static::BEATMAPSET_DOWNLOAD, true) ? $v : null,
+                    'type' => 'string',
+                    'validator' => fn ($v) => is_string($v) && in_array($v, static::BEATMAPSET_DOWNLOAD, true),
                     'default' => static::BEATMAPSET_DOWNLOAD[0],
                 ],
                 'beatmapset_show_nsfw' => [
-                    'cast' => 'get_bool',
+                    'type' => 'bool',
                     'default' => false,
                 ],
                 'beatmapset_title_show_original' => [
-                    'cast' => 'get_bool',
+                    'type' => 'bool',
                     'default' => false,
                 ],
                 'comments_show_deleted' => [
-                    'cast' => 'get_bool',
+                    'type' => 'bool',
                     'default' => false,
                 ],
                 'comments_sort' => [
-                    'cast' => fn ($v) => is_string($v) && array_key_exists($v, Comment::SORTS) ? $v : null,
+                    'type' => 'string',
+                    'validator' => fn ($v) => is_string($v) && array_key_exists($v, Comment::SORTS),
                     'default' => Comment::DEFAULT_SORT,
                 ],
                 'forum_posts_show_deleted' => [
-                    'cast' => 'get_bool',
+                    'type' => 'bool',
                     'default' => true,
                 ],
                 'user_list_filter' => [
-                    'cast' => fn ($v) => is_string($v) && in_array($v, static::USER_LIST['filters']['all'], true) ? $v : null,
+                    'type' => 'string',
+                    'validator' => fn ($v) => is_string($v) && in_array($v, static::USER_LIST['filters']['all'], true),
                     'default' => static::USER_LIST['filters']['default'],
                 ],
                 'user_list_sort' => [
-                    'cast' => fn ($v) => is_string($v) && in_array($v, static::USER_LIST['sorts']['all'], true) ? $v : null,
+                    'type' => 'string',
+                    'validator' => fn ($v) => is_string($v) && in_array($v, static::USER_LIST['sorts']['all'], true),
                     'default' => static::USER_LIST['sorts']['default'],
                 ],
                 'user_list_view' => [
-                    'cast' => fn ($v) => is_string($v) && in_array($v, static::USER_LIST['views']['all'], true) ? $v : null,
+                    'type' => 'string',
+                    'validator' => fn ($v) => is_string($v) && in_array($v, static::USER_LIST['views']['all'], true),
                     'default' => static::USER_LIST['views']['default'],
                 ],
                 'profile_cover_expanded' => [
-                    'cast' => 'get_bool',
+                    'type' => 'bool',
                     'default' => true,
                 ],
             ];
@@ -98,13 +104,12 @@ class UserPreferences implements CastsAttributes
     public function set($model, string $key, $value, array $attributes): array
     {
         $model->options ??= [];
-        $castedValue = static::attributes()[$key]['cast']($value);
-        if ($castedValue === null) {
+        if ($value === null) {
             if ($model->options->offsetExists($key)) {
                 unset($model->options[$key]);
             }
         } else {
-            $model->options[$key] = $castedValue;
+            $model->options[$key] = $value;
         }
 
         return [];

--- a/app/Http/Controllers/AccountController.php
+++ b/app/Http/Controllers/AccountController.php
@@ -5,6 +5,7 @@
 
 namespace App\Http\Controllers;
 
+use App\Casts\UserPreferences;
 use App\Exceptions\ImageProcessorException;
 use App\Exceptions\ModelNotSavedException;
 use App\Libraries\UserVerification;
@@ -208,21 +209,8 @@ class AccountController extends Controller
         ]);
 
         $profileParams = get_params($params, 'user_profile_customization', [
-            'audio_autoplay:bool',
-            'audio_muted:bool',
-            'audio_volume:float',
-            'beatmapset_card_size:string',
-            'beatmapset_download:string',
-            'beatmapset_show_nsfw:bool',
-            'beatmapset_title_show_original:bool',
-            'comments_show_deleted:bool',
-            'comments_sort:string',
+            ...array_map(fn ($v) => "{$v}:any", array_keys(UserPreferences::attributes())),
             'extras_order:string[]',
-            'forum_posts_show_deleted:bool',
-            'profile_cover_expanded:bool',
-            'user_list_filter:string',
-            'user_list_sort:string',
-            'user_list_view:string',
         ]);
 
         try {

--- a/app/Http/Controllers/AccountController.php
+++ b/app/Http/Controllers/AccountController.php
@@ -209,8 +209,8 @@ class AccountController extends Controller
         ]);
 
         $profileParams = get_params($params, 'user_profile_customization', [
-            ...array_map(fn ($v) => "{$v}:any", array_keys(UserPreferences::attributes())),
             'extras_order:string[]',
+            ...collect(UserPreferences::attributes())->map(fn ($attr, $f) => "{$f}:{$attr['type']}")->values(),
         ]);
 
         try {

--- a/app/Models/UserProfileCustomization.php
+++ b/app/Models/UserProfileCustomization.php
@@ -69,8 +69,8 @@ class UserProfileCustomization extends Model
             'options' => AsArrayObject::class,
         ];
         $class = UserPreferences::class;
-        foreach (UserPreferences::attributes() as $key => $_value) {
-            $ret[$key] = $class;
+        foreach (UserPreferences::attributes() as $field => $_attr) {
+            $ret[$field] = $class;
         }
 
         return $ret;

--- a/app/Models/UserProfileCustomization.php
+++ b/app/Models/UserProfileCustomization.php
@@ -5,6 +5,7 @@
 
 namespace App\Models;
 
+use App\Casts\UserPreferences;
 use App\Libraries\ProfileCover;
 use Illuminate\Database\Eloquent\Casts\AsArrayObject;
 
@@ -31,22 +32,16 @@ class UserProfileCustomization extends Model
         'kudosu',
     ];
 
-    const BEATMAPSET_CARD_SIZES = ['normal', 'extra'];
-
-    const BEATMAPSET_DOWNLOAD = ['all', 'no_video', 'direct'];
-
-    const USER_LIST = [
-        'filters' => ['all' => ['all', 'online', 'offline'], 'default' => 'all'],
-        'sorts' => ['all' => ['last_visit', 'rank', 'username'], 'default' => 'last_visit'],
-        'views' => ['all' => ['card', 'list', 'brick'], 'default' => 'card'],
-    ];
-
-    protected $casts = [
-        'cover_json' => 'array',
-        'options' => AsArrayObject::class,
-    ];
-
     private $cover;
+
+    public function __construct(array $attributes = [])
+    {
+        static $casts;
+        $casts ??= static::modelCasts();
+        $this->casts = $casts;
+
+        parent::__construct($attributes);
+    }
 
     public static function repairExtrasOrder($value)
     {
@@ -62,6 +57,20 @@ class UserProfileCustomization extends Model
                 )
             )
         );
+    }
+
+    private static function modelCasts(): array
+    {
+        $ret = [
+            'cover_json' => 'array',
+            'options' => AsArrayObject::class,
+        ];
+        $class = UserPreferences::class;
+        foreach (UserPreferences::attributes() as $key => $_value) {
+            $ret[$key] = $class;
+        }
+
+        return $ret;
     }
 
     public function cover()
@@ -80,159 +89,6 @@ class UserProfileCustomization extends Model
         $this->save();
     }
 
-    public function getAudioAutoplayAttribute()
-    {
-        return $this->options['audio_autoplay'] ?? false;
-    }
-
-    public function setAudioAutoplayAttribute($value)
-    {
-        $this->setOption('audio_autoplay', get_bool($value));
-    }
-
-    public function getAudioMutedAttribute()
-    {
-        return $this->options['audio_muted'] ?? false;
-    }
-
-    public function setAudioMutedAttribute($value)
-    {
-        $this->setOption('audio_muted', get_bool($value));
-    }
-
-    public function getAudioVolumeAttribute()
-    {
-        return $this->options['audio_volume'] ?? 0.45;
-    }
-
-    public function setAudioVolumeAttribute($value)
-    {
-        $this->setOption('audio_volume', get_float($value));
-    }
-
-    public function getBeatmapsetCardSizeAttribute()
-    {
-        return $this->options['beatmapset_card_size'] ?? static::BEATMAPSET_CARD_SIZES[0];
-    }
-
-    public function setBeatmapsetCardSizeAttribute($value)
-    {
-        if ($value !== null && !in_array($value, static::BEATMAPSET_CARD_SIZES, true)) {
-            $value = null;
-        }
-
-        $this->setOption('beatmapset_card_size', $value);
-    }
-
-    public function getBeatmapsetDownloadAttribute()
-    {
-        return $this->options['beatmapset_download'] ?? static::BEATMAPSET_DOWNLOAD[0];
-    }
-
-    public function setBeatmapsetDownloadAttribute($value)
-    {
-        if ($value !== null && !in_array($value, static::BEATMAPSET_DOWNLOAD, true)) {
-            $value = null;
-        }
-
-        $this->setOption('beatmapset_download', $value);
-    }
-
-    public function getBeatmapsetShowNsfwAttribute()
-    {
-        return $this->options['beatmapset_show_nsfw'] ?? false;
-    }
-
-    public function setBeatmapsetShowNsfwAttribute($value)
-    {
-        $this->setOption('beatmapset_show_nsfw', get_bool($value));
-    }
-
-    public function getBeatmapsetTitleShowOriginalAttribute()
-    {
-        return $this->options['beatmapset_title_show_original'] ?? false;
-    }
-
-    public function setBeatmapsetTitleShowOriginalAttribute($value)
-    {
-        $this->setOption('beatmapset_title_show_original', get_bool($value));
-    }
-
-    public function getCommentsShowDeletedAttribute()
-    {
-        return $this->options['comments_show_deleted'] ?? false;
-    }
-
-    public function setCommentsShowDeletedAttribute($value)
-    {
-        $this->setOption('comments_show_deleted', get_bool($value));
-    }
-
-    public function getCommentsSortAttribute()
-    {
-        return $this->options['comments_sort'] ?? Comment::DEFAULT_SORT;
-    }
-
-    public function setCommentsSortAttribute($value)
-    {
-        if ($value !== null && !array_key_exists($value, Comment::SORTS)) {
-            $value = null;
-        }
-
-        $this->setOption('comments_sort', $value);
-    }
-
-    public function getForumPostsShowDeletedAttribute()
-    {
-        return $this->options['forum_posts_show_deleted'] ?? true;
-    }
-
-    public function setForumPostsShowDeletedAttribute($value)
-    {
-        $this->setOption('forum_posts_show_deleted', get_bool($value));
-    }
-
-    public function getUserListFilterAttribute()
-    {
-        return $this->options['user_list_filter'] ?? static::USER_LIST['filters']['default'];
-    }
-
-    public function setUserListFilterAttribute($value)
-    {
-        if ($value !== null && !in_array($value, static::USER_LIST['filters']['all'], true)) {
-            $value = null;
-        }
-
-        $this->setOption('user_list_filter', $value);
-    }
-
-    public function getUserListSortAttribute()
-    {
-        return $this->options['user_list_sort'] ?? static::USER_LIST['sorts']['default'];
-    }
-
-    public function setUserListSortAttribute($value)
-    {
-        if ($value !== null && !in_array($value, static::USER_LIST['sorts']['all'], true)) {
-            $value = null;
-        }
-
-        $this->setOption('user_list_sort', $value);
-    }
-
-    public function getUserListViewAttribute()
-    {
-        return $this->options['user_list_view'] ?? static::USER_LIST['views']['default'];
-    }
-
-    public function setUserListViewAttribute($value)
-    {
-        if ($value !== null && !in_array($value, static::USER_LIST['views']['all'], true)) {
-            $value = null;
-        }
-
-        $this->setOption('user_list_view', $value);
-    }
 
     public function getExtrasOrderAttribute($value)
     {
@@ -252,22 +108,7 @@ class UserProfileCustomization extends Model
     public function setExtrasOrderAttribute($value)
     {
         $this->attributes['extras_order'] = null;
-        $this->setOption('extras_order', static::repairExtrasOrder($value));
-    }
-
-    public function getProfileCoverExpandedAttribute()
-    {
-        return $this->options['profile_cover_expanded'] ?? true;
-    }
-
-    public function setProfileCoverExpandedAttribute($value)
-    {
-        $this->setOption('profile_cover_expanded', get_bool($value));
-    }
-
-    private function setOption($key, $value)
-    {
         $this->options ??= [];
-        $this->options[$key] = $value;
+        $this->options['extras_order'] = static::repairExtrasOrder($value);
     }
 }

--- a/app/Transformers/UserCompactTransformer.php
+++ b/app/Transformers/UserCompactTransformer.php
@@ -5,6 +5,7 @@
 
 namespace App\Transformers;
 
+use App\Casts\UserPreferences;
 use App\Libraries\MorphMap;
 use App\Models\Beatmap;
 use App\Models\User;
@@ -410,21 +411,7 @@ class UserCompactTransformer extends TransformerAbstract
     {
         $customization = $this->userProfileCustomization($user);
 
-        return $this->primitive($customization->only([
-            'audio_autoplay',
-            'audio_muted',
-            'audio_volume',
-            'beatmapset_card_size',
-            'beatmapset_download',
-            'beatmapset_show_nsfw',
-            'beatmapset_title_show_original',
-            'comments_show_deleted',
-            'forum_posts_show_deleted',
-            'profile_cover_expanded',
-            'user_list_filter',
-            'user_list_sort',
-            'user_list_view',
-        ]));
+        return $this->primitive($customization->only(array_keys(UserPreferences::attributes())));
     }
 
     public function setMode(string $mode)

--- a/resources/views/accounts/_edit_options.blade.php
+++ b/resources/views/accounts/_edit_options.blade.php
@@ -28,7 +28,7 @@
                     @php
                         $statusIsRendered = false;
                     @endphp
-                    @foreach (App\Models\UserProfileCustomization::BEATMAPSET_DOWNLOAD as $name)
+                    @foreach (App\Casts\UserPreferences::BEATMAPSET_DOWNLOAD as $name)
                         @if ($name === 'direct' && !auth()->user()->isSupporter())
                             @continue
                         @endif


### PR DESCRIPTION
When trying to clean up score model, I found that returning empty array on `CastAttributes#set` results in noop. It can then be used to assign specific field instead of the casting field. This is what I originally intend #8550 to be 😐 

`extras_order` stays because it should be updated to get rid of the column first... (or the other way around by getting rid of it from `options`)

Also I don't know why I didn't make `user_id` the table's primary key 🤔 

It looks like I need to dig a bit deeper on this CastAttributes thing because it behaves in a rather unexpected way.