### PR TITLE
Add support for multiplayer auto countdown timers

### DIFF
--- a/app/Models/Multiplayer/Room.php
+++ b/app/Models/Multiplayer/Room.php
@@ -462,6 +462,7 @@ class Room extends Model
             'playlist:array',
             'type',
             'queue_mode',
+            'auto_start_duration:int',
         ], ['null_missing' => true]);
 
         $this->fill([
@@ -470,6 +471,7 @@ class Room extends Model
             'starts_at' => now(),
             'type' => $params['type'],
             'queue_mode' => $params['queue_mode'],
+            'auto_start_duration' => $params['auto_start_duration'],
             'user_id' => $host->getKey(),
         ]);
 
@@ -483,12 +485,16 @@ class Room extends Model
             if (!in_array($this->queue_mode, static::REALTIME_QUEUE_MODES, true)) {
                 $this->queue_mode = static::REALTIME_DEFAULT_QUEUE_MODE;
             }
+            if ($this->auto_start_duration === null) {
+                $this->auto_start_duration = 0;
+            }
             // only for realtime rooms for now
             $this->password = $params['password'];
             $this->ends_at = now()->addSeconds(30);
         } else {
             $this->type = static::PLAYLIST_TYPE;
             $this->queue_mode = static::PLAYLIST_QUEUE_MODE;
+            $this->auto_start_duration = 0;
             if ($params['ends_at'] !== null) {
                 $this->ends_at = $params['ends_at'];
             } elseif ($params['duration'] !== null) {

--- a/database/migrations/2022_03_18_125356_add_auto_start_duration_to_multiplayer_rooms.php
+++ b/database/migrations/2022_03_18_125356_add_auto_start_duration_to_multiplayer_rooms.php
@@ -1,5 +1,8 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2022_03_18_125356_add_auto_start_duration_to_multiplayer_rooms.php
+++ b/database/migrations/2022_03_18_125356_add_auto_start_duration_to_multiplayer_rooms.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddAutoStartDurationToMultiplayerRooms extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('multiplayer_rooms', function (Blueprint $table) {
+            $table->unsignedSmallInteger('auto_start_duration')->after('queue_mode')->default(0);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('multiplayer_rooms', function (Blueprint $table) {
+            $table->dropColumn('auto_start_duration');
+        });
+    }
+}


### PR DESCRIPTION
Duration provided in seconds as I don't believe there's a time-span compatible MYSQL data type. Capped at SMALLINT as we're likely never going to support auto-start countdowns longer than 5 minutes.