### PR TITLE
Update location bar when switching chat channels

### DIFF
--- a/resources/assets/less/bem-index.less
+++ b/resources/assets/less/bem-index.less
@@ -111,6 +111,7 @@
 @import "bem/chat-conversation-list";
 @import "bem/chat-conversation-list-item";
 @import "bem/chat-conversation-list-separator";
+@import "bem/chat-conversation-panel";
 @import "bem/chat-input";
 @import "bem/chat-message-group";
 @import "bem/chat-message-item";

--- a/resources/assets/less/bem/chat-conversation-panel.less
+++ b/resources/assets/less/bem/chat-conversation-panel.less
@@ -1,0 +1,31 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
+.chat-conversation-panel {
+  display: flex;
+  flex-direction: column;
+  flex: 1;
+  overflow-y: auto; // without this, firefox scroll breaks
+  position: relative;
+
+  &__instructions {
+    margin-top: 10px;
+  }
+
+  &__no-channel {
+    .center-content();
+    padding: 20px;
+    height: 100%;
+    width: 100%;
+    flex-direction: column;
+    min-height: 250px;
+    color: hsl(var(--hsl-l1));
+  }
+
+  &__title {
+    color: white;
+    .default-text-shadow();
+    font-size: 26px;
+    font-weight: 300;
+  }
+}

--- a/resources/assets/less/bem/chat.less
+++ b/resources/assets/less/bem/chat.less
@@ -8,38 +8,4 @@
   @media @mobile {
     flex-direction: column;
   }
-
-  &__conversation-area {
-    display: flex;
-    flex-direction: column;
-    flex: 1;
-    overflow-y: auto; // without this, firefox scroll breaks
-    position: relative;
-  }
-
-  &__instructions {
-    margin-top: 10px;
-  }
-
-  &__not-active {
-    .center-content();
-    padding: 20px;
-    height: 100%;
-    width: 100%;
-    flex-direction: column;
-    min-height: 250px;
-    color: @osu-colour-l1;
-  }
-
-  &__sidebar {
-    display: flex;
-    flex-direction: column;
-  }
-
-  &__title {
-    color: white;
-    .default-text-shadow();
-    font-size: 26px;
-    font-weight: 300;
-  }
 }

--- a/resources/assets/less/bem/footer.less
+++ b/resources/assets/less/bem/footer.less
@@ -47,7 +47,7 @@
     }
   }
 
-  .osu-layout--mobile-app & {
+  .u-chat & {
     @media @mobile {
       display: none;
     }

--- a/resources/assets/less/bem/osu-layout.less
+++ b/resources/assets/less/bem/osu-layout.less
@@ -12,15 +12,6 @@
 
   transition: filter 200ms ease-in-out, opacity 200ms ease-in-out; // for fading in after &--masked is removed
 
-  &--mobile-app {
-    .fancy-scrollbar();
-
-    @media @mobile {
-      position: fixed;
-      width: 100%;
-    }
-  }
-
   &--body {
     background-color: @osu-colour-b6;
   }

--- a/resources/assets/less/utilities.less
+++ b/resources/assets/less/utilities.less
@@ -18,8 +18,6 @@
 }
 
 .u-chat {
-  .fancy-scrollbar();
-
   @media @mobile {
     position: fixed;
     width: 100%;

--- a/resources/assets/less/utilities.less
+++ b/resources/assets/less/utilities.less
@@ -17,6 +17,15 @@
   z-index: @z-index--blackout-visible !important;
 }
 
+.u-chat {
+  .fancy-scrollbar();
+
+  @media @mobile {
+    position: fixed;
+    width: 100%;
+  }
+}
+
 .u-ellipsis-overflow {
   white-space: nowrap !important;
   text-overflow: ellipsis !important;

--- a/resources/assets/lib/chat/chat-state-store.ts
+++ b/resources/assets/lib/chat/chat-state-store.ts
@@ -17,18 +17,24 @@ import { updateQueryString } from 'utils/url';
 import ChannelJoinEvent from './channel-join-event';
 import ChannelPartEvent from './channel-part-event';
 import { getUpdates } from './chat-api';
+import MainView from './main-view';
 import PingService from './ping-service';
 
 @dispatchListener
 export default class ChatStateStore implements DispatchListener {
-  @observable isChatMounted = false;
   @observable isReady = false;
   skipRefresh = false;
+  @observable viewsMounted = new Set<MainView>();
   @observable private isConnected = false;
   private lastHistoryId: number | null = null;
   private pingService: PingService;
   @observable private selected = 0;
   private selectedIndex = 0;
+
+  @computed
+  get isChatMounted() {
+    return this.viewsMounted.size > 0;
+  }
 
   @computed
   get selectedChannel() {
@@ -49,6 +55,14 @@ export default class ChatStateStore implements DispatchListener {
       // refocus channels if any gets removed
       if (changes.type === 'delete') {
         this.refocusSelectedChannel();
+      }
+    });
+
+    autorun(() => {
+      if (this.isChatMounted) {
+        document.querySelector('html')?.classList.add('u-chat');
+      } else {
+        document.querySelector('html')?.classList.remove('u-chat');
       }
     });
 

--- a/resources/assets/lib/chat/chat-state-store.ts
+++ b/resources/assets/lib/chat/chat-state-store.ts
@@ -93,7 +93,7 @@ export default class ChatStateStore implements DispatchListener {
   }
 
   @action
-  selectChannel(channelId: number) {
+  selectChannel(channelId: number, updateUrl = true) {
     if (this.selected === channelId) return;
 
     // mark the channel being switched away from as read.
@@ -110,8 +110,10 @@ export default class ChatStateStore implements DispatchListener {
     this.selected = channelId;
     this.selectedIndex = this.channelList.indexOf(channel);
 
-    const url = updateQueryString(null, { channel_id: channelId.toString() });
-    Turbolinks.controller.advanceHistory(url);
+    if (updateUrl) {
+      const url = updateQueryString(null, { channel_id: channelId.toString() });
+      Turbolinks.controller.advanceHistory(url);
+    }
 
     // TODO: should this be here or have something else figure out if channel needs to be loaded?
     this.channelStore.loadChannel(channelId);
@@ -121,7 +123,7 @@ export default class ChatStateStore implements DispatchListener {
   selectFirst() {
     if (this.channelList.length === 0) return;
 
-    this.selectChannel(this.channelList[0].channelId);
+    this.selectChannel(this.channelList[0].channelId, false);
   }
 
   @action

--- a/resources/assets/lib/chat/chat-state-store.ts
+++ b/resources/assets/lib/chat/chat-state-store.ts
@@ -157,7 +157,7 @@ export default class ChatStateStore implements DispatchListener {
 
   @action
   private handleChatChannelJoinEvent(event: ChannelJoinEvent) {
-    this.channelStore.getOrCreate(event.json);
+    this.channelStore.update(event.json);
   }
 
   @action
@@ -214,7 +214,7 @@ export default class ChatStateStore implements DispatchListener {
         this.lastHistoryId = newHistoryId;
       }
 
-      this.channelStore.updateWithJson(json);
+      this.channelStore.updateWithChatUpdates(json);
     });
   }
 }

--- a/resources/assets/lib/chat/chat-state-store.ts
+++ b/resources/assets/lib/chat/chat-state-store.ts
@@ -13,6 +13,7 @@ import { clamp, maxBy } from 'lodash';
 import { action, autorun, computed, makeObservable, observable, observe, runInAction } from 'mobx';
 import Channel from 'models/chat/channel';
 import ChannelStore from 'stores/channel-store';
+import { updateQueryString } from 'utils/url';
 import ChannelJoinEvent from './channel-join-event';
 import ChannelPartEvent from './channel-part-event';
 import { getUpdates } from './chat-api';
@@ -108,6 +109,9 @@ export default class ChatStateStore implements DispatchListener {
 
     this.selected = channelId;
     this.selectedIndex = this.channelList.indexOf(channel);
+
+    const url = updateQueryString(null, { channel_id: channelId.toString() });
+    Turbolinks.controller.advanceHistory(url);
 
     // TODO: should this be here or have something else figure out if channel needs to be loaded?
     this.channelStore.loadChannel(channelId);

--- a/resources/assets/lib/chat/chat-state-store.ts
+++ b/resources/assets/lib/chat/chat-state-store.ts
@@ -93,7 +93,7 @@ export default class ChatStateStore implements DispatchListener {
   }
 
   @action
-  selectChannel(channelId: number, updateUrl = true) {
+  selectChannel(channelId: number, replaceUrl = false) {
     if (this.selected === channelId) return;
 
     // mark the channel being switched away from as read.
@@ -110,9 +110,12 @@ export default class ChatStateStore implements DispatchListener {
     this.selected = channelId;
     this.selectedIndex = this.channelList.indexOf(channel);
 
-    if (updateUrl) {
-      const url = updateQueryString(null, { channel_id: channelId.toString() });
-      Turbolinks.controller.advanceHistory(url);
+    if (replaceUrl) {
+      // Remove channel_id from location on selectFirst();
+      // also handles the case when history goes back to a channel that was removed.
+      Turbolinks.controller.replaceHistory(updateQueryString(null, { channel_id: null }));
+    } else {
+      Turbolinks.controller.advanceHistory(updateQueryString(null, { channel_id: channelId.toString() }));
     }
 
     // TODO: should this be here or have something else figure out if channel needs to be loaded?
@@ -123,7 +126,7 @@ export default class ChatStateStore implements DispatchListener {
   selectFirst() {
     if (this.channelList.length === 0) return;
 
-    this.selectChannel(this.channelList[0].channelId, false);
+    this.selectChannel(this.channelList[0].channelId, true);
   }
 
   @action

--- a/resources/assets/lib/chat/chat-state-store.ts
+++ b/resources/assets/lib/chat/chat-state-store.ts
@@ -59,14 +59,6 @@ export default class ChatStateStore implements DispatchListener {
     });
 
     autorun(() => {
-      if (this.isChatMounted) {
-        document.querySelector('html')?.classList.add('u-chat');
-      } else {
-        document.querySelector('html')?.classList.remove('u-chat');
-      }
-    });
-
-    autorun(() => {
       if (this.isReady && this.isChatMounted) {
         this.pingService.start();
         dispatch(new SocketMessageSendAction({ event: 'chat.start' }));

--- a/resources/assets/lib/chat/chat-state-store.ts
+++ b/resources/assets/lib/chat/chat-state-store.ts
@@ -110,12 +110,22 @@ export default class ChatStateStore implements DispatchListener {
     this.selected = channelId;
     this.selectedIndex = this.channelList.indexOf(channel);
 
-    if (replaceUrl) {
+    if (channel.newPmChannel) {
+      Turbolinks.controller.replaceHistory(updateQueryString(null, {
+        channel_id: null,
+      }));
+    } else if (replaceUrl) {
       // Remove channel_id from location on selectFirst();
       // also handles the case when history goes back to a channel that was removed.
-      Turbolinks.controller.replaceHistory(updateQueryString(null, { channel_id: null }));
+      Turbolinks.controller.replaceHistory(updateQueryString(null, {
+        channel_id: null,
+        sendto: null,
+      }));
     } else {
-      Turbolinks.controller.advanceHistory(updateQueryString(null, { channel_id: channelId.toString() }));
+      Turbolinks.controller.advanceHistory(updateQueryString(null, {
+        channel_id: channelId.toString(),
+        sendto: null,
+      }));
     }
 
     // TODO: should this be here or have something else figure out if channel needs to be loaded?

--- a/resources/assets/lib/chat/chat-state-store.ts
+++ b/resources/assets/lib/chat/chat-state-store.ts
@@ -99,7 +99,7 @@ export default class ChatStateStore implements DispatchListener {
   }
 
   @action
-  selectChannel(channelId: number, mode: 'advanceHistory' | 'replaceHistory' = 'advanceHistory', updateHistory = true) {
+  selectChannel(channelId: number, mode: 'advanceHistory' | 'replaceHistory' | null = 'advanceHistory') {
     // TODO: enfore location url even if channel doesn't change;
     // noticeable when navigating via ?sendto= on existing channel.
     if (this.selected === channelId) return;
@@ -121,7 +121,7 @@ export default class ChatStateStore implements DispatchListener {
     // TODO: should this be here or have something else figure out if channel needs to be loaded?
     this.channelStore.loadChannel(channelId);
 
-    if (updateHistory) {
+    if (mode != null) {
       const params = channel.newPmChannel
         ? { channel_id: null, sendto: channel.pmTarget?.toString() }
         : { channel_id: channel.channelId.toString(), sendto: null };
@@ -134,7 +134,7 @@ export default class ChatStateStore implements DispatchListener {
   selectFirst() {
     if (this.channelList.length === 0) return;
 
-    this.selectChannel(this.channelList[0].channelId, 'replaceHistory', false);
+    this.selectChannel(this.channelList[0].channelId, null);
     // Remove channel_id from location on selectFirst();
     // also handles the case when history goes back to a channel that was removed.
     Turbolinks.controller.replaceHistory(updateQueryString(null, {

--- a/resources/assets/lib/chat/chat-state-store.ts
+++ b/resources/assets/lib/chat/chat-state-store.ts
@@ -22,23 +22,12 @@ import PingService from './ping-service';
 export default class ChatStateStore implements DispatchListener {
   @observable isChatMounted = false;
   @observable isReady = false;
-  @observable selectedBoxed = observable.box(0);
   skipRefresh = false;
   @observable private isConnected = false;
   private lastHistoryId: number | null = null;
   private pingService: PingService;
+  @observable private selected = 0;
   private selectedIndex = 0;
-
-  @computed
-  get selected() {
-    return this.selectedBoxed.get();
-  }
-
-  // This setter should be considered private.
-  // Use selectChannel to change channel.
-  set selected(value: number) {
-    this.selectedBoxed.set(value);
-  }
 
   @computed
   get selectedChannel() {

--- a/resources/assets/lib/chat/chat-state-store.ts
+++ b/resources/assets/lib/chat/chat-state-store.ts
@@ -145,7 +145,7 @@ export default class ChatStateStore implements DispatchListener {
 
   @action
   private handleChatChannelJoinEvent(event: ChannelJoinEvent) {
-    this.channelStore.getOrCreate(event.json.channel_id).updateWithJson(event.json);
+    this.channelStore.getOrCreate(event.json);
   }
 
   @action

--- a/resources/assets/lib/chat/conversation-list-item.tsx
+++ b/resources/assets/lib/chat/conversation-list-item.tsx
@@ -3,32 +3,26 @@
 
 import UserAvatar from 'components/user-avatar';
 import { observer } from 'mobx-react';
+import Channel from 'models/chat/channel';
 import core from 'osu-core-singleton';
 import * as React from 'react';
-import RootDataStore from 'stores/root-data-store';
 import { classWithModifiers } from 'utils/css';
 
 interface Props {
-  channelId: number;
-  dataStore?: RootDataStore;
+  channel: Channel;
 }
 
 @observer
 export default class ConversationListItem extends React.Component<Props> {
   render(): React.ReactNode {
     const uiState = core.dataStore.chatState;
-    const conversation = core.dataStore.channelStore.get(this.props.channelId);
     const baseClassName = 'chat-conversation-list-item';
 
-    if (!conversation) {
-      return;
-    }
-
-    const selected = this.props.channelId === uiState.selected;
+    const selected = this.props.channel.channelId === uiState.selected;
 
     return (
       <div className={classWithModifiers(baseClassName, { selected })}>
-        {conversation.isUnread && !selected
+        {this.props.channel.isUnread && !selected
           ? <div className={`${baseClassName}__unread-indicator`} />
           : null}
 
@@ -38,9 +32,9 @@ export default class ConversationListItem extends React.Component<Props> {
 
         <button className={`${baseClassName}__tile`} onClick={this.switch}>
           <div className={`${baseClassName}__avatar`}>
-            <UserAvatar modifiers='full-circle' user={{ avatar_url: conversation.icon }} />
+            <UserAvatar modifiers='full-circle' user={{ avatar_url: this.props.channel.icon }} />
           </div>
-          <div className={`${baseClassName}__name`}>{conversation.name}</div>
+          <div className={`${baseClassName}__name`}>{this.props.channel.name}</div>
           <div className={`${baseClassName}__chevron`}>
             <i className='fas fa-chevron-right' />
           </div>
@@ -50,10 +44,10 @@ export default class ConversationListItem extends React.Component<Props> {
   }
 
   private part = () => {
-    core.dataStore.channelStore.partChannel(this.props.channelId);
+    core.dataStore.channelStore.partChannel(this.props.channel.channelId);
   };
 
   private switch = () => {
-    core.dataStore.chatState.selectChannel(this.props.channelId);
+    core.dataStore.chatState.selectChannel(this.props.channel.channelId);
   };
 }

--- a/resources/assets/lib/chat/conversation-list-item.tsx
+++ b/resources/assets/lib/chat/conversation-list-item.tsx
@@ -18,7 +18,7 @@ export default class ConversationListItem extends React.Component<Props> {
     const uiState = core.dataStore.chatState;
     const baseClassName = 'chat-conversation-list-item';
 
-    const selected = this.props.channel.channelId === uiState.selected;
+    const selected = this.props.channel.channelId === uiState.selectedChannel?.channelId;
 
     return (
       <div className={classWithModifiers(baseClassName, { selected })}>

--- a/resources/assets/lib/chat/conversation-list.tsx
+++ b/resources/assets/lib/chat/conversation-list.tsx
@@ -24,7 +24,7 @@ export default class ConversationList extends React.Component {
   }
 
   private renderChannels(channels: Channel[]) {
-    return channels.map((conversation) => <ConversationListItem key={conversation.channelId} channelId={conversation.channelId} />);
+    return channels.map((channel) => <ConversationListItem key={channel.channelId} channel={channel} />);
   }
 
   private renderSeparator() {

--- a/resources/assets/lib/chat/conversation-panel.tsx
+++ b/resources/assets/lib/chat/conversation-panel.tsx
@@ -2,43 +2,42 @@
 // See the LICENCE file in the repository root for full licence text.
 
 import Img2x from 'components/img2x';
-import { computed, makeObservable } from 'mobx';
 import { observer } from 'mobx-react';
 import core from 'osu-core-singleton';
 import * as React from 'react';
 import ConversationView from './conversation-view';
 import InputBox from './input-box';
 
-type Props = Record<string, never>;
+const lazerLink = 'https://github.com/ppy/osu/releases';
 
 @observer
-export default class ConversationPanel extends React.Component<Props> {
-  @computed
-  private get currentChannel() {
-    return core.dataStore.chatState.selectedChannel;
-  }
-
-  constructor(props: Props) {
-    super(props);
-
-    makeObservable(this);
-  }
-
+export default class ConversationPanel extends React.Component<Record<string, never>> {
   render() {
-    if (this.currentChannel == null) {
-      return (
-        <div className='chat__not-active'>
-          <Img2x alt='Art by Badou_Rammsteiner' src='/images/layout/chat/none-yet.png' title='Art by Badou_Rammsteiner' />
-          <div className='chat__title'>{osu.trans('chat.not_found')}</div>
-        </div>
-      );
-    }
-
     return (
-      <>
-        <ConversationView />
-        <InputBox />
-      </>
+      <div className='chat-conversation-panel'>
+        {core.dataStore.chatState.selectedChannel != null ? (
+          <>
+            <ConversationView />
+            <InputBox />
+          </>
+        ) : (
+          <div className='chat-conversation-panel__no-channel'>
+            <Img2x alt='Art by Badou_Rammsteiner' src='/images/layout/chat/none-yet.png' title='Art by Badou_Rammsteiner' />
+            {core.dataStore.channelStore.channels.size > 0 ? (
+              <>
+                <div className='chat-conversation-panel__title'>{osu.trans('chat.not_found.title')}</div>
+                <div className='chat-conversation-panel__instructions'>{osu.trans('chat.not_found.message')}</div>
+              </>
+            ) : (
+              <>
+                <div className='chat-conversation-panel__title'>{osu.trans('chat.no-conversations.title')}</div>
+                <div className='chat-conversation-panel__instructions'>{osu.trans('chat.no-conversations.howto')}</div>
+                <div dangerouslySetInnerHTML={{__html: osu.trans('chat.no-conversations.lazer', { link: lazerLink })}} />
+              </>
+            )}
+          </div>
+        )}
+      </div>
     );
   }
 }

--- a/resources/assets/lib/chat/conversation-panel.tsx
+++ b/resources/assets/lib/chat/conversation-panel.tsx
@@ -1,0 +1,44 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
+import Img2x from 'components/img2x';
+import { computed, makeObservable } from 'mobx';
+import { observer } from 'mobx-react';
+import core from 'osu-core-singleton';
+import * as React from 'react';
+import ConversationView from './conversation-view';
+import InputBox from './input-box';
+
+type Props = Record<string, never>;
+
+@observer
+export default class ConversationPanel extends React.Component<Props> {
+  @computed
+  private get currentChannel() {
+    return core.dataStore.chatState.selectedChannel;
+  }
+
+  constructor(props: Props) {
+    super(props);
+
+    makeObservable(this);
+  }
+
+  render() {
+    if (this.currentChannel == null) {
+      return (
+        <div className='chat__not-active'>
+          <Img2x alt='Art by Badou_Rammsteiner' src='/images/layout/chat/none-yet.png' title='Art by Badou_Rammsteiner' />
+          <div className='chat__title'>{osu.trans('chat.not_found')}</div>
+        </div>
+      );
+    }
+
+    return (
+      <>
+        <ConversationView />
+        <InputBox />
+      </>
+    );
+  }
+}

--- a/resources/assets/lib/chat/conversation-view.tsx
+++ b/resources/assets/lib/chat/conversation-view.tsx
@@ -107,7 +107,7 @@ export default class ConversationView extends React.Component<Props> {
 
     disposeOnUnmount(
       this,
-      reaction(() => core.dataStore.chatState.selected, (newValue, oldValue) => {
+      reaction(() => core.dataStore.chatState.selectedChannel, (newValue, oldValue) => {
         if (newValue !== oldValue) {
           this.didSwitchChannel = true;
         }

--- a/resources/assets/lib/chat/conversation-view.tsx
+++ b/resources/assets/lib/chat/conversation-view.tsx
@@ -7,7 +7,7 @@ import StringWithComponent from 'components/string-with-component';
 import UserAvatar from 'components/user-avatar';
 import { route } from 'laroute';
 import { each, isEmpty, last, throttle } from 'lodash';
-import { action, computed, makeObservable, observe, reaction } from 'mobx';
+import { action, computed, makeObservable, reaction } from 'mobx';
 import { disposeOnUnmount, observer } from 'mobx-react';
 import Message from 'models/chat/message';
 import * as moment from 'moment';
@@ -107,9 +107,8 @@ export default class ConversationView extends React.Component<Props> {
 
     disposeOnUnmount(
       this,
-      // TODO: change to reaction and remove boxed value.
-      observe(core.dataStore.chatState.selectedBoxed, (change) => {
-        if (change.newValue !== change.oldValue) {
+      reaction(() => core.dataStore.chatState.selected, (newValue, oldValue) => {
+        if (newValue !== oldValue) {
           this.didSwitchChannel = true;
         }
       }),

--- a/resources/assets/lib/chat/input-box.tsx
+++ b/resources/assets/lib/chat/input-box.tsx
@@ -5,7 +5,7 @@ import { ChatMessageSendAction } from 'actions/chat-message-send-action';
 import { dispatch } from 'app-dispatcher';
 import BigButton from 'components/big-button';
 import { trim } from 'lodash';
-import { action, autorun, computed, makeObservable, observe } from 'mobx';
+import { action, autorun, computed, makeObservable, reaction } from 'mobx';
 import { disposeOnUnmount, observer } from 'mobx-react';
 import { isModalShowing } from 'modal-helper';
 import Message from 'models/chat/message';
@@ -51,8 +51,8 @@ export default class InputBox extends React.Component<Props> {
 
     disposeOnUnmount(
       this,
-      observe(core.dataStore.chatState.selectedBoxed, (change) => {
-        if (change.newValue !== change.oldValue && core.windowSize.isDesktop) {
+      reaction(() => core.dataStore.chatState.selected, (newValue, oldValue) => {
+        if (newValue !== oldValue && core.windowSize.isDesktop) {
           this.focusInput();
         }
       }),

--- a/resources/assets/lib/chat/input-box.tsx
+++ b/resources/assets/lib/chat/input-box.tsx
@@ -51,8 +51,8 @@ export default class InputBox extends React.Component<Props> {
 
     disposeOnUnmount(
       this,
-      reaction(() => core.dataStore.chatState.selected, (newValue, oldValue) => {
-        if (newValue !== oldValue && core.windowSize.isDesktop) {
+      reaction(() => core.dataStore.chatState.selectedChannel, (newValue, oldValue) => {
+        if (newValue != null && newValue !== oldValue && core.windowSize.isDesktop) {
           this.focusInput();
         }
       }),
@@ -127,7 +127,9 @@ export default class InputBox extends React.Component<Props> {
   // TODO: move to channel?
   @action
   sendMessage(messageText?: string) {
-    if (!messageText || !osu.present(trim(messageText))) {
+    if (core.dataStore.chatState.selectedChannel == null
+      || messageText == null
+      || !osu.present(trim(messageText))) {
       return;
     }
 
@@ -151,7 +153,7 @@ export default class InputBox extends React.Component<Props> {
 
     const message = new Message();
     message.senderId = core.currentUserOrFail.id;
-    message.channelId = core.dataStore.chatState.selected;
+    message.channelId = core.dataStore.chatState.selectedChannel.channelId;
     message.content = messageText;
 
     // Technically we don't need to check command here, but doing so in case we add more commands

--- a/resources/assets/lib/chat/main-view.tsx
+++ b/resources/assets/lib/chat/main-view.tsx
@@ -21,18 +21,13 @@ export default class MainView extends React.Component<Record<string, never>> {
 
   @action
   componentDidMount() {
-    document.querySelector('html')?.classList.add('u-chat');
-    core.dataStore.chatState.isChatMounted = true;
+    core.dataStore.chatState.viewsMounted.add(this);
   }
 
   componentWillUnmount() {
-    // skip cleanup on unmount if navigation is still on chat.
-    if (document.querySelector('.js-chat') == null) {
-      document.querySelector('html')?.classList.remove('u-chat');
-      runInAction(() => {
-        core.dataStore.chatState.isChatMounted = false;
-      });
-    }
+    runInAction(() => {
+      core.dataStore.chatState.viewsMounted.delete(this);
+    });
   }
 
   render() {
@@ -41,7 +36,7 @@ export default class MainView extends React.Component<Record<string, never>> {
       <>
         <HeaderV4 theme='chat' />
         {core.dataStore.channelStore.channels.size > 0 ? (
-          <div className='chat osu-page osu-page--chat js-chat'>
+          <div className='chat osu-page osu-page--chat'>
             <div className='chat__sidebar'>
               <ConversationList />
             </div>
@@ -51,7 +46,7 @@ export default class MainView extends React.Component<Record<string, never>> {
             </div>
           </div>
         ) : (
-          <div className='chat osu-page osu-page--chat js-chat'>
+          <div className='chat osu-page osu-page--chat'>
             <div className='chat__not-active'>
               <Img2x alt='Art by Badou_Rammsteiner' src='/images/layout/chat/none-yet.png' title='Art by Badou_Rammsteiner' />
               <div className='chat__title'>{osu.trans('chat.no-conversations.title')}</div>

--- a/resources/assets/lib/chat/main-view.tsx
+++ b/resources/assets/lib/chat/main-view.tsx
@@ -21,12 +21,12 @@ export default class MainView extends React.Component<Record<string, never>> {
 
   @action
   componentDidMount() {
-    $('html').addClass('osu-layout--mobile-app');
+    $('html').addClass('u-chat');
     core.dataStore.chatState.isChatMounted = true;
   }
 
   componentWillUnmount() {
-    $('html').removeClass('osu-layout--mobile-app');
+    $('html').removeClass('u-chat');
     runInAction(() => {
       core.dataStore.chatState.isChatMounted = false;
     });

--- a/resources/assets/lib/chat/main-view.tsx
+++ b/resources/assets/lib/chat/main-view.tsx
@@ -21,24 +21,27 @@ export default class MainView extends React.Component<Record<string, never>> {
 
   @action
   componentDidMount() {
-    $('html').addClass('u-chat');
+    document.querySelector('html')?.classList.add('u-chat');
     core.dataStore.chatState.isChatMounted = true;
   }
 
   componentWillUnmount() {
-    $('html').removeClass('u-chat');
-    runInAction(() => {
-      core.dataStore.chatState.isChatMounted = false;
-    });
+    // skip cleanup on unmount if navigation is still on chat.
+    if (document.querySelector('.js-chat') == null) {
+      document.querySelector('html')?.classList.remove('u-chat');
+      runInAction(() => {
+        core.dataStore.chatState.isChatMounted = false;
+      });
+    }
   }
 
-  render(): React.ReactNode {
+  render() {
     const lazerLink = 'https://github.com/ppy/osu/releases';
     return (
       <>
         <HeaderV4 theme='chat' />
         {core.dataStore.channelStore.channels.size > 0 ? (
-          <div className='chat osu-page osu-page--chat'>
+          <div className='chat osu-page osu-page--chat js-chat'>
             <div className='chat__sidebar'>
               <ConversationList />
             </div>
@@ -48,7 +51,7 @@ export default class MainView extends React.Component<Record<string, never>> {
             </div>
           </div>
         ) : (
-          <div className='chat osu-page osu-page--chat'>
+          <div className='chat osu-page osu-page--chat js-chat'>
             <div className='chat__not-active'>
               <Img2x alt='Art by Badou_Rammsteiner' src='/images/layout/chat/none-yet.png' title='Art by Badou_Rammsteiner' />
               <div className='chat__title'>{osu.trans('chat.no-conversations.title')}</div>

--- a/resources/assets/lib/chat/main-view.tsx
+++ b/resources/assets/lib/chat/main-view.tsx
@@ -8,8 +8,9 @@ import { disposeOnUnmount, observer } from 'mobx-react';
 import core from 'osu-core-singleton';
 import * as React from 'react';
 import ConversationList from './conversation-list';
-import ConversationView from './conversation-view';
-import InputBox from './input-box';
+import ConversationPanel from './conversation-panel';
+
+const lazerLink = 'https://github.com/ppy/osu/releases';
 
 @observer
 export default class MainView extends React.Component<Record<string, never>> {
@@ -44,7 +45,6 @@ export default class MainView extends React.Component<Record<string, never>> {
   }
 
   render() {
-    const lazerLink = 'https://github.com/ppy/osu/releases';
     return (
       <>
         <HeaderV4 theme='chat' />
@@ -54,8 +54,7 @@ export default class MainView extends React.Component<Record<string, never>> {
               <ConversationList />
             </div>
             <div className='chat__conversation-area'>
-              <ConversationView />
-              <InputBox />
+              <ConversationPanel />
             </div>
           </div>
         ) : (

--- a/resources/assets/lib/chat/main-view.tsx
+++ b/resources/assets/lib/chat/main-view.tsx
@@ -2,15 +2,12 @@
 // See the LICENCE file in the repository root for full licence text.
 
 import HeaderV4 from 'components/header-v4';
-import Img2x from 'components/img2x';
 import { action, autorun, makeObservable, runInAction } from 'mobx';
 import { disposeOnUnmount, observer } from 'mobx-react';
 import core from 'osu-core-singleton';
 import * as React from 'react';
 import ConversationList from './conversation-list';
 import ConversationPanel from './conversation-panel';
-
-const lazerLink = 'https://github.com/ppy/osu/releases';
 
 @observer
 export default class MainView extends React.Component<Record<string, never>> {
@@ -48,25 +45,10 @@ export default class MainView extends React.Component<Record<string, never>> {
     return (
       <>
         <HeaderV4 theme='chat' />
-        {core.dataStore.channelStore.channels.size > 0 ? (
-          <div className='chat osu-page osu-page--chat'>
-            <div className='chat__sidebar'>
-              <ConversationList />
-            </div>
-            <div className='chat__conversation-area'>
-              <ConversationPanel />
-            </div>
-          </div>
-        ) : (
-          <div className='chat osu-page osu-page--chat'>
-            <div className='chat__not-active'>
-              <Img2x alt='Art by Badou_Rammsteiner' src='/images/layout/chat/none-yet.png' title='Art by Badou_Rammsteiner' />
-              <div className='chat__title'>{osu.trans('chat.no-conversations.title')}</div>
-              <div className='chat__instructions'>{osu.trans('chat.no-conversations.howto')}</div>
-              <div dangerouslySetInnerHTML={{__html: osu.trans('chat.no-conversations.lazer', {link: lazerLink})}} />
-            </div>
-          </div>
-        )}
+        <div className='chat osu-page osu-page--chat'>
+          {core.dataStore.channelStore.channels.size > 0 && <ConversationList />}
+          <ConversationPanel />
+        </div>
       </>
     );
   }

--- a/resources/assets/lib/chat/main-view.tsx
+++ b/resources/assets/lib/chat/main-view.tsx
@@ -3,8 +3,8 @@
 
 import HeaderV4 from 'components/header-v4';
 import Img2x from 'components/img2x';
-import { action, makeObservable, runInAction } from 'mobx';
-import { observer } from 'mobx-react';
+import { action, autorun, makeObservable, runInAction } from 'mobx';
+import { disposeOnUnmount, observer } from 'mobx-react';
 import core from 'osu-core-singleton';
 import * as React from 'react';
 import ConversationList from './conversation-list';
@@ -17,6 +17,19 @@ export default class MainView extends React.Component<Record<string, never>> {
     super(props);
 
     makeObservable(this);
+
+    disposeOnUnmount(
+      this,
+      autorun(() => {
+        if (core.dataStore.chatState.isChatMounted) {
+          // This keeps the body element (not the html element) from rubberbanding on mobile Safari
+          // when scroll hits the end.
+          document.documentElement.classList.add('u-chat');
+        } else {
+          document.documentElement.classList.remove('u-chat');
+        }
+      }),
+    );
   }
 
   @action

--- a/resources/assets/lib/entrypoints/chat.tsx
+++ b/resources/assets/lib/entrypoints/chat.tsx
@@ -35,7 +35,7 @@ function getInitialChannel() {
   if (initial != null) {
     if (Array.isArray(initial.presence)) {
       // initial population of channel/presence data
-      dataStore.channelStore.updateWithPresence(initial.presence);
+      dataStore.channelStore.updateMany(initial.presence);
       dataStore.chatState.skipRefresh = true;
     }
 

--- a/resources/assets/lib/entrypoints/chat.tsx
+++ b/resources/assets/lib/entrypoints/chat.tsx
@@ -54,7 +54,6 @@ core.reactTurbolinks.register('chat', action(() => {
     }
   } else {
     const channelId = parseInt(currentUrlParams().get('channel_id') ?? '', 10);
-    // TODO: should clear query string as well (and maybe update on channel selection?)
     initialChannel = dataStore.channelStore.get(channelId) != null ? channelId : dataStore.chatState.selectedChannel?.channelId;
   }
 

--- a/resources/assets/lib/entrypoints/chat.tsx
+++ b/resources/assets/lib/entrypoints/chat.tsx
@@ -28,6 +28,10 @@ function getParamValue(urlParams: URLSearchParams, key: string) {
   return Number.isInteger(value) && value > 0 ? value : null;
 }
 
+/**
+ * @returns The initial Channel; null, if requested initial Channel doesn't exist;
+ * undefined, if no initial Channel was requested.
+ */
 function getInitialChannel() {
   const dataStore = core.dataStore;
   const initial = parseJsonNullable<ChatInitialJson>('json-chat-initial', true);
@@ -64,19 +68,17 @@ function getInitialChannel() {
 
   const channelId = getParamValue(urlParams, 'channel_id');
   if (channelId != null) {
-    return dataStore.channelStore.get(channelId);
+    return dataStore.channelStore.get(channelId) ?? null;
   }
-
-  return null;
 }
 
 core.reactTurbolinks.register('chat', action(() => {
   const channel = getInitialChannel();
 
-  if (channel == null) {
+  if (channel === undefined) {
     core.dataStore.chatState.selectFirst();
   } else {
-    core.dataStore.chatState.selectChannel(channel.channelId, 'replaceHistory');
+    core.dataStore.chatState.selectChannel(channel?.channelId ?? null, 'replaceHistory');
   }
 
   return <MainView />;

--- a/resources/assets/lib/entrypoints/chat.tsx
+++ b/resources/assets/lib/entrypoints/chat.tsx
@@ -54,7 +54,7 @@ core.reactTurbolinks.register('chat', action(() => {
     }
   } else {
     const channelId = parseInt(currentUrlParams().get('channel_id') ?? '', 10);
-    initialChannel = dataStore.channelStore.get(channelId) != null ? channelId : dataStore.chatState.selectedChannel?.channelId;
+    initialChannel = dataStore.channelStore.get(channelId)?.channelId;
   }
 
   if (initialChannel == null) {

--- a/resources/assets/lib/entrypoints/chat.tsx
+++ b/resources/assets/lib/entrypoints/chat.tsx
@@ -37,7 +37,7 @@ core.reactTurbolinks.register('chat', action(() => {
     dataStore.channelStore.lastReceivedMessageId = initial.last_message_id ?? 0;
   }
 
-  let initialChannel = 0;
+  let initialChannel: number | undefined;
   const sendTo = initial?.send_to;
 
   if (sendTo != null) {
@@ -55,13 +55,13 @@ core.reactTurbolinks.register('chat', action(() => {
   } else {
     const channelId = parseInt(currentUrlParams().get('channel_id') ?? '', 10);
     // TODO: should clear query string as well (and maybe update on channel selection?)
-    initialChannel = dataStore.channelStore.get(channelId) != null ? channelId : dataStore.chatState.selected;
+    initialChannel = dataStore.channelStore.get(channelId) != null ? channelId : dataStore.chatState.selectedChannel?.channelId;
   }
 
-  if (initialChannel !== 0) {
-    dataStore.chatState.selectChannel(initialChannel);
-  } else {
+  if (initialChannel == null) {
     dataStore.chatState.selectFirst();
+  } else {
+    dataStore.chatState.selectChannel(initialChannel);
   }
 
   return <MainView />;

--- a/resources/assets/lib/stores/channel-store.ts
+++ b/resources/assets/lib/stores/channel-store.ts
@@ -246,7 +246,12 @@ export default class ChannelStore implements DispatchListener {
   @action
   private async handleChatMessageSendAction(event: ChatMessageSendAction) {
     const message = event.message;
-    const channel = this.getOrCreate(message.channelId);
+    const channel = this.get(message.channelId);
+    if (channel == null) {
+      console.debug('channel missing');
+      return;
+    }
+
     channel.addSendingMessage(message);
 
     try {

--- a/resources/assets/lib/stores/channel-store.ts
+++ b/resources/assets/lib/stores/channel-store.ts
@@ -81,8 +81,7 @@ export default class ChannelStore implements DispatchListener {
 
   @action
   addNewConversation(json: ChannelJson, message: MessageJson) {
-    const channel = this.getOrCreate(json.channel_id);
-    channel.updateWithJson(json);
+    const channel = this.getOrCreate(json);
     // TODO: need to handle user
     channel.addMessages([Message.fromJson(message)]);
 
@@ -117,7 +116,8 @@ export default class ChannelStore implements DispatchListener {
   }
 
   @action
-  getOrCreate(channelId: number): Channel {
+  getOrCreate(json: ChannelJson): Channel {
+    const channelId = json.channel_id;
     let channel = this.channels.get(channelId);
 
     if (!channel) {
@@ -125,6 +125,7 @@ export default class ChannelStore implements DispatchListener {
       this.channels.set(channelId, channel);
     }
 
+    channel.updateWithJson(json);
     return channel;
   }
 
@@ -216,7 +217,7 @@ export default class ChannelStore implements DispatchListener {
   @action
   updateWithPresence(presence: ChannelJson[]) {
     filterSupportedChannelTypes(presence).forEach((json) => {
-      this.getOrCreate(json.channel_id).updateWithJson(json);
+      this.getOrCreate(json);
     });
 
     // remove parted channels

--- a/resources/assets/lib/turbolinks.d.ts
+++ b/resources/assets/lib/turbolinks.d.ts
@@ -5,6 +5,7 @@ declare module 'turbolinks' {
   interface Controller {
     advanceHistory(url: string): void;
     currentVisit?: Visit;
+    replaceHistory(url: string): void;
   }
 
   interface Location {

--- a/resources/lang/en/chat.php
+++ b/resources/lang/en/chat.php
@@ -13,6 +13,8 @@ return [
         'user' => 'You cannot message this user at this time.',
     ],
 
+    'not_found' => 'channel not found',
+
     'input' => [
         'disabled' => 'unable to send message...',
         'disconnected' => 'Disconnected',

--- a/resources/lang/en/chat.php
+++ b/resources/lang/en/chat.php
@@ -13,7 +13,10 @@ return [
         'user' => 'You cannot message this user at this time.',
     ],
 
-    'not_found' => 'channel not found',
+    'not_found' => [
+        'message' => 'There\'s nothing here, maybe you left the channel or it doesn\'t exist...',
+        'title' => 'channel not found',
+    ],
 
     'input' => [
         'disabled' => 'unable to send message...',

--- a/resources/views/chat/index.blade.php
+++ b/resources/views/chat/index.blade.php
@@ -3,7 +3,7 @@
     See the LICENCE file in the repository root for full licence text.
 --}}
 @extends('master', [
-    'bodyAdditionalClasses' => 'osu-layout__no-scroll u-chat',
+    'bodyAdditionalClasses' => 'osu-layout__no-scroll u-fancy-scrollbar',
 ])
 
 @section("content")

--- a/resources/views/chat/index.blade.php
+++ b/resources/views/chat/index.blade.php
@@ -3,7 +3,7 @@
     See the LICENCE file in the repository root for full licence text.
 --}}
 @extends('master', [
-    'bodyAdditionalClasses' => 'osu-layout__no-scroll',
+    'bodyAdditionalClasses' => 'osu-layout__no-scroll u-chat',
 ])
 
 @section("content")


### PR DESCRIPTION
...although this is really about no longer returning uninitialized channels from the state store and removing the `selectedBoxed` boxed primitive so there'll be less layers to go through when updating the channel selection logic for create/join new channels/announcements.

- [x] don't remove chat stuff during component unmount if still on chat
- [x] initial channel selection needs fixing; previous assumptions don't quite work

~~The `u-chat`/`osu-layout--mobile-app` class is moved to the body since it _seems_ to work now on current mobile Safari, except there are new issues (that happen even without the change) with mobile Safari that need fixing separately.~~
Turns out it's needed on `html` thanks to safari's scrolling but the layout shift navigating through history seems fixed by applying `fancy-scrollbar` separately to the body...