### PR TITLE
Fix null return for replay field in scores

### DIFF
--- a/app/Transformers/ScoreTransformer.php
+++ b/app/Transformers/ScoreTransformer.php
@@ -81,7 +81,7 @@ class ScoreTransformer extends TransformerAbstract
             'pp' => $pp ?? null,
             // Ranks are hardcoded to "0" for legacy match scores atm, return F instead for now.
             'rank' => $score->rank === '0' ? 'F' : $score->rank,
-            'replay' => $replay ?? null,
+            'replay' => $replay ?? false,
             'score' => $score->score,
             'statistics' => $statistics,
             'user_id' => $score->user_id,


### PR DESCRIPTION
I noticed the client was receiving responses with `"replay": null` values, which causes client-side exceptions.

It was changed in https://github.com/ppy/osu-web/pull/8731, and I believe it to be an unintentional change since the sequence `?? null` doesn't make sense.