### PR TITLE
Tweak chat input box position on mobile safari

### DIFF
--- a/resources/assets/less/bem/chat-input.less
+++ b/resources/assets/less/bem/chat-input.less
@@ -16,7 +16,6 @@
   display: flex;
 
   @media @mobile {
-    position: fixed;
     font-size: 16px;
     padding-right: 0;
     padding-left: 20px

--- a/resources/assets/lib/core/sticky-header.ts
+++ b/resources/assets/lib/core/sticky-header.ts
@@ -97,7 +97,7 @@ export default class StickyHeader {
   }
 
   private shouldPin(offset?: number | null) {
-    return (offset ?? window.pageYOffset) > 30 || this.shouldStick;
+    return ((offset ?? window.pageYOffset) > 30 || this.shouldStick) && !document.body.classList.contains('osu-layout__no-scroll');
   }
 
   private readonly stickOrUnstick = () => {

--- a/resources/assets/lib/core/sticky-header.ts
+++ b/resources/assets/lib/core/sticky-header.ts
@@ -97,7 +97,7 @@ export default class StickyHeader {
   }
 
   private shouldPin(offset?: number | null) {
-    return ((offset ?? window.pageYOffset) > 30 || this.shouldStick) && !document.body.classList.contains('osu-layout__no-scroll');
+    return (offset ?? window.pageYOffset) > 30 || this.shouldStick;
   }
 
   private readonly stickOrUnstick = () => {


### PR DESCRIPTION
`position: fixed` with `bottom: 0` doesn't track with the bouncy scroll at the end. (noticed it only happens if we move the chat full screen class to `body` 🤔 )

There's still the stupid gap when the address bar is minimized but mobile safari doesn't appear to include that in any sizing (i.e. it returns all heights assuming the full bar is visible) and gets even worse when the keyboard is visible.
