### PR TITLE
Add additional icons in recent events

### DIFF
--- a/resources/assets/less/bem/profile-extra-entries.less
+++ b/resources/assets/less/bem/profile-extra-entries.less
@@ -94,6 +94,38 @@
     height: @item-height;
     margin-right: 5px;
     font-size: 14px; // icon size
+
+    &--ranked {
+      color: var(--beatmapset-ranked-bg);
+    }
+
+    &--qualified {
+      color: var(--beatmapset-qualified-bg);
+    }
+
+    &--loved {
+      color: var(--beatmapset-loved-bg);
+    }
+
+    &--approved {
+      color: var(--beatmapset-approved-bg);
+    }
+
+    &--danger {
+      color: hsl(var(--hsl-red-3));
+    }
+
+    &--green {
+      color: @green;
+    }
+
+    &--yellow {
+      color: @yellow;
+    }
+
+    &--pink {
+      color: @pink;
+    }
   }
 
   &__time {

--- a/resources/assets/less/bem/profile-extra-entries.less
+++ b/resources/assets/less/bem/profile-extra-entries.less
@@ -112,19 +112,19 @@
     }
 
     &--danger {
-      color: hsl(var(--hsl-red-3));
+      color: hsl(var(--hsl-red-1));
     }
 
     &--green {
-      color: @green;
+      color: hsl(var(--hsl-green-1));
     }
 
-    &--yellow {
-      color: @yellow;
+    &--orange {
+      color: hsl(var(--hsl-orange-1));
     }
 
     &--pink {
-      color: @pink;
+      color: hsl(var(--hsl-pink-1));
     }
   }
 

--- a/resources/assets/lib/profile-page/parse-event.tsx
+++ b/resources/assets/lib/profile-page/parse-event.tsx
@@ -36,6 +36,7 @@ export default function parseEvent(event: EventJson, modifiers: Modifiers): { ba
 
     case 'beatmapsetApprove':
       return {
+        badge: <span className='fas fa-check' />,
         mappings: {
           approval: osu.trans(`events.beatmapset_status.${event.approval}`),
           beatmapset: <a href={event.beatmapset.url}>{event.beatmapset.title}</a>,
@@ -45,6 +46,7 @@ export default function parseEvent(event: EventJson, modifiers: Modifiers): { ba
 
     case 'beatmapsetDelete':
       return {
+        badge: <span className='far fa-trash-alt' />,
         mappings: {
           beatmapset: event.beatmapset.title,
         },
@@ -68,6 +70,7 @@ export default function parseEvent(event: EventJson, modifiers: Modifiers): { ba
 
     case 'beatmapsetUpload':
       return {
+        badge: <span className='fas fa-arrow-up' />,
         mappings: {
           beatmapset: <a href={event.beatmapset.url}>{event.beatmapset.title}</a>,
           user: <strong><em><a href={event.user.url}>{event.user.username}</a></em></strong>,
@@ -96,6 +99,7 @@ export default function parseEvent(event: EventJson, modifiers: Modifiers): { ba
 
     case 'userSupportAgain':
       return {
+        badge: <span className='fas fa-heart' />,
         mappings: {
           user: <strong><a href={event.user.url}>{event.user.username}</a></strong>,
         },
@@ -103,6 +107,7 @@ export default function parseEvent(event: EventJson, modifiers: Modifiers): { ba
 
     case 'userSupportFirst':
       return {
+        badge: <span className='fas fa-heart' />,
         mappings: {
           user: <strong><a href={event.user.url}>{event.user.username}</a></strong>,
         },
@@ -110,6 +115,7 @@ export default function parseEvent(event: EventJson, modifiers: Modifiers): { ba
 
     case 'userSupportGift':
       return {
+        badge: <span className='fas fa-gift' />,
         mappings: {
           user: <strong><a href={event.user.url}>{event.user.username}</a></strong>,
         },
@@ -117,6 +123,7 @@ export default function parseEvent(event: EventJson, modifiers: Modifiers): { ba
 
     case 'usernameChange':
       return {
+        badge: <span className='fas fa-tag' />,
         mappings: {
           previousUsername: <strong>{event.user.previousUsername}</strong>,
           user: <strong><em><a href={event.user.url}>{event.user.username}</a></em></strong>,

--- a/resources/assets/lib/profile-page/parse-event.tsx
+++ b/resources/assets/lib/profile-page/parse-event.tsx
@@ -28,6 +28,7 @@ export default function parseEvent(event: EventJson, modifiers: Modifiers): { ba
 
     case 'beatmapPlaycount':
       return {
+        badge: <span className='fas fa-redo' />,
         mappings: {
           beatmap: <a href={event.beatmap.url}>{event.beatmap.title}</a>,
           count: event.count,
@@ -54,6 +55,7 @@ export default function parseEvent(event: EventJson, modifiers: Modifiers): { ba
 
     case 'beatmapsetRevive':
       return {
+        badge: <span className='fas fa-trash-restore' />,
         mappings: {
           beatmapset: <a href={event.beatmapset.url}>{event.beatmapset.title}</a>,
           user: <strong><a href={event.user.url}>{event.user.username}</a></strong>,
@@ -62,6 +64,7 @@ export default function parseEvent(event: EventJson, modifiers: Modifiers): { ba
 
     case 'beatmapsetUpdate':
       return {
+        badge: <span className='fas fa-sync-alt' />,
         mappings: {
           beatmapset: <em><a href={event.beatmapset.url}>{event.beatmapset.title}</a></em>,
           user: <strong><em><a href={event.user.url}>{event.user.username}</a></em></strong>,
@@ -90,6 +93,7 @@ export default function parseEvent(event: EventJson, modifiers: Modifiers): { ba
 
     case 'rankLost':
       return {
+        badge: <span className='fas fa-angle-double-down' />,
         mappings: {
           beatmap: <em><a href={event.beatmap.url}>{event.beatmap.title}</a></em>,
           mode: osu.trans(`beatmaps.mode.${event.mode}`),

--- a/resources/assets/lib/profile-page/parse-event.tsx
+++ b/resources/assets/lib/profile-page/parse-event.tsx
@@ -28,7 +28,7 @@ export default function parseEvent(event: EventJson, modifiers: Modifiers): { ba
 
     case 'beatmapPlaycount':
       return {
-        badge: <span className='fas fa-redo' />,
+        badge: <span className='fas fa-play' />,
         mappings: {
           beatmap: <a href={event.beatmap.url}>{event.beatmap.title}</a>,
           count: event.count,
@@ -37,7 +37,7 @@ export default function parseEvent(event: EventJson, modifiers: Modifiers): { ba
 
     case 'beatmapsetApprove':
       return {
-        badge: <span className='fas fa-check' />,
+        badge: <span className={`fas fa-check profile-extra-entries__icon--${event.approval}`} />,
         mappings: {
           approval: osu.trans(`events.beatmapset_status.${event.approval}`),
           beatmapset: <a href={event.beatmapset.url}>{event.beatmapset.title}</a>,
@@ -47,7 +47,7 @@ export default function parseEvent(event: EventJson, modifiers: Modifiers): { ba
 
     case 'beatmapsetDelete':
       return {
-        badge: <span className='far fa-trash-alt' />,
+        badge: <span className='far fa-trash-alt profile-extra-entries__icon--danger' />,
         mappings: {
           beatmapset: event.beatmapset.title,
         },
@@ -64,7 +64,7 @@ export default function parseEvent(event: EventJson, modifiers: Modifiers): { ba
 
     case 'beatmapsetUpdate':
       return {
-        badge: <span className='fas fa-sync-alt' />,
+        badge: <span className='fas fa-sync-alt profile-extra-entries__icon--green' />,
         mappings: {
           beatmapset: <em><a href={event.beatmapset.url}>{event.beatmapset.title}</a></em>,
           user: <strong><em><a href={event.user.url}>{event.user.username}</a></em></strong>,
@@ -73,7 +73,7 @@ export default function parseEvent(event: EventJson, modifiers: Modifiers): { ba
 
     case 'beatmapsetUpload':
       return {
-        badge: <span className='fas fa-arrow-up' />,
+        badge: <span className='fas fa-arrow-up profile-extra-entries__icon--yellow' />,
         mappings: {
           beatmapset: <a href={event.beatmapset.url}>{event.beatmapset.title}</a>,
           user: <strong><em><a href={event.user.url}>{event.user.username}</a></em></strong>,
@@ -103,7 +103,7 @@ export default function parseEvent(event: EventJson, modifiers: Modifiers): { ba
 
     case 'userSupportAgain':
       return {
-        badge: <span className='fas fa-heart' />,
+        badge: <span className='fas fa-heart profile-extra-entries__icon--pink' />,
         mappings: {
           user: <strong><a href={event.user.url}>{event.user.username}</a></strong>,
         },
@@ -111,7 +111,7 @@ export default function parseEvent(event: EventJson, modifiers: Modifiers): { ba
 
     case 'userSupportFirst':
       return {
-        badge: <span className='fas fa-heart' />,
+        badge: <span className='fas fa-heart profile-extra-entries__icon--pink' />,
         mappings: {
           user: <strong><a href={event.user.url}>{event.user.username}</a></strong>,
         },
@@ -119,7 +119,7 @@ export default function parseEvent(event: EventJson, modifiers: Modifiers): { ba
 
     case 'userSupportGift':
       return {
-        badge: <span className='fas fa-gift' />,
+        badge: <span className='fas fa-gift profile-extra-entries__icon--pink' />,
         mappings: {
           user: <strong><a href={event.user.url}>{event.user.username}</a></strong>,
         },

--- a/resources/assets/lib/profile-page/parse-event.tsx
+++ b/resources/assets/lib/profile-page/parse-event.tsx
@@ -7,7 +7,7 @@ import { Modifiers } from 'utils/css';
 import { switchNever } from 'utils/switch-never';
 import AchievementBadge from './achievement-badge';
 
-export default function parseEvent(event: EventJson, modifiers: Modifiers): { badge?: React.ReactNode; mappings?: Record<string, React.ReactNode> } {
+export default function parseEvent(event: EventJson, modifiers: Modifiers): { badge?: React.ReactNode; iconModifiers?: string; mappings?: Record<string, React.ReactNode> } {
   if (event.parse_error) return {};
 
   switch (event.type) {
@@ -37,7 +37,8 @@ export default function parseEvent(event: EventJson, modifiers: Modifiers): { ba
 
     case 'beatmapsetApprove':
       return {
-        badge: <span className={`fas fa-check profile-extra-entries__icon--${event.approval}`} />,
+        badge: <span className='fas fa-check' />,
+        iconModifiers: event.approval,
         mappings: {
           approval: osu.trans(`events.beatmapset_status.${event.approval}`),
           beatmapset: <a href={event.beatmapset.url}>{event.beatmapset.title}</a>,
@@ -47,7 +48,8 @@ export default function parseEvent(event: EventJson, modifiers: Modifiers): { ba
 
     case 'beatmapsetDelete':
       return {
-        badge: <span className='far fa-trash-alt profile-extra-entries__icon--danger' />,
+        badge: <span className='far fa-trash-alt' />,
+        iconModifiers: 'danger',
         mappings: {
           beatmapset: event.beatmapset.title,
         },
@@ -64,7 +66,8 @@ export default function parseEvent(event: EventJson, modifiers: Modifiers): { ba
 
     case 'beatmapsetUpdate':
       return {
-        badge: <span className='fas fa-sync-alt profile-extra-entries__icon--green' />,
+        badge: <span className='fas fa-sync-alt' />,
+        iconModifiers: 'green',
         mappings: {
           beatmapset: <em><a href={event.beatmapset.url}>{event.beatmapset.title}</a></em>,
           user: <strong><em><a href={event.user.url}>{event.user.username}</a></em></strong>,
@@ -73,7 +76,8 @@ export default function parseEvent(event: EventJson, modifiers: Modifiers): { ba
 
     case 'beatmapsetUpload':
       return {
-        badge: <span className='fas fa-arrow-up profile-extra-entries__icon--yellow' />,
+        badge: <span className='fas fa-arrow-up' />,
+        iconModifiers: 'orange',
         mappings: {
           beatmapset: <a href={event.beatmapset.url}>{event.beatmapset.title}</a>,
           user: <strong><em><a href={event.user.url}>{event.user.username}</a></em></strong>,
@@ -103,7 +107,8 @@ export default function parseEvent(event: EventJson, modifiers: Modifiers): { ba
 
     case 'userSupportAgain':
       return {
-        badge: <span className='fas fa-heart profile-extra-entries__icon--pink' />,
+        badge: <span className='fas fa-heart' />,
+        iconModifiers: 'pink',
         mappings: {
           user: <strong><a href={event.user.url}>{event.user.username}</a></strong>,
         },
@@ -111,7 +116,8 @@ export default function parseEvent(event: EventJson, modifiers: Modifiers): { ba
 
     case 'userSupportFirst':
       return {
-        badge: <span className='fas fa-heart profile-extra-entries__icon--pink' />,
+        badge: <span className='fas fa-heart' />,
+        iconModifiers: 'pink',
         mappings: {
           user: <strong><a href={event.user.url}>{event.user.username}</a></strong>,
         },
@@ -119,7 +125,8 @@ export default function parseEvent(event: EventJson, modifiers: Modifiers): { ba
 
     case 'userSupportGift':
       return {
-        badge: <span className='fas fa-gift profile-extra-entries__icon--pink' />,
+        badge: <span className='fas fa-gift' />,
+        iconModifiers: 'pink',
         mappings: {
           user: <strong><a href={event.user.url}>{event.user.username}</a></strong>,
         },

--- a/resources/assets/lib/profile-page/recent-activity.tsx
+++ b/resources/assets/lib/profile-page/recent-activity.tsx
@@ -9,6 +9,7 @@ import { snakeCase } from 'lodash';
 import { observer } from 'mobx-react';
 import ExtraHeader from 'profile-page/extra-header';
 import * as React from 'react';
+import { classWithModifiers } from 'utils/css';
 import { stripTags } from 'utils/html';
 import ExtraPageProps from './extra-page-props';
 import parseEvent from './parse-event';
@@ -48,13 +49,15 @@ export default class RecentActivity extends React.PureComponent<ExtraPageProps> 
   }
 
   private renderEntry = (event: EventJson) => {
-    const { badge, mappings } = parseEvent(event, 'recent-activity');
+    const { badge, iconModifiers, mappings } = parseEvent(event, 'recent-activity');
     if (mappings == null) return null;
 
     return (
       <li key={event.id} className='profile-extra-entries__item'>
         <div className='profile-extra-entries__detail'>
-          <div className='profile-extra-entries__icon'>
+          <div className={classWithModifiers('profile-extra-entries__icon', [
+            iconModifiers,
+          ])}>
             {badge}
           </div>
           <div className='profile-extra-entries__text'>


### PR DESCRIPTION
## Events

- [x] beatmapPlaycount
- [x] beatmapsetApprove
- [x] beatmapsetDelete
- [x] beatmapsetRevive
- [x] beatmapsetUpdate
- [x] beatmapsetUpload
- [x] rankLost
- [x] userSupportAgain
- [x] userSupportFirst
- [x] userSupportGift
- [x] usernameChange

### Colors

Should we color them as proposed initially? If so how?
With additionnal classes based on event type in `resources/assets/less/bem/page-extra.less` ?

closes #8410 