### PR TITLE
Remove use of nonexistent state

### DIFF
--- a/resources/assets/lib/beatmapsets-show/main.coffee
+++ b/resources/assets/lib/beatmapsets-show/main.coffee
@@ -188,7 +188,7 @@ export class Main extends React.Component
 
     @setHash()
 
-    if !@restoredState || @state.loading
+    if !@restoredState
       @setCurrentScoreboard null, scoreboardType: 'global', resetMods: true
 
 


### PR DESCRIPTION
Noticed this when preparing to typescript things. Leftover from updating score loader system.