### PR TITLE
Fix typing for beatmapset extended json

### DIFF
--- a/resources/assets/lib/interfaces/beatmapset-extended-json.ts
+++ b/resources/assets/lib/interfaces/beatmapset-extended-json.ts
@@ -21,7 +21,7 @@ interface BeatmapsetExtendedJsonAdditionalAttributes {
   discussion_locked: boolean;
   is_scoreable: boolean;
   last_updated: string;
-  legacy_thread_url: string;
+  legacy_thread_url: string | null;
   nominations_summary: NominationsSummary;
   ranked: number;
   ranked_date: string | null;


### PR DESCRIPTION
As it turned out the legacy thread url may be null...