### PR TITLE
Scroll bar for tags

### DIFF
--- a/resources/assets/less/bem/beatmapset-info.less
+++ b/resources/assets/less/bem/beatmapset-info.less
@@ -37,12 +37,22 @@
 
     &--meta {
       position: relative;
+      display: flex;
+      flex-direction: column;
 
       @media @desktop {
         width: 175px;
         overflow: hidden;
         margin-bottom: 10px;
       }
+    }
+
+    &--tags {
+      margin: 0;
+      flex: 1;
+      display: flex;
+      flex-direction: column;
+      height: 0;
     }
 
     &--success-rate {
@@ -107,5 +117,10 @@
 
   &__link {
     overflow-wrap: break-word;
+  }
+
+  &__tags {
+    flex: 1;
+    overflow-y: auto;
   }
 }

--- a/resources/assets/lib/beatmapsets-show/info.coffee
+++ b/resources/assets/lib/beatmapsets-show/info.coffee
@@ -156,12 +156,12 @@ export class Info extends React.Component
               @props.beatmapset.language.name
 
         if tags.length > 0
-          div null,
+          div className: 'beatmapset-info__box beatmapset-info__box--tags u-fancy-scrollbar',
             h3
               className: 'beatmapset-info__header'
               osu.trans 'beatmapsets.show.info.tags'
 
-            div null,
+            div className='beatmapset-info__tags',
               for tag in tags
                 [
                   a

--- a/resources/assets/lib/beatmapsets-show/info.coffee
+++ b/resources/assets/lib/beatmapsets-show/info.coffee
@@ -95,11 +95,7 @@ export class Info extends React.Component
     tags = _(@props.beatmapset.tags)
       .split(' ')
       .filter((t) -> t? && t != '')
-      .slice(0, 21)
       .value()
-
-    tagsOverload = tags.length == 21
-    tags.pop() if tagsOverload
 
     div className: 'beatmapset-info',
       if @state.isEditingDescription
@@ -175,7 +171,6 @@ export class Info extends React.Component
                     tag
                   span key: "#{tag}-space", ' '
                 ]
-              '...' if tagsOverload
 
       div className: 'beatmapset-info__box beatmapset-info__box--success-rate',
         if @props.beatmap.playcount > 0


### PR DESCRIPTION
resolves #5983

This shows all tags instead of the first 20 tags previously and adds a scroll bar if the tags will overflow.

before

![image](https://user-images.githubusercontent.com/23134847/162605928-27bfaef9-19ec-45d2-a84f-c0f3a513e2fe.png)

after

![image](https://user-images.githubusercontent.com/23134847/162605932-9434050e-6123-4731-ae4b-00d001e4044b.png)

I did it in a hacky way and probably need a better solution.

The example beatmap: https://osu.ppy.sh/beatmapsets/1656663#osu/3381471