### PR TITLE
👷 Add Docker push GitHub workflow

### DIFF
--- a/.github/workflows/pack.yml
+++ b/.github/workflows/pack.yml
@@ -1,0 +1,32 @@
+name: Build and publish
+
+on:
+  push:
+    tags:
+      - '*'
+
+jobs:
+  push_to_registry:
+    runs-on: ubuntu-latest
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v2
+      -
+        name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      -
+        name: Login to DockerHub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+      -
+        name: Build and push
+        uses: docker/build-push-action@v2
+        with:
+          context: .
+          file: ./Dockerfile.deployment
+          platforms: linux/amd64
+          push: true
+          tags: pppy/osu-web:latest,pppy/osu-web:${{ github.event.release.tag_name }}


### PR DESCRIPTION
Pushes to Docker Registry everytime a tag is added, pushing both `latest` and current git tag.

Credentials are already added in the GitHub organization.