### PR TITLE
Change button component type to non-pure

### DIFF
--- a/resources/assets/lib/components/big-button.tsx
+++ b/resources/assets/lib/components/big-button.tsx
@@ -20,7 +20,7 @@ interface Props {
   } | string;
 }
 
-export default class BigButton extends React.PureComponent<Props> {
+export default class BigButton extends React.Component<Props> {
   static readonly defaultProps = {
     disabled: false,
     extraClasses: [],


### PR DESCRIPTION
It's pretty difficult to pass non-changing props due to `text` and `props` attributes being objects and they're usually specified inline.