### PR TITLE
Allow moderator to change beatmap difficulty owner

### DIFF
--- a/app/Libraries/OsuAuthorize.php
+++ b/app/Libraries/OsuAuthorize.php
@@ -126,6 +126,10 @@ class OsuAuthorize
         $this->ensureLoggedIn($user);
         $this->ensureCleanRecord($user);
 
+        if ($user->isModerator()) {
+            return 'ok';
+        }
+
         if (
             $beatmapset !== null
             && in_array($beatmapset->status(), ['wip', 'graveyard', 'pending'], true)

--- a/tests/Controllers/BeatmapsControllerTest.php
+++ b/tests/Controllers/BeatmapsControllerTest.php
@@ -250,6 +250,24 @@ class BeatmapsControllerTest extends TestCase
         $this->assertSame($beatmapsetEventCount, BeatmapsetEvent::count());
     }
 
+    public function testUpdateOwnerModerator(): void
+    {
+        $moderator = User::factory()->withGroup('nat')->create();
+        $this->beatmap->beatmapset->update([
+            'approved' => Beatmapset::STATES['ranked'],
+            'approved_date' => now(),
+        ]);
+
+        $this->expectCountChange(fn () => BeatmapsetEvent::count(), 1);
+
+        $this->actingAsVerified($moderator)
+            ->json('PUT', route('beatmaps.update-owner', $this->beatmap), [
+                'beatmap' => ['user_id' => $this->user->getKey()],
+            ])->assertSuccessful();
+
+        $this->assertSame($this->user->getKey(), $this->beatmap->fresh()->user_id);
+    }
+
     public function testUpdateOwnerNotOwner(): void
     {
         $otherUser = User::factory()->create();


### PR DESCRIPTION
Part of #8243.

The test can use some clean up but it's a bit more tricky than I expected.