### PR TITLE
Always show cover for beatmap info page

### DIFF
--- a/resources/assets/lib/beatmapsets-show/header.coffee
+++ b/resources/assets/lib/beatmapsets-show/header.coffee
@@ -86,6 +86,7 @@ export class Header extends React.Component
         div className: 'beatmapset-header__cover',
           el BeatmapsetCover,
             beatmapset: @props.beatmapset
+            forceShowVisual: true # check already covered by parent component
             modifiers: 'full'
             size: 'cover'
 

--- a/resources/assets/lib/components/beatmapset-cover.tsx
+++ b/resources/assets/lib/components/beatmapset-cover.tsx
@@ -18,6 +18,7 @@ interface PropsWithSize {
 
 interface BaseProps {
   beatmapset?: BeatmapsetJson | null;
+  forceShowVisual?: boolean;
   modifiers?: Modifiers;
 }
 
@@ -37,7 +38,7 @@ export default function BeatmapsetCover(props: Props) {
     );
   }
 
-  const style = props.beatmapset != null && showVisual(props.beatmapset)
+  const style = props.beatmapset != null && (props.forceShowVisual || showVisual(props.beatmapset))
     ? cssVar2x(props.beatmapset.covers[props.size])
     : undefined;
 


### PR DESCRIPTION
I forgot there's already different check hiding the whole page.