### PR TITLE
Move guest participation beatmap listing on profile page

### DIFF
--- a/resources/assets/lib/profile-page/beatmapsets.tsx
+++ b/resources/assets/lib/profile-page/beatmapsets.tsx
@@ -26,14 +26,14 @@ const sectionKeys = [
     translationKey: 'loved',
   },
   {
-    countKey: 'pending_beatmapset_count',
-    key: 'pendingBeatmapsets',
-    translationKey: 'pending',
-  },
-  {
     countKey: 'guest_beatmapset_count',
     key: 'guestBeatmapsets',
     translationKey: 'guest',
+  },
+  {
+    countKey: 'pending_beatmapset_count',
+    key: 'pendingBeatmapsets',
+    translationKey: 'pending',
   },
   {
     countKey: 'graveyard_beatmapset_count',


### PR DESCRIPTION
To be after loved instead of pending.

Resolves #8828.