### PR TITLE
Change default discussion page to general all

### DIFF
--- a/resources/assets/coffee/_classes/beatmap-discussion-helper.coffee
+++ b/resources/assets/coffee/_classes/beatmap-discussion-helper.coffee
@@ -8,7 +8,7 @@ import { openBeatmapEditor, linkHtml } from 'utils/url'
 
 class window.BeatmapDiscussionHelper
   @DEFAULT_BEATMAP_ID: '-'
-  @DEFAULT_MODE: 'timeline'
+  @DEFAULT_MODE: 'generalAll'
   @DEFAULT_FILTER: 'total'
   @MAX_MESSAGE_PREVIEW_LENGTH: 100
   @MAX_LENGTH_TIMELINE: 750


### PR DESCRIPTION
Mainly so the <del>upcoming</del> banchobot post on older maps will always be the first visible thing when visiting the page but also probably makes more sense as mapper or moderators usually put note in there (maybe).