### PR TITLE
Fix forum topic auto pagination

### DIFF
--- a/app/Http/Controllers/Forum/TopicsController.php
+++ b/app/Http/Controllers/Forum/TopicsController.php
@@ -390,7 +390,7 @@ class TopicsController extends Controller
             'previous' => static::nextUrl(
                 $topic,
                 $cursorHelper->getSortName() === 'id_desc' ? 'id_asc' : 'id_desc',
-                $cursorHelper->next([$posts[0] ?? null]),
+                $cursorHelper->next([$posts->first()]),
                 $showDeleted
             ),
         ];


### PR DESCRIPTION
The collection stops being normal array ("list") and becomes associative array along the way and thus `0` isn't the first item in it.

Resolves #8846.