### PR TITLE
Trim username in beatmap owner editor

### DIFF
--- a/resources/assets/lib/beatmap-discussions/beatmap-owner-editor.tsx
+++ b/resources/assets/lib/beatmap-discussions/beatmap-owner-editor.tsx
@@ -115,9 +115,9 @@ export default class BeatmapOwnerEditor extends React.Component<Props> {
   };
 
   private handleUsernameInput = (e: React.ChangeEvent<HTMLInputElement>) => {
-    this.inputUsername = e.currentTarget.value.trim();
+    this.inputUsername = e.currentTarget.value;
 
-    this.inputUser = this.props.userByName.get(this.inputUsername);
+    this.inputUser = this.props.userByName.get(this.inputUsername.trim());
 
     window.clearTimeout(this.userLookupTimeout);
 

--- a/resources/assets/lib/beatmap-discussions/beatmap-owner-editor.tsx
+++ b/resources/assets/lib/beatmap-discussions/beatmap-owner-editor.tsx
@@ -117,7 +117,7 @@ export default class BeatmapOwnerEditor extends React.Component<Props> {
   private handleUsernameInput = (e: React.ChangeEvent<HTMLInputElement>) => {
     this.inputUsername = e.currentTarget.value;
 
-    this.inputUser = this.props.userByName.get(this.inputUsername.trim());
+    this.inputUser = this.props.userByName.get(this.inputUsername);
 
     window.clearTimeout(this.userLookupTimeout);
 
@@ -236,7 +236,7 @@ export default class BeatmapOwnerEditor extends React.Component<Props> {
     this.xhr.userLookup?.abort();
 
     this.xhr.userLookup = $.ajax(route('users.check-username-exists'), {
-      data: { username: this.inputUsername },
+      data: { username: this.inputUsername.trim() },
       method: 'POST',
     }).done((user: UserJson) => {
       if (user.id > 0) {

--- a/resources/assets/lib/beatmap-discussions/beatmap-owner-editor.tsx
+++ b/resources/assets/lib/beatmap-discussions/beatmap-owner-editor.tsx
@@ -115,7 +115,7 @@ export default class BeatmapOwnerEditor extends React.Component<Props> {
   };
 
   private handleUsernameInput = (e: React.ChangeEvent<HTMLInputElement>) => {
-    this.inputUsername = e.currentTarget.value;
+    this.inputUsername = e.currentTarget.value.trim();
 
     this.inputUser = this.props.userByName.get(this.inputUsername);
 


### PR DESCRIPTION
Noticed while assigning usernames earlier that e.g. `Andrea ` didn't link to `Andrea`, trimming should fix this.