### PR TITLE
Fix Docker build tagging

### DIFF
--- a/.github/workflows/pack.yml
+++ b/.github/workflows/pack.yml
@@ -24,7 +24,6 @@ jobs:
           tags: |
             type=raw,value=latest,enable=${{ !contains(github.ref_name, '-') }}
             type=raw,value=${{ github.ref_name }}
-            type=sha
           flavor: |
             latest=false
       -

--- a/.github/workflows/pack.yml
+++ b/.github/workflows/pack.yml
@@ -22,7 +22,7 @@ jobs:
             pppy/osu-web
           # generate Docker tags based on the following events/attributes
           tags: |
-            type=raw,value=latest,enable=${{ !contains(github.ref_name, "-") }}
+            type=raw,value=latest,enable=${{ !contains(github.ref_name, '-') }}
             type=raw,pattern=${{ github.ref_name }}
             type=sha
           flavor: |

--- a/.github/workflows/pack.yml
+++ b/.github/workflows/pack.yml
@@ -23,7 +23,7 @@ jobs:
           # generate Docker tags based on the following events/attributes
           tags: |
             type=raw,value=latest,enable=${{ !contains(github.ref_name, '-') }}
-            type=raw,pattern=${{ github.ref_name }}
+            type=raw,value=${{ github.ref_name }}
             type=sha
           flavor: |
             latest=false

--- a/.github/workflows/pack.yml
+++ b/.github/workflows/pack.yml
@@ -13,6 +13,21 @@ jobs:
         name: Checkout
         uses: actions/checkout@v2
       -
+        name: Docker meta
+        id: meta
+        uses: docker/metadata-action@v3
+        with:
+          # list of Docker images to use as base name for tags
+          images: |
+            pppy/osu-web
+          # generate Docker tags based on the following events/attributes
+          tags: |
+            type=raw,value=latest,enable=${{ !contains(github.ref_name, "-") }}
+            type=raw,pattern=${{ github.ref_name }}
+            type=sha
+          flavor: |
+            latest=false
+      -
         name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
       -
@@ -29,4 +44,5 @@ jobs:
           file: ./Dockerfile.deployment
           platforms: linux/amd64
           push: true
-          tags: pppy/osu-web:latest,pppy/osu-web:${{ github.event.release.tag_name }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
Runs build on Git tag events. Tagging the Docker image using the Git SHA, the Git tag, and `latest` if the tag doesn't contain a hyphen.