### PR TITLE
Update source for perfect combo score highlight

### DIFF
--- a/resources/assets/lib/beatmapsets-show/score-top.tsx
+++ b/resources/assets/lib/beatmapsets-show/score-top.tsx
@@ -18,7 +18,7 @@ import PpValue from 'scores/pp-value';
 import { rulesetName, shouldShowPp } from 'utils/beatmap-helper';
 import { classWithModifiers, Modifiers } from 'utils/css';
 import { formatNumber } from 'utils/html';
-import { modeAttributesMap } from 'utils/score-helper';
+import { isPerfect, modeAttributesMap } from 'utils/score-helper';
 
 interface Props {
   beatmap: BeatmapJson;
@@ -139,7 +139,7 @@ export default class ScoreTop extends React.PureComponent<Props> {
                 </div>
                 <div
                   className={classWithModifiers('beatmap-score-top__stat-value', {
-                    perfect: this.props.score.legacy_perfect,
+                    perfect: isPerfect(this.props.score),
                   })}
                 >
                   {formatNumber(this.props.score.max_combo)}x

--- a/resources/assets/lib/beatmapsets-show/score-top.tsx
+++ b/resources/assets/lib/beatmapsets-show/score-top.tsx
@@ -139,7 +139,7 @@ export default class ScoreTop extends React.PureComponent<Props> {
                 </div>
                 <div
                   className={classWithModifiers('beatmap-score-top__stat-value', {
-                    perfect: this.props.score.max_combo === this.props.beatmap.max_combo,
+                    perfect: this.props.score.legacy_perfect,
                   })}
                 >
                   {formatNumber(this.props.score.max_combo)}x

--- a/resources/assets/lib/beatmapsets-show/score-top.tsx
+++ b/resources/assets/lib/beatmapsets-show/score-top.tsx
@@ -18,7 +18,7 @@ import PpValue from 'scores/pp-value';
 import { rulesetName, shouldShowPp } from 'utils/beatmap-helper';
 import { classWithModifiers, Modifiers } from 'utils/css';
 import { formatNumber } from 'utils/html';
-import { isPerfect, modeAttributesMap } from 'utils/score-helper';
+import { isPerfectCombo, modeAttributesMap } from 'utils/score-helper';
 
 interface Props {
   beatmap: BeatmapJson;
@@ -139,7 +139,7 @@ export default class ScoreTop extends React.PureComponent<Props> {
                 </div>
                 <div
                   className={classWithModifiers('beatmap-score-top__stat-value', {
-                    perfect: isPerfect(this.props.score),
+                    perfect: isPerfectCombo(this.props.score),
                   })}
                 >
                   {formatNumber(this.props.score.max_combo)}x

--- a/resources/assets/lib/beatmapsets-show/scoreboard-table-row.tsx
+++ b/resources/assets/lib/beatmapsets-show/scoreboard-table-row.tsx
@@ -16,7 +16,7 @@ import PpValue from 'scores/pp-value';
 import { rulesetName } from 'utils/beatmap-helper';
 import { classWithModifiers, Modifiers } from 'utils/css';
 import { formatNumber } from 'utils/html';
-import { hasMenu, isPerfect, modeAttributesMap } from 'utils/score-helper';
+import { hasMenu, isPerfectCombo, modeAttributesMap } from 'utils/score-helper';
 
 const bn = 'beatmap-scoreboard-table';
 
@@ -123,7 +123,7 @@ export default class ScoreboardTableRow extends React.Component<Props> {
           </td>
         )}
 
-        <TdLink href={this.scoreUrl} modifiers={{ perfect: isPerfect(score) }}>
+        <TdLink href={this.scoreUrl} modifiers={{ perfect: isPerfectCombo(score) }}>
           {`${formatNumber(score.max_combo)}x`}
         </TdLink>
 

--- a/resources/assets/lib/beatmapsets-show/scoreboard-table-row.tsx
+++ b/resources/assets/lib/beatmapsets-show/scoreboard-table-row.tsx
@@ -16,7 +16,7 @@ import PpValue from 'scores/pp-value';
 import { rulesetName } from 'utils/beatmap-helper';
 import { classWithModifiers, Modifiers } from 'utils/css';
 import { formatNumber } from 'utils/html';
-import { hasMenu, modeAttributesMap } from 'utils/score-helper';
+import { hasMenu, isPerfect, modeAttributesMap } from 'utils/score-helper';
 
 const bn = 'beatmap-scoreboard-table';
 
@@ -123,7 +123,7 @@ export default class ScoreboardTableRow extends React.Component<Props> {
           </td>
         )}
 
-        <TdLink href={this.scoreUrl} modifiers={{ perfect: score.legacy_perfect }}>
+        <TdLink href={this.scoreUrl} modifiers={{ perfect: isPerfect(score) }}>
           {`${formatNumber(score.max_combo)}x`}
         </TdLink>
 

--- a/resources/assets/lib/scores-show/stats.tsx
+++ b/resources/assets/lib/scores-show/stats.tsx
@@ -9,7 +9,7 @@ import PpValue from 'scores/pp-value';
 import { rulesetName, shouldShowPp } from 'utils/beatmap-helper';
 import { classWithModifiers } from 'utils/css';
 import { formatNumber } from 'utils/html';
-import { isPerfect, modeAttributesMap } from 'utils/score-helper';
+import { isPerfectCombo, modeAttributesMap } from 'utils/score-helper';
 
 interface Props {
   beatmap: BeatmapJson;
@@ -38,7 +38,7 @@ export default function Stats(props: Props) {
             <div className='score-stats__stat-row score-stats__stat-row--label'>
               {osu.trans('beatmapsets.show.scoreboard.headers.combo')}
             </div>
-            <div className={classWithModifiers('score-stats__stat-row', { perfect: isPerfect(props.score) })}>
+            <div className={classWithModifiers('score-stats__stat-row', { perfect: isPerfectCombo(props.score) })}>
               {formatNumber(props.score.max_combo)}x
             </div>
           </div>

--- a/resources/assets/lib/scores-show/stats.tsx
+++ b/resources/assets/lib/scores-show/stats.tsx
@@ -38,7 +38,7 @@ export default function Stats(props: Props) {
             <div className='score-stats__stat-row score-stats__stat-row--label'>
               {osu.trans('beatmapsets.show.scoreboard.headers.combo')}
             </div>
-            <div className={classWithModifiers('score-stats__stat-row', { perfect: props.score.max_combo === props.beatmap.max_combo })}>
+            <div className={classWithModifiers('score-stats__stat-row', { perfect: props.score.legacy_perfect })}>
               {formatNumber(props.score.max_combo)}x
             </div>
           </div>

--- a/resources/assets/lib/scores-show/stats.tsx
+++ b/resources/assets/lib/scores-show/stats.tsx
@@ -9,7 +9,7 @@ import PpValue from 'scores/pp-value';
 import { rulesetName, shouldShowPp } from 'utils/beatmap-helper';
 import { classWithModifiers } from 'utils/css';
 import { formatNumber } from 'utils/html';
-import { modeAttributesMap } from 'utils/score-helper';
+import { isPerfect, modeAttributesMap } from 'utils/score-helper';
 
 interface Props {
   beatmap: BeatmapJson;
@@ -38,7 +38,7 @@ export default function Stats(props: Props) {
             <div className='score-stats__stat-row score-stats__stat-row--label'>
               {osu.trans('beatmapsets.show.scoreboard.headers.combo')}
             </div>
-            <div className={classWithModifiers('score-stats__stat-row', { perfect: props.score.legacy_perfect })}>
+            <div className={classWithModifiers('score-stats__stat-row', { perfect: isPerfect(props.score) })}>
               {formatNumber(props.score.max_combo)}x
             </div>
           </div>

--- a/resources/assets/lib/utils/score-helper.ts
+++ b/resources/assets/lib/utils/score-helper.ts
@@ -26,6 +26,19 @@ export function hasShow(score: SoloScoreJson): score is SoloScoreJson & Required
   return score.best_id != null;
 }
 
+export function isPerfect(score: SoloScoreJson) {
+  // TODO: Check against beatmap max_combo instead.
+  //       It's currently done this way because the beatmap data is sometimes
+  //       missing max_combo attribute for the score's mods combination.
+  return score.legacy_perfect ?? (
+    ([
+      'miss',
+      'large_tick_miss',
+      'small_tick_miss',
+    ] as const).every((attr) => score.statistics[attr] == null || score.statistics[attr] === 0)
+  );
+}
+
 interface AttributeData {
   attribute: SoloScoreStatisticsAttribute;
   label: string;

--- a/resources/assets/lib/utils/score-helper.ts
+++ b/resources/assets/lib/utils/score-helper.ts
@@ -26,7 +26,7 @@ export function hasShow(score: SoloScoreJson): score is SoloScoreJson & Required
   return score.best_id != null;
 }
 
-export function isPerfect(score: SoloScoreJson) {
+export function isPerfectCombo(score: SoloScoreJson) {
   // TODO: Check against beatmap max_combo instead.
   //       It's currently done this way because the beatmap data is sometimes
   //       missing max_combo attribute for the score's mods combination.

--- a/resources/assets/lib/utils/score-helper.ts
+++ b/resources/assets/lib/utils/score-helper.ts
@@ -34,7 +34,6 @@ export function isPerfect(score: SoloScoreJson) {
     ([
       'miss',
       'large_tick_miss',
-      'small_tick_miss',
     ] as const).every((attr) => score.statistics[attr] == null || score.statistics[attr] === 0)
   );
 }


### PR DESCRIPTION
Comparing `combo` attribute with beatmap's `max_combo` attribute seems to be the most correct method but there's currently nowhere to put it in the json. Even score's `beatmap.max_combo` in score display page could be wrong because that attribute ignores the score mods combination.