### PR TITLE
Include expected env vars for docker build

### DIFF
--- a/.github/workflows/pack.yml
+++ b/.github/workflows/pack.yml
@@ -39,6 +39,10 @@ jobs:
         name: Build and push
         uses: docker/build-push-action@v2
         with:
+          build-args: |
+            "APP_URL=https://osu.ppy.sh"
+            "DOCS_URL=https://osu.ppy.sh/docs/"
+            "GIT_SHA=${{ github.ref_name }}"
           context: .
           file: ./Dockerfile.deployment
           platforms: linux/amd64


### PR DESCRIPTION
This and the other two PRs should be all that's needed. During build, `APP_URL` and `DOCS_URL` are only for documentation and shouldn't affect normal/non production usage too much.