### PR TITLE
Create build on release event instead of tag

### DIFF
--- a/app/Libraries/GithubImporter.php
+++ b/app/Libraries/GithubImporter.php
@@ -27,8 +27,8 @@ class GithubImporter
             OsuWiki::updateFromGithub($this->data);
         } elseif ($this->isMergedPullRequest()) {
             return ChangelogEntry::importFromGithub($this->data);
-        } elseif ($this->isNewTag()) {
-            return Build::importFromGithubNewTag($this->data);
+        } elseif ($this->isNewRelease()) {
+            return Build::importFromGithubNewRelease($this->data);
         }
     }
 
@@ -39,10 +39,9 @@ class GithubImporter
             $this->data['pull_request']['merged'];
     }
 
-    public function isNewTag()
+    public function isNewRelease()
     {
-        return $this->eventType === 'push' &&
-            starts_with($this->data['ref'], 'refs/tags/');
+        return $this->eventType === 'release' && $this->data['action'] === 'published';
     }
 
     public function isPushTo(string $branch): bool

--- a/app/Models/Build.php
+++ b/app/Models/Build.php
@@ -45,11 +45,11 @@ class Build extends Model implements Commentable
 
     private $cache = [];
 
-    public static function importFromGithubNewTag($data)
+    public static function importFromGithubNewRelease($data)
     {
         $repository = Repository::where([
             'name' => $data['repository']['full_name'],
-            'build_on_tag' => true,
+            'build_on_release' => true,
         ])->first();
 
         // abort on unknown or non-auto build repository
@@ -57,7 +57,7 @@ class Build extends Model implements Commentable
             return;
         }
 
-        $tag = explode('-', substr($data['ref'], strlen('refs/tags/')));
+        $tag = explode('-', $data['release']['tag_name']);
         $version = $tag[0];
         $streamName = $tag[1] ?? null;
 
@@ -77,7 +77,7 @@ class Build extends Model implements Commentable
             'version' => $version,
         ]);
 
-        $lastChange = Carbon::parse($data['head_commit']['timestamp']);
+        $lastChange = Carbon::parse($data['release']['created_at']);
 
         $changelogEntry = new ChangelogEntry();
 

--- a/database/migrations/2022_05_23_072546_rename_builds_build_on_release.php
+++ b/database/migrations/2022_05_23_072546_rename_builds_build_on_release.php
@@ -1,0 +1,35 @@
+<?php
+
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('repositories', function (Blueprint $table) {
+            $table->renameColumn('build_on_tag', 'build_on_release');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('repositories', function (Blueprint $table) {
+            $table->renameColumn('build_on_release', 'build_on_tag');
+        });
+    }
+};


### PR DESCRIPTION
There's delay between tag and actual release so create the build entry on release instead.