### PR TITLE
Rename key amount to key count on beatmap info page

### DIFF
--- a/resources/lang/en/beatmapsets.php
+++ b/resources/lang/en/beatmapsets.php
@@ -188,7 +188,7 @@ return [
 
         'stats' => [
             'cs' => 'Circle Size',
-            'cs-mania' => 'Key Amount',
+            'cs-mania' => 'Key Count',
             'drain' => 'HP Drain',
             'accuracy' => 'Accuracy',
             'ar' => 'Approach Rate',


### PR DESCRIPTION
Keys are countable, so "amount" is wrong. Other reasons include:
- the [circle size wiki article](https://osu.ppy.sh/wiki/en/Beatmapping/Circle_size#osu!mania) uses key count
- the stable osu!mania editor uses key count
- most translations of this string are worded "number of keys" (going off google translate), and "number" indicates countable nouns.
- the circles and sliders statistic tooltip says "circle/slider count"
- the [hard coded string in lazer was once "key count"](https://github.com/ppy/osu/blob/2ef791069c67911d548c0da48886f32bd95b7634/osu.Game/Screens/Select/Details/AdvancedStats.cs#L123)

The translations don't need to be wiped as they are correct (as said in point 3).