### PR TITLE
Combine score ruleset function

### DIFF
--- a/app/Libraries/ReplayFile.php
+++ b/app/Libraries/ReplayFile.php
@@ -20,7 +20,7 @@ class ReplayFile
     public function __construct($score)
     {
         $this->filename = $score->getKey();
-        $mode = $score->gameModeString();
+        $mode = $score->getMode();
         $this->diskName = 'replays.'.$mode.'.'.config('osu.score_replays.storage');
         $this->score = $score;
     }

--- a/app/Models/LegacyMatch/Score.php
+++ b/app/Models/LegacyMatch/Score.php
@@ -53,7 +53,7 @@ class Score extends Model
         return $this->belongsTo(Game::class, 'game_id');
     }
 
-    public function gameModeString()
+    public function getMode(): string
     {
         return Beatmap::modeStr($this->game->play_mode);
     }

--- a/app/Models/Score/Best/Model.php
+++ b/app/Models/Score/Best/Model.php
@@ -55,7 +55,7 @@ abstract class Model extends BaseModel implements Traits\ReportableInterface
     {
         $instance = new static();
         $table = $instance->getTable();
-        $modeId = Beatmap::MODES[static::getMode()];
+        $modeId = Beatmap::MODES[$instance->getMode()];
 
         $instance->getConnection()->insert(
             "INSERT INTO score_process_queue (score_id, mode, status) SELECT score_id, {$modeId}, 1 FROM {$table} WHERE user_id = {$user->getKey()}"
@@ -380,7 +380,7 @@ abstract class Model extends BaseModel implements Traits\ReportableInterface
             $statsColumn = static::RANK_TO_STATS_COLUMN_MAPPING[$this->rank] ?? null;
 
             if ($statsColumn !== null && $this->isPersonalBest()) {
-                $userStats = $this->user?->statistics($this->gameModeString());
+                $userStats = $this->user?->statistics($this->getMode());
 
                 if ($userStats !== null) {
                     $userStats->decrement($statsColumn);

--- a/app/Models/Score/Model.php
+++ b/app/Models/Score/Model.php
@@ -23,14 +23,13 @@ abstract class Model extends BaseModel
 
     public $timestamps = false;
 
-    protected $primaryKey = 'score_id';
-
     protected $casts = [
         'pass' => 'bool',
         'perfect' => 'bool',
         'replay' => 'bool',
     ];
     protected $dates = ['date'];
+    protected $primaryKey = 'score_id';
 
     public static function getClass($modeInt)
     {
@@ -48,11 +47,6 @@ abstract class Model extends BaseModel
         }
 
         return get_class_namespace(static::class).'\\'.studly_case($mode);
-    }
-
-    public static function getMode(): string
-    {
-        return snake_case(get_class_basename(static::class));
     }
 
     public function scopeDefault($query)
@@ -118,6 +112,11 @@ abstract class Model extends BaseModel
         return $this->belongsTo("App\\Models\\Score\\Best\\{$basename}", 'high_score_id', 'score_id');
     }
 
+    public function getMode(): string
+    {
+        return snake_case(get_class_basename(static::class));
+    }
+
     public function user()
     {
         return $this->belongsTo(User::class, 'user_id');
@@ -125,7 +124,7 @@ abstract class Model extends BaseModel
 
     public function url()
     {
-        return route('scores.show', ['mode' => static::getMode(), 'score' => $this->getKey()]);
+        return route('scores.show', ['mode' => $this->getMode(), 'score' => $this->getKey()]);
     }
 
     public function getDataAttribute()
@@ -136,7 +135,7 @@ abstract class Model extends BaseModel
             'miss' => $this->countmiss,
             'great' => $this->count300,
         ];
-        $ruleset = static::getMode();
+        $ruleset = $this->getMode();
         switch ($ruleset) {
             case 'osu':
                 $statistics['ok'] = $this->count100;

--- a/app/Models/Solo/Score.php
+++ b/app/Models/Solo/Score.php
@@ -122,7 +122,7 @@ class Score extends Model
         return $score;
     }
 
-    public function getMode()
+    public function getMode(): string
     {
         return Beatmap::modeStr($this->ruleset_id);
     }

--- a/app/Models/Traits/Scoreable.php
+++ b/app/Models/Traits/Scoreable.php
@@ -10,16 +10,8 @@ use App\Libraries\ModsHelper;
 trait Scoreable
 {
     protected $_enabledMods = null;
-    private $gameModeString = null;
 
-    public function gameModeString()
-    {
-        if ($this->gameModeString === null) {
-            $this->gameModeString = snake_case(get_class_basename(static::class));
-        }
-
-        return $this->gameModeString;
-    }
+    abstract public function getMode(): string;
 
     public function getScoringType()
     {
@@ -37,36 +29,38 @@ trait Scoreable
 
     public function totalHits()
     {
-        if ($this->gameModeString() === 'osu') {
-            return ($this->count50 + $this->count100 + $this->count300 + $this->countmiss) * 300;
-        } elseif ($this->gameModeString() === 'fruits') {
-            return $this->count50 + $this->count100 + $this->count300 +
-                $this->countmiss + $this->countkatu;
-        } elseif ($this->gameModeString() === 'mania') {
-            if ($this->getScoringType() === 'scorev2') {
-                return ($this->count50 + $this->count100 + $this->count300 + $this->countmiss + $this->countkatu + $this->countgeki) * 305;
-            } else {
-                return ($this->count50 + $this->count100 + $this->count300 + $this->countmiss + $this->countkatu + $this->countgeki) * 300;
-            }
-        } elseif ($this->gameModeString() === 'taiko') {
-            return ($this->count100 + $this->count300 + $this->countmiss) * 300;
+        switch ($this->getMode()) {
+            case 'osu':
+                return ($this->count50 + $this->count100 + $this->count300 + $this->countmiss) * 300;
+            case 'fruits':
+                return $this->count50 + $this->count100 + $this->count300 +
+                    $this->countmiss + $this->countkatu;
+            case 'mania':
+                if ($this->getScoringType() === 'scorev2') {
+                    return ($this->count50 + $this->count100 + $this->count300 + $this->countmiss + $this->countkatu + $this->countgeki) * 305;
+                } else {
+                    return ($this->count50 + $this->count100 + $this->count300 + $this->countmiss + $this->countkatu + $this->countgeki) * 300;
+                }
+            case 'taiko':
+                return ($this->count100 + $this->count300 + $this->countmiss) * 300;
         }
     }
 
     public function hits()
     {
-        if ($this->gameModeString() === 'osu') {
-            return $this->count50 * 50 + $this->count100 * 100 + $this->count300 * 300;
-        } elseif ($this->gameModeString() === 'fruits') {
-            return $this->count50 + $this->count100 + $this->count300;
-        } elseif ($this->gameModeString() === 'mania') {
-            if ($this->getScoringType() === 'scorev2') {
-                return $this->count50 * 50 + $this->count100 * 100 + $this->countkatu * 200 + $this->count300 * 300 + $this->countgeki * 305;
-            } else {
-                return $this->count50 * 50 + $this->count100 * 100 + $this->countkatu * 200 + ($this->count300 + $this->countgeki) * 300;
-            }
-        } elseif ($this->gameModeString() === 'taiko') {
-            return $this->count100 * 150 + $this->count300 * 300;
+        switch ($this->getMode()) {
+            case 'osu':
+                return $this->count50 * 50 + $this->count100 * 100 + $this->count300 * 300;
+            case 'fruits':
+                return $this->count50 + $this->count100 + $this->count300;
+            case 'mania':
+                if ($this->getScoringType() === 'scorev2') {
+                    return $this->count50 * 50 + $this->count100 * 100 + $this->countkatu * 200 + $this->count300 * 300 + $this->countgeki * 305;
+                } else {
+                    return $this->count50 * 50 + $this->count100 * 100 + $this->countkatu * 200 + ($this->count300 + $this->countgeki) * 300;
+                }
+            case 'taiko':
+                return $this->count100 * 150 + $this->count300 * 300;
         }
     }
 

--- a/app/Transformers/ScoreTransformer.php
+++ b/app/Transformers/ScoreTransformer.php
@@ -46,7 +46,6 @@ class ScoreTransformer extends TransformerAbstract
             $best = $score->best;
 
             $createdAt = $score->date;
-            $mode = $score->getMode();
 
             if ($best !== null) {
                 $bestId = $best->getKey();
@@ -56,8 +55,9 @@ class ScoreTransformer extends TransformerAbstract
         } else {
             // LegacyMatch\Score
             $createdAt = $score->game->start_time;
-            $mode = $score->gameModeString();
         }
+
+        $mode = $score->getMode();
 
         $statistics = [
             'count_100' => $score->count100,

--- a/database/factories/Score/Best/ModelFactory.php
+++ b/database/factories/Score/Best/ModelFactory.php
@@ -18,7 +18,7 @@ abstract class ModelFactory extends Factory
         return [
             'beatmap_id' => fn () => Beatmap::factory()->state([
                 // force playmode to match score type
-                'playmode' => Beatmap::modeInt($this->model::getMode()),
+                'playmode' => Beatmap::modeInt((new $this->model())->getMode()),
             ]),
             'date' => fn () => $this->faker->dateTimeBetween('-5 years'),
             'enabled_mods' => array_rand_val([0, 16, 24, 64, 72]),


### PR DESCRIPTION
The `gameModeString` cache is removed but hopefully it doesn't affect much...? Functions where it's repeatedly accessed have been updated to only do it once.

And it's no longer static function because it's only useful for the main legacy score classes under `App\Models\Score`; solo/multiplayer/legacy match score classes aren't split by ruleset.