### PR TITLE
Fix pinned score visibility check

### DIFF
--- a/app/Models/ScorePin.php
+++ b/app/Models/ScorePin.php
@@ -51,7 +51,7 @@ class ScorePin extends Model
 
     public function scopeWithVisibleScore($query): Builder
     {
-        return $query->whereHasMorph('score', static::SCORES, fn ($q) => $q->visibleUsers());
+        return $query->whereHasMorph('score', static::SCORES);
     }
 
     public function score(): MorphTo


### PR DESCRIPTION
I don't remember why it was filtered by user visibility before when it's already specific to the user being viewed (or themselves).