### PR TITLE
Allow disabling comment on specific item

### DIFF
--- a/app/Http/Controllers/CommentsController.php
+++ b/app/Http/Controllers/CommentsController.php
@@ -194,7 +194,7 @@ class CommentsController extends Controller
         $comment = new Comment($params);
         $comment->setCommentable();
 
-        priv_check('CommentStore', $comment)->ensureCan();
+        priv_check('CommentStore', $comment->commentable)->ensureCan();
 
         try {
             $comment->saveOrExplode();

--- a/app/Libraries/CommentBundle.php
+++ b/app/Libraries/CommentBundle.php
@@ -122,7 +122,13 @@ class CommentBundle
             $result['total'] = $this->commentsQuery()->count();
         }
 
-        $commentables = $comments->pluck('commentable')->uniqueStrict('commentable_identifier')->concat([null]);
+        $commentables = $comments->pluck('commentable');
+        // Always include initial commentable in so it can be used for attributes
+        // check even when there's no comment on it.
+        if ($this->commentable !== null) {
+            $commentables[] = $this->commentable;
+        }
+        $commentables = $commentables->uniqueStrict('commentable_identifier')->concat([null]);
         $result['commentable_meta'] = json_collection($commentables, 'CommentableMeta');
 
         return $result;

--- a/app/Libraries/Commentable.php
+++ b/app/Libraries/Commentable.php
@@ -7,6 +7,8 @@ namespace App\Libraries;
 
 interface Commentable
 {
+    public function commentLocked(): bool;
+
     public function comments();
 
     public function commentableTitle();

--- a/app/Libraries/OsuAuthorize.php
+++ b/app/Libraries/OsuAuthorize.php
@@ -1163,15 +1163,13 @@ class OsuAuthorize
      * @return string
      * @throws AuthorizationCheckException
      */
-    public function checkCommentStore(?User $user, Comment $comment): string
+    public function checkCommentStore(?User $user, Commentable $commentable): string
     {
         $this->ensureLoggedIn($user);
         $this->ensureCleanRecord($user);
         $this->ensureHasPlayed($user);
 
-        $commentable = $comment->commentable;
-
-        if ($commentable instanceof Beatmapset && $commentable->downloadLimited()) {
+        if ($commentable->commentLocked()) {
             return 'comment.store.disabled';
         }
 

--- a/app/Models/Beatmapset.php
+++ b/app/Models/Beatmapset.php
@@ -922,6 +922,11 @@ class Beatmapset extends Model implements AfterCommit, Commentable, Indexable, T
         return config('osu.beatmapset.required_hype');
     }
 
+    public function commentLocked(): bool
+    {
+        return $this->comment_locked || $this->downloadLimited();
+    }
+
     public function commentableTitle()
     {
         return $this->title;

--- a/app/Models/Beatmapset.php
+++ b/app/Models/Beatmapset.php
@@ -111,6 +111,7 @@ class Beatmapset extends Model implements AfterCommit, Commentable, Indexable, T
 
     protected $casts = [
         'active' => 'boolean',
+        'comment_locked' => 'boolean',
         'discussion_enabled' => 'boolean',
         'discussion_locked' => 'boolean',
         'download_disabled' => 'boolean',

--- a/app/Models/Build.php
+++ b/app/Models/Build.php
@@ -182,6 +182,11 @@ class Build extends Model implements Commentable
         }
     }
 
+    public function commentLocked(): bool
+    {
+        return false;
+    }
+
     public function commentableTitle()
     {
         if ($this->stream_id === null || $this->updateStream === null) {

--- a/app/Models/NewsPost.php
+++ b/app/Models/NewsPost.php
@@ -200,6 +200,11 @@ class NewsPost extends Model implements Commentable, Wiki\WikiObject
         return $this->page['author'];
     }
 
+    public function commentLocked(): bool
+    {
+        return false;
+    }
+
     public function commentableTitle()
     {
         return $this->title();

--- a/app/Transformers/CommentableMetaTransformer.php
+++ b/app/Transformers/CommentableMetaTransformer.php
@@ -19,6 +19,9 @@ class CommentableMetaTransformer extends TransformerAbstract
             }
 
             return [
+                'current_user_attributes' => [
+                    'can_new_comment_reason' => priv_check('CommentStore', $commentable)->message(),
+                ],
                 'id' => $commentable->getKey(),
                 'type' => $commentable->getMorphClass(),
                 'title' => $commentable->commentableTitle(),

--- a/database/migrations/2022_06_08_065812_add_comment_locked_to_beatmapsets.php
+++ b/database/migrations/2022_06_08_065812_add_comment_locked_to_beatmapsets.php
@@ -1,0 +1,35 @@
+<?php
+
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('osu_beatmapsets', function (Blueprint $table) {
+            $table->boolean('comment_locked')->default(false);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('osu_beatmapsets', function (Blueprint $table) {
+            $table->dropColumn('comment_locked');
+        });
+    }
+};

--- a/resources/assets/lib/components/comment-editor.coffee
+++ b/resources/assets/lib/components/comment-editor.coffee
@@ -47,7 +47,7 @@ export class CommentEditor extends React.PureComponent
     canComment = @canComment()
 
     placeholder =
-      if mode == 'new' && !canComment
+      if mode in ['new', 'reply'] && !canComment
         @props.commentableMeta.current_user_attributes?.can_new_comment_reason ? osu.trans('authorization.comment.store.disabled')
       else
         osu.trans("comments.placeholder.#{mode}")
@@ -117,7 +117,7 @@ export class CommentEditor extends React.PureComponent
   canComment: =>
     return false if !core.currentUser?
 
-    if @mode() == 'new'
+    if @mode() in ['new', 'reply']
       @props.commentableMeta.current_user_attributes? && !@props.commentableMeta.current_user_attributes?.can_new_comment_reason?
     else
       true

--- a/resources/assets/lib/components/comment-editor.coffee
+++ b/resources/assets/lib/components/comment-editor.coffee
@@ -5,6 +5,7 @@ import BigButton from './big-button'
 import { Spinner } from './spinner'
 import UserAvatar from './user-avatar'
 import { route } from 'laroute'
+import core from 'osu-core-singleton'
 import * as React from 'react'
 import TextareaAutosize from 'react-autosize-textarea'
 import { button, div, span } from 'react-dom-factories'
@@ -42,11 +43,19 @@ export class CommentEditor extends React.PureComponent
 
 
   render: =>
-    blockClass = classWithModifiers bn, @props.modifiers
-    blockClass += " #{bn}--fancy" if @mode() == 'new'
+    mode = @mode()
+    canComment = @canComment()
+
+    placeholder =
+      if mode == 'new' && !canComment
+        @props.commentableMeta.current_user_attributes?.can_new_comment_reason ? osu.trans('authorization.comment.store.disabled')
+      else
+        osu.trans("comments.placeholder.#{mode}")
+
+    blockClass = classWithModifiers bn, @props.modifiers, fancy: mode == 'new'
 
     div className: blockClass,
-      if @mode() == 'new'
+      if mode == 'new'
         div className: "#{bn}__avatar",
           el UserAvatar, user: currentUser, modifiers: ['full-circle']
 
@@ -54,15 +63,15 @@ export class CommentEditor extends React.PureComponent
         className: "#{bn}__message"
         ref: @textarea
         value: @state.message
-        placeholder: osu.trans("comments.placeholder.#{@mode()}")
+        placeholder: placeholder
         onChange: @onChange
         onKeyDown: @handleKeyDown
-        disabled: !currentUser.id? || @state.posting
+        disabled: !canComment || @state.posting
       div
         className: "#{bn}__footer"
         div className: "#{bn}__footer-item #{bn}__footer-item--notice hidden-xs",
           osu.trans 'comments.editor.textarea_hint._',
-            action: osu.trans("comments.editor.textarea_hint.#{@mode()}")
+            action: osu.trans("comments.editor.textarea_hint.#{mode}")
 
         if @props.close?
           div className: "#{bn}__footer-item",
@@ -92,7 +101,7 @@ export class CommentEditor extends React.PureComponent
             el BigButton,
               extraClasses: ['js-user-link']
               modifiers: 'comment-editor'
-              text: osu.trans("comments.guest_button.#{@mode()}")
+              text: osu.trans("comments.guest_button.#{mode}")
 
 
   buttonText: =>
@@ -103,6 +112,15 @@ export class CommentEditor extends React.PureComponent
         when 'new' then 'post'
 
     osu.trans("common.buttons.#{key}")
+
+
+  canComment: =>
+    return false if !core.currentUser?
+
+    if @mode() == 'new'
+      @props.commentableMeta.current_user_attributes? && !@props.commentableMeta.current_user_attributes?.can_new_comment_reason?
+    else
+      true
 
 
   close: =>
@@ -151,8 +169,8 @@ export class CommentEditor extends React.PureComponent
       when 'reply', 'new'
         url = route 'comments.store'
         method = 'POST'
-        data.comment.commentable_type = @props.commentableType
-        data.comment.commentable_id = @props.commentableId
+        data.comment.commentable_type = @props.commentableMeta.type
+        data.comment.commentable_id = @props.commentableMeta.id
         data.comment.parent_id = @props.parent?.id
 
         onDone = (data) =>

--- a/resources/assets/lib/components/comment-editor.coffee
+++ b/resources/assets/lib/components/comment-editor.coffee
@@ -70,8 +70,9 @@ export class CommentEditor extends React.PureComponent
       div
         className: "#{bn}__footer"
         div className: "#{bn}__footer-item #{bn}__footer-item--notice hidden-xs",
-          osu.trans 'comments.editor.textarea_hint._',
-            action: osu.trans("comments.editor.textarea_hint.#{mode}")
+          if canComment
+            osu.trans 'comments.editor.textarea_hint._',
+              action: osu.trans("comments.editor.textarea_hint.#{mode}")
 
         if @props.close?
           div className: "#{bn}__footer-item",

--- a/resources/assets/lib/components/comment.coffee
+++ b/resources/assets/lib/components/comment.coffee
@@ -181,7 +181,7 @@ export class Comment extends React.PureComponent
               @renderDeletedBy()
               @renderRepliesText()
 
-            @renderReplyBox()
+            @renderReplyBox(meta)
 
         if @props.comment.repliesCount > 0
           div
@@ -317,11 +317,12 @@ export class Comment extends React.PureComponent
           span className: "fas #{if @state.expandReplies then 'fa-angle-up' else 'fa-angle-down'}"
 
 
-  renderReplyBox: =>
+  renderReplyBox: (commentableMeta) =>
     if @state.showNewReply
       div className: 'comment__reply-box',
         el CommentEditor,
           close: @closeNewReply
+          commentableMeta: commentableMeta
           modifiers: @props.modifiers
           onPosted: @handleReplyPosted
           parent: @props.comment

--- a/resources/assets/lib/components/comments-manager.coffee
+++ b/resources/assets/lib/components/comments-manager.coffee
@@ -49,8 +49,7 @@ export class CommentsManager extends React.PureComponent
   render: =>
     el Observer, null, () =>
       componentProps = _.assign {}, @props.componentProps
-      componentProps.commentableId = @props.commentableId
-      componentProps.commentableType = @props.commentableType
+      componentProps.commentableMeta = core.dataStore.commentableMetaStore.get @props.commentableType, @props.commentableId
       componentProps.user = @props.user
 
       el @props.component, componentProps

--- a/resources/assets/lib/components/comments.coffee
+++ b/resources/assets/lib/components/comments.coffee
@@ -37,8 +37,7 @@ export class Comments extends React.PureComponent
 
         div className: 'comments__new',
           el CommentEditor,
-            commentableType: @props.commentableType
-            commentableId: @props.commentableId
+            commentableMeta: @props.commentableMeta
             focus: false
             modifiers: @props.modifiers
 

--- a/resources/assets/lib/interfaces/comment-json.ts
+++ b/resources/assets/lib/interfaces/comment-json.ts
@@ -4,6 +4,9 @@
 import UserJson from 'interfaces/user-json';
 
 export type CommentableMetaJson = {
+  current_user_attributes: {
+    can_new_comment_reason: string | null;
+  };
   id: number;
   owner_id: number | null;
   owner_title: string | null;


### PR DESCRIPTION
Resolves #8985 but only for admins with database access (or whatever other system) to actually disable commenting.

```sql
update osu_beatmapsets set comment_locked = 1 where beatmapset_id = $beatmapsetId;
```

This involves adding `comment_locked` column of type boolean/tinyint with default value of 0. Migration entry is

```
2022_06_08_065812_add_comment_locked_to_beatmapsets
```

in case manual migration is needed @peppy.