### PR TITLE
Add form input length limits to Create Announcement UI

### DIFF
--- a/resources/assets/lib/chat/create-announcement.tsx
+++ b/resources/assets/lib/chat/create-announcement.tsx
@@ -53,6 +53,7 @@ export default class CreateAnnouncement extends React.Component<Props> {
             <input
               className='chat-form__input'
               defaultValue={this.model.inputs.name}
+              maxLength={50}
               name='name'
               onBlur={this.handleBlur}
               onChange={this.handleInput}
@@ -62,6 +63,7 @@ export default class CreateAnnouncement extends React.Component<Props> {
             <input
               className='chat-form__input'
               defaultValue={this.model.inputs.description}
+              maxLength={255}
               name='description'
               onBlur={this.handleBlur}
               onChange={this.handleInput}
@@ -89,6 +91,7 @@ export default class CreateAnnouncement extends React.Component<Props> {
               autoComplete='off'
               className='chat-form__input chat-form__input--box'
               defaultValue={this.model.inputs.message}
+              maxLength={1024}
               name='message'
               onBlur={this.handleBlur}
               onChange={this.handleInput}


### PR DESCRIPTION
Better? server-side message to be done separately.

This is just to limit the occurrences of `Unknown error occurred` when the database truncates the field for being too long. Naturally doesn't work well for multibyte characters.