### PR TITLE
Fix announcement notification group link

### DIFF
--- a/resources/assets/lib/models/notification-details.ts
+++ b/resources/assets/lib/models/notification-details.ts
@@ -3,7 +3,7 @@
 
 // FIXME: the type checks for details currently rely on Notification.name
 export default interface NotificationDetails extends Record<string, any> {
-  channel_id?: number;
+  channelId?: number;
   content?: string;
   coverUrl: string | null;
   embeds?: {

--- a/resources/assets/lib/notification-maps/url.ts
+++ b/resources/assets/lib/notification-maps/url.ts
@@ -29,7 +29,9 @@ export function urlGroup(item: Notification) {
     case 'beatmapset':
       return route('beatmapsets.discussion', { beatmapset: item.objectId });
     case 'channel':
-      return item.details.channel_id != null ? route('chat.index', { channel_id: item.details.channelId }) : route('chat.index', { sendto: item.sourceUserId });
+      return item.details.channelId != null
+        ? route('chat.index', { channel_id: item.details.channelId })
+        : route('chat.index', { sendto: item.sourceUserId });
     case 'forum_topic':
       return route('forum.topics.show', { start: 'unread', topic: item.objectId });
   }


### PR DESCRIPTION
Somehow managed to use the correct key for single item but wrong one for group items.

closes #9001