### PR TITLE
Fix error on changing mod on score listing while loading

### DIFF
--- a/resources/assets/lib/beatmapsets-show/scoreboard/controller.ts
+++ b/resources/assets/lib/beatmapsets-show/scoreboard/controller.ts
@@ -150,8 +150,8 @@ export default class Controller {
     this.xhr.done((data) => runInAction(() => {
       this.allData[dataKey] = data;
       this.xhrState = null;
-    })).fail(action(() => {
-      this.xhrState = 'error';
+    })).fail((_xhr, status) => runInAction(() => {
+      this.xhrState = status === 'abort' ? null : 'error';
     }));
   };
 


### PR DESCRIPTION
After the initial scores are loaded, selecting mod and immediately unselecting it will show error instead of showing the already loaded scores.