### PR TITLE
👷 Trigger automated staging deploy on tags push

### DIFF
--- a/.github/workflows/pack.yml
+++ b/.github/workflows/pack.yml
@@ -50,7 +50,16 @@ jobs:
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
 
-      - name: Create Sentry release
+  push_to_sentry:
+    runs-on: ubuntu-latest
+    needs:
+      - push_to_registry
+    steps:
+      -
+        name: Checkout
+        uses: actions/checkout@v2
+      -
+        name: Create Sentry release
         uses: getsentry/action-release@v1
         env:
           SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
@@ -60,3 +69,17 @@ jobs:
         with:
           environment: production
           version: osu-web@${{ github.ref_name }}
+
+  push_to_staging:
+    runs-on: ubuntu-latest
+    needs:
+      - push_to_registry
+    steps:
+      -
+        name: Repository Dispatch
+        uses: peter-evans/repository-dispatch@v2
+        with:
+          token: ${{ secrets.KUBERNETES_CONFIG_REPO_ACCESS_TOKEN }}
+          repository: ppy/osu-kubernetes-config
+          event-type: dev-ppy-sh-deploy
+          client-payload: '{"tag": "${{ github.ref_name }}"}'


### PR DESCRIPTION
Added a job to trigger our staging deployment workflow on new builds.

Also split Sentry releasing into its own job, to avoid the whole workflow to fail even if build succeeds.

The deploy job requires the `KUBERNETES_CONFIG_REPO_ACCESS_TOKEN` secret; see https://github.com/marketplace/actions/repository-dispatch#token

Pending on further modifications depending on workflow validation in the internal repository.