### PR TITLE
Fix comment load replies

### DIFF
--- a/resources/assets/lib/components/comment-show-more.coffee
+++ b/resources/assets/lib/components/comment-show-more.coffee
@@ -65,8 +65,8 @@ export class CommentShowMore extends React.PureComponent
     @setState loading: true
 
     params =
-      commentable_type: @props.parent?.commentable_type ? @props.commentableMeta.type
-      commentable_id: @props.parent?.commentable_id ? @props.commentableMeta.id
+      commentable_type: @props.parent?.commentableType ? @props.commentableMeta.type
+      commentable_id: @props.parent?.commentableId ? @props.commentableMeta.id
       parent_id: @props.parent?.id ? 0
       sort: uiState.comments.currentSort
 


### PR DESCRIPTION
Not sure why I expected the parent comment to still be using the old property names ಠ_ಠ

On further inspection, it seems that `load replies` hasn't been accounting for deleted comments in the replies for a while, since it has been passing the `parent_id` of the parent but not the `commentable_type` and `commentable_id`


closes #9015