### PR TITLE
Pin important wiki notices to the top of the page

### DIFF
--- a/resources/assets/less/bem/page-extra-tabs.less
+++ b/resources/assets/less/bem/page-extra-tabs.less
@@ -2,14 +2,6 @@
 // See the LICENCE file in the repository root for full licence text.
 
 .page-extra-tabs {
-  position: sticky;
-  --navbar-height: @navbar-height;
-  // 1px overlap with navbar to prevent possible gap in some cases.
-  // Reference: https://bugs.chromium.org/p/chromium/issues/detail?id=1261852
-  top: calc(var(--navbar-height) - 1px);
+  .sticky-below-navbar();
   z-index: @z-index--page-extra-tabs;
-
-  @media @desktop {
-    --navbar-height: @nav2-height--pinned;
-  }
 }

--- a/resources/assets/less/bem/wiki-notice.less
+++ b/resources/assets/less/bem/wiki-notice.less
@@ -27,15 +27,7 @@
   }
 
   &__pinned-container {
+    .sticky-below-navbar();
     background-color: hsl(var(--hsl-b5));
-    position: sticky;
-    --navbar-height: @navbar-height;
-    // 1px overlap with navbar to prevent possible gap in some cases.
-    // Reference: https://bugs.chromium.org/p/chromium/issues/detail?id=1261852
-    top: calc(var(--navbar-height) - 1px);
-
-    @media @desktop {
-      --navbar-height: @nav2-height--pinned;
-    }
   }
 }

--- a/resources/assets/less/bem/wiki-notice.less
+++ b/resources/assets/less/bem/wiki-notice.less
@@ -25,4 +25,17 @@
       margin: 0;
     }
   }
+
+  &__pinned-container {
+    background-color: hsl(var(--hsl-b5));
+    position: sticky;
+    --navbar-height: @navbar-height;
+    // 1px overlap with navbar to prevent possible gap in some cases.
+    // Reference: https://bugs.chromium.org/p/chromium/issues/detail?id=1261852
+    top: calc(var(--navbar-height) - 1px);
+
+    @media @desktop {
+      --navbar-height: @nav2-height--pinned;
+    }
+  }
 }

--- a/resources/assets/less/functions.less
+++ b/resources/assets/less/functions.less
@@ -322,3 +322,15 @@
   /* autoprefixer: ignore next */
   -webkit-box-orient: vertical;
 }
+
+.sticky-below-navbar() {
+  position: sticky;
+  --navbar-height: @navbar-height;
+  // 1px overlap with navbar to prevent possible gap in some cases.
+  // Reference: https://bugs.chromium.org/p/chromium/issues/detail?id=1261852
+  top: calc(var(--navbar-height) - 1px);
+
+  @media @desktop {
+    --navbar-height: @nav2-height--pinned;
+  }
+}

--- a/resources/views/wiki/_notice.blade.php
+++ b/resources/views/wiki/_notice.blade.php
@@ -8,21 +8,23 @@
     </div>
 @endif
 
-@if ($page->isLegalTranslation())
-    <div class="wiki-notice wiki-notice--important">
-        {!! osu_trans('wiki.show.translation.legal', [
-            'default' => '<a href="'.e(wiki_url($page->path, config('app.fallback_locale'))).'">'.e(osu_trans('wiki.show.translation.default')).'</a>',
-        ]) !!}
-    </div>
-@endif
+<div class="wiki-notice__pinned-container">
+    @if ($page->isLegalTranslation())
+        <div class="wiki-notice wiki-notice--important">
+            {!! osu_trans('wiki.show.translation.legal', [
+                'default' => '<a href="'.e(wiki_url($page->path, config('app.fallback_locale'))).'">'.e(osu_trans('wiki.show.translation.default')).'</a>',
+            ]) !!}
+        </div>
+    @endif
 
-@if ($page->isOutdatedTranslation())
-    <div class="wiki-notice">
-        {!! osu_trans('wiki.show.translation.outdated', [
-            'default' => '<a href="'.e(wiki_url($page->path, config('app.fallback_locale'))).'">'.e(osu_trans('wiki.show.translation.default')).'</a>',
-        ]) !!}
-    </div>
-@endif
+    @if ($page->isOutdatedTranslation())
+        <div class="wiki-notice">
+            {!! osu_trans('wiki.show.translation.outdated', [
+                'default' => '<a href="'.e(wiki_url($page->path, config('app.fallback_locale'))).'">'.e(osu_trans('wiki.show.translation.default')).'</a>',
+            ]) !!}
+        </div>
+    @endif
+</div>
 
 @if ($page->isOutdated())
     <div class="wiki-notice">


### PR DESCRIPTION
so ppl will still see them when they open a wiki page from a section link, or just scroll past the notices at the beginning

looks a little strange when other not-pinned notices scroll under it, but I'm not sure if anything should be done about that