### PR TITLE
Create legacy score id mapping table

### DIFF
--- a/database/migrations/2022_06_27_073817_create_solo_scores_legacy_id_map.php
+++ b/database/migrations/2022_06_27_073817_create_solo_scores_legacy_id_map.php
@@ -1,0 +1,36 @@
+<?php
+
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('solo_scores_legacy_id_map', function (Blueprint $table) {
+            $table->unsignedSmallInteger('ruleset_id');
+            $table->unsignedInteger('old_score_id');
+            $table->unsignedBigInteger('score_id');
+            $table->primary(['ruleset_id', 'old_score_id']);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('solo_scores_legacy_id_map');
+    }
+};


### PR DESCRIPTION
Resolves #9060 (nothing is using it at the moment).

@peppy the existing table has wrong type for `score_id`. It should be `unsigned bigint` but currently it's just `bigint`. That said, practically it shouldn't be a problem? And migration name for this is `2022_06_27_073817_create_solo_scores_legacy_id_map`.