### PR TITLE
Fix notifications being clicked when not visible

### DIFF
--- a/resources/views/layout/_nav2.blade.php
+++ b/resources/views/layout/_nav2.blade.php
@@ -158,7 +158,7 @@
                     class="nav-click-popup js-click-menu js-react--notification-widget"
                     data-click-menu-id="nav2-chat-notification-widget"
                     data-visibility="hidden"
-                    data-notification-widget="{{ json_encode(['extraClasses' => 'js-nav2--centered-popup', 'only' => 'channel']) }}"
+                    data-notification-widget="{{ json_encode(['extraClasses' => 'js-nav2--centered-popup hidden', 'only' => 'channel']) }}"
                     data-turbolinks-permanent
                     id="notification-widget-chat"
                 ></div>
@@ -182,7 +182,7 @@
                     class="nav-click-popup js-click-menu js-react--notification-widget"
                     data-click-menu-id="nav2-notification-widget"
                     data-visibility="hidden"
-                    data-notification-widget="{{ json_encode(['extraClasses' => 'js-nav2--centered-popup', 'excludes' => ['channel']]) }}"
+                    data-notification-widget="{{ json_encode(['extraClasses' => 'js-nav2--centered-popup hidden', 'excludes' => ['channel']]) }}"
                     data-turbolinks-permanent
                     id="notification-widget"
                 ></div>


### PR DESCRIPTION
Notification popups are part of the layout on initial render; they need to be set to `hidden` on start, otherwise, pointer events go through to the widget and is clickable.

Toggling the widget "fixes" it because it adds/removes `hidden` from the popup element removing them from the layout itself.