### PR TITLE
Sync mods data

### DIFF
--- a/database/mods.json
+++ b/database/mods.json
@@ -362,10 +362,6 @@
             "Type": "boolean"
           },
           {
-            "Name": "fixed_follow_circle_hit_area",
-            "Type": "boolean"
-          },
-          {
             "Name": "always_play_tail_sample",
             "Type": "boolean"
           }


### PR DESCRIPTION
I wonder what should happen if a score is submitted from older client with the removed settings set 🤔 I think currently it'll throw error.