### PR TITLE
Move BeatmapsetTransformer includes

### DIFF
--- a/app/Transformers/BeatmapCompactTransformer.php
+++ b/app/Transformers/BeatmapCompactTransformer.php
@@ -11,10 +11,28 @@ use App\Models\BeatmapFailtimes;
 class BeatmapCompactTransformer extends TransformerAbstract
 {
     protected $availableIncludes = [
+        'accuracy',
+        'ar',
         'beatmapset',
+        'bpm',
         'checksum',
+        'convert',
+        'count_circles',
+        'count_sliders',
+        'count_spinners',
+        'cs',
+        'deleted_at',
+        'drain',
         'failtimes',
+        'hit_length',
+        'is_scoreable',
+        'last_updated',
         'max_combo',
+        'mode_int',
+        'passcount',
+        'playcount',
+        'ranked',
+        'url',
     ];
 
     protected $beatmapsetTransformer = BeatmapsetCompactTransformer::class;
@@ -33,6 +51,21 @@ class BeatmapCompactTransformer extends TransformerAbstract
         ];
     }
 
+    public function includeAccuracy(Beatmap $beatmap)
+    {
+        return $this->primitive($beatmap->diff_overall);
+    }
+
+    public function includeAr(Beatmap $beatmap)
+    {
+        return $this->primitive($beatmap->diff_approach);
+    }
+
+    public function includeBpm(Beatmap $beatmap)
+    {
+        return $this->primitive($beatmap->bpm);
+    }
+
     public function includeBeatmapset(Beatmap $beatmap)
     {
         $beatmapset = $beatmap->beatmapset;
@@ -45,6 +78,42 @@ class BeatmapCompactTransformer extends TransformerAbstract
     public function includeChecksum(Beatmap $beatmap)
     {
         return $this->primitive($beatmap->checksum);
+    }
+
+
+    public function includeConvert(Beatmap $beatmap)
+    {
+        return $this->primitive($beatmap->convert);
+    }
+
+    public function includeCountCircles(Beatmap $beatmap)
+    {
+        return $this->primitive($beatmap->countNormal);
+    }
+
+    public function includeCountSliders(Beatmap $beatmap)
+    {
+        return $this->primitive($beatmap->countSlider);
+    }
+
+    public function includeCountSpinners(Beatmap $beatmap)
+    {
+        return $this->primitive($beatmap->countSpinner);
+    }
+
+    public function includeCs(Beatmap $beatmap)
+    {
+        return $this->primitive($beatmap->diff_size);
+    }
+
+    public function includeDeletedAt(Beatmap $beatmap)
+    {
+        return $this->primitive($beatmap->deleted_at);
+    }
+
+    public function includeDrain(Beatmap $beatmap)
+    {
+        return $this->primitive($beatmap->diff_drain);
     }
 
     public function includeFailtimes(Beatmap $beatmap)
@@ -66,8 +135,47 @@ class BeatmapCompactTransformer extends TransformerAbstract
         return $this->primitive($result);
     }
 
+    public function includeHitLength(Beatmap $beatmap)
+    {
+        return $this->primitive($beatmap->hit_length);
+    }
+
+    public function includeIsScoreable(Beatmap $beatmap)
+    {
+        return $this->primitive($beatmap->isScoreable());
+    }
+
+    public function includeLastUpdated(Beatmap $beatmap)
+    {
+        return $this->primitive(json_time($beatmap->last_update));
+    }
     public function includeMaxCombo(Beatmap $beatmap)
     {
         return $this->primitive($beatmap->maxCombo());
+    }
+
+    public function includeModeInt(Beatmap $beatmap)
+    {
+        return $this->primitive($beatmap->playmode);
+    }
+
+    public function includePasscount(Beatmap $beatmap)
+    {
+        return $this->primitive($beatmap->passcount);
+    }
+
+    public function includePlaycount(Beatmap $beatmap)
+    {
+        return $this->primitive($beatmap->playcount);
+    }
+
+    public function includeRanked(Beatmap $beatmap)
+    {
+        return $this->primitive($beatmap->approved);
+    }
+
+    public function includeUrl(Beatmap $beatmap)
+    {
+        return $this->primitive(route('beatmaps.show', ['beatmap' => $beatmap->beatmap_id]));
     }
 }

--- a/app/Transformers/BeatmapTransformer.php
+++ b/app/Transformers/BeatmapTransformer.php
@@ -5,40 +5,30 @@
 
 namespace App\Transformers;
 
-use App\Models\Beatmap;
-
 class BeatmapTransformer extends BeatmapCompactTransformer
 {
     protected $beatmapsetTransformer = BeatmapsetTransformer::class;
     protected $requiredPermission = 'BeatmapShow';
 
     protected $defaultIncludes = [
+        'accuracy',
+        'ar',
+        'bpm',
         'checksum',
+        'convert',
+        'count_circles',
+        'count_sliders',
+        'count_spinners',
+        'cs',
+        'deleted_at',
+        'drain',
+        'hit_length',
+        'is_scoreable',
+        'last_updated',
+        'mode_int',
+        'passcount',
+        'playcount',
+        'ranked',
+        'url',
     ];
-
-    public function transform(Beatmap $beatmap)
-    {
-        $result = parent::transform($beatmap);
-
-        return array_merge($result, [
-            'accuracy' => $beatmap->diff_overall,
-            'ar' => $beatmap->diff_approach,
-            'bpm' => $beatmap->bpm,
-            'convert' => $beatmap->convert,
-            'count_circles' => $beatmap->countNormal,
-            'count_sliders' => $beatmap->countSlider,
-            'count_spinners' => $beatmap->countSpinner,
-            'cs' => $beatmap->diff_size,
-            'deleted_at' => $beatmap->deleted_at,
-            'drain' => $beatmap->diff_drain,
-            'hit_length' => $beatmap->hit_length,
-            'is_scoreable' => $beatmap->isScoreable(),
-            'last_updated' => json_time($beatmap->last_update),
-            'mode_int' => $beatmap->playmode,
-            'passcount' => $beatmap->passcount,
-            'playcount' => $beatmap->playcount,
-            'ranked' => $beatmap->approved,
-            'url' => route('beatmaps.show', ['beatmap' => $beatmap->beatmap_id]),
-        ]);
-    }
 }

--- a/app/Transformers/BeatmapsetTransformer.php
+++ b/app/Transformers/BeatmapsetTransformer.php
@@ -5,40 +5,27 @@
 
 namespace App\Transformers;
 
-use App\Models\Beatmapset;
-
 class BeatmapsetTransformer extends BeatmapsetCompactTransformer
 {
     protected $beatmapTransformer = BeatmapTransformer::class;
 
     protected $defaultIncludes = [
+        'availability',
+        'bpm',
+        'can_be_hyped',
+        'discussion_enabled',
+        'discussion_locked',
         'has_favourited',
+        'is_scoreable',
+        'last_updated',
+        'legacy_thread_url',
+        'nominations_summary',
+        'ranked',
+        'ranked_date',
+        'storyboard',
+        'submitted_date',
+        'tags',
     ];
 
     protected $requiredPermission = 'BeatmapsetShow';
-
-    public function transform(Beatmapset $beatmapset)
-    {
-        $result = parent::transform($beatmapset);
-
-        return array_merge($result, [
-            'availability' => [
-                'download_disabled' => $beatmapset->download_disabled,
-                'more_information' => $beatmapset->download_disabled_url,
-            ],
-            'bpm' => $beatmapset->bpm,
-            'can_be_hyped' => $beatmapset->canBeHyped(),
-            'discussion_enabled' => true, // TODO: deprecated 2022-06-08
-            'discussion_locked' => $beatmapset->discussion_locked,
-            'is_scoreable' => $beatmapset->isScoreable(),
-            'last_updated' => json_time($beatmapset->last_update),
-            'legacy_thread_url' => $beatmapset->thread_id !== 0 ? route('forum.topics.show', $beatmapset->thread_id) : null,
-            'nominations_summary' => $beatmapset->nominationsSummaryMeta(),
-            'ranked' => $beatmapset->approved,
-            'ranked_date' => json_time($beatmapset->approved_date),
-            'storyboard' => $beatmapset->storyboard,
-            'submitted_date' => json_time($beatmapset->submit_date),
-            'tags' => $beatmapset->tags,
-        ]);
-    }
 }


### PR DESCRIPTION
No need to `array_merge` now that we know `primitive` is a thing..or is there 🤔 
Seems a bit slower:

`array_merge`
```
>>> $s=microtime(true); $beatmapsets = Beatmapset::limit(100)->get(); for ($i = 0; $i < 100; $i++) { $r = json_collection($beatmapsets, new BeatmapsetTransformer()); };  microtime(true) - $s;
=> 1.0002069473267
=> 0.99510312080383
=> 1.002110004425
```

`includes`
```
>>> $s=microtime(true); $beatmapsets = Beatmapset::limit(100)->get(); for ($i = 0; $i < 100; $i++) { $r = json_collection($beatmapsets, new BeatmapsetTransformer()); };  microtime(true) - $s;
=> 1.2349479198456
=> 1.2817931175232
=> 1.2342507839203
```