### PR TITLE
Allow api request to obtain scores in new json format

### DIFF
--- a/app/Transformers/ScoreTransformer.php
+++ b/app/Transformers/ScoreTransformer.php
@@ -46,7 +46,7 @@ class ScoreTransformer extends TransformerAbstract
 
     public function __construct(?string $type = null)
     {
-        $type ??= is_api_request()
+        $type ??= is_api_request() && api_version() < 20220705
             ? static::TYPE_LEGACY
             : static::TYPE_SOLO;
 

--- a/resources/views/docs/_structures/score.md
+++ b/resources/views/docs/_structures/score.md
@@ -1,6 +1,6 @@
 ## Score
 
-The following is the format returned when API v2 version header is below 20220705.
+The following is the format returned when API v2 version header is 20220704 or lower.
 
 Field                 | Type    | Description
 --------------------- | ------- | -----------

--- a/resources/views/docs/_structures/score.md
+++ b/resources/views/docs/_structures/score.md
@@ -1,5 +1,7 @@
 ## Score
 
+The following is the format returned when API v2 version header is below 20220705.
+
 Field                 | Type    | Description
 --------------------- | ------- | -----------
 id                    |         | |


### PR DESCRIPTION
Looking again it's a bit weird as int but should be fine as long it's in the expected format (with all the paddings) until year 9999.

Docs to be added later. The docs is currently missing version header info entirely and that also needs to be added.