### PR TITLE
👷 Tag Docker dev images as latest-dev

### DIFF
--- a/.github/workflows/pack.yml
+++ b/.github/workflows/pack.yml
@@ -24,9 +24,10 @@ jobs:
             pppy/osu-web
           # generate Docker tags based on the following events/attributes
           # on tag event: tag using git tag, and as latest if the tag doesn't contain hyphens (pre-releases)
-          # on push event: tag using git sha
+          # on push event: tag using git sha, branch name and as latest-dev
           tags: |
             type=raw,value=latest,enable=${{ github.ref_type == 'tag' && !contains(github.ref_name, '-') }}
+            type=raw,value=latest-dev,enable=${{ github.ref_type == 'branch' }}
             type=raw,value=${{ github.ref_name }}
             type=raw,value=${{ github.sha }},enable=${{ github.ref_type == 'branch' }}
           flavor: |


### PR DESCRIPTION
This is so we can use `latest-dev` in our staging deployment manifests rather than `latest`, which doesn't reflect the nature of the actually deployed images.

This is something we should probably add to our other pipelines.