### PR TITLE
Generate docs as part of docker image build

### DIFF
--- a/Dockerfile.deployment
+++ b/Dockerfile.deployment
@@ -55,6 +55,8 @@ ARG APP_URL
 ARG DOCS_URL
 RUN yarn production
 
+RUN php artisan scribe:generate
+
 RUN rm -rf node_modules
 
 ARG GIT_SHA

--- a/config/scribe.php
+++ b/config/scribe.php
@@ -331,11 +331,8 @@ INTRO
             \Knuckles\Scribe\Extracting\Strategies\BodyParameters\GetFromBodyParamTag::class,
         ],
         'responses' => [
-            \Knuckles\Scribe\Extracting\Strategies\Responses\UseTransformerTags::class,
             \Knuckles\Scribe\Extracting\Strategies\Responses\UseResponseTag::class,
             \Knuckles\Scribe\Extracting\Strategies\Responses\UseResponseFileTag::class,
-            \Knuckles\Scribe\Extracting\Strategies\Responses\UseApiResourceTags::class,
-            \Knuckles\Scribe\Extracting\Strategies\Responses\ResponseCalls::class,
         ],
         'responseFields' => [
             \Knuckles\Scribe\Extracting\Strategies\ResponseFields\GetFromResponseFieldTag::class,


### PR DESCRIPTION
Most of the current responses which actually hit database (or more like hit the endpoint) are already returning 401 anyway.