### PR TITLE
Add `allow_performance` column to `osu_builds`

### DIFF
--- a/database/migrations/2022_07_08_085310_add_allow_performance_to_osu_builds.php
+++ b/database/migrations/2022_07_08_085310_add_allow_performance_to_osu_builds.php
@@ -18,6 +18,7 @@ class AddAllowPerformanceToOsuBuilds extends Migration
     {
         Schema::table('osu_builds', function (Blueprint $table) {
             $table->boolean('allow_performance')->default(false);
+            $table->index('allow_performance');
         });
     }
 
@@ -30,6 +31,7 @@ class AddAllowPerformanceToOsuBuilds extends Migration
     {
         Schema::table('osu_builds', function (Blueprint $table) {
             $table->dropColumn('allow_performance');
+            $table->dropIndex('allow_performance');
         });
     }
 }

--- a/database/migrations/2022_07_08_085310_add_allow_performance_to_osu_builds.php
+++ b/database/migrations/2022_07_08_085310_add_allow_performance_to_osu_builds.php
@@ -31,7 +31,6 @@ class AddAllowPerformanceToOsuBuilds extends Migration
     {
         Schema::table('osu_builds', function (Blueprint $table) {
             $table->dropColumn('allow_performance');
-            $table->dropIndex('allow_performance');
         });
     }
 }

--- a/database/migrations/2022_07_08_085310_add_allow_performance_to_osu_builds.php
+++ b/database/migrations/2022_07_08_085310_add_allow_performance_to_osu_builds.php
@@ -17,7 +17,7 @@ class AddAllowPerformanceToOsuBuilds extends Migration
     public function up()
     {
         Schema::table('osu_builds', function (Blueprint $table) {
-            $table->boolean('allow_performance')->default(false);
+            $table->boolean('allow_performance')->default(false)->after('allow_bancho');
             $table->index('allow_performance');
         });
     }

--- a/database/migrations/2022_07_08_085310_add_allow_performance_to_osu_builds.php
+++ b/database/migrations/2022_07_08_085310_add_allow_performance_to_osu_builds.php
@@ -1,0 +1,35 @@
+<?php
+
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddAllowPerformanceToOsuBuilds extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('osu_builds', function (Blueprint $table) {
+            $table->boolean('allow_performance')->default(false);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('osu_builds', function (Blueprint $table) {
+            $table->dropColumn('allow_performance');
+        });
+    }
+}


### PR DESCRIPTION
Not sure what the correct default value should be - I've gone with `false` for now but maybe it'll be `true` in the future when lazer is more "stable"?

Kinda required for https://github.com/ppy/osu-queue-score-statistics/pull/44.