### PR TITLE
Fix docker default command and assets expiration header

### DIFF
--- a/Dockerfile.deployment
+++ b/Dockerfile.deployment
@@ -69,4 +69,4 @@ EXPOSE 8000
 EXPOSE 8080
 
 ENTRYPOINT ["/app/docker/deployment/entrypoint.sh"]
-CMD ["php"]
+CMD ["octane"]

--- a/docker/deployment/nginx-assets.conf
+++ b/docker/deployment/nginx-assets.conf
@@ -17,10 +17,24 @@ http {
         listen 8080;
         root /app/public;
 
+        expires 30d;
+
         location ~ \.php$ {
             access_log off;
 
             return 404;
+        }
+
+        location = /docs/ {
+            expires off;
+        }
+
+        location = /docs/index.html {
+            expires off;
+        }
+
+        location /docs/ {
+            expires 7d;
         }
     }
 }


### PR DESCRIPTION
`php` command has been removed. Also assets should have expires header.