### PR TITLE
Set COMPRESSED row format on solo_scores

### DIFF
--- a/database/migrations/2022_07_19_060203_set_compressed_row_format_on_solo_scores.php
+++ b/database/migrations/2022_07_19_060203_set_compressed_row_format_on_solo_scores.php
@@ -1,0 +1,36 @@
+<?php
+
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class SetCompressedRowFormatOnSoloScores extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        $this->setRowFormat('solo_scores', 'COMPRESSED');
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        $this->setRowFormat('solo_scores', 'DEFAULT');
+    }
+
+    private function setRowFormat($table, $format)
+    {
+        DB::statement("ALTER TABLE `{$table}` ROW_FORMAT={$format};");
+    }
+}


### PR DESCRIPTION
Something that's eventually going to come up as data.ppy.sh dumps start being generated for the new table. This table is a bit chonky.