### PR TITLE
Add beatmap leader for solo scores

### DIFF
--- a/app/Console/Commands/BeatmapLeadersRefresh.php
+++ b/app/Console/Commands/BeatmapLeadersRefresh.php
@@ -1,0 +1,55 @@
+<?php
+
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Models\Beatmap;
+use App\Models\BeatmapLeader;
+use Illuminate\Console\Command;
+use Illuminate\Database\Eloquent\Collection;
+
+class BeatmapLeadersRefresh extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'beatmap-leaders:refresh {--yes}';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Refresh beatmap leaders table';
+
+    /**
+     * Execute the console command.
+     *
+     * @return mixed
+     */
+    public function handle()
+    {
+        $continue = $this->option('yes') || $this->confirm('This will recalculate beatmap leaders, continue?');
+
+        if (!$continue) {
+            return $this->error('User aborted!');
+        }
+
+        $bar = $this->output->createProgressBar();
+
+        Beatmap::select('beatmap_id')->scoreable()->chunkById(100, function (Collection $beatmaps) use ($bar): void {
+            foreach ($beatmaps as $beatmap) {
+                foreach (Beatmap::MODES as $ruleset => $rulesetId) {
+                    BeatmapLeader::sync($beatmap->getKey(), $rulesetId);
+                    $bar->advance();
+                }
+            }
+        });
+    }
+}

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -69,6 +69,8 @@ class Kernel extends ConsoleKernel
 
         Commands\ChatExpireAck::class,
         Commands\ChatChannelSetLastMessageId::class,
+
+        Commands\BeatmapLeadersRefresh::class,
     ];
 
     /**

--- a/app/Models/BeatmapLeader.php
+++ b/app/Models/BeatmapLeader.php
@@ -1,0 +1,62 @@
+<?php
+
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
+namespace App\Models;
+
+use App\Libraries\Search\ScoreSearch;
+use App\Libraries\Search\ScoreSearchParams;
+use DB;
+
+/**
+ * @property int $id
+ * @property int $ruleset_id
+ * @property int $beatmap_id
+ * @property int $user_id
+ * @property int $score_id
+ */
+class BeatmapLeader extends Model
+{
+    public $timestamps = false;
+
+    protected $primaryKey = 'score_id';
+
+    public static function sync(int $beatmapId, int $rulesetId): void
+    {
+        $searchParams = ScoreSearchParams::fromArray([
+            'beatmap_ids' => [$beatmapId],
+            'limit' => 1,
+            'ruleset_id' => $rulesetId,
+            'sort' => 'score_desc',
+        ]);
+
+        $score = (new ScoreSearch($searchParams))->records()->first();
+
+        DB::transaction(function () use ($beatmapId, $rulesetId, $score): void {
+            $scoreLeader = static::where([
+                'beatmap_id' => $beatmapId,
+                'ruleset_id' => $rulesetId,
+            ])->lockForUpdate()->first();
+
+            if ($score === null) {
+                $scoreLeader?->delete();
+
+                return;
+            }
+
+            $params = [
+                'beatmap_id' => $beatmapId,
+                'ruleset_id' => $rulesetId,
+                'score_id' => $score->getKey(),
+                'user_id' => $score->user_id,
+            ];
+
+            if ($scoreLeader === null) {
+                static::create($params);
+            } else {
+                $scoreLeader->update($params);
+            }
+        });
+    }
+}

--- a/database/migrations/2022_07_27_000000_create_beatmap_leaders.php
+++ b/database/migrations/2022_07_27_000000_create_beatmap_leaders.php
@@ -1,0 +1,41 @@
+<?php
+
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up(): void
+    {
+        Schema::create('beatmap_leaders', function (Blueprint $table) {
+            $table->unsignedBigInteger('score_id');
+            $table->unsignedMediumInteger('beatmap_id');
+            $table->unsignedSmallInteger('ruleset_id');
+            $table->unsignedInteger('user_id');
+            $table->unique(['beatmap_id', 'ruleset_id']);
+            $table->index(['user_id', 'ruleset_id']);
+            $table->primary('score_id');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('beatmap_leaders');
+    }
+};


### PR DESCRIPTION
This only creates the table and a command to fill it up. `refresh` name is a bit of lie because it doesn't delete scores which beatmap have been unranked/disqualified...