### PR TITLE
Fix setHash triggering on wrong page after navigation.

### DIFF
--- a/resources/assets/lib/beatmapsets-show/main.tsx
+++ b/resources/assets/lib/beatmapsets-show/main.tsx
@@ -6,7 +6,7 @@ import { CommentsManager } from 'components/comments-manager';
 import HeaderV4 from 'components/header-v4';
 import PlaymodeTabs from 'components/playmode-tabs';
 import GameMode, { gameModes } from 'interfaces/game-mode';
-import { action, autorun, computed, makeObservable, observable } from 'mobx';
+import { action, autorun, computed, IReactionDisposer, makeObservable, observable } from 'mobx';
 import { observer } from 'mobx-react';
 import * as React from 'react';
 import { generate, setHash } from 'utils/beatmapset-page-hash';
@@ -25,8 +25,7 @@ interface Props {
 @observer
 export default class Main extends React.Component<Props> {
   @observable private controller: Controller;
-  private disposers = new Set<(() => void) | undefined>();
-  private ref = React.createRef<HTMLDivElement>();
+  private setHashDisposer?: IReactionDisposer;
 
   @computed
   private get headerLinksAppend() {
@@ -63,17 +62,18 @@ export default class Main extends React.Component<Props> {
   }
 
   componentDidMount() {
-    this.disposers.add(autorun(this.setHash));
+    this.setHashDisposer = autorun(this.setHash);
+    $(document).one('turbolinks:before-cache', () => this.setHashDisposer?.());
   }
 
   componentWillUnmount() {
-    this.disposers.forEach((disposer) => disposer?.());
+    this.setHashDisposer?.();
     this.controller.destroy();
   }
 
   render() {
     return (
-      <div ref={this.ref} className='osu-layout osu-layout--full'>
+      <div className='osu-layout osu-layout--full'>
         {this.renderPageHeader()}
         {this.controller.state.showingNsfwWarning
           ? <NsfwWarning onClose={this.onCloseNsfwWarning} />
@@ -145,7 +145,6 @@ export default class Main extends React.Component<Props> {
   }
 
   private readonly setHash = () => {
-    if (!window.newBody?.contains(this.ref.current)) return;
     setHash(generate({ beatmap: this.controller.currentBeatmap }));
   };
 }

--- a/resources/assets/lib/beatmapsets-show/main.tsx
+++ b/resources/assets/lib/beatmapsets-show/main.tsx
@@ -26,6 +26,7 @@ interface Props {
 export default class Main extends React.Component<Props> {
   @observable private controller: Controller;
   private disposers = new Set<(() => void) | undefined>();
+  private ref = React.createRef<HTMLDivElement>();
 
   @computed
   private get headerLinksAppend() {
@@ -72,7 +73,7 @@ export default class Main extends React.Component<Props> {
 
   render() {
     return (
-      <div className='osu-layout osu-layout--full'>
+      <div ref={this.ref} className='osu-layout osu-layout--full'>
         {this.renderPageHeader()}
         {this.controller.state.showingNsfwWarning
           ? <NsfwWarning onClose={this.onCloseNsfwWarning} />
@@ -144,6 +145,7 @@ export default class Main extends React.Component<Props> {
   }
 
   private readonly setHash = () => {
+    if (!window.newBody?.contains(this.ref.current)) return;
     setHash(generate({ beatmap: this.controller.currentBeatmap }));
   };
 }


### PR DESCRIPTION
Seems like this isn't as new as it looks but the exact condition to trigger it might not be so common 🤔 

Because the component of the next page mounts before the current out unmount, `autorun` ends up triggering `setHash` if any of the observables it's watching gets updated.

It just so happens that current user `playmode` ends up being observed if via `findDefault()` through `currentBeatmap()`
if a beatmap hasn't explicitly been selected yet, which causes `autorun` to trigger when `core.setCurrentUser` is triggered on navigation.

A more complete fix would to be set the default beatmap when initializing `beatmapsets-show/controller` so that currentUser doesn't set sometimes observed.

closes #9114