### PR TITLE
Set max length on channel message input box

### DIFF
--- a/app/Models/Chat/Channel.php
+++ b/app/Models/Chat/Channel.php
@@ -39,6 +39,7 @@ class Channel extends Model
 {
     use Memoizes, Validatable;
 
+    const ANNOUNCE_MESSAGE_LENGTH_LIMIT = 1024; // limited by column length
     const CHAT_ACTIVITY_TIMEOUT = 60; // in seconds.
 
     public ?string $uuid = null;
@@ -397,7 +398,8 @@ class Channel extends Model
             throw new API\ChatMessageEmptyException(osu_trans('api.error.chat.empty'));
         }
 
-        if (!$this->isAnnouncement() && mb_strlen($content, 'UTF-8') >= config('osu.chat.message_length_limit')) {
+        $maxLength = $this->isAnnouncement() ? static::ANNOUNCE_MESSAGE_LENGTH_LIMIT : config('osu.chat.message_length_limit');
+        if (mb_strlen($content, 'UTF-8') >= $maxLength) {
             throw new API\ChatMessageTooLongException(osu_trans('api.error.chat.too_long'));
         }
 

--- a/app/Models/Chat/Channel.php
+++ b/app/Models/Chat/Channel.php
@@ -399,7 +399,7 @@ class Channel extends Model
         }
 
         $maxLength = $this->isAnnouncement() ? static::ANNOUNCE_MESSAGE_LENGTH_LIMIT : config('osu.chat.message_length_limit');
-        if (mb_strlen($content, 'UTF-8') >= $maxLength) {
+        if (mb_strlen($content, 'UTF-8') > $maxLength) {
             throw new API\ChatMessageTooLongException(osu_trans('api.error.chat.too_long'));
         }
 

--- a/resources/assets/less/bem/btn-osu-big.less
+++ b/resources/assets/less/bem/btn-osu-big.less
@@ -102,6 +102,7 @@
     min-width: 80px;
     border-radius: 10000px;
     padding: 10px;
+    align-self: flex-end;
 
     --bg: hsl(var(--hsl-h2));
     --hover-bg: hsl(var(--hsl-h1));

--- a/resources/assets/less/bem/chat-input.less
+++ b/resources/assets/less/bem/chat-input.less
@@ -9,8 +9,7 @@
 
   background: linear-gradient(to bottom, hsla(var(--hsl-b4), 0), hsla(var(--hsl-b4), 0.95) 40%, hsla(var(--hsl-b4), 0.95) 100%);
   width: calc(100% - 20px); // this prevents the gradient drawing over the browser's scroll-bar
-  height: 80px;
-  padding: 10px 30px 10px 50px;
+  padding: 10px 30px 15px 50px;
 
   align-items: center;
   display: flex;

--- a/resources/assets/lib/chat/create-announcement.tsx
+++ b/resources/assets/lib/chat/create-announcement.tsx
@@ -9,6 +9,7 @@ import UserJson from 'interfaces/user-json';
 import { action, computed, makeObservable, runInAction } from 'mobx';
 import { observer } from 'mobx-react';
 import { isInputKey } from 'models/chat/create-announcement';
+import { maxLength } from 'models/chat/message';
 import core from 'osu-core-singleton';
 import * as React from 'react';
 
@@ -91,7 +92,7 @@ export default class CreateAnnouncement extends React.Component<Props> {
               autoComplete='off'
               className='chat-form__input chat-form__input--box'
               defaultValue={this.model.inputs.message}
-              maxLength={1024}
+              maxLength={maxLength}
               name='message'
               onBlur={this.handleBlur}
               onChange={this.handleInput}

--- a/resources/assets/lib/chat/input-box.tsx
+++ b/resources/assets/lib/chat/input-box.tsx
@@ -104,7 +104,7 @@ export default class InputBox extends React.Component<Props> {
           className={classWithModifiers('chat-input__box', { disabled: this.inputDisabled })}
           disabled={this.inputDisabled}
           maxLength={maxLength}
-          maxRows={3}
+          maxRows={channel?.type === 'ANNOUNCE' ? 10 : 3}
           name='textbox'
           onChange={this.handleChange}
           onKeyDown={this.checkIfEnterPressed}

--- a/resources/assets/lib/chat/input-box.tsx
+++ b/resources/assets/lib/chat/input-box.tsx
@@ -8,7 +8,7 @@ import { trim } from 'lodash';
 import { action, autorun, computed, makeObservable, reaction } from 'mobx';
 import { disposeOnUnmount, observer } from 'mobx-react';
 import { isModalShowing } from 'modal-helper';
-import Message from 'models/chat/message';
+import Message, { maxLength } from 'models/chat/message';
 import core from 'osu-core-singleton';
 import * as React from 'react';
 import TextareaAutosize from 'react-autosize-textarea';
@@ -103,6 +103,7 @@ export default class InputBox extends React.Component<Props> {
           autoComplete='off'
           className={classWithModifiers('chat-input__box', { disabled: this.inputDisabled })}
           disabled={this.inputDisabled}
+          maxLength={maxLength}
           maxRows={3}
           name='textbox'
           onChange={this.handleChange}

--- a/resources/assets/lib/models/chat/message.ts
+++ b/resources/assets/lib/models/chat/message.ts
@@ -9,6 +9,8 @@ import * as moment from 'moment';
 import core from 'osu-core-singleton';
 import { linkify } from 'utils/url';
 
+export const maxLength = 1024;
+
 export default class Message {
   @observable channelId = -1;
   @observable content = '';


### PR DESCRIPTION
Limit max length so it doesn't get truncated by mysql.

Also increases the maximum height of the textbox in announcement channels to the same size as those in creating announcements, and anchors the textarea to the bottom.

Was going to add a message length counter but I figure that should be separate 🤔 