### PR TITLE
Truncate long channel names in channel list

### DIFF
--- a/resources/assets/less/bem/chat-conversation-list-item.less
+++ b/resources/assets/less/bem/chat-conversation-list-item.less
@@ -73,6 +73,7 @@
     align-self: stretch;
     flex: 1;
     margin-left: @tile-margin;
+    min-width: 0;
 
     @media @mobile {
       margin-left: @indicator-width * 2;

--- a/resources/assets/lib/chat/conversation-list-item.tsx
+++ b/resources/assets/lib/chat/conversation-list-item.tsx
@@ -37,7 +37,7 @@ export default class ConversationListItem extends React.Component<Props> {
           <div className={`${baseClassName}__avatar`}>
             <UserAvatar modifiers='full-circle' user={{ avatar_url: this.props.channel.icon }} />
           </div>
-          <div className={`${baseClassName}__name`}>{this.props.channel.name}</div>
+          <div className={`${baseClassName}__name u-ellipsis-overflow`}>{this.props.channel.name}</div>
           <div className={`${baseClassName}__chevron`}>
             <i className='fas fa-chevron-right' />
           </div>


### PR DESCRIPTION
Mobile view will still show the full length of the name.