### PR TITLE
Add missing `finish()` call on progress bars

### DIFF
--- a/app/Console/Commands/BeatmapLeadersRefresh.php
+++ b/app/Console/Commands/BeatmapLeadersRefresh.php
@@ -51,6 +51,7 @@ class BeatmapLeadersRefresh extends Command
                 }
             }
         });
+        $bar->finish();
         $this->line('');
     }
 }

--- a/app/Console/Commands/ForumTopicCoversCleanup.php
+++ b/app/Console/Commands/ForumTopicCoversCleanup.php
@@ -54,6 +54,7 @@ class ForumTopicCoversCleanup extends Command
             }
         });
 
+        $progress->finish();
         $this->line('');
         $this->info("Done. Deleted {$deleted} cover(s).");
     }


### PR DESCRIPTION
Otherwise it may not display the actual final number and not quite filled up.