### PR TITLE
Clean up account edit simple entry view

### DIFF
--- a/resources/views/accounts/_edit_entry_simple.blade.php
+++ b/resources/views/accounts/_edit_entry_simple.blade.php
@@ -4,14 +4,15 @@
 --}}
 @php
     $user = auth()->user();
+    $value = $user->$field;
 @endphp
 <div class="account-edit-entry js-account-edit js-form-error js-form-error--field" data-account-edit-auto-submit="1" data-skip-ajax-error-popup="1">
     <input
         class="account-edit-entry__input js-account-edit__input"
         name="user[{{ $field }}]"
-        data-last-value="{{ $user->$field }}"
+        data-last-value="{{ $value }}"
         maxlength="{{ $user::MAX_FIELD_LENGTHS[$field] }}"
-        value="{{ $user->$field }}"
+        value="{{ $value }}"
         @if ($user->isSilenced())
             disabled
         @endif

--- a/resources/views/accounts/_edit_entry_simple.blade.php
+++ b/resources/views/accounts/_edit_entry_simple.blade.php
@@ -2,16 +2,17 @@
     Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
     See the LICENCE file in the repository root for full licence text.
 --}}
+@php
+    $user = auth()->user();
+@endphp
 <div class="account-edit-entry js-account-edit js-form-error js-form-error--field" data-account-edit-auto-submit="1" data-skip-ajax-error-popup="1">
     <input
         class="account-edit-entry__input js-account-edit__input"
         name="user[{{ $field }}]"
-        data-last-value="{{ Auth::user()->$field }}"
-        @if (($maxLength = App\Models\User::MAX_FIELD_LENGTHS[$field]) !== null)
-            maxlength="{{ $maxLength }}"
-        @endif
-        value="{{ Auth::user()->$field }}"
-        @if (Auth::user()->isSilenced())
+        data-last-value="{{ $user->$field }}"
+        maxlength="{{ $user::MAX_FIELD_LENGTHS[$field] }}"
+        value="{{ $user->$field }}"
+        @if ($user->isSilenced())
             disabled
         @endif
     >


### PR DESCRIPTION
- set user variable instead of repeatedly call function
- remove null field length check because it doesn't make sense to have  null limit and those without limit probably don't have entry in the  first place and thus will cause error instead
- access const from instance instead of specifying full class name
- reduce model field access