### PR TITLE
Fix click event on menu button not propagated

### DIFF
--- a/resources/assets/lib/core/click-menu.ts
+++ b/resources/assets/lib/core/click-menu.ts
@@ -98,7 +98,6 @@ export default class ClickMenu {
     const tree = this.tree();
 
     e.preventDefault();
-    e.stopPropagation();
 
     const target = menu.dataset.clickMenuTarget;
     let next = target;


### PR DESCRIPTION
This prevented other things which are listening to click event on document from being triggered.

If I remember correctly this was originally to prevent parent menu from being hidden but the current system have full tree on which menu should be shown so it shouldn't be a problem anymore. Maybe 👀 

Resolves #9105. The hover menu z-index will be fixed separately.