### PR TITLE
Skip global throttle for beatmapset download endpoint

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -378,6 +378,7 @@ Route::group(['middleware' => ['web']], function () {
 
 // API
 // require-scopes is not in the api group at the moment to reduce the number of things that need immediate fixing.
+// There's also a different group which skips throttle middleware.
 Route::group(['as' => 'api.', 'prefix' => 'api', 'middleware' => ['api', ThrottleRequests::getApiThrottle(), 'require-scopes']], function () {
     Route::group(['prefix' => 'v2'], function () {
         Route::group(['as' => 'beatmaps.', 'prefix' => 'beatmaps'], function () {
@@ -473,8 +474,6 @@ Route::group(['as' => 'api.', 'prefix' => 'api', 'middleware' => ['api', Throttl
         Route::get('beatmapsets/search/{filters?}', 'BeatmapsetsController@search');
         //   GET /api/v2/beatmapsets/lookup
         Route::get('beatmapsets/lookup', 'API\BeatmapsetsController@lookup');
-        //   GET /api/v2/beatmapsets/:beatmapset/download
-        Route::get('beatmapsets/{beatmapset}/download', 'BeatmapsetsController@download');
         //   GET /api/v2/beatmapsets/:beatmapset_id
         Route::resource('beatmapsets', 'BeatmapsetsController', ['only' => ['show']]);
 
@@ -517,6 +516,12 @@ Route::group(['as' => 'api.', 'prefix' => 'api', 'middleware' => ['api', Throttl
 
         Route::get('wiki/{locale}/{path}', 'WikiController@show')->name('wiki.show')->where('path', '.+');
     });
+});
+
+// Duplicate of the other api group but without throttle.
+Route::group(['as' => 'api.', 'prefix' => 'api/v2', 'middleware' => ['api', 'require-scopes']], function () {
+    //   GET /api/v2/beatmapsets/:beatmapset/download
+    Route::get('beatmapsets/{beatmapset}/download', 'BeatmapsetsController@download');
 });
 
 // Callbacks for legacy systems to interact with

--- a/tests/api_routes.json
+++ b/tests/api_routes.json
@@ -880,19 +880,6 @@
         ]
     },
     {
-        "uri": "api/v2/beatmapsets/{beatmapset}/download",
-        "methods": [
-            "GET",
-            "HEAD"
-        ],
-        "controller": "App\\Http\\Controllers\\BeatmapsetsController@download",
-        "middlewares": [
-            "throttle:1200,1,api:",
-            "require-scopes"
-        ],
-        "scopes": []
-    },
-    {
         "uri": "api/v2/beatmapsets/{beatmapset}",
         "methods": [
             "GET",
@@ -1174,6 +1161,18 @@
         "controller": "App\\Http\\Controllers\\WikiController@show",
         "middlewares": [
             "throttle:1200,1,api:",
+            "require-scopes"
+        ],
+        "scopes": []
+    },
+    {
+        "uri": "api/v2/beatmapsets/{beatmapset}/download",
+        "methods": [
+            "GET",
+            "HEAD"
+        ],
+        "controller": "App\\Http\\Controllers\\BeatmapsetsController@download",
+        "middlewares": [
             "require-scopes"
         ],
         "scopes": []


### PR DESCRIPTION
Mainly to allow the client to be sure that it's actually too many downloads and not related to the global request limit.

And nginx update is probably in order as well? 🤔 But at least I think one will return json and the other... whatever nginx returns (usually html).

Also I could make it a same top group divided by throttle existence but that'll rearrange middleware order.

Something like this
```php
Route::group(['as' => 'api.', 'prefix' => 'api/v2', 'middleware' => ['api', 'require-scopes']], function () {
    Route::group(['middleware' => [ThrottleRequests::getApiThrottle()]], function () {
        ...
    }

    Route::get('beatmapsets/{beatmapset}/download', 'BeatmapsetsController@download');
}
```

(also I don't know about the `v2` separation there if it still makes sense at all)

Related: ppy/osu#19522