### PR TITLE
Set correct elasticsearch host for solo scores index on docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,7 @@ x-env: &x-env
   DB_HOST: db
   ES_HOST: elasticsearch:9200
   ES_SCORES_HOST: elasticsearch:9200
+  ES_SOLO_SCORES_HOST: elasticsearch:9200
   GITHUB_TOKEN: "${GITHUB_TOKEN}"
   NOTIFICATION_REDIS_HOST: redis
   REDIS_HOST: redis


### PR DESCRIPTION
Noticed while trying to get score indexing to work locally.