### PR TITLE
Add migration for creating `bss_process_queue` table

### DIFF
--- a/database/migrations/2022_08_04_220851_create_bss_process_queue.php
+++ b/database/migrations/2022_08_04_220851_create_bss_process_queue.php
@@ -1,0 +1,41 @@
+<?php
+
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateBssProcessQueue extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('bss_process_queue', function (Blueprint $table) {
+            $table->increments('queue_id');
+
+            $table->unsignedInteger('beatmapset_id');
+            $table->timestamp('start_time')->useCurrent();
+            $table->tinyInteger('status')->default(0);
+            $table->timestamp('update_time')->nullable()->default(null)->useCurrentOnUpdate();
+
+            $table->index('status', 'status');
+            $table->index('beatmapset_id', 'beatmapset_id');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('bss_process_queue');
+    }
+}


### PR DESCRIPTION
- Closes #9091 

Migration done as per the table creation showcase that was [posted in the thread](https://github.com/ppy/osu-web/issues/9091#issuecomment-1177198550):
```mysql
CREATE TABLE `bss_process_queue` (
  `queue_id` int unsigned NOT NULL AUTO_INCREMENT,
  `beatmapset_id` int unsigned NOT NULL,
  `start_time` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP,
  `status` tinyint(1) NOT NULL DEFAULT '0',
  `update_time` timestamp NULL DEFAULT NULL ON UPDATE CURRENT_TIMESTAMP,
  PRIMARY KEY (`queue_id`),
  KEY `status` (`status`),
  KEY `beatmapset_id` (`beatmapset_id`)
) ENGINE=InnoDB
```