### PR TITLE
Use score id for progress bar number

### DIFF
--- a/app/Console/Commands/EsIndexScoresQueue.php
+++ b/app/Console/Commands/EsIndexScoresQueue.php
@@ -126,7 +126,7 @@ class EsIndexScoresQueue extends Command
             $ids,
         ));
 
-        $this->bar->advance($count);
+        $this->bar->setProgress(array_last($ids) ?? 0);
         $this->total += $count;
     }
 }


### PR DESCRIPTION
Makes it easy to figure out where to resume from after it's stopped midway.