### PR TITLE
Support indexing to active schemas

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -46,8 +46,6 @@ env:
   SHOPIFY_DOMAIN: notarealdomainortld
   SHOPIFY_STOREFRONT_TOKEN: notreal
   SLACK_ENDPOINT: https://myconan.net/null/
-  # make sure to match the one specified for osu-elastic-indexer
-  schema: test
 
 jobs:
   tests:
@@ -100,6 +98,7 @@ jobs:
 
       osu-elastic-indexer:
         image: pppy/osu-elastic-indexer
+        # make sure the schema specified here and the one in set-schema command match
         options: >-
           -e DB_CONNECTION_STRING=Server=db;Database=osu;Uid=root
           -e ES_HOST=http://elasticsearch-score:9200
@@ -157,7 +156,7 @@ jobs:
           php artisan es:create-search-blacklist
           php artisan es:index-documents --yes
           php artisan es:index-wiki --create-only --yes
-          php artisan es:index-scores:set-schema
+          php artisan es:index-scores:set-schema --schema test
 
       - name: Generate docs
         run: php artisan scribe:generate

--- a/app/Console/Commands/EsIndexScoresQueue.php
+++ b/app/Console/Commands/EsIndexScoresQueue.php
@@ -96,7 +96,7 @@ class EsIndexScoresQueue extends Command
             });
         }
 
-        (new ScoreSearch())->refresh();
+        $this->search->refresh();
 
         $this->bar->finish();
         $this->line('');

--- a/app/Console/Commands/EsIndexScoresQueue.php
+++ b/app/Console/Commands/EsIndexScoresQueue.php
@@ -44,6 +44,8 @@ class EsIndexScoresQueue extends Command
      */
     public function handle()
     {
+        $this->search = new ScoreSearch();
+
         if (!$this->confirm('This will queue scores for indexing, continue?', true)) {
             return $this->info('User aborted');
         }
@@ -51,9 +53,9 @@ class EsIndexScoresQueue extends Command
         $schema = presence($this->option('schema'));
 
         if ($schema === null) {
-            $this->schemas = $this->score->getActiveSchemas();
+            $this->schemas = $this->search->getActiveSchemas();
 
-            if (count($schemas) === 0) {
+            if (count($this->schemas) === 0) {
                 return $this->error('Index schema is not specified and there is no active schemas');
             }
         } else {

--- a/app/Console/Commands/EsIndexScoresSetSchema.php
+++ b/app/Console/Commands/EsIndexScoresSetSchema.php
@@ -16,7 +16,7 @@ class EsIndexScoresSetSchema extends Command
      * @var string
      */
     protected $signature = 'es:index-scores:set-schema
-        {--schema= : Schema version to be set (can also be specified using environment variable "schema")}';
+        {--schema= : Schema version to be set}';
 
     /**
      * The console command description.
@@ -32,7 +32,7 @@ class EsIndexScoresSetSchema extends Command
      */
     public function handle()
     {
-        $schema = presence($this->option('schema')) ?? presence(env('schema'));
+        $schema = presence($this->option('schema'));
 
         if ($schema === null) {
             return $this->error('Index schema must be specified');


### PR DESCRIPTION
Also removed unused indexAll and support for env `schema`.

- [x] depends on #9187
- [x] The docker image for osu-elastic-indexer is rather outdated 🤔 