### PR TITLE
QOL change: Opens the download link in a new tab.

### DIFF
--- a/resources/views/packs/raw.blade.php
+++ b/resources/views/packs/raw.blade.php
@@ -6,7 +6,7 @@
 
 <div class="beatmap-pack-description">
     @if(Auth::check())
-        <a href="{{ $pack->url }}"
+        <a href="{{ $pack->url }}" target="_blank"
             class="beatmap-pack-download__link">{{ osu_trans('beatmappacks.show.download') }}</a>
     @else
         {!! require_login('beatmappacks.require_login._', 'beatmappacks.require_login.link_text') !!}


### PR DESCRIPTION
As someone who would download 10s of map packs at a time, this would be a life saver.