### PR TITLE
Add beatmap id index on solo scores

### DIFF
--- a/database/migrations/2022_08_15_074123_index_beatmap_id_on_solo_scores.php
+++ b/database/migrations/2022_08_15_074123_index_beatmap_id_on_solo_scores.php
@@ -1,0 +1,35 @@
+<?php
+
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('solo_scores', function (Blueprint $table) {
+            $table->index('beatmap_id');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('solo_scores', function (Blueprint $table) {
+            $table->dropIndex(['beatmap_id']);
+        });
+    }
+};


### PR DESCRIPTION
To be used for deleting scores when its beatmap(set) state is changed.

migration entry is `2022_08_15_074123_index_beatmap_id_on_solo_scores`
index name is `solo_scores_beatmap_id_index`

- [x] add to production