### PR TITLE
Add index for user recent solo scores

### DIFF
--- a/database/migrations/2022_08_15_081810_index_user_ruleset_id_on_solo_scores.php
+++ b/database/migrations/2022_08_15_081810_index_user_ruleset_id_on_solo_scores.php
@@ -1,0 +1,37 @@
+<?php
+
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('solo_scores', function (Blueprint $table) {
+            $table->dropIndex(['user_id']);
+            $table->index(['user_id', 'ruleset_id', DB::raw('id DESC')], 'user_ruleset_id_index');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('solo_scores', function (Blueprint $table) {
+            $table->index('user_id');
+            $table->dropIndex('user_ruleset_id_index');
+        });
+    }
+};


### PR DESCRIPTION
Replaces index on `user_id` column.

migration entry is `2022_08_15_081810_index_user_ruleset_id_on_solo_scores`
index name is `user_ruleset_id_index`, the columns are `(user_id, ruleset_id, id DESC)`
also drop index `solo_scores_user_id_index` since it's redundant with the new index

- [x] add to production