### PR TITLE
Fix bbcode email and url parsing

### DIFF
--- a/app/Libraries/BBCodeFromDB.php
+++ b/app/Libraries/BBCodeFromDB.php
@@ -118,7 +118,7 @@ class BBCodeFromDB
             "<a rel='nofollow' href='mailto:\\1'>\\1</a>",
             $text
         );
-        $text = preg_replace("#\[email=(.+?):{$this->uid}\]#", "<a rel='nofollow' href='mailto:\\1'>", $text);
+        $text = preg_replace("#\[email=([^\]]+):{$this->uid}\]#", "<a rel='nofollow' href='mailto:\\1'>", $text);
         $text = str_replace("[/email:{$this->uid}]", '</a>', $text);
 
         return $text;
@@ -275,7 +275,7 @@ class BBCodeFromDB
     public function parseUrl($text)
     {
         $text = preg_replace("#\[url:{$this->uid}\](.+?)\[/url:{$this->uid}\]#", "<a rel='nofollow' href='\\1'>\\1</a>", $text);
-        $text = preg_replace("#\[url=(.+?):{$this->uid}\]#", "<a rel='nofollow' href='\\1'>", $text);
+        $text = preg_replace("#\[url=([^\]]+):{$this->uid}\]#", "<a rel='nofollow' href='\\1'>", $text);
         $text = str_replace("[/url:{$this->uid}]", '</a>', $text);
 
         return $text;

--- a/tests/Libraries/bbcode_examples/invalid_email_url.db.txt
+++ b/tests/Libraries/bbcode_examples/invalid_email_url.db.txt
@@ -1,0 +1,4 @@
+[email=]foo[/email]:1]
+[email=test@example.org][/email]:1]
+[url=]foo[/url]:1]
+[url=https://osu.ppy.sh][/url]:1]

--- a/tests/Libraries/bbcode_examples/invalid_email_url.html
+++ b/tests/Libraries/bbcode_examples/invalid_email_url.html
@@ -1,0 +1,4 @@
+[email=]foo[/email]:1]<br />
+[email=test@example.org][/email]:1]<br />
+[url=]foo[/url]:1]<br />
+[url=https://osu.ppy.sh][/url]:1]

--- a/tests/Libraries/bbcode_examples/invalid_email_url.txt
+++ b/tests/Libraries/bbcode_examples/invalid_email_url.txt
@@ -1,0 +1,4 @@
+[email=]foo[/email]:1]
+[email=test@example.org][/email]:1]
+[url=]foo[/url]:1]
+[url=https://osu.ppy.sh][/url]:1]


### PR DESCRIPTION
Stop at the unescaped closing tag.

There's still some weirdness if there's another tag inside (e.g. `profile`), where, `email` won't link it and `url` will try to turn `profile` into a link (and creates 2 links instead because `a` can't be in `a`) due to differences in their escaping in `BBCodeForDB`

Not sure what to do about that so I left it for the moment 🤔 

closes #9191