### PR TITLE
Fix timestamps being set for solo score performance

### DIFF
--- a/app/Models/Solo/ScorePerformance.php
+++ b/app/Models/Solo/ScorePerformance.php
@@ -14,6 +14,7 @@ use App\Models\Model;
 class ScorePerformance extends Model
 {
     public $incrementing = false;
+    public $timestamps = false;
 
     protected $primaryKey = 'score_id';
     protected $table = 'solo_scores_performance';


### PR DESCRIPTION
The table doesn't have the relevant columns.