### PR TITLE
Add new statistics attributes for score data json

### DIFF
--- a/app/Models/Solo/ScoreData.php
+++ b/app/Models/Solo/ScoreData.php
@@ -22,6 +22,7 @@ class ScoreData implements Castable, JsonSerializable
     public Carbon $endedAt;
     public ?int $legacyScoreId;
     public int $maxCombo;
+    public ScoreDataStatistics $maximumStatistics;
     public array $mods;
     public bool $passed;
     public string $rank;
@@ -51,6 +52,7 @@ class ScoreData implements Castable, JsonSerializable
         $this->endedAt = parse_time_to_carbon($data['ended_at']);
         $this->legacyScoreId = $data['legacy_score_id'] ?? null;
         $this->maxCombo = $data['max_combo'] ?? 0;
+        $this->maximumStatistics = new ScoreDataStatistics($data['maximum_statistics'] ?? []);
         // TODO: create a proper Mod object
         $this->mods = $mods;
         $this->passed = $data['passed'] ?? false;
@@ -114,6 +116,7 @@ class ScoreData implements Castable, JsonSerializable
             'ended_at' => json_time($this->endedAt),
             'legacy_score_id' => $this->legacyScoreId,
             'max_combo' => $this->maxCombo,
+            'maximum_statistics' => $this->maximumStatistics,
             'mods' => $this->mods,
             'passed' => $this->passed,
             'rank' => $this->rank,

--- a/app/Models/Solo/ScoreDataStatistics.php
+++ b/app/Models/Solo/ScoreDataStatistics.php
@@ -18,6 +18,7 @@ class ScoreDataStatistics implements JsonSerializable
     public int $largeBonus;
     public int $largeTickHit;
     public int $largeTickMiss;
+    public int $legacyComboIncrease;
     public int $meh;
     public int $miss;
     public int $ok;
@@ -49,6 +50,7 @@ class ScoreDataStatistics implements JsonSerializable
                 'largeBonus',
                 'largeTickHit',
                 'largeTickMiss',
+                'legacyComboIncrease',
                 'meh',
                 'miss',
                 'ok',

--- a/resources/assets/lib/interfaces/solo-score-json.ts
+++ b/resources/assets/lib/interfaces/solo-score-json.ts
@@ -18,6 +18,7 @@ export type SoloScoreStatisticsAttribute =
   | 'large_bonus'
   | 'large_tick_hit'
   | 'large_tick_miss'
+  | 'legacy_combo_increase'
   | 'meh'
   | 'miss'
   | 'ok'
@@ -36,6 +37,7 @@ interface SoloScoreJsonDefaultAttributes {
   legacy_perfect: boolean | null;
   legacy_score_id: number | null;
   max_combo: number;
+  maximum_statistics: Partial<Record<SoloScoreStatisticsAttribute, number>>;
   mods: Mod[];
   passed: boolean;
   pp: number | null;


### PR DESCRIPTION
Up next will be replacing `total_score` with `legacy_total_score` and calculation function in js for display.