### PR TITLE
Ensure http kernel and router middleware groups are set

### DIFF
--- a/app/Libraries/RouteScopesHelper.php
+++ b/app/Libraries/RouteScopesHelper.php
@@ -10,6 +10,7 @@ namespace App\Libraries;
 use App\Http\Middleware\RequireScopes;
 use Closure;
 use Ds\Set;
+use Illuminate\Contracts\Http\Kernel as HttpKernelContract;
 use Route;
 
 class RouteScopesHelper
@@ -50,6 +51,10 @@ class RouteScopesHelper
 
     public function loadRoutes()
     {
+        // Force the http kernel singleton to boot if it hasn't.
+        // This ensures the router has the middleware groups loaded.
+        app(HttpKernelContract::class);
+
         $this->routes = [];
         $apiGroup = new Set(Route::getMiddlewareGroups()['api']);
 


### PR DESCRIPTION
Fixes apidocs not being generated on production builds.

It turns out that `laravel-query-detector` causes the `Http\Kernel` boot via its `QueryDetectorServiceProvider` registration, which gets excluded if dev dependencies are not installed, causing the middleware groups to not be set on the router when run from the console.

Or maybe we should always have the http kernel and middleware groups set even in console... 🤔 