### PR TITLE
Fix Solo Score factory generated total_score

### DIFF
--- a/database/factories/Solo/ScoreFactory.php
+++ b/database/factories/Solo/ScoreFactory.php
@@ -52,7 +52,7 @@ class ScoreFactory extends Factory
                 'rank' => fn (): string => array_rand_val(['A', 'S', 'B', 'SH', 'XH', 'X']),
                 'ruleset_id' => $attr['ruleset_id'],
                 'started_at' => fn (): DateTime => now()->subSeconds(600),
-                'total_score' => fn (): int => $this->faker->randomNumber(1, 1000000),
+                'total_score' => fn (): int => $this->faker->randomNumber(7),
                 'user_id' => $attr['user_id'],
             ], $overrides ?? []),
         );


### PR DESCRIPTION
faker uses number of digits, not a range... 👀 