### PR TITLE
Fix maximum statistics attribute not being stored

### DIFF
--- a/app/Http/Controllers/Solo/ScoresController.php
+++ b/app/Http/Controllers/Solo/ScoresController.php
@@ -32,6 +32,7 @@ class ScoresController extends BaseController
                 $params = get_params(request()->all(), null, [
                     'accuracy:float',
                     'max_combo:int',
+                    'maximum_statistics:array',
                     'mods:array',
                     'passed:bool',
                     'rank:string',


### PR DESCRIPTION
Uh ( ﾟ ヮﾟ)

@peppy, if client has been sending it, it's never stored in the db.