### PR TITLE
Update env name for score indexer service

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -103,7 +103,7 @@ jobs:
           -e DB_CONNECTION_STRING=Server=db;Database=osu;Uid=root
           -e ES_HOST=http://elasticsearch-score:9200
           -e REDIS_HOST=redis
-          -e schema=test
+          -e SCHEMA=test
           --entrypoint sh pppy/osu-elastic-indexer -c "exec dotnet osu.ElasticIndexer.dll queue"
 
       osu-notification-server:


### PR DESCRIPTION
I vaguely remember about this when seeing the PR yesterday but then followed by nothing.