### PR TITLE
Queue beatmapset for bss process when ranked

### DIFF
--- a/app/Models/Beatmapset.php
+++ b/app/Models/Beatmapset.php
@@ -222,6 +222,11 @@ class Beatmapset extends Model implements AfterCommit, Commentable, Indexable, T
         return $this->hasMany(BeatmapDiscussion::class);
     }
 
+    public function bssProcessQueues()
+    {
+        return $this->hasMany(BssProcessQueue::class);
+    }
+
     public function recentFavourites($limit = 50)
     {
         $favourites = FavouriteBeatmapset::where('beatmapset_id', $this->beatmapset_id)
@@ -826,6 +831,7 @@ class Beatmapset extends Model implements AfterCommit, Commentable, Indexable, T
             $this->update(['play_count' => 0]);
             $this->beatmaps()->update(['playcount' => 0, 'passcount' => 0]);
             $this->setApproved('ranked', null);
+            $this->bssProcessQueues()->create();
 
             // global event
             Event::generate('beatmapsetApprove', ['beatmapset' => $this]);

--- a/app/Models/BssProcessQueue.php
+++ b/app/Models/BssProcessQueue.php
@@ -1,0 +1,27 @@
+<?php
+
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+/**
+ * @property int $queue_id
+ * @property int $beatmapset_id
+ * @property \Carbon\CarbonImmutable|null $start_time
+ * @property int $status
+ * @property \Carbon\CarbonImmutable|null $update_time
+ */
+class BssProcessQueue extends Model
+{
+    public $timestamps = false;
+
+    protected $casts = [
+        'start_time' => 'immutable_datetime',
+        'update_time' => 'immutable_datetime',
+    ];
+    protected $primaryKey = 'queue_id';
+    protected $table = 'bss_process_queue';
+}

--- a/tests/Models/BeatmapsetTest.php
+++ b/tests/Models/BeatmapsetTest.php
@@ -12,7 +12,6 @@ use App\Models\Beatmap;
 use App\Models\BeatmapMirror;
 use App\Models\Beatmapset;
 use App\Models\BeatmapsetNomination;
-use App\Models\BssProcessQueue;
 use App\Models\Genre;
 use App\Models\Language;
 use App\Models\Notification;
@@ -148,7 +147,7 @@ class BeatmapsetTest extends TestCase
 
         $beatmapset->watches()->create(['user_id' => $otherUser->getKey()]);
 
-        $this->expectCountChange(fn () => BssProcessQueue::count(), 1);
+        $this->expectCountChange(fn () => $beatmapset->bssProcessQueues()->count(), 1);
         $this->expectCountChange(fn () => UserNotification::count(), 1);
         $this->expectCountChange(fn () => Notification::count(), 1);
         $this->expectCountChange(fn () => $beatmap->scoresBest()->count(), -1);


### PR DESCRIPTION
The model name and relation seem rather questionable but otherwise should work 🤷‍♀️

Resolves #9246.