### PR TITLE
Add contest vote requirement

### DIFF
--- a/app/Http/Controllers/ContestsController.php
+++ b/app/Http/Controllers/ContestsController.php
@@ -5,6 +5,7 @@
 
 namespace App\Http\Controllers;
 
+use App\Exceptions\InvariantException;
 use App\Models\Contest;
 use Auth;
 
@@ -42,9 +43,16 @@ class ContestsController extends Controller
         }
 
         if ($contest->isVotingStarted()) {
+            try {
+                $contest->assertVoteRequirement($user);
+            } catch (InvariantException $e) {
+                $noVoteReason = $e->getMessage();
+            }
+
             return ext_view('contests.voting', [
                 'contestMeta' => $contest,
                 'contests' => $contests,
+                'noVoteReason' => $noVoteReason ?? null,
             ]);
         } else {
             return ext_view('contests.enter', [

--- a/app/Http/Controllers/ContestsController.php
+++ b/app/Http/Controllers/ContestsController.php
@@ -43,6 +43,7 @@ class ContestsController extends Controller
         }
 
         if ($contest->isVotingStarted()) {
+            // TODO: add support for $contests requirement instead of at parent
             try {
                 $contest->assertVoteRequirement($user);
             } catch (InvariantException $e) {

--- a/app/Models/Contest.php
+++ b/app/Models/Contest.php
@@ -5,11 +5,13 @@
 
 namespace App\Models;
 
+use App\Exceptions\InvariantException;
 use App\Traits\Memoizes;
 use App\Transformers\ContestEntryTransformer;
 use App\Transformers\ContestTransformer;
 use App\Transformers\UserContestEntryTransformer;
 use Cache;
+use Exception;
 
 /**
  * @property \Carbon\Carbon|null $created_at
@@ -59,6 +61,36 @@ class Contest extends Model
     public function votes()
     {
         return $this->hasMany(ContestVote::class);
+    }
+
+    public function assertVoteRequirement(User $user): void
+    {
+        $requirement = $this->getExtraOptions()['requirement'] ?? null;
+
+        if ($requirement === null) {
+            return;
+        }
+
+        switch ($requirement['name']) {
+            // requires playing (and optionally passing) all the beatmapsets in the specified room ids
+            case 'playlist_beatmapsets':
+                $roomIds = $requirement['room_ids'];
+                $mustPass = $requirement['must_pass'] ?? true;
+                $beatmapIdsQuery = Multiplayer\PlaylistItem::whereIn('room_id', $roomIds)->select('beatmap_id');
+                $requiredBeatmapsetCount = Beatmap::whereIn('beatmap_id', $beatmapIdsQuery)->distinct('beatmapset_id')->count();
+                $playedBeatmapIdsQuery = Multiplayer\Score::whereIn('room_id', $roomIds)->select('beatmap_id');
+                if ($mustPass) {
+                    $playedBeatmapIdsQuery->where('passed', true);
+                }
+                $playedBeatmapsetCount = Beatmap::whereIn('beatmap_id', $playedBeatmapIdsQuery)->distinct('beatmapset_id')->count();
+
+                if ($playedBeatmapsetCount !== $requiredBeatmapsetCount) {
+                    throw new InvariantException(osu_trans('contest.voting.requirement.playlist_beatmapsets.incomplete_play'));
+                }
+                break;
+            default:
+                throw new Exception('unknown requirement');
+        }
     }
 
     public function isBestOf(): bool
@@ -187,6 +219,7 @@ class Contest extends Model
         if ($vote->exists()) {
             $vote->delete();
         } else {
+            $this->assertVoteRequirement($user);
             // there's probably a race-condition here, but abusing this just results in the user diluting their vote... so *shrug*
             if ($this->votes()->where('user_id', $user->user_id)->count() < $this->max_votes) {
                 $this->votes()->create(['user_id' => $user->user_id, 'contest_entry_id' => $entry->id]);

--- a/app/Models/Contest.php
+++ b/app/Models/Contest.php
@@ -78,7 +78,10 @@ class Contest extends Model
                 $mustPass = $requirement['must_pass'] ?? true;
                 $beatmapIdsQuery = Multiplayer\PlaylistItem::whereIn('room_id', $roomIds)->select('beatmap_id');
                 $requiredBeatmapsetCount = Beatmap::whereIn('beatmap_id', $beatmapIdsQuery)->distinct('beatmapset_id')->count();
-                $playedBeatmapIdsQuery = Multiplayer\Score::whereIn('room_id', $roomIds)->select('beatmap_id');
+                $playedBeatmapIdsQuery = Multiplayer\Score
+                    ::whereIn('room_id', $roomIds)
+                    ->where(['user_id' => $user->getKey()])
+                    ->select('beatmap_id');
                 if ($mustPass) {
                     $playedBeatmapIdsQuery->where('passed', true);
                 }

--- a/app/Models/Contest.php
+++ b/app/Models/Contest.php
@@ -81,6 +81,7 @@ class Contest extends Model
                 $playedBeatmapIdsQuery = Multiplayer\Score
                     ::whereIn('room_id', $roomIds)
                     ->where(['user_id' => $user->getKey()])
+                    ->completed()
                     ->select('beatmap_id');
                 if ($mustPass) {
                     $playedBeatmapIdsQuery->where('passed', true);

--- a/resources/lang/en/contest.php
+++ b/resources/lang/en/contest.php
@@ -31,6 +31,12 @@ return [
         'progress' => [
             '_' => ':used / :max votes used',
         ],
+
+        'requirement' => [
+            'playlist_beatmapsets' => [
+                'incomplete_play' => 'Must play all beatmaps in the specified playlists before voting',
+            ],
+        ],
     ],
     'entry' => [
         '_' => 'entry',

--- a/resources/views/contests/voting.blade.php
+++ b/resources/views/contests/voting.blade.php
@@ -10,21 +10,27 @@
     @if ($contestMeta->voting_ends_at !== null && $contestMeta->voting_ends_at->isPast())
         <div class='contest__voting-notice'>{{osu_trans('contest.voting.over')}}</div>
     @endif
-    @if (count($contests) === 1)
-        @include('contests._voting-entrylist', ['contest' => $contests->first()])
-    @else
-        <div class='contest__accordion' id='contests-accordion'>
-            @foreach ($contests as $contest)
-                <div class='panel contest__group'>
-                    <a href="#{{$contest->id}}" class='contest__group-heading' data-toggle='collapse' data-parent='#contests-accordion' aria-expanded='false'>
-                        <span>{!! $contest->name !!}</span>
-                        <i class="contest__section-toggle fas fa-fw fa-chevron-down"></i>
-                    </a>
-                    <div class='contest__multi-panel collapse' id="{{$contest->id}}">
-                        @include('contests._voting-entrylist')
+    @if ($noVoteReason === null)
+        @if (count($contests) === 1)
+            @include('contests._voting-entrylist', ['contest' => $contests->first()])
+        @else
+            <div class='contest__accordion' id='contests-accordion'>
+                @foreach ($contests as $contest)
+                    <div class='panel contest__group'>
+                        <a href="#{{$contest->id}}" class='contest__group-heading' data-toggle='collapse' data-parent='#contests-accordion' aria-expanded='false'>
+                            <span>{!! $contest->name !!}</span>
+                            <i class="contest__section-toggle fas fa-fw fa-chevron-down"></i>
+                        </a>
+                        <div class='contest__multi-panel collapse' id="{{$contest->id}}">
+                            @include('contests._voting-entrylist')
+                        </div>
                     </div>
-                </div>
-            @endforeach
+                @endforeach
+            </div>
+        @endif
+    @else
+        <div class='contest__voting-notice'>
+            {{ $noVoteReason }}
         </div>
     @endif
 @endsection

--- a/tests/Models/ContestTest.php
+++ b/tests/Models/ContestTest.php
@@ -64,6 +64,7 @@ class ContestTest extends TestCase
 
         if ($played) {
             $userId = $user->getKey();
+            $endedAt = now();
             foreach ($beatmapsets as $beatmapset) {
                 $room = array_rand_val($rooms);
                 $playlistItem = $room
@@ -71,6 +72,7 @@ class ContestTest extends TestCase
                     ->whereIn('beatmap_id', array_column($beatmapset->beatmaps->all(), 'beatmap_id'))
                     ->first();
                 factory(MultiplayerScore::class)->create([
+                    'ended_at' => $endedAt,
                     'passed' => $passed,
                     'playlist_item_id' => $playlistItem->getKey(),
                     'user_id' => $userId,

--- a/tests/Models/ContestTest.php
+++ b/tests/Models/ContestTest.php
@@ -1,0 +1,104 @@
+<?php
+
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
+declare(strict_types=1);
+
+namespace Tests\Models;
+
+use App\Exceptions\InvariantException;
+use App\Models\Beatmap;
+use App\Models\Contest;
+use App\Models\ContestEntry;
+use App\Models\Multiplayer\PlaylistItem;
+use App\Models\Multiplayer\Room;
+use App\Models\Multiplayer\Score as MultiplayerScore;
+use App\Models\User;
+use Tests\TestCase;
+
+class ContestTest extends TestCase
+{
+    /**
+     * @dataProvider dataProviderForTestAssertVoteRequirementPlaylistBeatmapsets
+     */
+    public function testAssertVoteRequirementPlaylistBeatmapsets(bool $played, bool $passed, ?bool $mustPass, bool $canVote): void
+    {
+        $beatmaps = Beatmap::factory()->count(5)->create();
+        // extra beatmap
+        Beatmap::factory()->create();
+
+        $rooms = factory(Room::class, 2)->create();
+        foreach ($rooms as $room) {
+            foreach ($beatmaps as $beatmap) {
+                $playlistItems[] = factory(PlaylistItem::class)->create([
+                    'room_id' => $room->getKey(),
+                    'beatmap_id' => $beatmap->getKey(),
+                ]);
+            }
+        }
+        $contest = factory(Contest::class)->create([
+            'extra_options' => [
+                'requirement' => [
+                    'must_pass' => $mustPass,
+                    'name' => 'playlist_beatmapsets',
+                    'room_ids' => array_column($rooms->all(), 'id'),
+                ],
+            ],
+        ]);
+        $entries = factory(ContestEntry::class, 2)->create(['contest_id' => $contest->getKey()]);
+
+        if (!$canVote) {
+            $this->expectException(InvariantException::class);
+        }
+
+        $user = User::factory()->create();
+
+        if ($played) {
+            $userId = $user->getKey();
+            foreach ($beatmaps as $beatmap) {
+                $room = array_rand_val($rooms);
+                $playlistItem = $room->playlist()->firstWhere(['beatmap_id' => $beatmap->getKey()]);
+                factory(MultiplayerScore::class)->create([
+                    'passed' => $passed,
+                    'playlist_item_id' => $playlistItem->getKey(),
+                    'user_id' => $userId,
+                ]);
+            }
+        }
+
+        $contest->assertVoteRequirement($user);
+
+        if ($canVote) {
+            $this->assertTrue(true, 'no exception');
+        }
+    }
+
+    public function testAssertVoteRequirementNoRequirement(): void
+    {
+        $contest = factory(Contest::class)->create();
+        $entry = factory(ContestEntry::class)->create(['contest_id' => $contest->getKey()]);
+        $user = User::factory()->create();
+
+        $contest->assertVoteRequirement($user, $entry);
+        $this->assertTrue(true, 'no exception');
+    }
+
+    public function dataProviderForTestAssertVoteRequirementPlaylistBeatmapsets(): array
+    {
+        return [
+            // when passing is required
+            [true, true, true, true],
+            [true, false, true, false],
+            [false, false, true, false],
+            // when passing is not specified (default required)
+            [true, true, null, true],
+            [true, false, null, false],
+            [false, false, null, false],
+            // when passing is not required
+            [true, true, false, true],
+            [true, false, false, true],
+            [false, false, false, false],
+        ];
+    }
+}


### PR DESCRIPTION
Add `requirement` object inside `extra_options`:

```json5
{
  "requirement": {
    "name": "playlist_beatmapsets",
    "room_ids": [1, 2, 3],
    "must_pass": false // optional (default true)
  },
  // ...other options...
}
```

Contest with child contest(s) is currently not supported quite right. Namely the requirement must be duplicated and they all must be the same.