### PR TITLE
Remove unused broken `UserReport#score` relation

### DIFF
--- a/app/Models/UserReport.php
+++ b/app/Models/UserReport.php
@@ -23,9 +23,7 @@ use Illuminate\Notifications\RoutesNotifications;
  * @property mixed|null $reportable_type
  * @property User $reporter
  * @property int $reporter_id
- * @property mixed $score
  * @property int $score_id
- * @property mixed $score_type
  * @property \Carbon\Carbon $timestamp
  * @property User $user
  * @property int $user_id
@@ -87,19 +85,9 @@ class UserReport extends Model
         }
     }
 
-    public function score()
-    {
-        return $this->morphTo();
-    }
-
     public function user()
     {
         return $this->belongsTo(User::class, 'user_id');
-    }
-
-    public function getScoreTypeAttribute()
-    {
-        return BestModel::getClass($this->mode);
     }
 
     public function isValid()


### PR DESCRIPTION
The fix is a bit long and involves overriding function (see [this](/staudenmeir/eloquent-json-relations/issues/52) for example) and nothing is using it at the moment anyway (otherwise errors would've been thrown a long time ago).