### PR TITLE
Uniform `getClass` between UserStatistics and Score

### DIFF
--- a/app/Http/Controllers/BeatmapsController.php
+++ b/app/Http/Controllers/BeatmapsController.php
@@ -493,7 +493,7 @@ class BeatmapsController extends Controller
     {
         $beatmap = Beatmap::scoreable()->findOrFail($beatmapId);
         $mode = presence(get_string(request('mode'))) ?? $beatmap->mode;
-        $scores = BestModel::getClassByString($mode)
+        $scores = BestModel::getClass($mode)
             ::default()
             ->where([
                 'beatmap_id' => $beatmap->getKey(),
@@ -507,7 +507,7 @@ class BeatmapsController extends Controller
 
     private static function baseScoreQuery(Beatmap $beatmap, $mode, $mods, $type = null)
     {
-        $query = BestModel::getClassByString($mode)
+        $query = BestModel::getClass($mode)
             ::default()
             ->where('beatmap_id', $beatmap->getKey())
             ->with(['beatmap', 'user.country', 'user.userProfileCustomization'])

--- a/app/Http/Controllers/LegacyInterOpController.php
+++ b/app/Http/Controllers/LegacyInterOpController.php
@@ -344,7 +344,7 @@ class LegacyInterOpController extends Controller
         dispatch(new EsDocument($user));
 
         foreach (Beatmap::MODES as $modeStr => $modeId) {
-            $class = Best\Model::getClassByString($modeStr);
+            $class = Best\Model::getClass($modeStr);
             $class::queueIndexingForUser($user);
         }
         Artisan::queue('es:index-scores:queue', [

--- a/app/Http/Controllers/ScoresController.php
+++ b/app/Http/Controllers/ScoresController.php
@@ -47,7 +47,7 @@ class ScoresController extends Controller
             }
             $ruleset = $rulesetOrSoloId;
             // don't limit downloading replays of restricted users for review purpose
-            $score = ScoreBest::getClassByString($ruleset)
+            $score = ScoreBest::getClass($ruleset)
                 ::where('score_id', $id)
                 ->where('replay', true)
                 ->firstOrFail();
@@ -81,7 +81,7 @@ class ScoresController extends Controller
     {
         $score = $legacyId === null
             ? SoloScore::whereHas('beatmap.beatmapset')->findOrFail($rulesetOrSoloId)
-            : ScoreBest::getClassByString($rulesetOrSoloId)
+            : ScoreBest::getClass($rulesetOrSoloId)
                 ::whereHas('beatmap.beatmapset')
                 ->visibleUsers()
                 ->findOrFail($legacyId);
@@ -118,7 +118,7 @@ class ScoresController extends Controller
         }
 
         $score = ScoreBest
-            ::getClass($params['rulesetId'])
+            ::getClassByRulesetId($params['rulesetId'])
             ::where([
                 'beatmap_id' => $params['beatmapId'],
                 'hidden' => false,

--- a/app/Jobs/RemoveBeatmapsetBestScores.php
+++ b/app/Jobs/RemoveBeatmapsetBestScores.php
@@ -32,7 +32,7 @@ class RemoveBeatmapsetBestScores implements ShouldQueue
         $this->beatmapset = $beatmapset;
 
         foreach (Beatmap::MODES as $mode => $_modeInt) {
-            $this->maxScoreIds[$mode] = Model::getClassByString($mode)::max('score_id');
+            $this->maxScoreIds[$mode] = Model::getClass($mode)::max('score_id');
         }
     }
 
@@ -57,7 +57,7 @@ class RemoveBeatmapsetBestScores implements ShouldQueue
                 'client' => ['ignore' => 404],
             ]);
 
-            $class = Model::getClassByString($mode);
+            $class = Model::getClass($mode);
             // Just delete until no more matching rows.
             $query = $class
                 ::with('user')

--- a/app/Libraries/Search/BeatmapsetSearch.php
+++ b/app/Libraries/Search/BeatmapsetSearch.php
@@ -388,7 +388,7 @@ class BeatmapsetSearch extends RecordSearch
         $select = $rank === null ? 'beatmap_id' : ['beatmap_id', 'score', 'rank'];
 
         foreach ($this->getSelectedModes() as $mode) {
-            $newQuery = Score\Best\Model::getClass($mode)
+            $newQuery = Score\Best\Model::getClassByRulesetId($mode)
                 ::forUser($this->params->user)
                 ->select($select);
 

--- a/app/Libraries/User/ScorePins.php
+++ b/app/Libraries/User/ScorePins.php
@@ -47,7 +47,7 @@ class ScorePins
         $attributes->remove($prefix.MorphMap::getType(Solo\Score::class));
 
         foreach (Beatmap::MODES as $ruleset => $rulesetId) {
-            $type = MorphMap::getType(Score\Best\Model::getClassByString($ruleset));
+            $type = MorphMap::getType(Score\Best\Model::getClass($ruleset));
             $attributes->remove("{$prefix}{$type}");
         }
     }

--- a/app/Libraries/UserBestScoresCheck.php
+++ b/app/Libraries/UserBestScoresCheck.php
@@ -50,7 +50,7 @@ class UserBestScoresCheck
         $this->dbIdsFound = 0;
         $this->esIdsFound = 0;
 
-        $clazz = Best\Model::getClassByString($mode);
+        $clazz = Best\Model::getClass($mode);
 
         $search = $this->newSearch($mode);
         $cursor = [0];

--- a/app/Models/Score/Model.php
+++ b/app/Models/Score/Model.php
@@ -31,22 +31,22 @@ abstract class Model extends BaseModel
     protected $dates = ['date'];
     protected $primaryKey = 'score_id';
 
-    public static function getClass($modeInt)
+    public static function getClassByRulesetId(int $rulesetId): ?string
     {
-        $modeStr = Beatmap::modeStr($modeInt);
+        $ruleset = Beatmap::modeStr($rulesetId);
 
-        if ($modeStr !== null) {
-            return static::getClassByString($modeStr);
+        if ($ruleset !== null) {
+            return static::getClass($ruleset);
         }
     }
 
-    public static function getClassByString(string $mode)
+    public static function getClass(string $ruleset): string
     {
-        if (!Beatmap::isModeValid($mode)) {
+        if (!Beatmap::isModeValid($ruleset)) {
             throw new ClassNotFoundException();
         }
 
-        return get_class_namespace(static::class).'\\'.studly_case($mode);
+        return get_class_namespace(static::class).'\\'.studly_case($ruleset);
     }
 
     public function scopeDefault($query)

--- a/app/Models/Solo/Score.php
+++ b/app/Models/Solo/Score.php
@@ -134,14 +134,14 @@ class Score extends Model implements Traits\ReportableInterface
 
         return $id === null
             ? null
-            : LegacyScore\Best\Model::getClass($this->ruleset_id)::find($id);
+            : LegacyScore\Best\Model::getClass($this->getMode())::find($id);
     }
 
     public function makeLegacyEntry(): LegacyScore\Model
     {
         $data = $this->data;
         $statistics = $data->statistics;
-        $scoreClass = LegacyScore\Model::getClass($this->ruleset_id);
+        $scoreClass = LegacyScore\Model::getClass($this->getMode());
 
         $score = new $scoreClass([
             'beatmap_id' => $this->beatmap_id,

--- a/app/Models/Spotlight.php
+++ b/app/Models/Spotlight.php
@@ -56,7 +56,7 @@ class Spotlight extends Model
      */
     public function scores(string $mode)
     {
-        $clazz = ScoreBest\Model::getClass(Beatmap::MODES[$mode]);
+        $clazz = ScoreBest\Model::getClass($mode);
         $model = new $clazz();
         $model->setTable($this->bestScoresTableName($mode));
         $model->setConnection('mysql-charts');

--- a/app/Models/Traits/UserScoreable.php
+++ b/app/Models/Traits/UserScoreable.php
@@ -85,7 +85,7 @@ trait UserScoreable
     public function beatmapBestScores(string $mode, int $limit, int $offset = 0, $with = [])
     {
         $ids = array_slice($this->beatmapBestScoreIds($mode), $offset, $limit);
-        $clazz = Best\Model::getClassByString($mode);
+        $clazz = Best\Model::getClass($mode);
 
         $results = $clazz::whereIn('score_id', $ids)->orderByField('score_id', $ids)->with($with)->get();
 

--- a/app/Models/UserStatistics/Model.php
+++ b/app/Models/UserStatistics/Model.php
@@ -103,7 +103,7 @@ abstract class Model extends BaseModel
 
     public static function recalculateRankedScoreForUser(User $user)
     {
-        $bestClass = Best\Model::getClassByString(static::getMode());
+        $bestClass = Best\Model::getClass(static::getMode());
 
         $instance = new static();
         $statsTable = $instance->getTable();

--- a/database/seeders/ModelSeeders/SpotlightSeeder.php
+++ b/database/seeders/ModelSeeders/SpotlightSeeder.php
@@ -83,12 +83,12 @@ class SpotlightSeeder extends Seeder
             // users
             $users = User::orderByRaw('RAND()')->limit(1000)->get();
 
-            foreach (Beatmap::MODES as $mode => $v) {
+            foreach (Beatmap::MODES as $ruleset => $rulesetId) {
                 // beatmaps
-                $beatmaps = Beatmap::where('playmode', $v)->orderByRaw('RAND()')->limit(rand(4, 10))->get();
+                $beatmaps = Beatmap::where('playmode', $rulesetId)->orderByRaw('RAND()')->limit(rand(4, 10))->get();
                 $beatmapsetIds = array_unique($beatmaps->pluck('beatmapset_id')->toArray());
 
-                DB::connection('mysql-charts')->table($spotlight->beatmapsetsTableName($mode))->insert(
+                DB::connection('mysql-charts')->table($spotlight->beatmapsetsTableName($ruleset))->insert(
                     array_map(function ($id) {
                         return ['beatmapset_id' => $id];
                     }, $beatmapsetIds)
@@ -96,13 +96,13 @@ class SpotlightSeeder extends Seeder
 
                 foreach ($users as $user) {
                     // user_stats
-                    $stats = factory(UserStatisticsModel::getClass($mode))->make(['user_id' => $user->user_id]);
-                    $stats->setTable($spotlight->userStatsTableName($mode));
+                    $stats = factory(UserStatisticsModel::getClass($ruleset))->make(['user_id' => $user->user_id]);
+                    $stats->setTable($spotlight->userStatsTableName($ruleset));
 
                     $stats->save();
 
                     // scores
-                    $scoresClass = ScoresBestModel::getClass($v);
+                    $scoresClass = ScoresBestModel::getClass($ruleset);
                     $possible_ranks = ['A', 'S', 'B', 'SH', 'XH', 'X'];
 
                     foreach ($beatmaps as $beatmap) {
@@ -124,7 +124,7 @@ class SpotlightSeeder extends Seeder
                         ]);
 
                         $score->setConnection('mysql-charts');
-                        $score->setTable($spotlight->bestScoresTableName($mode));
+                        $score->setTable($spotlight->bestScoresTableName($ruleset));
                         $score->save();
                     }
                 }

--- a/tests/Controllers/BeatmapsControllerTest.php
+++ b/tests/Controllers/BeatmapsControllerTest.php
@@ -221,7 +221,7 @@ class BeatmapsControllerTest extends TestCase
     public function testScoresByCountry()
     {
         $countryAcronym = $this->user->country_acronym;
-        $scoreClass = ScoreBest::getClassRulesetId($this->beatmap->playmode);
+        $scoreClass = ScoreBest::getClassByRulesetId($this->beatmap->playmode);
         $scores = [
             $scoreClass::factory()->create([
                 'beatmap_id' => $this->beatmap,

--- a/tests/Controllers/BeatmapsControllerTest.php
+++ b/tests/Controllers/BeatmapsControllerTest.php
@@ -179,7 +179,7 @@ class BeatmapsControllerTest extends TestCase
 
     public function testScores()
     {
-        $scoreClass = ScoreBest::getClass($this->beatmap->playmode);
+        $scoreClass = ScoreBest::getClassByRulesetId($this->beatmap->playmode);
         $scores = [
             $scoreClass::factory()->create([
                 'beatmap_id' => $this->beatmap,
@@ -209,7 +209,7 @@ class BeatmapsControllerTest extends TestCase
             'user_id' => $this->user,
         ]);
         // Unrelated score
-        ScoreBest::getClassByString(array_rand(Beatmap::MODES))::factory()->create();
+        ScoreBest::getClass(array_rand(Beatmap::MODES))::factory()->create();
 
         $resp = $this->actingAs($this->user)
             ->json('GET', route('beatmaps.scores', $this->beatmap))
@@ -221,7 +221,7 @@ class BeatmapsControllerTest extends TestCase
     public function testScoresByCountry()
     {
         $countryAcronym = $this->user->country_acronym;
-        $scoreClass = ScoreBest::getClass($this->beatmap->playmode);
+        $scoreClass = ScoreBest::getClassRulesetId($this->beatmap->playmode);
         $scores = [
             $scoreClass::factory()->create([
                 'beatmap_id' => $this->beatmap,
@@ -255,7 +255,7 @@ class BeatmapsControllerTest extends TestCase
     public function testScoresByFriend()
     {
         $friend = User::factory()->create();
-        $scoreClass = ScoreBest::getClass($this->beatmap->playmode);
+        $scoreClass = ScoreBest::getClassByRulesetId($this->beatmap->playmode);
         $scores = [
             $scoreClass::factory()->create([
                 'beatmap_id' => $this->beatmap,
@@ -290,7 +290,7 @@ class BeatmapsControllerTest extends TestCase
     public function testScoresModsFilter()
     {
         $modsHelper = app('mods');
-        $scoreClass = ScoreBest::getClass($this->beatmap->playmode);
+        $scoreClass = ScoreBest::getClassByRulesetId($this->beatmap->playmode);
         $scores = [
             $scoreClass::factory()->create([
                 'beatmap_id' => $this->beatmap,
@@ -339,7 +339,7 @@ class BeatmapsControllerTest extends TestCase
     public function testScoresModsWithImpliedFilter()
     {
         $modsHelper = app('mods');
-        $scoreClass = ScoreBest::getClass($this->beatmap->playmode);
+        $scoreClass = ScoreBest::getClassByRulesetId($this->beatmap->playmode);
         $scores = [
             $scoreClass::factory()->create([
                 'beatmap_id' => $this->beatmap,
@@ -371,7 +371,7 @@ class BeatmapsControllerTest extends TestCase
     public function testScoresModsWithNomodsFilter()
     {
         $modsHelper = app('mods');
-        $scoreClass = ScoreBest::getClass($this->beatmap->playmode);
+        $scoreClass = ScoreBest::getClassByRulesetId($this->beatmap->playmode);
         $scores = [
             $scoreClass::factory()->create([
                 'beatmap_id' => $this->beatmap,
@@ -403,7 +403,7 @@ class BeatmapsControllerTest extends TestCase
     public function testScoresNomodsFilter()
     {
         $modsHelper = app('mods');
-        $scoreClass = ScoreBest::getClass($this->beatmap->playmode);
+        $scoreClass = ScoreBest::getClassByRulesetId($this->beatmap->playmode);
         $scores = [
             $scoreClass::factory()->create([
                 'beatmap_id' => $this->beatmap,

--- a/tests/Controllers/Solo/ScoresControllerTest.php
+++ b/tests/Controllers/Solo/ScoresControllerTest.php
@@ -17,7 +17,7 @@ class ScoresControllerTest extends TestCase
     public function testStore()
     {
         $scoreToken = ScoreToken::factory()->create();
-        $legacyScoreClass = LegacyScore\Model::getClass($scoreToken->beatmap->playmode);
+        $legacyScoreClass = LegacyScore\Model::getClassByRulesetId($scoreToken->beatmap->playmode);
 
         $this->expectCountChange(fn () => Score::count(), 1);
         $this->expectCountChange(fn () => $legacyScoreClass::count(), 1);

--- a/tests/Models/Score/Best/ModelTest.php
+++ b/tests/Models/Score/Best/ModelTest.php
@@ -19,7 +19,7 @@ class ModelTest extends TestCase
 
     public function testDelete()
     {
-        $class = Model::getClassByString(static::getRandomMode());
+        $class = Model::getClass(static::getRandomMode());
         $score = $class::factory()->create();
 
         $initialCount = $class::count();
@@ -32,7 +32,7 @@ class ModelTest extends TestCase
     public function testDeleteAlsoDecrementUserRankCount()
     {
         $mode = static::getRandomMode();
-        $class = Model::getClassByString($mode);
+        $class = Model::getClass($mode);
         $score = $class::factory()->create(['rank' => 'X']);
         $statsClass = UserStatistics\Model::getClass($mode);
         $stats = factory($statsClass)->create([
@@ -50,7 +50,7 @@ class ModelTest extends TestCase
     public function testDeleteNonPersonalBestKeepUserRankCount()
     {
         $mode = static::getRandomMode();
-        $class = Model::getClassByString($mode);
+        $class = Model::getClass($mode);
         $bestScore = $class::factory()->create(['rank' => 'X']);
         $score = $class::factory()->create([
             'beatmap_id' => $bestScore->beatmap_id,
@@ -77,7 +77,7 @@ class ModelTest extends TestCase
     public function testDeletePersonalBestUpdateUserRankCountWhenThereIsOtherScore()
     {
         $mode = static::getRandomMode();
-        $class = Model::getClassByString($mode);
+        $class = Model::getClass($mode);
         $bestScore = $class::factory()->create(['rank' => 'X']);
         $score = $class::factory()->create([
             'beatmap_id' => $bestScore->beatmap_id,

--- a/tests/Models/Score/Best/ModelTest.php
+++ b/tests/Models/Score/Best/ModelTest.php
@@ -12,14 +12,14 @@ use Tests\TestCase;
 
 class ModelTest extends TestCase
 {
-    private static function getRandomMode(): string
+    private static function getRandomRuleset(): string
     {
         return array_rand(Beatmap::MODES);
     }
 
     public function testDelete()
     {
-        $class = Model::getClass(static::getRandomMode());
+        $class = Model::getClass(static::getRandomRuleset());
         $score = $class::factory()->create();
 
         $initialCount = $class::count();
@@ -31,10 +31,10 @@ class ModelTest extends TestCase
 
     public function testDeleteAlsoDecrementUserRankCount()
     {
-        $mode = static::getRandomMode();
-        $class = Model::getClass($mode);
+        $ruleset = static::getRandomRuleset();
+        $class = Model::getClass($ruleset);
         $score = $class::factory()->create(['rank' => 'X']);
-        $statsClass = UserStatistics\Model::getClass($mode);
+        $statsClass = UserStatistics\Model::getClass($ruleset);
         $stats = factory($statsClass)->create([
             'user_id' => $score->user_id,
             'x_rank_count' => 10,
@@ -49,8 +49,8 @@ class ModelTest extends TestCase
 
     public function testDeleteNonPersonalBestKeepUserRankCount()
     {
-        $mode = static::getRandomMode();
-        $class = Model::getClass($mode);
+        $ruleset = static::getRandomRuleset();
+        $class = Model::getClass($ruleset);
         $bestScore = $class::factory()->create(['rank' => 'X']);
         $score = $class::factory()->create([
             'beatmap_id' => $bestScore->beatmap_id,
@@ -58,7 +58,7 @@ class ModelTest extends TestCase
             'score' => $bestScore->score - 10,
             'user_id' => $bestScore->user_id,
         ]);
-        $statsClass = UserStatistics\Model::getClass($mode);
+        $statsClass = UserStatistics\Model::getClass($ruleset);
         $stats = factory($statsClass)->create([
             'a_rank_count' => 10,
             'user_id' => $score->user_id,
@@ -76,8 +76,8 @@ class ModelTest extends TestCase
 
     public function testDeletePersonalBestUpdateUserRankCountWhenThereIsOtherScore()
     {
-        $mode = static::getRandomMode();
-        $class = Model::getClass($mode);
+        $ruleset = static::getRandomRuleset();
+        $class = Model::getClass($ruleset);
         $bestScore = $class::factory()->create(['rank' => 'X']);
         $score = $class::factory()->create([
             'beatmap_id' => $bestScore->beatmap_id,
@@ -85,7 +85,7 @@ class ModelTest extends TestCase
             'score' => $bestScore->score - 10,
             'user_id' => $bestScore->user_id,
         ]);
-        $statsClass = UserStatistics\Model::getClass($mode);
+        $statsClass = UserStatistics\Model::getClass($ruleset);
         $stats = factory($statsClass)->create([
             'a_rank_count' => 10,
             'user_id' => $score->user_id,

--- a/tests/Models/Score/ModelTest.php
+++ b/tests/Models/Score/ModelTest.php
@@ -12,25 +12,24 @@ use Tests\TestCase;
 
 class ModelTest extends TestCase
 {
-    public function testGetClass()
+    public function testGetClass(): void
     {
-        $modes = array_keys(Beatmap::MODES);
-        foreach ($modes as $mode) {
-            $class = Model::getClass($mode);
+        foreach (Beatmap::MODES as $ruleset => $_rulesetId) {
+            $class = Model::getClass($ruleset);
             $this->assertInstanceOf(Model::class, new $class());
         }
     }
 
     /**
-     * @dataProvider modes
+     * @dataProvider dataProviderForTestGetClassInvalidRuleset
      */
-    public function testGetClassThrowsExceptionIfModeDoesNotExist($mode)
+    public function testGetClassInvalidRuleset(string $ruleset)
     {
         $this->expectException(ClassNotFoundException::class);
-        Model::getClass($mode);
+        Model::getClass($ruleset);
     }
 
-    public function modes()
+    public function dataProviderForTestGetClassInvalidRuleset(): array
     {
         return [
             ['does'],

--- a/tests/Models/Score/ModelTest.php
+++ b/tests/Models/Score/ModelTest.php
@@ -12,11 +12,11 @@ use Tests\TestCase;
 
 class ModelTest extends TestCase
 {
-    public function testGetClassByString()
+    public function testGetClass()
     {
         $modes = array_keys(Beatmap::MODES);
         foreach ($modes as $mode) {
-            $class = Model::getClassByString($mode);
+            $class = Model::getClass($mode);
             $this->assertInstanceOf(Model::class, new $class());
         }
     }
@@ -24,10 +24,10 @@ class ModelTest extends TestCase
     /**
      * @dataProvider modes
      */
-    public function testGetClassByStringThrowsExceptionIfModeDoesNotExist($mode)
+    public function testGetClassThrowsExceptionIfModeDoesNotExist($mode)
     {
         $this->expectException(ClassNotFoundException::class);
-        Model::getClassByString($mode);
+        Model::getClass($mode);
     }
 
     public function modes()


### PR DESCRIPTION
Also updated some variables to the latest naming `$ruleset` and `$rulesetId`.

It looks like the method itself should be called `getClassOrFail`... (but that's topic for another day)

- [x] depends on #9261