### PR TITLE
Add migration changing all `score_id`s to `BIGINT`

### DIFF
--- a/database/migrations/2022_09_09_011035_upgrade_legacy_scoreids_to_bigint.php
+++ b/database/migrations/2022_09_09_011035_upgrade_legacy_scoreids_to_bigint.php
@@ -20,28 +20,28 @@ class UpgradeLegacyScoreidsToBigint extends Migration
     {
         foreach (static::MODE_SUFFIXES as $modeSuffix) {
             Schema::table("osu_leaders{$modeSuffix}", function (Blueprint $table) {
-                $table->bigInteger("score_id")->unsigned()->nullable(false)->change();
+                $table->bigInteger('score_id')->unsigned()->nullable(false)->change();
             });
 
             Schema::table("osu_replays{$modeSuffix}", function (Blueprint $table) {
-                $table->bigInteger("score_id")->unsigned()->default(0)->change();
+                $table->bigInteger('score_id')->unsigned()->default(0)->change();
             });
 
             Schema::table("osu_scores{$modeSuffix}_high", function (Blueprint $table) {
-                $table->bigIncrements("score_id")->change();
+                $table->bigIncrements('score_id')->change();
             });
 
             Schema::table("osu_scores{$modeSuffix}", function (Blueprint $table) {
-                $table->bigIncrements("score_id")->change();
+                $table->bigIncrements('score_id')->change();
             });
         }
 
         Schema::table('osu_user_reports', function (Blueprint $table) {
-            $table->bigInteger("score_id")->unsigned()->default(0)->change();
+            $table->bigInteger('score_id')->unsigned()->default(0)->change();
         });
 
         Schema::table('solo_scores_legacy_id_map', function (Blueprint $table) {
-            $table->bigInteger("old_score_id")->unsigned()->change();
+            $table->bigInteger('old_score_id')->unsigned()->change();
         });
     }
 
@@ -58,26 +58,26 @@ class UpgradeLegacyScoreidsToBigint extends Migration
             });
 
             Schema::table("osu_replays{$modeSuffix}", function (Blueprint $table) {
-                $table->integer("score_id")->unsigned()->default(0)->change();
+                $table->integer('score_id')->unsigned()->default(0)->change();
             });
 
             Schema::table("osu_scores{$modeSuffix}_high", function (Blueprint $table) {
-                $table->increments("score_id")->change();
+                $table->increments('score_id')->change();
             });
         }
 
         // osu_scores remains as BIGINT
 
-        Schema::table("osu_scores_fruits", function (Blueprint $table) {
-            $table->increments("score_id")->change();
+        Schema::table('osu_scores_fruits', function (Blueprint $table) {
+            $table->increments('score_id')->change();
         });
 
-        Schema::table("osu_scores_taiko", function (Blueprint $table) {
-            $table->increments("score_id")->change();
+        Schema::table('osu_scores_taiko', function (Blueprint $table) {
+            $table->increments('score_id')->change();
         });
 
-        Schema::table("osu_scores_mania", function (Blueprint $table) {
-            $table->increments("score_id")->change();
+        Schema::table('osu_scores_mania', function (Blueprint $table) {
+            $table->increments('score_id')->change();
         });
 
         Schema::table('osu_user_reports', function (Blueprint $table) {
@@ -85,7 +85,7 @@ class UpgradeLegacyScoreidsToBigint extends Migration
         });
 
         Schema::table('solo_scores_legacy_id_map', function (Blueprint $table) {
-            $table->integer("old_score_id")->unsigned()->change();
+            $table->integer('old_score_id')->unsigned()->change();
         });
     }
 }

--- a/database/migrations/2022_09_09_011035_upgrade_legacy_scoreids_to_bigint.php
+++ b/database/migrations/2022_09_09_011035_upgrade_legacy_scoreids_to_bigint.php
@@ -39,6 +39,10 @@ class UpgradeLegacyScoreidsToBigint extends Migration
         Schema::table('osu_user_reports', function (Blueprint $table) {
             $table->bigInteger("score_id")->unsigned()->default(0)->change();
         });
+
+        Schema::table('solo_scores_legacy_id_map', function (Blueprint $table) {
+            $table->bigInteger("old_score_id")->unsigned()->change();
+        });
     }
 
     /**
@@ -78,6 +82,10 @@ class UpgradeLegacyScoreidsToBigint extends Migration
 
         Schema::table('osu_user_reports', function (Blueprint $table) {
             $table->integer('score_id')->unsigned()->default(0)->change();
+        });
+
+        Schema::table('solo_scores_legacy_id_map', function (Blueprint $table) {
+            $table->integer("old_score_id")->unsigned()->change();
         });
     }
 }

--- a/database/migrations/2022_09_09_011035_upgrade_legacy_scoreids_to_bigint.php
+++ b/database/migrations/2022_09_09_011035_upgrade_legacy_scoreids_to_bigint.php
@@ -1,0 +1,83 @@
+<?php
+
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class UpgradeLegacyScoreidsToBigint extends Migration
+{
+    const MODE_SUFFIXES = ['', '_fruits', '_mania', '_taiko'];
+
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        foreach (static::MODE_SUFFIXES as $modeSuffix) {
+            Schema::table("osu_leaders{$modeSuffix}", function (Blueprint $table) {
+                $table->bigInteger("score_id")->unsigned()->nullable(false)->change();
+            });
+
+            Schema::table("osu_replays{$modeSuffix}", function (Blueprint $table) {
+                $table->bigInteger("score_id")->unsigned()->default(0)->change();
+            });
+
+            Schema::table("osu_scores{$modeSuffix}_high", function (Blueprint $table) {
+                $table->bigIncrements("score_id")->change();
+            });
+
+            Schema::table("osu_scores{$modeSuffix}", function (Blueprint $table) {
+                $table->bigIncrements("score_id")->change();
+            });
+        }
+
+        Schema::table('osu_user_reports', function (Blueprint $table) {
+            $table->bigInteger("score_id")->unsigned()->default(0)->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        foreach (static::MODE_SUFFIXES as $modeSuffix) {
+            Schema::table("osu_leaders{$modeSuffix}", function (Blueprint $table) {
+                $table->integer('score_id')->unsigned()->nullable()->default(null)->change();
+            });
+
+            Schema::table("osu_replays{$modeSuffix}", function (Blueprint $table) {
+                $table->integer("score_id")->unsigned()->default(0)->change();
+            });
+
+            Schema::table("osu_scores{$modeSuffix}_high", function (Blueprint $table) {
+                $table->increments("score_id")->change();
+            });
+        }
+
+        // osu_scores remains as BIGINT
+
+        Schema::table("osu_scores_fruits", function (Blueprint $table) {
+            $table->increments("score_id")->change();
+        });
+
+        Schema::table("osu_scores_taiko", function (Blueprint $table) {
+            $table->increments("score_id")->change();
+        });
+
+        Schema::table("osu_scores_mania", function (Blueprint $table) {
+            $table->increments("score_id")->change();
+        });
+
+        Schema::table('osu_user_reports', function (Blueprint $table) {
+            $table->integer('score_id')->unsigned()->default(0)->change();
+        });
+    }
+}


### PR DESCRIPTION
- [x] migration entry `2022_09_09_011035_upgrade_legacy_scoreids_to_bigint`

This PR is just to get the ball rolling to make sure the change isn't forgotten about. I have not tested if osu!web doesn't actually fall over in some way with `score_id > int_max`.

So @nanaya / @notbakaneko please feel free to take over this PR and/or build on top of it if any additional changes are necessary.

For comparison:

[Before](https://github.com/ppy/osu-web/files/9531736/before.txt)
[After](https://github.com/ppy/osu-web/files/9531737/after.txt)
[Rollback](https://github.com/ppy/osu-web/files/9531780/rollback.txt)