### PR TITLE
Remove `get_model_basename` helper

### DIFF
--- a/app/Transformers/KudosuHistoryTransformer.php
+++ b/app/Transformers/KudosuHistoryTransformer.php
@@ -5,6 +5,7 @@
 
 namespace App\Transformers;
 
+use App\Models\BeatmapDiscussion;
 use App\Models\KudosuHistory;
 
 class KudosuHistoryTransformer extends TransformerAbstract
@@ -26,13 +27,16 @@ class KudosuHistoryTransformer extends TransformerAbstract
 
             $model = 'forum_post';
             $action = $kudosuHistory->action;
-        } elseif ($kudosuHistory->kudosuable !== null) {
+        } elseif (($kudosuable = $kudosuHistory->kudosuable) !== null) {
             $post = [
-                'url' => $kudosuHistory->kudosuable->url(),
-                'title' => $kudosuHistory->kudosuable->title(),
+                'url' => $kudosuable->url(),
+                'title' => $kudosuable->title(),
             ];
 
-            $model = get_model_basename($kudosuHistory->kudosuable);
+            $model = $kudosuable instanceof BeatmapDiscussion
+                // Old name, used at least in translation file.
+                ? 'beatmap_discussion'
+                : $kudosuable->getMorphClass();
             $action = $kudosuHistory->details['event'].'.'.$kudosuHistory->action;
         } else {
             $post = [

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -1419,15 +1419,6 @@ function get_class_namespace($className)
     return substr($className, 0, strrpos($className, '\\'));
 }
 
-function get_model_basename($model)
-{
-    if (!is_string($model)) {
-        $model = get_class($model);
-    }
-
-    return str_replace('\\', '', snake_case(substr($model, strlen('App\\Models\\'))));
-}
-
 function ci_file_search($fileName)
 {
     if (file_exists($fileName)) {


### PR DESCRIPTION
Found this when checking if there's a better way to get class by ruleset ಠಿ_ಠ