### PR TITLE
Redirect old tumblr news post urls

### DIFF
--- a/app/Http/Controllers/NewsController.php
+++ b/app/Http/Controllers/NewsController.php
@@ -119,6 +119,13 @@ class NewsController extends Controller
         }
     }
 
+    public function redirect($tumblrId)
+    {
+        $post = NewsPost::where('tumblr_id', $tumblrId)->firstOrFail();
+
+        return ujs_redirect(route('news.show', $post->slug));
+    }
+
     /**
      * Get News Post
      *

--- a/database/migrations/2022_09_13_080115_index_news_posts_tumblr_id.php
+++ b/database/migrations/2022_09_13_080115_index_news_posts_tumblr_id.php
@@ -1,0 +1,37 @@
+<?php
+
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('news_posts', function (Blueprint $table): void {
+            $table->index('tumblr_id');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('news_posts', function (Blueprint $table): void {
+            $table->dropIndex(['tumblr_id']);
+        });
+    }
+};

--- a/resources/assets/lib/utils/url.ts
+++ b/resources/assets/lib/utils/url.ts
@@ -23,6 +23,7 @@ const internalUrls = [
   'groups',
   'legal',
   'multiplayer',
+  'news',
   'notifications',
   'oauth',
   'rankings',

--- a/routes/web.php
+++ b/routes/web.php
@@ -257,6 +257,8 @@ Route::group(['middleware' => ['web']], function () {
         Route::resource('rooms', 'RoomsController', ['only' => ['show']]);
     });
 
+    Route::get('news/{tumblrId}', 'NewsController@redirect');
+
     Route::group(['as' => 'oauth.', 'prefix' => 'oauth', 'namespace' => 'OAuth'], function () {
         Route::resource('authorized-clients', 'AuthorizedClientsController', ['only' => ['destroy']]);
         Route::resource('clients', 'ClientsController', ['except' => ['create', 'edit', 'show']]);


### PR DESCRIPTION
@peppy the nginx config needs updating so `/news/` isn't handled by old web as defined in `osu_fallback_common.conf`.

Also I wonder if we should just move the news url to `/news/2022-07-27-some-slugs` from current `/home/news/2022-07-27-some-slugs`.

Resolves #9239.