### PR TITLE
Fix docker deployment build

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -11,6 +11,5 @@ public/uploads
 public/uploads-avatar
 public/uploads-replay
 resources/assets/build/
-resources/assets/js/ziggy.js
 storage/
 vendor/

--- a/resources/assets/lib/cli/mod-names-generator.js
+++ b/resources/assets/lib/cli/mod-names-generator.js
@@ -17,7 +17,9 @@ function modNamesGenerator() {
     }
   }
 
-  fs.writeFileSync(`${root}/resources/assets/build/mod-names.json`, JSON.stringify(modNames));
+  const outDir = `${root}/resources/assets/build`;
+  fs.mkdirSync(outDir, { recursive: true });
+  fs.writeFileSync(`${outDir}/mod-names.json`, JSON.stringify(modNames));
 }
 
 module.exports = modNamesGenerator;


### PR DESCRIPTION
The `.dockerignore` ignores a bit too many things...

Create build directory on the fly instead. This may or may not get annoying as anything writing to the directory has to create the directory first.