### PR TITLE
Order returned beatmaps by id

### DIFF
--- a/app/Http/Controllers/BeatmapsController.php
+++ b/app/Http/Controllers/BeatmapsController.php
@@ -146,6 +146,7 @@ class BeatmapsController extends Controller
                     'beatmapset.userRatings' => fn ($q) => $q->select('beatmapset_id', 'rating'),
                     'failtimes',
                 ])->withMaxCombo()
+                ->orderBy('beatmap_id')
                 ->get();
         }
 


### PR DESCRIPTION
Mainly to ensure reliable test. The alternative is for the test to ignore order when checking but that would require some more changes.