### PR TITLE
Sideload beatmapsets in bundle instead of embedding in discussions

### DIFF
--- a/app/Libraries/ModdingHistoryEventsBundle.php
+++ b/app/Libraries/ModdingHistoryEventsBundle.php
@@ -10,6 +10,7 @@ use App\Models\Beatmap;
 use App\Models\BeatmapDiscussion;
 use App\Models\BeatmapDiscussionPost;
 use App\Models\BeatmapDiscussionVote;
+use App\Models\Beatmapset;
 use App\Models\BeatmapsetEvent;
 use App\Models\User;
 use App\Traits\Memoizes;
@@ -106,10 +107,15 @@ class ModdingHistoryEventsBundle
                     'Beatmap'
                 );
 
+                $array['beatmapsets'] = json_collection(
+                    $this->getBeatmapsets(),
+                    'Beatmapset'
+                );
+
                 $array['discussions'] = json_collection(
                     $this->getDiscussions(),
                     'BeatmapDiscussion',
-                    ['starting_post', 'beatmap', 'beatmapset', 'current_user_attributes']
+                    ['starting_post', 'current_user_attributes']
                 );
 
                 $array['posts'] = json_collection(
@@ -168,12 +174,26 @@ class ModdingHistoryEventsBundle
                 return collect();
             }
 
+            $beatmapsetId = $this->getBeatmapsets()
+                ->pluck('beatmapset_id');
+
+            return Beatmap::whereIn('beatmapset_id', $beatmapsetId)->get();
+        });
+    }
+
+    private function getBeatmapsets()
+    {
+        return $this->memoize(__FUNCTION__, function () {
+            if (!$this->withExtras) {
+                return collect();
+            }
+
             $beatmapsetId = $this->getDiscussions()
                 ->pluck('beatmapset_id')
                 ->unique()
                 ->toArray();
 
-            return Beatmap::whereIn('beatmapset_id', $beatmapsetId)->get();
+            return Beatmapset::whereIn('beatmapset_id', $beatmapsetId)->get();
         });
     }
 

--- a/resources/assets/lib/beatmap-discussions/beatmapsets-context.ts
+++ b/resources/assets/lib/beatmap-discussions/beatmapsets-context.ts
@@ -1,0 +1,9 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
+import BeatmapetExtendedJson from 'interfaces/beatmapset-extended-json';
+import * as React from 'react';
+
+const defaultValue: Partial<Record<number, BeatmapetExtendedJson>> = {};
+
+export const BeatmapsetsContext = React.createContext(defaultValue);

--- a/resources/assets/lib/entrypoints/beatmap-discussions-history.coffee
+++ b/resources/assets/lib/entrypoints/beatmap-discussions-history.coffee
@@ -11,6 +11,7 @@ core.reactTurbolinks.register 'beatmap-discussions-history', (container) ->
 
   # TODO: rename props to match
   createElement Main,
+    beatmapsets: bundle.beatmapsets
     discussions: bundle.discussions
     users: bundle.users
     relatedBeatmaps: bundle.beatmaps

--- a/resources/assets/lib/entrypoints/modding-profile.coffee
+++ b/resources/assets/lib/entrypoints/modding-profile.coffee
@@ -9,6 +9,7 @@ import { Main } from 'modding-profile/main'
 core.reactTurbolinks.register 'modding-profile', (container) ->
   createElement Main,
     beatmaps: parseJson('json-beatmaps')
+    beatmapsets: parseJson('json-beatmapsets')
     container: container
     discussions: parseJson('json-discussions')
     events: parseJson('json-events')

--- a/resources/assets/lib/interfaces/beatmapset-discussion-json.ts
+++ b/resources/assets/lib/interfaces/beatmapset-discussion-json.ts
@@ -54,8 +54,7 @@ export default BeatmapsetDiscussionJson;
 export type BeatmapsetDiscussionJsonForBundle =
 Omit<BeatmapsetDiscussionJson, 'posts'> // bundle explicitly does not include posts; need this for type discrimination.
 & Required<Pick<BeatmapsetDiscussionJson,
-'beatmapset'
-| 'current_user_attributes'
+'current_user_attributes'
 | 'starting_post'
 >>;
 

--- a/resources/assets/lib/modding-profile/discussions.coffee
+++ b/resources/assets/lib/modding-profile/discussions.coffee
@@ -2,6 +2,7 @@
 # See the LICENCE file in the repository root for full licence text.
 
 import { BeatmapsContext } from 'beatmap-discussions/beatmaps-context'
+import { BeatmapsetsContext } from 'beatmap-discussions/beatmapsets-context'
 import BeatmapsetCover from 'components/beatmapset-cover'
 import { route } from 'laroute'
 import * as React from 'react'
@@ -18,30 +19,31 @@ export class Discussions extends React.Component
         if @props.discussions.length == 0
           div className: 'modding-profile-list__empty', osu.trans('users.show.extra.none')
         else
-          el BeatmapsContext.Consumer, null, (beatmaps) =>
-            el React.Fragment, null,
-              for discussion in @props.discussions
-                div
-                  className: 'modding-profile-list__row'
-                  key: discussion.id,
+          el BeatmapsetsContext.Consumer, null, (beatmapsets) =>
+            el BeatmapsContext.Consumer, null, (beatmaps) =>
+              el React.Fragment, null,
+                for discussion in @props.discussions
+                  div
+                    className: 'modding-profile-list__row'
+                    key: discussion.id,
 
-                  a
-                    className: 'modding-profile-list__thumbnail'
-                    href: BeatmapDiscussionHelper.url(discussion: discussion),
+                    a
+                      className: 'modding-profile-list__thumbnail'
+                      href: BeatmapDiscussionHelper.url(discussion: discussion),
 
-                    el BeatmapsetCover, beatmapset: discussion.beatmapset, size: 'list'
+                      el BeatmapsetCover, beatmapset: beatmapsets[discussion.beatmapset_id], size: 'list'
 
-                  el Discussion,
-                    discussion: discussion
-                    users: @props.users
-                    currentBeatmap: beatmaps[discussion.beatmap_id]
-                    currentUser: currentUser
-                    beatmapset: discussion.beatmapset
-                    isTimelineVisible: false
-                    visible: false
-                    showDeleted: true
-                    preview: true
-              a
-                className: 'modding-profile-list__show-more'
-                href: route('beatmapsets.discussions.index', {user: @props.user.id}),
-                osu.trans('users.show.extra.discussions.show_more')
+                    el Discussion,
+                      discussion: discussion
+                      users: @props.users
+                      currentBeatmap: beatmaps[discussion.beatmap_id]
+                      currentUser: currentUser
+                      beatmapset: beatmapsets[discussion.beatmapset_id]
+                      isTimelineVisible: false
+                      visible: false
+                      showDeleted: true
+                      preview: true
+                a
+                  className: 'modding-profile-list__show-more'
+                  href: route('beatmapsets.discussions.index', {user: @props.user.id}),
+                  osu.trans('users.show.extra.discussions.show_more')


### PR DESCRIPTION
Bringing the modding profile and discussion history pages more in line with the actual discussions page (no embedded `beatmapset`, explicit prop).

This PR is mainly to check for breakage against the existing components while I convert `Discussion` to typescript as that doesn't seem to make any reference to `discussion.beatmapset` but some parts look like they would benefit from having `beatmapset` being `BeatmapsetExtendedJson` instead of just `BeatmapsetJson` 👀 