### PR TITLE
Better beatmap scoreboard performance on mobile Safari

### DIFF
--- a/resources/assets/less/utilities.less
+++ b/resources/assets/less/utilities.less
@@ -72,6 +72,10 @@
   pointer-events: none;
 }
 
+.u-own-layer {
+  .own-layer();
+}
+
 .u-nav-float {
   z-index: @z-index--nav-float !important;
 }

--- a/resources/assets/lib/beatmapsets-show/scoreboard/table-row.tsx
+++ b/resources/assets/lib/beatmapsets-show/scoreboard/table-row.tsx
@@ -89,7 +89,7 @@ export default class ScoreboardTableRow extends React.Component<Props> {
           {`${formatNumber(score.accuracy * 100, 2)}%`}
         </TdLink>
 
-        <td className={`${bn}__cell`}>
+        <td className={`${bn}__cell u-own-layer`}>
           {score.user.country_code != null &&
             <a
               className={`${bn}__cell-content`}


### PR DESCRIPTION
...maybe 🤔 

`overflow-x: scroll` on the scoreboard causes Safari to always compose the scoreboard as a separate layer which Safari apparently takes as a free license to discard and recompose whenever it feels like while scrolling (instead of just repainting)...and then has to recompose all over again with cpu rendered `filter`

This makes Safari use the gpu for the scoreboard flag layer (and apparently stop throwing away the whole scoreboard).
The new issue is the colour levels applied by `filter` on gpu rendered layers are different, and it's not applied to all flags because it makes the larger flags become a blurry mess in Chrome.

