### PR TITLE
Add migration for `osu_difficulty_attribs` table

### DIFF
--- a/database/migrations/2022_09_21_052117_create_osu_difficulty_attribs.php
+++ b/database/migrations/2022_09_21_052117_create_osu_difficulty_attribs.php
@@ -1,0 +1,50 @@
+<?php
+
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class CreateOsuDifficultyAttribs extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::create('osu_difficulty_attribs', function (Blueprint $table) {
+            $table->unsignedSmallInteger('attrib_id');
+            $table->string('name', 256)->default('');
+            $table->boolean('visible')->default(0);
+            $table->primary('attrib_id');
+        });
+
+        DB::table('osu_difficulty_attribs')->insert([
+            ['attrib_id' => 1, 'name' => 'Aim', 'visible' => 1],
+            ['attrib_id' => 3, 'name' => 'Speed', 'visible' => 1],
+            ['attrib_id' => 5, 'name' => 'OD', 'visible' => 0],
+            ['attrib_id' => 7, 'name' => 'AR', 'visible' => 0],
+            ['attrib_id' => 9, 'name' => 'Max combo', 'visible' => 0],
+            ['attrib_id' => 11, 'name' => 'Strain', 'visible' => 1],
+            ['attrib_id' => 13, 'name' => 'Hit window 300', 'visible' => 0],
+            ['attrib_id' => 15, 'name' => 'Score multiplier', 'visible' => 0],
+            ['attrib_id' => 17, 'name' => 'Flashlight', 'visible' => 0],
+            ['attrib_id' => 19, 'name' => 'Slider factor', 'visible' => 0],
+            ['attrib_id' => 21, 'name' => 'Speed note count', 'visible' => 0],
+        ]);
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::dropIfExists('osu_difficulty_attribs');
+    }
+}


### PR DESCRIPTION
- [x] migration entry `2022_09_21_052117_create_osu_difficulty_attribs`

Expected:
```sql
> SHOW CREATE TABLE osu_difficulty_attribs\G;
***************************[ 1. row ]***************************
Table        | osu_difficulty_attribs
Create Table | CREATE TABLE `osu_difficulty_attribs` (
  `attrib_id` smallint unsigned NOT NULL,
  `name` varchar(256) COLLATE utf8mb4_general_ci NOT NULL DEFAULT '',
  `visible` tinyint(1) NOT NULL DEFAULT '0',
  PRIMARY KEY (`attrib_id`)
) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci
```
Actual:
```sql
> SHOW CREATE TABLE osu_difficulty_attribs\G;
*************************** 1. row ***************************
       Table: osu_difficulty_attribs
Create Table: CREATE TABLE `osu_difficulty_attribs` (
  `attrib_id` smallint unsigned NOT NULL,
  `name` varchar(256) NOT NULL DEFAULT '',
  `visible` tinyint(1) NOT NULL DEFAULT '0',
  PRIMARY KEY (`attrib_id`)
) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_0900_ai_ci
```
The collation on `name` matches the one on the table, should be fine?