### PR TITLE
Faster and less blurry flags

### DIFF
--- a/resources/assets/less/bem/flag-country.less
+++ b/resources/assets/less/bem/flag-country.less
@@ -3,7 +3,7 @@
 
 .flag-country {
   --height: 1em;
-  --width-height-ratio: calc(100 / 75);
+  --width-height-ratio: calc(100 / 72); // Original flag svg ratio; using a different ratio turns the flag into a blurry mess on Chrome.
 
   height: var(--height);
   width: calc(var(--height) * var(--width-height-ratio));

--- a/resources/assets/less/bem/flag-country.less
+++ b/resources/assets/less/bem/flag-country.less
@@ -14,6 +14,8 @@
   position: relative;
   filter: saturate(1.1);
 
+  .own-layer(); // Force gpu filter: on Safari.
+
   &::after {
     .full-size();
     background: inherit;

--- a/resources/assets/less/utilities.less
+++ b/resources/assets/less/utilities.less
@@ -72,10 +72,6 @@
   pointer-events: none;
 }
 
-.u-own-layer {
-  .own-layer();
-}
-
 .u-nav-float {
   z-index: @z-index--nav-float !important;
 }

--- a/resources/assets/lib/beatmapsets-show/scoreboard/table-row.tsx
+++ b/resources/assets/lib/beatmapsets-show/scoreboard/table-row.tsx
@@ -89,7 +89,7 @@ export default class ScoreboardTableRow extends React.Component<Props> {
           {`${formatNumber(score.accuracy * 100, 2)}%`}
         </TdLink>
 
-        <td className={`${bn}__cell u-own-layer`}>
+        <td className={`${bn}__cell`}>
           {score.user.country_code != null &&
             <a
               className={`${bn}__cell-content`}


### PR DESCRIPTION
Always render flag in a separate layer; speeds up rendering on Safari especially on pages with a lot of flags (particularly mobile safari - desktop Safari doesn't seem to have the issue to the same extent unless in a scrollable element).
This was generally avoided previously due it turning the flags into a blurry mess on Chrome, except a recent update seems to always turn it into a blurry mess anyway.

The flag ratio is changed to the original 100/72 of the svg instead of 4/3; this stops the flag from turning into a blurry mess on Chrome.

fixes #9299