### PR TITLE
Remove solo scores on beatmap state change

### DIFF
--- a/app/Jobs/RemoveBeatmapsetSoloScores.php
+++ b/app/Jobs/RemoveBeatmapsetSoloScores.php
@@ -1,0 +1,75 @@
+<?php
+
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
+declare(strict_types=1);
+
+namespace App\Jobs;
+
+use App\Libraries\Search\ScoreSearch;
+use App\Models\Beatmap;
+use App\Models\Beatmapset;
+use App\Models\Solo\Score;
+use App\Models\Solo\ScorePerformance;
+use DB;
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Database\Eloquent\Collection;
+
+class RemoveBeatmapsetSoloScores implements ShouldQueue
+{
+    use Queueable;
+
+    public $timeout = 3600;
+
+    private int $beatmapsetId;
+    private int $maxScoreId;
+    private array $schemas;
+    private ScoreSearch $scoreSearch;
+
+    /**
+     * Create a new job instance.
+     *
+     * @return void
+     */
+    public function __construct(Beatmapset $beatmapset)
+    {
+        $this->beatmapsetId = $beatmapset->getKey();
+        $this->maxScoreId = Score::max('id') ?? 0;
+    }
+
+    /**
+     * Execute the job.
+     *
+     * @return void
+     */
+    public function handle()
+    {
+        $this->scoreSearch = new ScoreSearch();
+        $this->schemas = $this->scoreSearch->getActiveSchemas();
+
+        $beatmapIds = Beatmap::where('beatmapset_id', $this->beatmapsetId)->pluck('beatmap_id');
+        Score
+            ::whereIn('beatmap_id', $beatmapIds)
+            ->where('id', '<=', $this->maxScoreId)
+            ->chunkById(1000, fn ($scores) => $this->deleteScores($scores));
+    }
+
+    private function deleteScores(Collection $scores): void
+    {
+        $ids = $scores->pluck('id')->all();
+
+        $scoresQuery = Score::whereKey($ids);
+        // Queue delete ahead of time in case process is stopped right after
+        // db delete is committed. It's fine queuing deleted score ahead of
+        // time as best score check doesn't use index.
+        // Set the flag first so indexer will correctly delete it.
+        $scoresQuery->update(['preserve' => false]);
+        $this->scoreSearch->queueForIndex($this->schemas, $ids);
+        DB::transaction(function () use ($ids, $scoresQuery): void {
+            ScorePerformance::whereKey($ids)->delete();
+            $scoresQuery->delete();
+        });
+    }
+}

--- a/app/Models/Beatmapset.php
+++ b/app/Models/Beatmapset.php
@@ -19,6 +19,7 @@ use App\Jobs\Notifications\BeatmapsetRank;
 use App\Jobs\Notifications\BeatmapsetRemoveFromLoved;
 use App\Jobs\Notifications\BeatmapsetResetNominations;
 use App\Jobs\RemoveBeatmapsetBestScores;
+use App\Jobs\RemoveBeatmapsetSoloScores;
 use App\Libraries\BBCodeFromDB;
 use App\Libraries\Commentable;
 use App\Libraries\Elasticsearch\Indexable;
@@ -561,6 +562,7 @@ class Beatmapset extends Model implements AfterCommit, Commentable, Indexable, T
 
         if ($this->isScoreable() !== $oldScoreable || $this->isRanked()) {
             dispatch(new RemoveBeatmapsetBestScores($this));
+            dispatch(new RemoveBeatmapsetSoloScores($this));
         }
 
         if ($this->isScoreable() !== $oldScoreable) {

--- a/tests/Jobs/RemoveBeatmapsetSoloScoresTest.php
+++ b/tests/Jobs/RemoveBeatmapsetSoloScoresTest.php
@@ -1,0 +1,106 @@
+<?php
+
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
+declare(strict_types=1);
+
+namespace Tests\Jobs;
+
+use App\Jobs\RemoveBeatmapsetSoloScores;
+use App\Libraries\Search\ScoreSearch;
+use App\Models\Beatmap;
+use App\Models\Beatmapset;
+use App\Models\Country;
+use App\Models\Genre;
+use App\Models\Group;
+use App\Models\Language;
+use App\Models\Solo\Score;
+use App\Models\Solo\ScorePerformance;
+use App\Models\User;
+use App\Models\UserGroup;
+use App\Models\UserGroupEvent;
+use Tests\TestCase;
+
+/**
+ * @group EsSoloScores
+ */
+class RemoveBeatmapsetSoloScoresTest extends TestCase
+{
+    protected $connectionsToTransact = [];
+
+    public function testHandle()
+    {
+        $beatmapset = Beatmapset::factory()->qualified()->has(Beatmap::factory()->qualified()->count(4))->create();
+        $scores = array_map(
+            fn (): Score => $this->createScore($beatmapset),
+            array_fill(0, 10, null),
+        );
+        foreach ($scores as $i => $score) {
+            $score->performance()->create(['pp' => rand(0, 1000)]);
+        }
+        $userAdditionalScores = array_map(
+            fn (Score $score) => $this->createScore($beatmapset, $score->user_id, $score->ruleset_id),
+            $scores,
+        );
+
+        $job = new RemoveBeatmapsetSoloScores($beatmapset);
+
+        // These scores shouldn't be deleted
+        for ($i = 0; $i < 10; $i++) {
+            $score = $this->createScore($beatmapset);
+            $score->performance()->create(['pp' => rand(0, 1000)]);
+        }
+
+        $this->expectCountChange(fn () => Score::count(), count($scores) * -2, 'removes scores');
+        $this->expectCountChange(fn () => ScorePerformance::count(), count($scores) * -1, 'removes score performances');
+
+        static::reindexScores();
+
+        $job->handle();
+
+        $search = new ScoreSearch();
+        // this also makes sure the job deletes scores from index
+        $search->indexWait();
+
+        $this->beforeApplicationDestroyed(function () use ($search) {
+            $this->refreshApplication();
+            $db = app('db');
+            Beatmap::truncate();
+            Beatmapset::truncate();
+            Country::truncate();
+            Genre::truncate();
+            Group::truncate();
+            Language::truncate();
+            Score::truncate();
+            ScorePerformance::truncate();
+            User::truncate();
+            UserGroup::truncate();
+            UserGroupEvent::truncate();
+            $search->deleteAll();
+            foreach (config('database.connections') as $name => $_dbConfig) {
+                $conn = $db->connection($name);
+                $conn->rollBack();
+                $conn->disconnect();
+            }
+        });
+    }
+
+    private function createScore(Beatmapset $beatmapset, ?int $userId = null, ?int $rulesetId = null): Score
+    {
+        $params = [
+            'beatmap_id' => array_rand_val($beatmapset->beatmaps),
+            'preserve' => true,
+        ];
+        if ($userId !== null) {
+            $params['user_id'] = $userId;
+        }
+        if ($rulesetId !== null) {
+            $params['ruleset_id'] = $rulesetId;
+        }
+
+        return Score::factory()->withData([
+            'rank' => array_rand_val(['A', 'S', 'SH', 'X', 'XH']),
+        ])->create($params);
+    }
+}


### PR DESCRIPTION
This only deletes the scores without adjusting user statistics (still done by `BestScores` removal job).