### PR TITLE
Skip rebuilding redundant transformer includes

### DIFF
--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -466,19 +466,17 @@ class UsersController extends Controller
             abort(404);
         }
 
-        $userIncludes = [
-            ...$this->showUserIncludes(),
-            ...array_map(
-                fn (string $ruleset) => "statistics_rulesets.{$ruleset}",
-                array_keys(Beatmap::MODES),
-            ),
-        ];
-
-        return json_item(
+        return $this->fillDeprecatedDuplicateFields(json_item(
             $user,
             (new UserTransformer())->setMode($currentMode),
-            $userIncludes
-        );
+            [
+                ...$this->showUserIncludes(),
+                ...array_map(
+                    fn (string $ruleset) => "statistics_rulesets.{$ruleset}",
+                    array_keys(Beatmap::MODES),
+                ),
+            ],
+        ));
     }
 
     /**
@@ -541,13 +539,11 @@ class UsersController extends Controller
             abort(404);
         }
 
-        $userIncludes = $this->showUserIncludes();
-
-        $userArray = json_item(
+        $userArray = $this->fillDeprecatedDuplicateFields(json_item(
             $user,
             (new UserTransformer())->setMode($currentMode),
-            $userIncludes
-        );
+            $this->showUserIncludes(),
+        ));
 
         if (is_api_request()) {
             return $userArray;
@@ -779,7 +775,6 @@ class UsersController extends Controller
             'monthly_playcounts',
             'page',
             'pending_beatmapset_count',
-            'rankHistory',
             'rank_history',
             'ranked_beatmapset_count',
             'replays_watched_counts',
@@ -792,10 +787,6 @@ class UsersController extends Controller
             'statistics.rank',
             'statistics.variants',
             'user_achievements',
-
-            // TODO: deprecated
-            'ranked_and_approved_beatmapset_count',
-            'unranked_beatmapset_count',
         ];
 
         if (priv_check('UserSilenceShowExtendedInfo')->can() && !is_api_request()) {
@@ -804,5 +795,22 @@ class UsersController extends Controller
         }
 
         return $userIncludes;
+    }
+
+    private function fillDeprecatedDuplicateFields(array $userJson): array
+    {
+        static $map = [
+            'rankHistory' => 'rank_history',
+            'ranked_and_approved_beatmapset_count' => 'ranked_beatmapset_count',
+            'unranked_beatmapset_count' => 'pending_beatmapset_count',
+        ];
+
+        foreach ($map as $legacyKey => $key) {
+            if (array_key_exists($key, $userJson)) {
+                $userJson[$legacyKey] = $userJson[$key];
+            }
+        }
+
+        return $userJson;
     }
 }

--- a/app/Transformers/UserCompactTransformer.php
+++ b/app/Transformers/UserCompactTransformer.php
@@ -74,6 +74,7 @@ class UserCompactTransformer extends TransformerAbstract
         'page',
         'pending_beatmapset_count',
         'previous_usernames',
+        'rank_history',
         'ranked_beatmapset_count',
         'replays_watched_counts',
         'scores_best_count',
@@ -86,14 +87,6 @@ class UserCompactTransformer extends TransformerAbstract
         'unread_pm_count',
         'user_achievements',
         'user_preferences',
-        // TODO: should be changed to rank_history
-        // TODO: should be alphabetically ordered but lazer relies on being after statistics. can revert to alphabetical after 2020-05-01
-        'rankHistory',
-        'rank_history',
-
-        // TODO: deprecated
-        'ranked_and_approved_beatmapset_count',
-        'unranked_beatmapset_count',
     ];
 
     protected $permissions = [
@@ -339,11 +332,6 @@ class UserCompactTransformer extends TransformerAbstract
             : $this->item($rankHistoryData, new RankHistoryTransformer());
     }
 
-    public function includeRankedAndApprovedBeatmapsetCount(User $user)
-    {
-        return $this->includeRankedBeatmapsetCount($user);
-    }
-
     public function includeRankedBeatmapsetCount(User $user)
     {
         return $this->primitive($user->profileBeatmapsetCountByGroupedStatus('ranked'));
@@ -392,11 +380,6 @@ class UserCompactTransformer extends TransformerAbstract
     public function includeSupportLevel(User $user)
     {
         return $this->primitive($user->supportLevel());
-    }
-
-    public function includeUnrankedBeatmapsetCount(User $user)
-    {
-        return $this->includePendingBeatmapsetCount($user);
     }
 
     public function includeUnreadPmCount(User $user)


### PR DESCRIPTION
Reorder the includes while at it.

The alternative is to remove them entirely. We've marked them deprecated for long enough now.