### PR TITLE
Fix total value handling for legacy score

### DIFF
--- a/app/Libraries/Elasticsearch/SearchResponse.php
+++ b/app/Libraries/Elasticsearch/SearchResponse.php
@@ -126,7 +126,10 @@ class SearchResponse implements \ArrayAccess, \Countable, \Iterator
 
     public function total()
     {
-        return $this->raw()['hits']['total']['value'];
+        $total = $this->raw()['hits']['total'];
+
+        // total an object in elasticsearch 7+
+        return is_array($total) ? $total['value'] : $total;
     }
 
     //================


### PR DESCRIPTION
Apparently it's still being used by legacy score search.