### PR TITLE
Fix empty elasticsearch response

### DIFF
--- a/app/Libraries/Elasticsearch/SearchResponse.php
+++ b/app/Libraries/Elasticsearch/SearchResponse.php
@@ -200,15 +200,9 @@ class SearchResponse implements \ArrayAccess, \Countable, \Iterator
 
     public static function failed($exception)
     {
-        return new static([
-            'hits' => [
-                'hits' => [],
-                'total' => [
-                    'relation' => 'eq',
-                    'value' => 0,
-                ],
-            ],
-            'exception' => $exception,
-        ]);
+        $ret = static::empty();
+        $ret->raw['exception'] = $exception;
+
+        return $ret;
     }
 }

--- a/app/Libraries/Elasticsearch/SearchResponse.php
+++ b/app/Libraries/Elasticsearch/SearchResponse.php
@@ -190,7 +190,10 @@ class SearchResponse implements \ArrayAccess, \Countable, \Iterator
         return new static([
             'hits' => [
                 'hits' => [],
-                'total' => 0,
+                'total' => [
+                    'relation' => 'eq',
+                    'value' => 0,
+                ],
             ],
         ]);
     }
@@ -200,7 +203,10 @@ class SearchResponse implements \ArrayAccess, \Countable, \Iterator
         return new static([
             'hits' => [
                 'hits' => [],
-                'total' => 0,
+                'total' => [
+                    'relation' => 'eq',
+                    'value' => 0,
+                ],
             ],
             'exception' => $exception,
         ]);


### PR DESCRIPTION
The other error from removal of total's response compat function (which was reverted due to also used by legacy score search).