### PR TITLE
Skip laravel casting for beatmap and beatmapset transformers

### DIFF
--- a/app/Models/Beatmap.php
+++ b/app/Models/Beatmap.php
@@ -191,7 +191,7 @@ class Beatmap extends Model
     public function getVersionAttribute($value)
     {
         if ($this->mode === 'mania') {
-            $keys = $this->getDiffSizeAttribute($this->attributes['diff_size']);
+            $keys = $this->getDiffSizeAttribute($this->attributes['diff_size'] ?? null);
 
             if (strpos($value, "{$keys}k") === false && strpos($value, "{$keys}K") === false) {
                 return "[{$keys}K] {$value}";

--- a/app/Models/Beatmap.php
+++ b/app/Models/Beatmap.php
@@ -139,7 +139,7 @@ class Beatmap extends Model
                 $this->relationLoaded('baseDifficultyRatings')
                     ? $this->baseDifficultyRatings
                     : $this->baseDifficultyRatings()
-            )->firstWhere('mode', $this->playmode)
+            )->firstWhere('mode', $this->attributes['playmode'] ?? null)
             ?->diff_unified ?? 0;
         }
 
@@ -148,7 +148,7 @@ class Beatmap extends Model
 
     public function getModeAttribute()
     {
-        return static::modeStr($this->playmode);
+        return static::modeStr($this->attributes['playmode'] ?? null);
     }
 
     public function getDiffSizeAttribute($value)
@@ -160,15 +160,16 @@ class Beatmap extends Model
          * - (implementation) https://github.com/ppy/osu/blob/6bbc23c831cd73bf126b31edb0bb4fa729f947d1/osu.Game.Rulesets.Mania/Beatmaps/ManiaBeatmapConverter.cs#L40
          * - (rounding) https://msdn.microsoft.com/en-us/library/wyk4d9cy(v=vs.110).aspx
          */
-        if ($this->mode === 'mania') {
+        $attrs = $this->attributes;
+        if (($attrs['playmode'] ?? null) === static::MODES['mania']) {
             $roundedValue = (int) round($value, 0, PHP_ROUND_HALF_EVEN);
 
             if ($this->convert) {
-                $sliderOrSpinner = $this->countSlider + $this->countSpinner;
-                $total = max(1, $sliderOrSpinner + $this->countNormal);
+                $sliderOrSpinner = ($attrs['countSlider'] ?? 0) + ($attrs['countSpinner'] ?? 0);
+                $total = max(1, $sliderOrSpinner + ($attrs['countNormal'] ?? 0));
                 $percentSliderOrSpinner = $sliderOrSpinner / $total;
 
-                $accuracy = (int) round($this->diff_overall, 0, PHP_ROUND_HALF_EVEN);
+                $accuracy = (int) round($attrs['diff_overall'] ?? 0, 0, PHP_ROUND_HALF_EVEN);
 
                 if ($percentSliderOrSpinner < 0.2) {
                     return 7;
@@ -190,7 +191,7 @@ class Beatmap extends Model
     public function getVersionAttribute($value)
     {
         if ($this->mode === 'mania') {
-            $keys = $this->diff_size;
+            $keys = $this->getDiffSizeAttribute($this->attributes['diff_size']);
 
             if (strpos($value, "{$keys}k") === false && strpos($value, "{$keys}K") === false) {
                 return "[{$keys}K] {$value}";
@@ -273,7 +274,8 @@ class Beatmap extends Model
 
     public function isScoreable()
     {
-        return $this->approved > 0;
+        return isset($this->attributes['approved'])
+            && $this->attributes['approved'] > 0;
     }
 
     public function canBeConverted()
@@ -319,7 +321,7 @@ class Beatmap extends Model
 
     public function status()
     {
-        return array_search($this->approved, Beatmapset::STATES, true);
+        return array_search($this->attributes['approved'] ?? null, Beatmapset::STATES, true);
     }
 
     private function getScores($modelPath, $mode)

--- a/app/Models/Beatmapset.php
+++ b/app/Models/Beatmapset.php
@@ -372,12 +372,12 @@ class Beatmapset extends Model implements AfterCommit, Commentable, Indexable, T
 
     public function isLoveable()
     {
-        return $this->approved <= 0;
+        return ($this->attributes['approved'] ?? 0) <= 0;
     }
 
     public function isScoreable()
     {
-        return $this->approved > 0;
+        return ($this->attributes['approved'] ?? 0) > 0;
     }
 
     public function allCoverURLs()
@@ -400,7 +400,9 @@ class Beatmapset extends Model implements AfterCommit, Commentable, Indexable, T
 
     public function coverPath()
     {
-        return "beatmaps/{$this->beatmapset_id}/covers/";
+        $id = $this->attributes['beatmapset_id'] ?? 0;
+
+        return "beatmaps/{$id}/covers/";
     }
 
     public function storeCover($target_filename, $source_path)
@@ -941,7 +943,7 @@ class Beatmapset extends Model implements AfterCommit, Commentable, Indexable, T
 
     public function canBeHyped()
     {
-        return in_array($this->approved, static::HYPEABLE_STATES, true);
+        return in_array($this->attributes['approved'] ?? null, static::HYPEABLE_STATES, true);
     }
 
     public function validateHypeBy($user)
@@ -1314,7 +1316,7 @@ class Beatmapset extends Model implements AfterCommit, Commentable, Indexable, T
 
     public function getArtistUnicodeAttribute($value)
     {
-        return $value ?? $this->artist;
+        return $value ?? $this->attributes['artist'] ?? null;
     }
 
     public function getDisplayArtist(?User $user)
@@ -1350,7 +1352,7 @@ class Beatmapset extends Model implements AfterCommit, Commentable, Indexable, T
 
     public function getTitleUnicodeAttribute($value)
     {
-        return $value ?? $this->title;
+        return $value ?? $this->attributes['title'] ?? null;
     }
 
     public function freshHype()
@@ -1429,6 +1431,6 @@ class Beatmapset extends Model implements AfterCommit, Commentable, Indexable, T
 
     private function defaultCoverTimestamp(): string
     {
-        return $this->cover_updated_at?->format('U') ?? '0';
+        return parse_time_to_carbon($this->attributes['cover_updated_at'] ?? null)?->format('U') ?? '0';
     }
 }

--- a/app/Transformers/BeatmapCompactTransformer.php
+++ b/app/Transformers/BeatmapCompactTransformer.php
@@ -21,15 +21,17 @@ class BeatmapCompactTransformer extends TransformerAbstract
 
     public function transform(Beatmap $beatmap)
     {
+        $attrs = $beatmap->getAttributes();
+
         return [
-            'beatmapset_id' => $beatmap->beatmapset_id,
-            'difficulty_rating' => $beatmap->difficultyrating,
-            'id' => $beatmap->beatmap_id,
-            'mode' => $beatmap->mode,
+            'beatmapset_id' => $attrs['beatmapset_id'] ?? null,
+            'difficulty_rating' => $beatmap->getDifficultyRatingAttribute($attrs['difficultyrating'] ?? null),
+            'id' => $attrs['beatmap_id'] ?? null,
+            'mode' => $beatmap->getModeAttribute(),
             'status' => $beatmap->status(),
-            'total_length' => $beatmap->total_length,
-            'user_id' => $beatmap->user_id,
-            'version' => $beatmap->version,
+            'total_length' => $attrs['total_length'] ?? null,
+            'user_id' => $attrs['user_id'] ?? null,
+            'version' => $beatmap->getVersionAttribute($attrs['version'] ?? null),
         ];
     }
 

--- a/app/Transformers/BeatmapTransformer.php
+++ b/app/Transformers/BeatmapTransformer.php
@@ -20,25 +20,27 @@ class BeatmapTransformer extends BeatmapCompactTransformer
     {
         $result = parent::transform($beatmap);
 
+        $attrs = $beatmap->getAttributes();
+
         return array_merge($result, [
-            'accuracy' => $beatmap->diff_overall,
-            'ar' => $beatmap->diff_approach,
-            'bpm' => $beatmap->bpm,
+            'accuracy' => $attrs['diff_overall'] ?? null,
+            'ar' => $attrs['diff_approach'] ?? null,
+            'bpm' => $attrs['bpm'] ?? null,
             'convert' => $beatmap->convert,
-            'count_circles' => $beatmap->countNormal,
-            'count_sliders' => $beatmap->countSlider,
-            'count_spinners' => $beatmap->countSpinner,
-            'cs' => $beatmap->diff_size,
-            'deleted_at' => $beatmap->deleted_at,
-            'drain' => $beatmap->diff_drain,
-            'hit_length' => $beatmap->hit_length,
+            'count_circles' => $attrs['countNormal'] ?? null,
+            'count_sliders' => $attrs['countSlider'] ?? null,
+            'count_spinners' => $attrs['countSpinner'] ?? null,
+            'cs' => $beatmap->getDiffSizeAttribute($attrs['diff_size'] ?? null),
+            'deleted_at' => json_time_from_db_timestamp($attrs['deleted_at'] ?? null),
+            'drain' => $attrs['diff_drain'] ?? null,
+            'hit_length' => $attrs['hit_length'] ?? null,
             'is_scoreable' => $beatmap->isScoreable(),
-            'last_updated' => json_time($beatmap->last_update),
-            'mode_int' => $beatmap->playmode,
-            'passcount' => $beatmap->passcount,
-            'playcount' => $beatmap->playcount,
-            'ranked' => $beatmap->approved,
-            'url' => route('beatmaps.show', ['beatmap' => $beatmap->beatmap_id]),
+            'last_updated' => json_time_from_db_timestamp($attrs['last_update'] ?? null),
+            'mode_int' => $attrs['playmode'] ?? null,
+            'passcount' => $attrs['passcount'] ?? null,
+            'playcount' => $attrs['playcount'] ?? null,
+            'ranked' => $attrs['approved'] ?? null,
+            'url' => route('beatmaps.show', ['beatmap' => $attrs['beatmap_id'] ?? null]),
         ]);
     }
 }

--- a/app/Transformers/BeatmapsetCompactTransformer.php
+++ b/app/Transformers/BeatmapsetCompactTransformer.php
@@ -43,29 +43,31 @@ class BeatmapsetCompactTransformer extends TransformerAbstract
 
     public function transform(Beatmapset $beatmapset)
     {
+        $attrs = $beatmapset->getAttributes();
+
         return [
-            'artist' => $beatmapset->artist,
-            'artist_unicode' => $beatmapset->artist_unicode,
+            'artist' => $attrs['artist'] ?? null,
+            'artist_unicode' => $beatmapset->getArtistUnicodeAttribute($attrs['artist_unicode'] ?? null),
             'covers' => $beatmapset->allCoverURLs(),
-            'creator' => $beatmapset->creator,
-            'favourite_count' => $beatmapset->favourite_count,
+            'creator' => $attrs['creator'] ?? null,
+            'favourite_count' => $attrs['favourite_count'] ?? null,
             'hype' => $beatmapset->canBeHyped() ? [
-                'current' => $beatmapset->hype,
+                'current' => $attrs['hype'] ?? null,
                 'required' => $beatmapset->requiredHype(),
             ] : null,
-            'id' => $beatmapset->beatmapset_id,
-            'nsfw' => $beatmapset->nsfw,
-            'offset' => $beatmapset->offset,
-            'play_count' => $beatmapset->play_count,
+            'id' => $attrs['beatmapset_id'] ?? null,
+            'nsfw' => $attrs['nsfw'] ?? null,
+            'offset' => $attrs['offset'] ?? null,
+            'play_count' => $attrs['play_count'] ?? null,
             'preview_url' => $beatmapset->previewURL(),
-            'source' => $beatmapset->source,
-            'spotlight' => $beatmapset->spotlight,
+            'source' => $attrs['source'] ?? null,
+            'spotlight' => $attrs['spotlight'] ?? null,
             'status' => $beatmapset->status(),
-            'title' => $beatmapset->title,
-            'title_unicode' => $beatmapset->title_unicode,
-            'track_id' => $beatmapset->track_id,
-            'user_id' => $beatmapset->user_id,
-            'video' => $beatmapset->video,
+            'title' => $attrs['title'] ?? null,
+            'title_unicode' => $beatmapset->getTitleUnicodeAttribute($attrs['title_unicode'] ?? null),
+            'track_id' => $attrs['track_id'] ?? null,
+            'user_id' => $attrs['user_id'] ?? null,
+            'video' => (bool) ($attrs['video'] ?? false),
         ];
     }
 

--- a/app/Transformers/BeatmapsetTransformer.php
+++ b/app/Transformers/BeatmapsetTransformer.php
@@ -21,24 +21,26 @@ class BeatmapsetTransformer extends BeatmapsetCompactTransformer
     {
         $result = parent::transform($beatmapset);
 
+        $attrs = $beatmapset->getAttributes();
+
         return array_merge($result, [
             'availability' => [
-                'download_disabled' => $beatmapset->download_disabled,
-                'more_information' => $beatmapset->download_disabled_url,
+                'download_disabled' => $attrs['download_disabled'] ?? null,
+                'more_information' => $attrs['download_disabled_url'] ?? null,
             ],
-            'bpm' => $beatmapset->bpm,
+            'bpm' => $attrs['bpm'] ?? null,
             'can_be_hyped' => $beatmapset->canBeHyped(),
             'discussion_enabled' => true, // TODO: deprecated 2022-06-08
-            'discussion_locked' => $beatmapset->discussion_locked,
+            'discussion_locked' => (bool) ($attrs['discussion_locked'] ?? false),
             'is_scoreable' => $beatmapset->isScoreable(),
-            'last_updated' => json_time($beatmapset->last_update),
-            'legacy_thread_url' => $beatmapset->thread_id !== 0 ? route('forum.topics.show', $beatmapset->thread_id) : null,
+            'last_updated' => json_time_from_db_timestamp($attrs['last_update'] ?? null),
+            'legacy_thread_url' => ($attrs['thread_id'] ?? 0) !== 0 ? route('forum.topics.show', $attrs['thread_id']) : null,
             'nominations_summary' => $beatmapset->nominationsSummaryMeta(),
-            'ranked' => $beatmapset->approved,
-            'ranked_date' => json_time($beatmapset->approved_date),
-            'storyboard' => $beatmapset->storyboard,
-            'submitted_date' => json_time($beatmapset->submit_date),
-            'tags' => $beatmapset->tags,
+            'ranked' => $attrs['approved'] ?? null,
+            'ranked_date' => json_time_from_db_timestamp($attrs['approved_date'] ?? null),
+            'storyboard' => (bool) ($attrs['storyboard'] ?? false),
+            'submitted_date' => json_time_from_db_timestamp($attrs['submit_date'] ?? null),
+            'tags' => $attrs['tags'] ?? null,
         ]);
     }
 }

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -428,6 +428,19 @@ function json_time(?DateTime $time): ?string
     return $time === null ? null : $time->format(DateTime::ATOM);
 }
 
+function json_time_from_db_timestamp(?string $time): ?string
+{
+    if ($time === null) {
+        return null;
+    }
+
+    // From: "2020-10-10 10:10:10"
+    // To: "2020-10-10T10:10:10Z"
+    $time[10] = 'T';
+
+    return "{$time}Z";
+}
+
 function log_error($exception)
 {
     Log::error($exception);


### PR DESCRIPTION
Boy, is it ever ugly. The following wrk test on my dev with clockwork and debug disabled went from:

```
$ wrk -t 4 -c 12 -d 10s https://on.nanaya.pro/beatmapsets/
Running 10s test @ https://on.nanaya.pro/beatmapsets/
  4 threads and 12 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency   387.51ms   34.22ms 733.90ms   90.55%
    Req/Sec     8.07      4.26    20.00     84.00%
  307 requests in 10.14s, 91.35MB read
Requests/sec:     30.28
Transfer/sec:      9.01MB
```

to:

```
$ wrk -t 4 -c 12 -d 10s https://on.nanaya.pro/beatmapsets/
Running 10s test @ https://on.nanaya.pro/beatmapsets/
  4 threads and 12 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency   228.60ms   21.20ms 450.01ms   89.46%
    Req/Sec    12.91      4.76    20.00     66.46%
  522 requests in 10.09s, 154.16MB read
Requests/sec:     51.74
Transfer/sec:     15.28MB
```

...yay? 🤷 