### PR TITLE
Simpler model `getKey` function

### DIFF
--- a/app/Models/Model.php
+++ b/app/Models/Model.php
@@ -30,6 +30,11 @@ abstract class Model extends BaseModel
         static::addGlobalScope(new MacroableModelScope());
     }
 
+    public function getKey()
+    {
+        return $this->attributes[$this->primaryKey] ?? null;
+    }
+
     public function getForeignKey()
     {
         if ($this->primaryKey === null || $this->primaryKey === 'id') {


### PR DESCRIPTION
The original `getKey` uses `getAttribute` which is not the fastest thing. By "not the fastest" thing I mean it does a lot of things to deal with casting magic, *especially* when there's no casting involved for the specified field. Speed improvement is minimal but it's definitely there.