### PR TITLE
Cache beatmaps page json response for guest

### DIFF
--- a/app/Http/Controllers/BeatmapsetsController.php
+++ b/app/Http/Controllers/BeatmapsetsController.php
@@ -45,11 +45,17 @@ class BeatmapsetsController extends Controller
 
     public function index()
     {
-        $beatmaps = $this->getSearchResponse()['content'];
+        $canAdvancedSearch = priv_check('BeatmapsetAdvancedSearch')->can();
+        // only cache if guest user and guest advanced search is disabled
+        $beatmapsets = !auth()->check() && !$canAdvancedSearch
+            ? cache_remember_mutexed('beatmapsets_guest', 600, [], fn () => $this->getSearchResponse([])['content'])
+            : $this->getSearchResponse()['content'];
 
-        $filters = BeatmapsetSearchRequestParams::getAvailableFilters();
-
-        return ext_view('beatmapsets.index', compact('filters', 'beatmaps'));
+        return ext_view('beatmapsets.index', [
+            'beatmapsets' => $beatmapsets,
+            'canAdvancedSearch' => $canAdvancedSearch,
+            'filters' => BeatmapsetSearchRequestParams::getAvailableFilters(),
+        ]);
     }
 
     public function lookup()
@@ -327,9 +333,9 @@ class BeatmapsetsController extends Controller
         return $this->showJson($beatmapset);
     }
 
-    private function getSearchResponse()
+    private function getSearchResponse(?array $params = null)
     {
-        $params = new BeatmapsetSearchRequestParams(request()->all(), Auth::user());
+        $params = new BeatmapsetSearchRequestParams($params ?? request()->all(), auth()->user());
         $search = (new BeatmapsetSearchCached($params));
 
         $records = datadog_timing(function () use ($search) {

--- a/resources/views/beatmapsets/index.blade.php
+++ b/resources/views/beatmapsets/index.blade.php
@@ -2,9 +2,6 @@
     Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
     See the LICENCE file in the repository root for full licence text.
 --}}
-@php
-    $canAdvancedSearch = priv_check('BeatmapsetAdvancedSearch')->can();
-@endphp
 @extends('master', [
   'pageDescription' => osu_trans('beatmapsets.index.title'),
 ])
@@ -36,7 +33,7 @@
   </script>
 
   <script id="json-beatmaps" type="application/json">
-    {!! json_encode($beatmaps) !!}
+    {!! json_encode($beatmapsets) !!}
   </script>
 
   @include('layout._react_js', ['src' => 'js/beatmaps.js'])


### PR DESCRIPTION
10 minutes caching for guest user (when guest advanced search is disabled). Just the transformed data. My db is quite slow so the actual improvement might not be as dramatic since one hits db and the other doesn't.

Before:
```
Run 1:   600 requests in 10.10s, 177.53MB read
Run 2:   568 requests in 10.09s, 168.07MB read
Run 3:   607 requests in 10.08s, 179.61MB read
Run 4:   627 requests in 10.09s, 185.52MB read
Run 5:   608 requests in 10.09s, 179.90MB read
Run 6:   611 requests in 10.07s, 180.79MB read
Run 7:   623 requests in 10.06s, 184.34MB read
Run 8:   568 requests in 10.09s, 168.07MB read
Run 9:   575 requests in 10.10s, 170.14MB read
Run 10:   577 requests in 10.07s, 170.73MB read
Final run:
Running 10s test @ https://on.nanaya.pro/beatmapsets/
  4 threads and 12 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency   195.90ms   36.35ms 522.08ms   90.44%
    Req/Sec    15.23      6.55    39.00     88.54%
  605 requests in 10.01s, 179.01MB read
Requests/sec:     60.44
Transfer/sec:     17.88MB
```

After:
```
Run 1:   1904 requests in 10.09s, 563.39MB read
Run 2:   1910 requests in 10.08s, 565.15MB read
Run 3:   1847 requests in 10.10s, 546.51MB read
Run 4:   1891 requests in 10.10s, 559.55MB read
Run 5:   1914 requests in 10.09s, 566.35MB read
Run 6:   1854 requests in 10.09s, 548.83MB read
Run 7:   1863 requests in 10.10s, 551.24MB read
Run 8:   1893 requests in 10.08s, 560.12MB read
Run 9:   1895 requests in 10.09s, 560.71MB read
Run 10:   1888 requests in 10.09s, 558.64MB read
Final run:
Running 10s test @ https://on.nanaya.pro/beatmapsets/
  4 threads and 12 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency    70.35ms   31.41ms 447.73ms   97.13%
    Req/Sec    43.97     10.34    60.00     67.50%
  1775 requests in 10.10s, 525.21MB read
Requests/sec:    175.71
Transfer/sec:     51.99MB
```

