### PR TITLE
Cache beatmapset filters

### DIFF
--- a/app/Http/Controllers/BeatmapsetsController.php
+++ b/app/Http/Controllers/BeatmapsetsController.php
@@ -47,9 +47,7 @@ class BeatmapsetsController extends Controller
     {
         $beatmaps = $this->getSearchResponse()['content'];
 
-        $filters = BeatmapsetSearchRequestParams::getAvailableFilters();
-
-        return ext_view('beatmapsets.index', compact('filters', 'beatmaps'));
+        return ext_view('beatmapsets.index', compact('beatmaps'));
     }
 
     public function lookup()

--- a/app/Libraries/LayoutCache.php
+++ b/app/Libraries/LayoutCache.php
@@ -11,7 +11,7 @@ class LayoutCache
 
     public function getBeatmapsetFilters()
     {
-        $key = 'beatmapset_filters:'.app()->getLocale();
+        $key = __FUNCTION__.':'.app()->getLocale();
 
         return $this->cache[$key] ??= view('beatmapsets._filters')->render();
     }

--- a/app/Libraries/LayoutCache.php
+++ b/app/Libraries/LayoutCache.php
@@ -1,0 +1,18 @@
+<?php
+
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
+namespace App\Libraries;
+
+class LayoutCache
+{
+    private array $cache = [];
+
+    public function getBeatmapsetFilters()
+    {
+        $key = 'beatmapset_filters:'.app()->getLocale();
+
+        return $this->cache[$key] ??= view('beatmapsets._filters')->render();
+    }
+}

--- a/app/Libraries/LayoutCache.php
+++ b/app/Libraries/LayoutCache.php
@@ -3,13 +3,15 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 namespace App\Libraries;
 
 class LayoutCache
 {
     private array $cache = [];
 
-    public function getBeatmapsetFilters()
+    public function getBeatmapsetFilters(): string
     {
         $key = __FUNCTION__.':'.app()->getLocale();
 

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -11,6 +11,7 @@ use App\Libraries\BroadcastsPendingForTests;
 use App\Libraries\ChatFilters;
 use App\Libraries\CleanHTML;
 use App\Libraries\Groups;
+use App\Libraries\LayoutCache;
 use App\Libraries\Mods;
 use App\Libraries\MorphMap;
 use App\Libraries\OsuAuthorize;
@@ -38,6 +39,7 @@ class AppServiceProvider extends ServiceProvider
         'chat-filters' => ChatFilters::class,
         'clean-html' => CleanHTML::class,
         'groups' => Groups::class,
+        'layout-cache' => LayoutCache::class,
         'mods' => Mods::class,
         'route-section' => RouteSection::class,
         'score-pins' => ScorePins::class,

--- a/resources/views/beatmapsets/_filters.blade.php
+++ b/resources/views/beatmapsets/_filters.blade.php
@@ -1,0 +1,3 @@
+<script id="json-filters" type="application/json">
+    {!! json_encode(App\Libraries\Search\BeatmapsetSearchRequestParams::getAvailableFilters()) !!}
+</script>

--- a/resources/views/beatmapsets/_filters.blade.php
+++ b/resources/views/beatmapsets/_filters.blade.php
@@ -1,3 +1,7 @@
+{{--
+    Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+    See the LICENCE file in the repository root for full licence text.
+--}}
 <script id="json-filters" type="application/json">
     {!! json_encode(App\Libraries\Search\BeatmapsetSearchRequestParams::getAvailableFilters()) !!}
 </script>

--- a/resources/views/beatmapsets/index.blade.php
+++ b/resources/views/beatmapsets/index.blade.php
@@ -31,9 +31,7 @@
 @section("script")
   @parent
 
-  <script id="json-filters" type="application/json">
-    {!! json_encode($filters) !!}
-  </script>
+  {!! app('layout-cache')->getBeatmapsetFilters() !!}
 
   <script id="json-beatmaps" type="application/json">
     {!! json_encode($beatmaps) !!}


### PR DESCRIPTION
This makes restarting server required when updating language and genre but then again we don't do that, so... 🤷‍♀️

Also I think the workers are currently restarted every 500 requests (default) so it should eventually be correct.

Maybe just use this for Groups caching as well... 🤔 

Before:
```
Run 1:   1781 requests in 10.10s, 526.98MB read
Run 2:   1873 requests in 10.10s, 554.21MB read
Run 3:   1784 requests in 10.10s, 528.06MB read
Run 4:   1832 requests in 10.09s, 542.07MB read
Run 5:   1808 requests in 10.19s, 534.97MB read
Run 6:   1855 requests in 10.09s, 548.88MB read
Run 7:   1844 requests in 10.08s, 545.64MB read
Run 8:   1843 requests in 10.00s, 545.37MB read
Run 9:   1804 requests in 10.08s, 533.79MB read
Run 10:   1874 requests in 10.18s, 554.55MB read
Final run:
Running 10s test @ https://on.nanaya.pro/beatmapsets/
  4 threads and 12 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency    65.75ms   16.69ms 408.26ms   97.58%
    Req/Sec    45.83      9.63    60.00     69.25%
  1849 requests in 10.08s, 547.10MB read
Requests/sec:    183.37
Transfer/sec:     54.26MB
```

After:
```
Run 1:   2251 requests in 10.07s, 666.38MB read
Run 2:   2179 requests in 10.16s, 644.86MB read
Run 3:   2193 requests in 10.07s, 648.90MB read
Run 4:   2253 requests in 10.08s, 666.64MB read
Run 5:   2222 requests in 10.08s, 657.47MB read
Run 6:   2224 requests in 10.08s, 658.06MB read
Run 7:   2161 requests in 10.07s, 639.42MB read
Run 8:   2244 requests in 10.08s, 663.98MB read
Run 9:   2154 requests in 10.08s, 637.35MB read
Run 10:   2210 requests in 10.15s, 653.92MB read
Final run:
Running 10s test @ https://on.nanaya.pro/beatmapsets/
  4 threads and 12 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency    55.02ms   14.90ms 392.70ms   96.26%
    Req/Sec    54.91      7.46    70.00     88.50%
  2208 requests in 10.07s, 653.34MB read
Requests/sec:    219.28
Transfer/sec:     64.89MB
```