### PR TITLE
Define attributes for score best model

### DIFF
--- a/app/Libraries/ReplayFile.php
+++ b/app/Libraries/ReplayFile.php
@@ -52,7 +52,7 @@ class ReplayFile
 
     public function getVersion()
     {
-        return optional($this->score->replayViewCount)->version ?? static::DEFAULT_VERSION;
+        return $this->score->replayViewCount?->version ?? static::DEFAULT_VERSION;
     }
 
     /**

--- a/app/Models/Score/Best/Model.php
+++ b/app/Models/Score/Best/Model.php
@@ -56,6 +56,43 @@ abstract class Model extends BaseModel implements Traits\ReportableInterface
         );
     }
 
+    public function getAttribute($key)
+    {
+        return match ($key) {
+            'beatmap_id',
+            'count100',
+            'count300',
+            'count50',
+            'countgeki',
+            'countkatu',
+            'countmiss',
+            'country_acronym',
+            'maxcombo',
+            'pp',
+            'rank',
+            'score',
+            'score_id',
+            'user_id' => $this->getRawAttribute($key),
+
+            'hidden',
+            'perfect',
+            'replay' => (bool) $this->getRawAttribute($key),
+
+            'date' => $this->getTimeFast($key),
+
+            'date_json' => $this->getJsonTimeFast($key),
+
+            'best' => $this,
+            'data' => $this->getDataAttribute(),
+            'enabled_mods' => $this->getEnabledModsAttribute($this->getRawAttribute('enabled_mods')),
+            'pass' => true,
+
+            'beatmap',
+            'replayViewCount',
+            'user' => $this->getRelationValue($key),
+        };
+    }
+
     public function replayFile(): ?ReplayFile
     {
         if ($this->replay) {
@@ -267,11 +304,6 @@ abstract class Model extends BaseModel implements Traits\ReportableInterface
         return $query;
     }
 
-    public function getPassAttribute(): bool
-    {
-        return true;
-    }
-
     public function isPersonalBest(): bool
     {
         return !static
@@ -297,7 +329,7 @@ abstract class Model extends BaseModel implements Traits\ReportableInterface
 
     public function trashed()
     {
-        return (bool) $this->getAttributes()['hidden'];
+        return $this->getAttribute('hidden');
     }
 
     public function user()
@@ -342,14 +374,9 @@ abstract class Model extends BaseModel implements Traits\ReportableInterface
             return parent::delete();
         });
 
-        optional($this->replayFile())->delete();
+        $this->replayFile()?->delete();
 
         return $result;
-    }
-
-    public function getBestAttribute()
-    {
-        return $this;
     }
 
     protected function newReportableExtraParams(): array

--- a/app/Models/Score/Model.php
+++ b/app/Models/Score/Model.php
@@ -129,7 +129,6 @@ abstract class Model extends BaseModel
 
     public function getDataAttribute()
     {
-        $attributes = $this->getAttributes();
         $mods = array_map(fn ($m) => ['acronym' => $m, 'settings' => []], $this->enabled_mods);
         $statistics = [
             'miss' => $this->countmiss,
@@ -160,7 +159,7 @@ abstract class Model extends BaseModel
         return new ScoreData([
             'accuracy' => $this->accuracy(),
             'beatmap_id' => $this->beatmap_id,
-            'ended_at' => $attributes['date'],
+            'ended_at' => $this->date,
             'max_combo' => $this->maxcombo,
             'mods' => $mods,
             'passed' => $this->pass,

--- a/tests/Libraries/ReplayFileTest.php
+++ b/tests/Libraries/ReplayFileTest.php
@@ -7,7 +7,6 @@ namespace Tests\Libraries;
 
 use App\Libraries\ReplayFile;
 use App\Models\Beatmap;
-use App\Models\ReplayViewCount;
 use App\Models\Score\Best;
 use App\Models\User;
 use Tests\TestCase;
@@ -85,13 +84,11 @@ class ReplayFileTest extends TestCase
         ]);
 
         if ($hasReplayRecord) {
-            $score->fill([
-                'replayViewCount' => ReplayViewCount\Osu::make([
-                    'score_id' => 2493013207,
-                    'play_count' => 1,
-                    'version' => $version,
-                ]),
-            ]);
+            $score->setRelation('replayViewCount', $score->replayViewCount()->make([
+                'score_id' => 2493013207,
+                'play_count' => 1,
+                'version' => $version,
+            ]));
         }
 
         return $score;


### PR DESCRIPTION
Included fix for setting `replayViewCount` relation correctly.

Before:
```
Run 1:   628 requests in 10.10s, 34.38MB read
Run 2:   594 requests in 10.06s, 32.51MB read
Run 3:   625 requests in 10.20s, 34.21MB read
Run 4:   622 requests in 10.12s, 34.05MB read
Run 5:   631 requests in 10.09s, 34.54MB read
Run 6:   602 requests in 10.10s, 32.95MB read
Run 7:   615 requests in 10.15s, 33.67MB read
Run 8:   622 requests in 10.09s, 34.05MB read
Run 9:   619 requests in 10.09s, 33.88MB read
Run 10:   619 requests in 10.10s, 33.88MB read
Final run:
Running 10s test @ https://on.nanaya.pro/beatmaps/567606/scores?mode=osu&type=global
  4 threads and 12 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency   199.70ms   33.47ms 617.46ms   93.87%
    Req/Sec    14.94      5.81    30.00     65.20%
  600 requests in 10.10s, 32.84MB read
Requests/sec:     59.39
Transfer/sec:      3.25MB
```

After:
```
Run 1:   727 requests in 10.11s, 39.80MB read
Run 2:   740 requests in 10.11s, 40.51MB read
Run 3:   721 requests in 10.09s, 39.47MB read
Run 4:   722 requests in 10.05s, 39.52MB read
Run 5:   722 requests in 10.09s, 39.52MB read
Run 6:   714 requests in 10.08s, 39.08MB read
Run 7:   714 requests in 10.09s, 39.08MB read
Run 8:   717 requests in 9.96s, 39.25MB read
Run 9:   717 requests in 10.12s, 39.25MB read
Run 10:   700 requests in 10.04s, 38.32MB read
Final run:
Running 10s test @ https://on.nanaya.pro/beatmaps/567606/scores?mode=osu&type=global
  4 threads and 12 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency   166.45ms   22.97ms 477.05ms   97.37%
    Req/Sec    17.92      7.12    30.00     50.14%
  719 requests in 10.09s, 39.36MB read
Requests/sec:     71.28
Transfer/sec:      3.90MB
```

Combined with #9339:
```
Run 1:   993 requests in 10.05s, 54.36MB read
Run 2:   979 requests in 10.05s, 53.59MB read
Run 3:   1013 requests in 10.16s, 55.45MB read
Run 4:   991 requests in 10.05s, 54.25MB read
Run 5:   993 requests in 10.05s, 54.36MB read
Run 6:   1005 requests in 10.07s, 55.01MB read
Run 7:   995 requests in 10.06s, 54.47MB read
Run 8:   993 requests in 10.06s, 54.37MB read
Run 9:   999 requests in 10.15s, 54.68MB read
Run 10:   1003 requests in 10.05s, 54.90MB read
Final run:
Running 10s test @ https://on.nanaya.pro/beatmaps/567606/scores?mode=osu&type=global
  4 threads and 12 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency   123.76ms   16.25ms 263.80ms   89.27%
    Req/Sec    24.02      6.98    30.00     88.21%
  967 requests in 10.06s, 52.93MB read
Requests/sec:     96.13
Transfer/sec:      5.26MB
```