### PR TITLE
Allow null key for getRawAttribute

### DIFF
--- a/app/Models/Model.php
+++ b/app/Models/Model.php
@@ -69,7 +69,7 @@ abstract class Model extends BaseModel
         throw new ClassMorphViolationException($this);
     }
 
-    public function getRawAttribute(string $key)
+    public function getRawAttribute(?string $key)
     {
         return $this->attributes[$key] ?? null;
     }


### PR DESCRIPTION
Clockwork calls `getKey()` on everything in `Clockwork\DataSource\EloquentDataSource::collectModelEvent` and some models have `$primaryKey` explicitly set to `null`.