### PR TITLE
Define attributes for comment model

### DIFF
--- a/app/Models/Comment.php
+++ b/app/Models/Comment.php
@@ -136,6 +136,47 @@ class Comment extends Model implements Traits\ReportableInterface
         $this->attributes['commentable_type'] = $value;
     }
 
+    public function getAttribute($key)
+    {
+        return match ($key) {
+            'commentable_id',
+            'commentable_type',
+            'deleted_by_id',
+            'disqus_id',
+            'disqus_parent_id',
+            'disqus_thread_id',
+            'edited_by_id',
+            'id',
+            'message',
+            'parent_id',
+            'replies_count_cache',
+            'user_id',
+            'votes_count_cache' => $this->getRawAttribute($key),
+
+            'created_at',
+            'deleted_at',
+            'edited_at',
+            'updated_at' => $this->getTimeFast($key),
+
+            'created_at_json',
+            'deleted_at_json',
+            'edited_at_json',
+            'updated_at_json' => $this->getJsonTimeFast($key),
+
+            'pinned' => (bool) $this->getRawAttribute($key),
+
+            'disqus_user_data' => $this->getDisqusUserData(),
+
+            'commentable',
+            'editor',
+            'parent',
+            'replies',
+            'reportedIn',
+            'user',
+            'votes' => $this->getRelationValue($key),
+        };
+    }
+
     public function setCommentable()
     {
         if ($this->parent_id === null || $this->parent === null) {
@@ -250,5 +291,12 @@ class Comment extends Model implements Traits\ReportableInterface
             'reason' => 'Spam',
             'user_id' => $this->user_id,
         ];
+    }
+
+    private function getDisqusUserData(): ?array
+    {
+        $value = $this->getRawAttribute('disqus_user_data');
+
+        return $value === null ? null : json_decode($value, true);
     }
 }

--- a/app/Transformers/CommentTransformer.php
+++ b/app/Transformers/CommentTransformer.php
@@ -40,12 +40,12 @@ class CommentTransformer extends TransformerAbstract
 
             'legacy_name' => $comment->legacyName(),
 
-            'created_at' => json_time($comment->created_at),
-            'updated_at' => json_time($comment->updated_at),
+            'created_at' => $comment->created_at_json,
+            'updated_at' => $comment->updated_at_json,
 
-            'deleted_at' => json_time($comment->deleted_at),
+            'deleted_at' => $comment->deleted_at_json,
 
-            'edited_at' => json_time($comment->edited_at),
+            'edited_at' => $comment->edited_at_json,
             'edited_by_id' => $comment->edited_by_id,
         ];
     }


### PR DESCRIPTION
The beatmap page can definitely use some more speedups...

Before:
```
Run 1:   143 requests in 10.07s, 24.77MB read
Run 2:   154 requests in 10.11s, 26.67MB read
Run 3:   155 requests in 10.12s, 26.84MB read
Run 4:   156 requests in 10.03s, 27.02MB read
Run 5:   154 requests in 10.03s, 26.67MB read
Run 6:   148 requests in 10.03s, 25.63MB read
Run 7:   146 requests in 10.04s, 25.29MB read
Run 8:   156 requests in 10.04s, 27.02MB read
Run 9:   156 requests in 10.11s, 27.02MB read
Run 10:   153 requests in 10.03s, 26.50MB read
Final run:
Running 10s test @ https://on.nanaya.pro/beatmapsets/41823
  4 threads and 12 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency   765.35ms  141.59ms   1.35s    92.26%
    Req/Sec     7.07      6.51    20.00     81.08%
  155 requests in 10.12s, 26.84MB read
Requests/sec:     15.32
Transfer/sec:      2.65MB
```

After
```
Run 1:   168 requests in 10.13s, 28.97MB read
Run 2:   167 requests in 10.13s, 28.80MB read
Run 3:   172 requests in 10.04s, 29.66MB read
Run 4:   167 requests in 10.04s, 28.80MB read
Run 5:   167 requests in 10.04s, 28.80MB read
Run 6:   166 requests in 10.04s, 28.63MB read
Run 7:   168 requests in 10.04s, 28.97MB read
Run 8:   169 requests in 10.04s, 29.15MB read
Run 9:   173 requests in 10.13s, 29.84MB read
Run 10:   168 requests in 10.03s, 28.97MB read
Final run:
Running 10s test @ https://on.nanaya.pro/beatmapsets/41823
  4 threads and 12 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency   697.20ms   88.59ms   1.13s    92.86%
    Req/Sec     6.68      5.80    20.00     86.67%
  168 requests in 10.04s, 28.97MB read
Requests/sec:     16.73
Transfer/sec:      2.89MB
```