### PR TITLE
Define attributes for chat message model

### DIFF
--- a/app/Models/Chat/Message.php
+++ b/app/Models/Chat/Message.php
@@ -43,4 +43,23 @@ class Message extends Model
     {
         return $query->where('message_id', '>', $messageId);
     }
+
+    public function getAttribute($key)
+    {
+        return match ($key) {
+            'channel_id',
+            'content',
+            'message_id',
+            'user_id' => $this->getRawAttribute($key),
+
+            'is_action' => (bool) $this->getRawAttribute($key),
+
+            'timestamp' => $this->getTimeFast($key),
+
+            'timestamp_json' => $this->getJsonTimeFast($key),
+
+            'channel',
+            'sender' => $this->getRelationValue($key),
+        };
+    }
 }

--- a/app/Transformers/Chat/MessageTransformer.php
+++ b/app/Transformers/Chat/MessageTransformer.php
@@ -22,7 +22,7 @@ class MessageTransformer extends TransformerAbstract
             'message_id' => $message->message_id,
             'sender_id' => $message->user_id,
             'channel_id' => $message->channel_id,
-            'timestamp' => json_time($message->timestamp),
+            'timestamp' => $message->timestamp_json,
             'content' => $message->content,
             'is_action' => $message->is_action,
         ];


### PR DESCRIPTION
Benchmark below is with #9372.

Before:
```
Run 1:   2052 requests in 10.09s, 32.28MB read
Run 2:   2058 requests in 10.10s, 32.38MB read
Run 3:   1950 requests in 10.09s, 30.69MB read
Run 4:   2032 requests in 10.09s, 31.97MB read
Run 5:   1950 requests in 10.10s, 30.68MB read
Run 6:   2020 requests in 10.08s, 31.78MB read
Run 7:   2018 requests in 10.09s, 31.75MB read
Run 8:   2059 requests in 10.09s, 32.39MB read
Run 9:   1965 requests in 10.10s, 30.91MB read
Run 10:   1925 requests in 10.18s, 30.29MB read
Final run:
Running 10s test @ https://on.nanaya.pro/community/chat/channels/861699/messages?return_object=1
  4 threads and 12 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency    63.11ms   28.50ms 436.36ms   97.27%
    Req/Sec    49.06     10.13    60.00     65.50%
  1978 requests in 10.10s, 31.12MB read
Requests/sec:    195.86
Transfer/sec:      3.08MB
```

After:
```
Run 1:   2370 requests in 10.08s, 36.72MB read
Run 2:   2596 requests in 10.06s, 40.22MB read
Run 3:   2538 requests in 10.07s, 39.32MB read
Run 4:   2495 requests in 10.07s, 38.66MB read
Run 5:   2615 requests in 10.07s, 40.52MB read
Run 6:   2595 requests in 10.15s, 40.21MB read
Run 7:   2653 requests in 10.07s, 41.10MB read
Run 8:   2606 requests in 10.07s, 40.38MB read
Run 9:   2556 requests in 10.07s, 39.60MB read
Run 10:   2557 requests in 10.07s, 39.62MB read
Final run:
Running 10s test @ https://on.nanaya.pro/community/chat/channels/861699/messages?return_object=1
  4 threads and 12 connections
  Thread Stats   Avg      Stdev     Max   +/- Stdev
    Latency    47.79ms   23.91ms 409.55ms   97.77%
    Req/Sec    64.90     10.31    90.00     73.25%
  2606 requests in 10.07s, 40.38MB read
Requests/sec:    258.87
Transfer/sec:      4.01MB
```