### PR TITLE
Add actual hostname tag to datadog

### DIFF
--- a/app/Http/Middleware/DatadogMetrics.php
+++ b/app/Http/Middleware/DatadogMetrics.php
@@ -21,12 +21,21 @@ class DatadogMetrics extends LaravelDatadogMiddleware
      */
     protected static function logDuration(Request $request, Response $response, $startTime)
     {
+        static $hostname;
+        if (!isset($hostname)) {
+            $hostname = gethostname();
+            if (!is_string($hostname)) {
+                $hostname = 'unknown';
+            }
+        }
+
         $duration = microtime(true) - $startTime;
         $tags = [
             'action' => 'error_page',
             'api' => $request->is('api/*') ? 'true' : 'false',
             'controller' => 'error',
             'namespace' => 'error',
+            'pod_name' => $hostname,
             'section' => 'error',
             'status_code' => $response->getStatusCode(),
             'status_code_extra' => $request->attributes->get('status_code_extra'),


### PR DESCRIPTION
The datadog daemon may run on different host so the host tag will be incorrect (mainly on k8s deployment).