### PR TITLE
Fix discussion model-related test

### DIFF
--- a/app/Models/BeatmapDiscussionPost.php
+++ b/app/Models/BeatmapDiscussionPost.php
@@ -261,6 +261,7 @@ class BeatmapDiscussionPost extends Model implements Traits\ReportableInterface
                 return true;
             });
         } catch (ModelNotSavedException $_e) {
+            $this->exists = false;
             $this->validationErrors()->merge($this->beatmapDiscussion->validationErrors());
 
             return false;

--- a/tests/Browser/SanityTest.php
+++ b/tests/Browser/SanityTest.php
@@ -139,7 +139,7 @@ class SanityTest extends DuskTestCase
             'beatmap_id' => self::$scaffolding['beatmap'],
             'user_id' => self::$scaffolding['user'],
         ]);
-        self::$scaffolding['beatmap_discussion_post'] = BeatmapDiscussionPost::factory()->create([
+        self::$scaffolding['beatmap_discussion_post'] = BeatmapDiscussionPost::factory()->timeline()->create([
             'beatmap_discussion_id' => self::$scaffolding['beatmap_discussion'],
             'user_id' => self::$scaffolding['user'],
         ]);


### PR DESCRIPTION
`save()` sets `$exists` to true, bypassing actual existence check in `callAfterCreating` in factory.

And then also fix the underlying problem of creating non-timeline starting post for a (potentially) timeline discussion.