### PR TITLE
Declare missing instance variables

### DIFF
--- a/app/Console/Commands/UserRecalculateRankCounts.php
+++ b/app/Console/Commands/UserRecalculateRankCounts.php
@@ -13,6 +13,9 @@ use Illuminate\Console\Command;
 
 class UserRecalculateRankCounts extends Command
 {
+    private ?int $from;
+    private ?int $until;
+
     /**
      * The name and signature of the console command.
      *
@@ -34,8 +37,8 @@ class UserRecalculateRankCounts extends Command
      */
     public function handle()
     {
-        $this->from = $this->option('from');
-        $this->until = $this->option('until');
+        $this->from = get_int($this->option('from'));
+        $this->until = get_int($this->option('until'));
 
         $continue = $this->confirm('This will recalculate and update the rank counts for user statistics, continue?');
 

--- a/app/Events/Fulfillments/PaymentEvent.php
+++ b/app/Events/Fulfillments/PaymentEvent.php
@@ -11,7 +11,6 @@ class PaymentEvent implements HasOrder
 {
     public function __construct(public Order $order)
     {
-        $this->order = $order;
     }
 
     public function getOrder()

--- a/app/Events/Fulfillments/PaymentEvent.php
+++ b/app/Events/Fulfillments/PaymentEvent.php
@@ -9,7 +9,7 @@ use App\Models\Store\Order;
 
 class PaymentEvent implements HasOrder
 {
-    public function __construct(Order $order)
+    public function __construct(private Order $order)
     {
         $this->order = $order;
     }

--- a/app/Events/Fulfillments/PaymentEvent.php
+++ b/app/Events/Fulfillments/PaymentEvent.php
@@ -9,7 +9,7 @@ use App\Models\Store\Order;
 
 class PaymentEvent implements HasOrder
 {
-    public function __construct(private Order $order)
+    public function __construct(public Order $order)
     {
         $this->order = $order;
     }

--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -62,6 +62,11 @@ class UsersController extends Controller
 
     protected $maxResults = 100;
 
+    private ?string $mode = null;
+    private ?int $offset = null;
+    private ?int $perPage = null;
+    private ?User $user = null;
+
     public function __construct()
     {
         $this->middleware('guest', ['only' => 'store']);

--- a/app/Libraries/BBCodeFromDB.php
+++ b/app/Libraries/BBCodeFromDB.php
@@ -18,6 +18,8 @@ class BBCodeFromDB
     public $refId;
     public $withGallery;
 
+    private array $options;
+
     public function __construct($text, $uid = '', $options = [])
     {
         $defaultOptions = [

--- a/app/Libraries/CurrentStats.php
+++ b/app/Libraries/CurrentStats.php
@@ -12,10 +12,11 @@ use Cache;
 
 class CurrentStats
 {
-    public $currentOnline;
-    public $currentGames;
-    public $graphData;
-    public $totalUsers;
+    public int $currentOnline;
+    public int $currentGames;
+    public array $graphData;
+    public int $onlineFriends;
+    public int $totalUsers;
 
     public function __construct()
     {

--- a/app/Libraries/Elasticsearch/SearchParams.php
+++ b/app/Libraries/Elasticsearch/SearchParams.php
@@ -10,6 +10,10 @@ abstract class SearchParams
     /** @var int */
     public $from = 0;
 
+    public ?string $queryString = null;
+
+    // FIXME: some of the assignments to these variables have have the wrong type.
+
     /** @var int */
     public $size = 50;
 

--- a/app/Libraries/Fulfillments/GenericFulfillment.php
+++ b/app/Libraries/Fulfillments/GenericFulfillment.php
@@ -33,6 +33,6 @@ class GenericFulfillment extends OrderFulfiller
 
     public function validationErrorsTranslationPrefix()
     {
-        // noop
+        return '';
     }
 }

--- a/app/Libraries/ImageProcessorService.php
+++ b/app/Libraries/ImageProcessorService.php
@@ -10,7 +10,9 @@ use App\Models\Beatmapset;
 
 class ImageProcessorService
 {
-    public function __construct($endpoint = null)
+    private string $endpoint;
+
+    public function __construct(?string $endpoint = null)
     {
         $this->endpoint = $endpoint ?? config('osu.beatmap_processor.thumbnailer');
     }

--- a/app/Libraries/NewForumTopic.php
+++ b/app/Libraries/NewForumTopic.php
@@ -5,17 +5,15 @@
 
 namespace App\Libraries;
 
+use App\Models\Forum\Forum;
 use App\Models\Forum\Post;
+use App\Models\User;
 use Carbon\Carbon;
 
 class NewForumTopic
 {
-    private $forum;
-
-    public function __construct($forum, $user)
+    public function __construct(private Forum $forum, private ?User $user)
     {
-        $this->forum = $forum;
-        $this->user = $user;
     }
 
     public function cover()

--- a/app/Libraries/Payments/CentiliSignature.php
+++ b/app/Libraries/Payments/CentiliSignature.php
@@ -9,9 +9,8 @@ use Illuminate\Http\Request;
 
 class CentiliSignature implements PaymentSignature
 {
-    public function __construct(Request $request)
+    public function __construct(private Request $request)
     {
-        $this->request = $request;
     }
 
     public function isValid()

--- a/app/Libraries/Payments/PaypalSignature.php
+++ b/app/Libraries/Payments/PaypalSignature.php
@@ -12,9 +12,8 @@ class PaypalSignature implements PaymentSignature
 {
     const VERIFIED_RESPONSE = 'VERIFIED';
 
-    public function __construct(Request $request)
+    public function __construct(private Request $request)
     {
-        $this->request = $request;
     }
 
     public function isValid()

--- a/app/Libraries/Payments/XsollaSignature.php
+++ b/app/Libraries/Payments/XsollaSignature.php
@@ -9,9 +9,8 @@ use Illuminate\Http\Request;
 
 class XsollaSignature implements PaymentSignature
 {
-    public function __construct(Request $request)
+    public function __construct(private Request $request)
     {
-        $this->request = $request;
     }
 
     public function isValid()

--- a/app/Libraries/Search/ArtistTrackSearchParams.php
+++ b/app/Libraries/Search/ArtistTrackSearchParams.php
@@ -30,7 +30,6 @@ class ArtistTrackSearchParams extends SearchParams
     public ?string $genre;
     public bool $isDefaultSort = false;
     public ?array $length;
-    public ?string $queryString;
     public string $sortField;
     public string $sortOrder;
 

--- a/app/Libraries/Search/BeatmapsetSearchParams.php
+++ b/app/Libraries/Search/BeatmapsetSearchParams.php
@@ -32,7 +32,6 @@ class BeatmapsetSearchParams extends SearchParams
     public ?int $language = null;
     public ?int $mode = null;
     public ?string $playedFilter = null; // null means any state
-    public ?string $queryString = null;
     public array $rank = [];
     public ?array $ranked = null;
     public bool $showFeaturedArtists = false;

--- a/app/Libraries/Search/ForumSearchParams.php
+++ b/app/Libraries/Search/ForumSearchParams.php
@@ -22,9 +22,6 @@ class ForumSearchParams extends SearchParams
     /** @var bool */
     public $includeSubforums = false;
 
-    /** @var string|null */
-    public $queryString = null;
-
     /** {@inheritdoc} */
     public $size = 20;
 

--- a/app/Libraries/Search/UserSearchParams.php
+++ b/app/Libraries/Search/UserSearchParams.php
@@ -14,7 +14,6 @@ class UserSearchParams extends SearchParams
 
     // all public because lazy.
 
-    public $queryString = null;
     public $recentOnly = false;
 
     public $sortField = 'relevance';

--- a/app/Libraries/Search/WikiSearchParams.php
+++ b/app/Libraries/Search/WikiSearchParams.php
@@ -12,9 +12,6 @@ class WikiSearchParams extends SearchParams
     // all public because lazy.
 
     /** @var string|null */
-    public $queryString = null;
-
-    /** @var string|null */
     public $locale = null;
 
     /**

--- a/app/Libraries/Search/WikiSuggestionsParams.php
+++ b/app/Libraries/Search/WikiSuggestionsParams.php
@@ -9,9 +9,6 @@ use App\Libraries\Elasticsearch\SearchParams;
 
 class WikiSuggestionsParams extends SearchParams
 {
-    /** @var string|null */
-    public $queryString = null;
-
     public $size = 10;
 
     /**

--- a/app/Libraries/ValidationErrors.php
+++ b/app/Libraries/ValidationErrors.php
@@ -11,10 +11,8 @@ class ValidationErrors
 {
     private $errors = [];
 
-    public function __construct($prefix, $keyBase = 'model_validation.')
+    public function __construct(private string $prefix, private string $keyBase = 'model_validation.')
     {
-        $this->prefix = $prefix;
-        $this->keyBase = $keyBase;
     }
 
     public function add($column, $rawMessage, $params = null): self

--- a/app/Listeners/Fulfillments/PaymentSubscribers.php
+++ b/app/Listeners/Fulfillments/PaymentSubscribers.php
@@ -26,6 +26,7 @@ class PaymentSubscribers
 
     public function onPaymentCompleted($eventName, $data)
     {
+        /** @var \App\Events\Fulfillments\PaymentEvent $event */
         $event = $data[0] ?? null;
         $fulfillers = FulfillmentFactory::createFulfillersFor($event->order);
         $count = count($fulfillers);

--- a/app/Mail/UserNotificationDigest.php
+++ b/app/Mail/UserNotificationDigest.php
@@ -16,17 +16,14 @@ use Illuminate\Mail\Mailable;
 class UserNotificationDigest extends Mailable
 {
     private $groups = [];
-    private $notifications;
 
     /**
      * Create a new message instance.
      *
      * @return void
      */
-    public function __construct(array $notifications, User $user)
+    public function __construct(private array $notifications, private User $user)
     {
-        $this->user = $user;
-        $this->notifications = $notifications;
     }
 
     private function addToGroups(Notification $notification)

--- a/app/Models/Event.php
+++ b/app/Models/Event.php
@@ -24,7 +24,9 @@ use Sentry\State\Scope;
  */
 class Event extends Model
 {
+    public ?array $details = null;
     public $parsed = false;
+    public ?string $type = null;
 
     public $patterns = [
         'achievement' => "!^(?:<b>)+<a href='(?<userUrl>.+?)'>(?<userName>.+?)</a>(?:</b>)+ unlocked the \"<b>(?<achievementName>.+?)</b>\" achievement\!$!",

--- a/app/Models/Forum/TopicVote.php
+++ b/app/Models/Forum/TopicVote.php
@@ -13,6 +13,7 @@ class TopicVote
 {
     use Validatable;
 
+    private array $params = [];
     private $topic;
     private $validated = false;
 


### PR DESCRIPTION
Explicitly declare used instance variables.

Some cleanups in the process of adding static analysis. 
This doesn't bother with fixing the magic laravel stuff.