### PR TITLE
Clean up discussion reply handling

### DIFF
--- a/resources/assets/lib/beatmap-discussions/new-reply.tsx
+++ b/resources/assets/lib/beatmap-discussions/new-reply.tsx
@@ -79,6 +79,7 @@ export class NewReply extends React.Component<Props> {
     this.handleKeyDown = makeTextAreaHandler(this.handleKeyDownCallback);
   }
 
+  @action
   componentDidUpdate(prevProps: Readonly<Props>) {
     if (prevProps.discussion.id !== this.props.discussion.id) {
       this.message = this.storedMessage;

--- a/resources/assets/lib/beatmap-discussions/new-reply.tsx
+++ b/resources/assets/lib/beatmap-discussions/new-reply.tsx
@@ -90,8 +90,6 @@ export class NewReply extends React.Component<Props> {
       this.startEditing = false;
       this.box.current?.focus();
     }
-
-    this.storeMessage();
   }
 
   componentWillUnmount() {
@@ -107,6 +105,10 @@ export class NewReply extends React.Component<Props> {
     if (core.userLogin.showIfGuest(this.editStart)) return;
     this.editing = true;
     this.startEditing = true;
+  };
+
+  private readonly handleChange = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
+    this.setMessage(e.target.value);
   };
 
   @action
@@ -126,7 +128,7 @@ export class NewReply extends React.Component<Props> {
     if (osu.present(this.message) && !confirm(osu.trans('common.confirmation_unsaved'))) return;
 
     this.editing = false;
-    this.message = '';
+    this.setMessage('');
   };
 
   @action
@@ -156,7 +158,7 @@ export class NewReply extends React.Component<Props> {
     this.postXhr
       .done((json) => runInAction(() => {
         this.editing = false;
-        this.message = '';
+        this.setMessage('');
         $.publish('beatmapDiscussionPost:markRead', { id: json.beatmap_discussion_post_ids });
         $.publish('beatmapsetDiscussions:update', { beatmapset: json.beatmapset });
       }))
@@ -181,7 +183,7 @@ export class NewReply extends React.Component<Props> {
               ref={this.box}
               className={`${bn}__message ${bn}__message--editor`}
               disabled={this.posting != null}
-              onChange={this.setMessage}
+              onChange={this.handleChange}
               onKeyDown={this.handleKeyDown}
               placeholder={osu.trans('beatmaps.discussions.reply_placeholder')}
               value={this.message}
@@ -257,9 +259,10 @@ export class NewReply extends React.Component<Props> {
   }
 
   @action
-  private readonly setMessage = (e: React.ChangeEvent<HTMLTextAreaElement>) => {
-    this.message = e.target.value;
-  };
+  private setMessage(message: string) {
+    this.message = message;
+    this.storeMessage();
+  }
 
   private storeMessage() {
     if (!osu.present(this.message)) {

--- a/resources/assets/lib/beatmap-discussions/new-reply.tsx
+++ b/resources/assets/lib/beatmap-discussions/new-reply.tsx
@@ -261,10 +261,7 @@ export class NewReply extends React.Component<Props> {
   @action
   private setMessage(message: string) {
     this.message = message;
-    this.storeMessage();
-  }
 
-  private storeMessage() {
     if (!osu.present(this.message)) {
       localStorage.removeItem(this.storageKey);
     } else {

--- a/resources/assets/lib/beatmap-discussions/new-reply.tsx
+++ b/resources/assets/lib/beatmap-discussions/new-reply.tsx
@@ -46,6 +46,7 @@ export class NewReply extends React.Component<Props> {
   @observable private message = this.storedMessage;
   @observable private posting: string | null = null;
   private postXhr: JQuery.jqXHR<BeatmapsetDiscussionPostStoreResponseJson> | null = null;
+  private startEditing = false;
 
   private get canReopen() {
     return this.props.discussion.can_be_resolved && this.props.discussion.current_user_attributes.can_reopen;
@@ -84,7 +85,8 @@ export class NewReply extends React.Component<Props> {
       return;
     }
 
-    if (this.editing) {
+    if (this.startEditing) {
+      this.startEditing = false;
       this.box.current?.focus();
     }
 
@@ -103,6 +105,7 @@ export class NewReply extends React.Component<Props> {
   private readonly editStart = () => {
     if (core.userLogin.showIfGuest(this.editStart)) return;
     this.editing = true;
+    this.startEditing = true;
   };
 
   @action


### PR DESCRIPTION
May or may not resolve issue mentioned in #9405. I couldn't reproduce it but updating the storage synchronously seem to make more sense.

Also only focus input box after pressing the reply button and nothing else (posting reply on another open box).