### PR TITLE
Remove unneeded return in __construct()

### DIFF
--- a/app/Http/Controllers/Account/SessionsController.php
+++ b/app/Http/Controllers/Account/SessionsController.php
@@ -16,7 +16,7 @@ class SessionsController extends Controller
         $this->middleware('auth');
         $this->middleware('verify-user');
 
-        return parent::__construct();
+        parent::__construct();
     }
 
     public function destroy($id)

--- a/app/Http/Controllers/AccountController.php
+++ b/app/Http/Controllers/AccountController.php
@@ -59,7 +59,7 @@ class AccountController extends Controller
             'verifyLink',
         ]]);
 
-        return parent::__construct();
+        parent::__construct();
     }
 
     public function avatar()

--- a/app/Http/Controllers/Admin/Controller.php
+++ b/app/Http/Controllers/Admin/Controller.php
@@ -22,6 +22,6 @@ abstract class Controller extends BaseController
             return $next($request);
         });
 
-        return parent::__construct();
+        parent::__construct();
     }
 }

--- a/app/Http/Controllers/BeatmapDiscussionPostsController.php
+++ b/app/Http/Controllers/BeatmapDiscussionPostsController.php
@@ -26,7 +26,7 @@ class BeatmapDiscussionPostsController extends Controller
         $this->middleware('auth', ['except' => ['index', 'show']]);
         $this->middleware('require-scopes:public', ['only' => ['index']]);
 
-        return parent::__construct();
+        parent::__construct();
     }
 
     public function destroy($id)

--- a/app/Http/Controllers/BeatmapDiscussionsController.php
+++ b/app/Http/Controllers/BeatmapDiscussionsController.php
@@ -23,7 +23,7 @@ class BeatmapDiscussionsController extends Controller
         $this->middleware('auth', ['except' => ['index', 'show']]);
         $this->middleware('require-scopes:public', ['only' => ['index']]);
 
-        return parent::__construct();
+        parent::__construct();
     }
 
     public function allowKudosu($id)

--- a/app/Http/Controllers/BeatmapsetDiscussionVotesController.php
+++ b/app/Http/Controllers/BeatmapsetDiscussionVotesController.php
@@ -16,7 +16,7 @@ class BeatmapsetDiscussionVotesController extends Controller
     {
         $this->middleware('require-scopes:public');
 
-        return parent::__construct();
+        parent::__construct();
     }
 
     /**

--- a/app/Http/Controllers/BeatmapsetEventsController.php
+++ b/app/Http/Controllers/BeatmapsetEventsController.php
@@ -13,7 +13,7 @@ class BeatmapsetEventsController extends Controller
     {
         $this->middleware('require-scopes:public', ['only' => ['index']]);
 
-        return parent::__construct();
+        parent::__construct();
     }
 
     public function index()

--- a/app/Http/Controllers/BlocksController.php
+++ b/app/Http/Controllers/BlocksController.php
@@ -24,7 +24,7 @@ class BlocksController extends Controller
             ],
         ]);
 
-        return parent::__construct();
+        parent::__construct();
     }
 
     public function store()

--- a/app/Http/Controllers/Chat/ChannelsController.php
+++ b/app/Http/Controllers/Chat/ChannelsController.php
@@ -22,7 +22,7 @@ class ChannelsController extends Controller
     {
         $this->middleware('require-scopes:chat.write', ['only' => 'store']);
 
-        return parent::__construct();
+        parent::__construct();
     }
 
     /**

--- a/app/Http/Controllers/Chat/ChatController.php
+++ b/app/Http/Controllers/Chat/ChatController.php
@@ -25,7 +25,7 @@ class ChatController extends Controller
         $this->middleware('require-scopes:chat.write', ['only' => 'newConversation']);
         $this->middleware('auth');
 
-        return parent::__construct();
+        parent::__construct();
     }
 
     public function ack()

--- a/app/Http/Controllers/Chat/Controller.php
+++ b/app/Http/Controllers/Chat/Controller.php
@@ -13,6 +13,6 @@ abstract class Controller extends BaseController
     {
         $this->middleware('auth');
 
-        return parent::__construct();
+        parent::__construct();
     }
 }

--- a/app/Http/Controllers/ChatController.php
+++ b/app/Http/Controllers/ChatController.php
@@ -23,7 +23,7 @@ class ChatController extends Controller
             $this->middleware('verify-user');
         }
 
-        return parent::__construct();
+        parent::__construct();
     }
 
     public function index()

--- a/app/Http/Controllers/ClientVerificationsController.php
+++ b/app/Http/Controllers/ClientVerificationsController.php
@@ -15,7 +15,7 @@ class ClientVerificationsController extends Controller
         $this->middleware('verify-user');
         $this->middleware('throttle:60,10');
 
-        return parent::__construct();
+        parent::__construct();
     }
 
     public function create()

--- a/app/Http/Controllers/Forum/PostsController.php
+++ b/app/Http/Controllers/Forum/PostsController.php
@@ -25,7 +25,7 @@ class PostsController extends Controller
 
         $this->middleware('require-scopes:forum.write', ['only' => ['update']]);
 
-        return parent::__construct();
+        parent::__construct();
     }
 
     public function destroy($id)

--- a/app/Http/Controllers/FriendsController.php
+++ b/app/Http/Controllers/FriendsController.php
@@ -26,7 +26,7 @@ class FriendsController extends Controller
 
         $this->middleware('require-scopes:friends.read', ['only' => ['index']]);
 
-        return parent::__construct();
+        parent::__construct();
     }
 
     public function index()

--- a/app/Http/Controllers/HomeController.php
+++ b/app/Http/Controllers/HomeController.php
@@ -30,7 +30,7 @@ class HomeController extends Controller
 
         $this->middleware('require-scopes:public', ['only' => 'search']);
 
-        return parent::__construct();
+        parent::__construct();
     }
 
     public function bbcodePreview()

--- a/app/Http/Controllers/Payments/PaypalController.php
+++ b/app/Http/Controllers/Payments/PaypalController.php
@@ -31,7 +31,7 @@ class PaypalController extends Controller
         $this->middleware('check-user-restricted', ['except' => ['ipn']]);
         $this->middleware('verify-user', ['except' => ['ipn']]);
 
-        return parent::__construct();
+        parent::__construct();
     }
 
     // When user has approved a payment at Paypal and is redirected back here.

--- a/app/Http/Controllers/Payments/XsollaController.php
+++ b/app/Http/Controllers/Payments/XsollaController.php
@@ -28,7 +28,7 @@ class XsollaController extends Controller
         $this->middleware('check-user-restricted', ['except' => ['callback']]);
         $this->middleware('verify-user', ['except' => ['callback']]);
 
-        return parent::__construct();
+        parent::__construct();
     }
 
     public function token()

--- a/app/Http/Controllers/ScorePinsController.php
+++ b/app/Http/Controllers/ScorePinsController.php
@@ -16,7 +16,7 @@ class ScorePinsController extends Controller
     {
         $this->middleware('auth');
 
-        return parent::__construct();
+        parent::__construct();
     }
 
     public function destroy()

--- a/app/Http/Controllers/SessionsController.php
+++ b/app/Http/Controllers/SessionsController.php
@@ -20,7 +20,7 @@ class SessionsController extends Controller
             'store',
         ]]);
 
-        return parent::__construct();
+        parent::__construct();
     }
 
     public function store()

--- a/app/Http/Controllers/Store/CartController.php
+++ b/app/Http/Controllers/Store/CartController.php
@@ -23,7 +23,7 @@ class CartController extends Controller
             ]]);
         }
 
-        return parent::__construct();
+        parent::__construct();
     }
 
     public function show()

--- a/app/Http/Controllers/Store/CheckoutController.php
+++ b/app/Http/Controllers/Store/CheckoutController.php
@@ -27,7 +27,7 @@ class CheckoutController extends Controller
         }
         $this->middleware('verify-user');
 
-        return parent::__construct();
+        parent::__construct();
     }
 
     public function show($id)

--- a/app/Http/Controllers/Store/NotificationRequestsController.php
+++ b/app/Http/Controllers/Store/NotificationRequestsController.php
@@ -18,7 +18,7 @@ class NotificationRequestsController extends Controller
             $this->middleware('check-user-restricted');
         }
 
-        return parent::__construct();
+        parent::__construct();
     }
 
     public function store($productId)

--- a/app/Http/Controllers/StoreController.php
+++ b/app/Http/Controllers/StoreController.php
@@ -37,7 +37,7 @@ class StoreController extends Controller
             'postUpdateAddress',
         ]]);
 
-        return parent::__construct();
+        parent::__construct();
     }
 
     public function getListing()

--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -94,7 +94,7 @@ class UsersController extends Controller
             'only' => ['extraPages', 'scores', 'beatmapsets', 'kudosu', 'recentActivity'],
         ]);
 
-        return parent::__construct();
+        parent::__construct();
     }
 
     public function card($id)

--- a/app/Models/UserStatistics/Model.php
+++ b/app/Models/UserStatistics/Model.php
@@ -151,7 +151,7 @@ abstract class Model extends BaseModel
             ], $attributes);
         }
 
-        return parent::__construct($attributes);
+        parent::__construct($attributes);
     }
 
     public function countryRank()

--- a/app/Models/UserStatistics/Spotlight/Model.php
+++ b/app/Models/UserStatistics/Spotlight/Model.php
@@ -34,6 +34,6 @@ abstract class Model extends BaseModel implements HasDynamicTable
             $this->a_rank_count = 0;
         }
 
-        return parent::__construct($attributes, false);
+        parent::__construct($attributes, false);
     }
 }


### PR DESCRIPTION
`new Thing()` should always be returning the object and no one should be calling `->__construct()` anyway...