### PR TITLE
Add chat/ack endpoint to api

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -431,6 +431,7 @@ Route::group(['as' => 'api.', 'prefix' => 'api', 'middleware' => ['api', Throttl
         Route::delete('comments/{comment}/vote', 'CommentsController@voteDestroy');
 
         Route::group(['as' => 'chat.', 'prefix' => 'chat', 'namespace' => 'Chat'], function () {
+            Route::post('ack', 'ChatController@ack')->name('ack');
             Route::post('new', 'ChatController@newConversation')->name('new');
             Route::get('updates', 'ChatController@updates')->name('updates');
             Route::get('presence', 'ChatController@presence')->name('presence');

--- a/tests/api_routes.json
+++ b/tests/api_routes.json
@@ -322,6 +322,19 @@
         "scopes": []
     },
     {
+        "uri": "api/v2/chat/ack",
+        "methods": [
+            "POST"
+        ],
+        "controller": "App\\Http\\Controllers\\Chat\\ChatController@ack",
+        "middlewares": [
+            "App\\Http\\Middleware\\ThrottleRequests:1200,1,api:",
+            "App\\Http\\Middleware\\RequireScopes",
+            "Illuminate\\Auth\\Middleware\\Authenticate"
+        ],
+        "scopes": []
+    },
+    {
         "uri": "api/v2/chat/new",
         "methods": [
             "POST"


### PR DESCRIPTION
Seems useful for chat  👀 

```
POST /api/v2/chat/ack
{ since: $id_of_last_received_message }
```

also returns recent silences since the last message