### PR TITLE
Add default chat ack parameter value

### DIFF
--- a/app/Http/Controllers/Chat/ChatController.php
+++ b/app/Http/Controllers/Chat/ChatController.php
@@ -38,7 +38,7 @@ class ChatController extends Controller
         ], ['null_missing' => true]);
 
         return [
-            'silences' => json_collection($this->getSilences($params['history_since'], $params['since']), new UserSilenceTransformer()),
+            'silences' => json_collection($this->getSilences($params['history_since'], $params['since'] ?? 0), new UserSilenceTransformer()),
         ];
     }
 


### PR DESCRIPTION
Otherwise it'll query `->where('message_id', '<=', null)` which is invalid 🤷 