### PR TITLE
Silence lint warnings output

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Install js dependencies
         run: yarn --frozen-lockfile
 
-      - run: yarn lint --max-warnings 201
+      - run: 'yarn lint --max-warnings 197 > /dev/null'
 
       - run: ./bin/update_licence.sh -nf
 


### PR DESCRIPTION
GitHub PR files tab may hang otherwise ಠ_ಠ

Looks like it's been fixed (or the unchanged files annotation is removed). But it's probably still a good idea anyway if they're going to readd the thing later? 🤷‍♀️