### PR TITLE
Fix error when weird id for beatmapset download is passed

### DIFF
--- a/app/Http/Controllers/BeatmapsetsController.php
+++ b/app/Http/Controllers/BeatmapsetsController.php
@@ -168,7 +168,7 @@ class BeatmapsetsController extends Controller
     public function download($id)
     {
         if (!is_api_request() && !from_app_url()) {
-            return ujs_redirect(route('beatmapsets.show', ['beatmapset' => $id]));
+            return ujs_redirect(route('beatmapsets.show', ['beatmapset' => rawurlencode($id)]));
         }
 
         $beatmapset = Beatmapset::findOrFail($id);


### PR DESCRIPTION
It's laravel/framework#26715 again which apparently isn't going to be fixed (or more like "isn't a problem") and should be manually done everywhere (still happens on latest laravel 9.19).