### PR TITLE
Fix `TransformerAbstract::callIncludeMethod()` docs and return value

### DIFF
--- a/app/Transformers/TransformerAbstract.php
+++ b/app/Transformers/TransformerAbstract.php
@@ -22,13 +22,10 @@ class TransformerAbstract extends Fractal\TransformerAbstract
         return $this->requiredPermission;
     }
 
-    /**
-     * {@inheritcoc}
-     */
     protected function callIncludeMethod(Fractal\Scope $scope, $includeName, $data)
     {
         if (!$this->hasPermission($includeName, $data)) {
-            return; // or false apparently
+            return false;
         }
 
         return parent::callIncludeMethod($scope, $includeName, $data);


### PR DESCRIPTION
just random thing i noticed

- typo in docs, but it doesnt seem necessary anyway
- return value worked as-is but the parent only returns ResourceInterface or false, so I think this should match.