### PR TITLE
Split score search mod exclusion into separate terms

### DIFF
--- a/app/Libraries/Search/ScoreSearch.php
+++ b/app/Libraries/Search/ScoreSearch.php
@@ -49,7 +49,9 @@ class ScoreSearch extends RecordSearch
             $query->filter(['term' => ['user_id' => $this->params->userId]]);
         }
         if ($this->params->excludeMods !== null && count($this->params->excludeMods) > 0) {
-            $query->mustNot(['terms' => ['mods' => $this->params->excludeMods]]);
+            foreach ($this->params->excludeMods as $excludedMod) {
+                $query->mustNot(['term' => ['mods' => $excludedMod]]);
+            }
         }
 
         $this->addModsFilter($query);
@@ -143,7 +145,12 @@ class ScoreSearch extends RecordSearch
         $allSearchMods = [];
         foreach ($mods as $mod) {
             if ($mod === 'NM') {
-                $noModSubQuery ??= (new BoolQuery())->mustNot(['terms' => ['mods' => $allMods->toArray()]]);
+                if (!isset($noModSubQuery)) {
+                    $noModSubQuery = new BoolQuery();
+                    foreach ($allMods->toArray() as $excludedMod) {
+                        $noModSubQuery->mustNot(['term' => ['mods' => $excludedMod]]);
+                    }
+                }
                 continue;
             }
             $modsSubQuery ??= new BoolQuery();
@@ -159,7 +166,9 @@ class ScoreSearch extends RecordSearch
         if (isset($modsSubQuery)) {
             $excludedMods = array_values(array_diff($allMods->toArray(), $allSearchMods));
             if (count($excludedMods) > 0) {
-                $modsSubQuery->mustNot(['terms' => ['mods' => $excludedMods]]);
+                foreach ($excludedMods as $excludedMod) {
+                    $modsSubQuery->mustNot(['term' => ['mods' => $excludedMod]]);
+                }
             }
         }
 


### PR DESCRIPTION
There appears to be some implicit limit in the number of items that can go in the `terms` condition before elasticsearch starts rewriting that portion of the query into many smaller combinations of the query (and it's not an A+B+C union situation)

From some initial testing, 18 mods seems fine, 19 starts to take 1+ second, 35 took 9 seconds, etc.
Breaking the into smaller terms seems to avoid the issue...even if it's in sets of 10 🤔 

This needs a bit more testing to ensure the mod filter behaves as expected

maybe fixes #9432?