### PR TITLE
Fix inconsistent verification logic when bypassing

### DIFF
--- a/app/Http/Middleware/VerifyUserAlways.php
+++ b/app/Http/Middleware/VerifyUserAlways.php
@@ -12,7 +12,9 @@ class VerifyUserAlways extends VerifyUser
 {
     public static function isRequired($user)
     {
-        return $user !== null && ($user->isPrivileged() || $user->isInactive());
+        return !config('osu.user.bypass_verification')
+            && $user !== null
+            && ($user->isPrivileged() || $user->isInactive());
     }
 
     public function requiresVerification($request)

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -2166,7 +2166,7 @@ class User extends Model implements AfterCommit, AuthenticatableContract, HasLoc
 
     public function isSessionVerified()
     {
-        return $this->isSessionVerified;
+        return $this->isSessionVerified || config('osu.user.bypass_verification');
     }
 
     public function markSessionVerified()


### PR DESCRIPTION
isSessionVerified fixes #9460

the middleware change lets the notifications server use this setting too (but it's only updated on user login when bypassing, didn't bother to fix for this PR)