### PR TITLE
Refactor session verification

### DIFF
--- a/app/Http/Controllers/Controller.php
+++ b/app/Http/Controllers/Controller.php
@@ -8,6 +8,7 @@ namespace App\Http\Controllers;
 use App;
 use App\Http\Middleware\VerifyUserAlways;
 use App\Libraries\LocaleMeta;
+use App\Libraries\UserVerificationState;
 use App\Models\Log;
 use Auth;
 use Carbon\Carbon;
@@ -47,10 +48,10 @@ abstract class Controller extends BaseController
         $session->flush();
         $session->regenerateToken();
         $session->put('requires_verification', VerifyUserAlways::isRequired($user));
-        if (config('osu.user.bypass_verification')) {
-            (new UserVerificationState($user, $session, null))->markVerified();
-        }
         Auth::login($user, $remember);
+        if (config('osu.user.bypass_verification')) {
+            UserVerificationState::fromCurrentRequest()->markVerified();
+        }
         $session->migrate(true, $user->getKey());
     }
 

--- a/app/Http/Controllers/Controller.php
+++ b/app/Http/Controllers/Controller.php
@@ -43,11 +43,15 @@ abstract class Controller extends BaseController
     {
         cleanup_cookies();
 
-        session()->flush();
-        session()->regenerateToken();
-        session()->put('requires_verification', VerifyUserAlways::isRequired($user));
+        $session = session();
+        $session->flush();
+        $session->regenerateToken();
+        $session->put('requires_verification', VerifyUserAlways::isRequired($user));
+        if (config('osu.user.bypass_verification')) {
+            (new UserVerificationState($user, $session, null))->markVerified();
+        }
         Auth::login($user, $remember);
-        session()->migrate(true, Auth::user()->user_id);
+        $session->migrate(true, $user->getKey());
     }
 
     protected function logout()

--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -35,6 +35,7 @@ class Kernel extends HttpKernel
             \Illuminate\View\Middleware\ShareErrorsFromSession::class,
             Middleware\AutologinFromLegacyCookie::class,
             Middleware\VerifyCsrfToken::class,
+            Middleware\SetSessionVerification::class,
             Middleware\SetLocale::class,
             Middleware\UpdateUserLastvisit::class,
             Middleware\VerifyUserAlways::class,

--- a/app/Http/Middleware/SetSessionVerification.php
+++ b/app/Http/Middleware/SetSessionVerification.php
@@ -1,0 +1,41 @@
+<?php
+
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
+declare(strict_types=1);
+
+namespace App\Http\Middleware;
+
+use App\Events\UserSessionEvent;
+use App\Libraries\UserVerificationState;
+use Closure;
+use Illuminate\Http\Request;
+
+class SetSessionVerification
+{
+    public function handle(Request $request, Closure $next)
+    {
+        $user = auth()->user();
+        if ($user !== null) {
+            $isVerified = UserVerificationState::fromCurrentRequest()->isDone();
+
+            if ($isVerified) {
+                $user->markSessionVerified();
+            } else {
+                $isRequired = VerifyUserAlways::isRequired($user);
+                $session = session();
+                if ($session->get('requires_verification') !== $isRequired) {
+                    $session->put('requires_verification', $isRequired);
+                    $session->save();
+                    UserSessionEvent::newVerificationRequirementChange(
+                        $user->getKey(),
+                        $isRequired,
+                    )->broadcast();
+                }
+            }
+        }
+
+        return $next($request);
+    }
+}

--- a/app/Http/Middleware/UpdateUserLastvisit.php
+++ b/app/Http/Middleware/UpdateUserLastvisit.php
@@ -5,7 +5,6 @@
 
 namespace App\Http\Middleware;
 
-use App\Libraries\UserVerification;
 use App\Models\Country;
 use Carbon\Carbon;
 use Closure;
@@ -22,13 +21,13 @@ class UpdateUserLastvisit
 
     public function handle($request, Closure $next)
     {
-        if ($this->auth->check()) {
-            $user = auth()->user();
+        $user = $this->auth->user();
 
+        if ($user !== null) {
             $isInactive = $user->isInactive();
 
             if ($isInactive) {
-                $isVerified = UserVerification::fromCurrentRequest()->isDone();
+                $isVerified = $user->isSessionVerified();
             }
 
             if (!$isInactive || $isVerified) {

--- a/app/Http/Middleware/VerifyUser.php
+++ b/app/Http/Middleware/VerifyUser.php
@@ -13,6 +13,19 @@ use Illuminate\Http\Request;
 
 class VerifyUser
 {
+    const SKIP_VERIFICATION_ROUTES = [
+        'account_controller@reissue_code' => true,
+        'account_controller@verify' => true,
+        'account_controller@verify_link' => true,
+        'notifications_controller@endpoint' => true,
+        'sessions_controller@destroy' => true,
+        'sessions_controller@store' => true,
+        'wiki_controller@image' => true,
+        'wiki_controller@show' => true,
+        'wiki_controller@sitemap' => true,
+        'wiki_controller@suggestions' => true,
+    ];
+
     protected ?User $user;
 
     public function __construct(AuthGuard $auth)
@@ -44,19 +57,6 @@ class VerifyUser
         $currentRouteData = app('route-section')->getCurrent();
         $currentRoute = "{$currentRouteData['controller']}@{$currentRouteData['action']}";
 
-        static $routes = [
-            'account_controller@reissue_code',
-            'account_controller@verify',
-            'account_controller@verify_link',
-            'notifications_controller@endpoint',
-            'sessions_controller@destroy',
-            'sessions_controller@store',
-            'wiki_controller@image',
-            'wiki_controller@show',
-            'wiki_controller@sitemap',
-            'wiki_controller@suggestions',
-        ];
-
-        return in_array($currentRoute, $routes, true);
+        return isset(static::SKIP_VERIFICATION_ROUTES[$currentRoute]);
     }
 }

--- a/app/Http/Middleware/VerifyUser.php
+++ b/app/Http/Middleware/VerifyUser.php
@@ -26,18 +26,17 @@ class VerifyUser
         'wiki_controller@suggestions' => true,
     ];
 
-    protected ?User $user;
-
-    public function __construct(AuthGuard $auth)
+    public function __construct(protected AuthGuard $auth)
     {
-        $this->user = $auth->user();
     }
 
     public function handle(Request $request, Closure $next)
     {
+        $user = $this->auth->user();
+
         if (
-            $this->user !== null
-            && !$this->user->isSessionVerified()
+            $user !== null
+            && !$user->isSessionVerified()
             && !$this->alwaysSkipVerification()
             && $this->requiresVerification($request)
         ) {

--- a/app/Http/Middleware/VerifyUser.php
+++ b/app/Http/Middleware/VerifyUser.php
@@ -6,7 +6,6 @@
 namespace App\Http\Middleware;
 
 use App\Libraries\UserVerification;
-use App\Models\User;
 use Closure;
 use Illuminate\Contracts\Auth\Guard as AuthGuard;
 use Illuminate\Http\Request;

--- a/app/Http/Middleware/VerifyUserAlways.php
+++ b/app/Http/Middleware/VerifyUserAlways.php
@@ -20,10 +20,6 @@ class VerifyUserAlways extends VerifyUser
 
     public function requiresVerification($request)
     {
-        if ($this->user === null) {
-            return false;
-        }
-
         $method = $request->getMethod();
         $isPostAction = config('osu.user.post_action_verification')
             ? !isset(static::GET_ACTION_METHODS[$method])

--- a/app/Http/Middleware/VerifyUserAlways.php
+++ b/app/Http/Middleware/VerifyUserAlways.php
@@ -7,6 +7,12 @@ namespace App\Http\Middleware;
 
 class VerifyUserAlways extends VerifyUser
 {
+    const GET_ACTION_METHODS = [
+        'GET' => true,
+        'HEAD' => true,
+        'OPTIONS' => true,
+    ];
+
     public static function isRequired($user)
     {
         return $user !== null && ($user->isPrivileged() || $user->isInactive());
@@ -20,7 +26,7 @@ class VerifyUserAlways extends VerifyUser
 
         $method = $request->getMethod();
         $isPostAction = config('osu.user.post_action_verification')
-            ? !in_array($method, ['GET', 'HEAD', 'OPTIONS'], true)
+            ? !isset(static::GET_ACTION_METHODS[$method])
             : false;
 
         $isRequired = $isPostAction || $method === 'DELETE' || session()->get('requires_verification');

--- a/app/Libraries/UserVerification.php
+++ b/app/Libraries/UserVerification.php
@@ -20,15 +20,17 @@ class UserVerification
 
     public static function fromCurrentRequest()
     {
-        $verification = request()->attributes->get('user_verification');
+        $request = request();
+        $attributes = $request->attributes;
+        $verification = $attributes->get('user_verification');
 
         if ($verification === null) {
             $verification = new static(
                 auth()->user(),
-                request(),
+                $request,
                 UserVerificationState::fromCurrentRequest()
             );
-            request()->attributes->set('user_verification', $verification);
+            $attributes->set('user_verification', $verification);
         }
 
         return $verification;

--- a/app/Libraries/UserVerificationState.php
+++ b/app/Libraries/UserVerificationState.php
@@ -61,11 +61,12 @@ class UserVerificationState
         $this->session = $session;
         $this->user = $user;
 
-        if ($this->session->getId() === session()->getId()) {
+        $currentSession = session();
+        if ($this->session->getId() === $currentSession->getId()) {
             // Override passed session if it's the same as current session
             // otherwise the changes here will be overriden when current
             // session is saved.
-            $this->session = session();
+            $this->session = $currentSession;
         }
     }
 

--- a/app/Libraries/UserVerificationState.php
+++ b/app/Libraries/UserVerificationState.php
@@ -55,7 +55,7 @@ class UserVerificationState
         );
     }
 
-    private function __construct($user, $session, $legacySessionQueryWhere)
+    public function __construct($user, $session, $legacySessionQueryWhere)
     {
         $this->legacySessionQueryWhere = $legacySessionQueryWhere;
         $this->session = $session;

--- a/app/Libraries/UserVerificationState.php
+++ b/app/Libraries/UserVerificationState.php
@@ -55,7 +55,7 @@ class UserVerificationState
         );
     }
 
-    public function __construct($user, $session, $legacySessionQueryWhere)
+    private function __construct($user, $session, $legacySessionQueryWhere)
     {
         $this->legacySessionQueryWhere = $legacySessionQueryWhere;
         $this->session = $session;


### PR DESCRIPTION
- only use bypass verification option on login
  - this means changing the variable later doesn't update existing sessions retroactively but shouldn't be too much hassle...?
  - better than checking the option every time for production
- set verification related variables early
- only change verification requirement if not yet verified
- only check user privilege for verification requirement
- set frequently used variables
- use User#isSessionVerified for user lastvisit update check

Resolves #9460.

I've only done basic testing 👀 