### PR TITLE
Reset review editor cursor position after posting

### DIFF
--- a/resources/assets/lib/beatmap-discussions/editor.tsx
+++ b/resources/assets/lib/beatmap-discussions/editor.tsx
@@ -516,6 +516,7 @@ export default class Editor extends React.Component<Props, State> {
   // "correct" way to reset slate to initial value
   // https://docs.slatejs.org/walkthroughs/06-saving-to-a-database
   private resetEditorValue() {
+    Transforms.deselect(this.slateEditor);
     this.slateEditor.children = emptyDocTemplate;
     this.slateEditor.onChange();
   }


### PR DESCRIPTION
May cause errors if the selection isn't unset when resetting the editor value as slate tries to make a selection at a position that doesn't exist.