### PR TITLE
Remove osu.isIos

### DIFF
--- a/resources/assets/coffee/bootstrap-modal.coffee
+++ b/resources/assets/coffee/bootstrap-modal.coffee
@@ -4,9 +4,6 @@
 fixedElements = document.getElementsByClassName('js-fixed-element')
 
 $(document).on 'shown.bs.modal', '.modal', (e) ->
-  # safari breaks when calling focus() on most conditions.
-  return if osu.isIos
-
   $(e.target).find('.modal-af').focus()
 
 

--- a/resources/assets/coffee/osu_common.coffee
+++ b/resources/assets/coffee/osu_common.coffee
@@ -5,8 +5,6 @@ import { formatNumber } from 'utils/html'
 import { currentUrl } from 'utils/turbolinks'
 
 window.osu =
-  isIos: /iPad|iPhone|iPod/.test(navigator.platform)
-
   groupColour: (group) ->
     '--group-colour': group?.colour ? 'initial'
 


### PR DESCRIPTION
Can't seem to trigger any issue on iOS in the other place that makes use of this (verification modal).
Also, mobile safari seems to ignore the focus() anyway 🤷 

- [x] #9477 (removes other usage of `osu.isIos`)