### PR TITLE
Query beatmapset description post once

### DIFF
--- a/app/Models/Beatmapset.php
+++ b/app/Models/Beatmapset.php
@@ -1320,16 +1320,12 @@ class Beatmapset extends Model implements AfterCommit, Commentable, Indexable, T
 
     public function description()
     {
-        $bbcode = $this->getBBCode();
-
-        return $bbcode ? $bbcode->toHTML() : null;
+        return $this->getBBCode()?->toHTML();
     }
 
     public function editableDescription()
     {
-        $bbcode = $this->getBBCode();
-
-        return $bbcode ? $bbcode->toEditor() : null;
+        return $this->getBBCode()?->toEditor();
     }
 
     public function updateDescription($bbcode, $user)

--- a/app/Models/Beatmapset.php
+++ b/app/Models/Beatmapset.php
@@ -1416,13 +1416,7 @@ class Beatmapset extends Model implements AfterCommit, Commentable, Indexable, T
 
     public function getPost()
     {
-        $topic = $this->topic;
-
-        if ($topic === null) {
-            return;
-        }
-
-        return Forum\Post::find($topic->topic_first_post_id);
+        return $this->topic?->firstPost;
     }
 
     public function freshHype()

--- a/app/Models/Beatmapset.php
+++ b/app/Models/Beatmapset.php
@@ -993,6 +993,7 @@ class Beatmapset extends Model implements AfterCommit, Commentable, Indexable, T
             'bssProcessQueues',
             'comments',
             'defaultBeatmaps',
+            'descriptionPost',
             'events',
             'favourites',
             'genre',
@@ -1272,6 +1273,18 @@ class Beatmapset extends Model implements AfterCommit, Commentable, Indexable, T
         return $this->belongsTo(User::class, 'approvedby_id');
     }
 
+    public function descriptionPost()
+    {
+        return $this->hasOneThrough(
+            Forum\Post::class,
+            Forum\Topic::class,
+            'topic_id',
+            'post_id',
+            'thread_id',
+            'topic_first_post_id',
+        );
+    }
+
     public function topic()
     {
         return $this->belongsTo(Forum\Topic::class, 'thread_id');
@@ -1330,7 +1343,7 @@ class Beatmapset extends Model implements AfterCommit, Commentable, Indexable, T
 
     public function updateDescription($bbcode, $user)
     {
-        $post = $this->getPost();
+        $post = $this->descriptionPost;
         if ($post === null) {
             return;
         }
@@ -1374,7 +1387,7 @@ class Beatmapset extends Model implements AfterCommit, Commentable, Indexable, T
 
     private function getBBCode()
     {
-        $post = $this->getPost();
+        $post = $this->descriptionPost;
 
         if ($post === null) {
             return;
@@ -1408,11 +1421,6 @@ class Beatmapset extends Model implements AfterCommit, Commentable, Indexable, T
         }
 
         return $this->title;
-    }
-
-    public function getPost()
-    {
-        return $this->topic?->firstPost;
     }
 
     public function freshHype()


### PR DESCRIPTION
Use relation cache so it's not loaded multiple times (for `#description` and `#editableDescription`).

...although it really only affects beatmap owner and admins 🤷‍♀️

Cleaned up related functions a bit while at it.