### PR TITLE
Remove nulls before whereIn query in comment bundle

### DIFF
--- a/app/Libraries/CommentBundle.php
+++ b/app/Libraries/CommentBundle.php
@@ -112,7 +112,7 @@ class CommentBundle
             'pinned_comments' => json_collection($pinnedComments, 'Comment'),
             'user_votes' => $this->getUserVotes($allComments),
             'user_follow' => $this->getUserFollow(),
-            'users' => json_collection($this->getUsers($comments->concat($allComments)), 'UserCompact'),
+            'users' => json_collection($this->getUsers($allComments), 'UserCompact'),
             'sort' => $this->params->sort,
             'cursor' => $this->params->cursorHelper->next($comments),
         ];

--- a/app/Libraries/CommentBundle.php
+++ b/app/Libraries/CommentBundle.php
@@ -72,7 +72,7 @@ class CommentBundle
 
         // Get parents when listing comments index or loading comment replies
         if ($this->commentable === null || $this->params->parentId !== null) {
-            $parentIds = array_filter_set($comments->pluck('parent_id'));
+            $parentIds = array_reject_null($comments->pluck('parent_id'));
             if (count($parentIds) > 0) {
                 $parents = $this->getComments(Comment::whereIn('id', $parentIds));
                 $includedComments = $includedComments->concat($parents);
@@ -88,7 +88,7 @@ class CommentBundle
             for ($i = 0; $i < $this->depth; $i++) {
                 $nestedComments = $this->getComments(Comment::whereIn('parent_id', $nestedParentIds));
                 $includedComments = $includedComments->concat($nestedComments);
-                $nestedParentIds = array_filter_set($nestedComments->pluck('id'));
+                $nestedParentIds = array_reject_null($nestedComments->pluck('id'));
                 if (count($nestedParentIds) === 0) {
                     break;
                 }
@@ -233,6 +233,6 @@ class CommentBundle
             $userIds = $userIds->concat($comments->pluck('deleted_by_id'));
         }
 
-        return User::whereIn('user_id', array_filter_set($userIds))->get();
+        return User::whereIn('user_id', array_reject_null($userIds))->get();
     }
 }

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -19,6 +19,18 @@ function api_version(): int
     return $version;
 }
 
+function array_filter_set(array|ArrayAccess $array): array
+{
+    $ret = [];
+    foreach ($array as $item) {
+        if ($item !== null) {
+            $ret[] = $item;
+        }
+    }
+
+    return $ret;
+}
+
 /*
  * Like array_search but returns null if not found instead of false.
  * Strict mode only.

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -19,7 +19,7 @@ function api_version(): int
     return $version;
 }
 
-function array_filter_set(array|ArrayAccess $array): array
+function array_reject_null(array|ArrayAccess $array): array
 {
     $ret = [];
     foreach ($array as $item) {


### PR DESCRIPTION
Also:
- combine parent fetching on null commentable and reply request
- skip querying on empty ids
- use Set for reject lookup
- don't reconcat `$allComments` with `$comments`