### PR TITLE
Remove ajaxError from osu_common

### DIFF
--- a/resources/assets/coffee/osu_common.coffee
+++ b/resources/assets/coffee/osu_common.coffee
@@ -9,11 +9,6 @@ window.osu =
     '--group-colour': group?.colour ? 'initial'
 
 
-  emitAjaxError: (element = document.body) =>
-    (xhr, status, error) =>
-      $(element).trigger 'ajax:error', [xhr, status, error]
-
-
   formatBytes: (bytes, decimals=2) ->
     suffixes = ['B', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB']
     k = 1000

--- a/resources/assets/coffee/osu_common.coffee
+++ b/resources/assets/coffee/osu_common.coffee
@@ -9,13 +9,6 @@ window.osu =
     '--group-colour': group?.colour ? 'initial'
 
 
-  ajaxError: (xhr) ->
-    return if osuCore.userLogin.showOnError(xhr)
-    return if osuCore.userVerification.showOnError(xhr)
-
-    osu.popup osu.xhrErrorMessage(xhr), 'danger'
-
-
   emitAjaxError: (element = document.body) =>
     (xhr, status, error) =>
       $(element).trigger 'ajax:error', [xhr, status, error]

--- a/resources/assets/coffee/ujs-common.coffee
+++ b/resources/assets/coffee/ujs-common.coffee
@@ -1,6 +1,7 @@
 # Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 # See the LICENCE file in the repository root for full licence text.
 
+import { onError } from 'utils/ajax'
 import { hideLoadingOverlay, showLoadingOverlay } from 'utils/loading-overlay'
 
 $(document).on 'ajax:before', ->
@@ -27,4 +28,4 @@ $(document).on 'ajax:error', (event, xhr) ->
   # authentication logic is handled in user-dropdown-modal.js
   return if xhr.status == 401
 
-  osu.ajaxError xhr
+  onError xhr

--- a/resources/assets/lib/admin/contest/user-entry-delete-button.coffee
+++ b/resources/assets/lib/admin/contest/user-entry-delete-button.coffee
@@ -1,6 +1,7 @@
 # Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 # See the LICENCE file in the repository root for full licence text.
 
+import { onError } from 'utils/ajax'
 import { route } from 'laroute'
 import * as React from 'react'
 import { br, tr, td, button, a, img, dl, dt, dd, i } from 'react-dom-factories'
@@ -22,7 +23,7 @@ export class UserEntryDeleteButton extends React.Component
     $.ajax route("admin.user-contest-entries.#{destroyOrRestore}", user_contest_entry: @props.entry.id), params
       .done (data) =>
         $.publish "admin:contest:entries:#{destroyOrRestore}", entry: @props.entry.id
-      .fail osu.ajaxError
+      .fail onError
 
   delete: (e) =>
     e.preventDefault()

--- a/resources/assets/lib/beatmap-discussions/discussion.coffee
+++ b/resources/assets/lib/beatmap-discussions/discussion.coffee
@@ -6,6 +6,7 @@ import { route } from 'laroute'
 import * as React from 'react'
 import { renderToStaticMarkup } from 'react-dom/server'
 import { button, div, i, span, a } from 'react-dom-factories'
+import { onError } from 'utils/ajax'
 import { badgeGroup, canModeratePosts, formatTimestamp } from 'utils/beatmapset-discussion-helper'
 import { classWithModifiers } from 'utils/css'
 import { hideLoadingOverlay, showLoadingOverlay } from 'utils/loading-overlay'
@@ -198,7 +199,7 @@ export class Discussion extends React.PureComponent
     .done (data) =>
       $.publish 'beatmapsetDiscussions:update', beatmapset: data
 
-    .fail osu.ajaxError
+    .fail onError
 
     .always hideLoadingOverlay
 

--- a/resources/assets/lib/beatmap-discussions/nominations.coffee
+++ b/resources/assets/lib/beatmap-discussions/nominations.coffee
@@ -12,6 +12,7 @@ import { UserLink } from 'components/user-link'
 import { route } from 'laroute'
 import * as React from 'react'
 import { a, div, i, span } from 'react-dom-factories'
+import { onError } from 'utils/ajax'
 import { canModeratePosts, format, previewMessage } from 'utils/beatmapset-discussion-helper'
 import { nominationsCount } from 'utils/beatmapset-helper'
 import { hideLoadingOverlay, showLoadingOverlay } from 'utils/loading-overlay'
@@ -139,7 +140,7 @@ export class Nominations extends React.PureComponent
     @xhr.delete = $.ajax(url, params)
       .done ->
         Turbolinks.visit route('users.show', { user })
-      .fail osu.ajaxError
+      .fail onError
       .always hideLoadingOverlay
 
 
@@ -158,7 +159,7 @@ export class Nominations extends React.PureComponent
     @xhr.discussionLock = $.ajax(url, params)
       .done (response) =>
         $.publish 'beatmapsetDiscussions:update', beatmapset: response
-      .fail osu.ajaxError
+      .fail onError
       .always hideLoadingOverlay
 
 
@@ -175,7 +176,7 @@ export class Nominations extends React.PureComponent
     @xhr.discussionLock = $.ajax(url, params)
       .done (response) =>
         $.publish 'beatmapsetDiscussions:update', beatmapset: response
-      .fail osu.ajaxError
+      .fail onError
       .always hideLoadingOverlay
 
 
@@ -196,7 +197,7 @@ export class Nominations extends React.PureComponent
     @xhr.removeFromLoved = $.ajax(url, params)
       .done (response) =>
         $.publish 'beatmapsetDiscussions:update', beatmapset: response
-      .fail osu.ajaxError
+      .fail onError
       .always hideLoadingOverlay
 
 

--- a/resources/assets/lib/beatmap-discussions/subscribe.coffee
+++ b/resources/assets/lib/beatmap-discussions/subscribe.coffee
@@ -5,6 +5,7 @@ import BigButton from 'components/big-button'
 import { route } from 'laroute'
 import * as React from 'react'
 import { a, button, div, h1, h2, p } from 'react-dom-factories'
+import { emitError } from 'utils/ajax'
 
 el = React.createElement
 
@@ -43,6 +44,6 @@ export class Subscribe extends React.PureComponent
     .done (data) =>
       $.publish 'beatmapsetDiscussions:update', watching: !@isWatching()
     .fail (xhr) =>
-      osu.emitAjaxError() xhr
+      emitError() xhr
     .always =>
       @setState loading: false

--- a/resources/assets/lib/components/comment.coffee
+++ b/resources/assets/lib/components/comment.coffee
@@ -6,6 +6,7 @@ import { Observer } from 'mobx-react'
 import core from 'osu-core-singleton'
 import * as React from 'react'
 import { a, button, div, span, textarea, p } from 'react-dom-factories'
+import { onError } from 'utils/ajax'
 import { classWithModifiers } from 'utils/css'
 import { estimateMinLines } from 'utils/estimate-min-lines'
 import { createClickCallback, formatNumberSuffixed } from 'utils/html'
@@ -513,7 +514,7 @@ export class Comment extends React.PureComponent
     .fail (xhr, status) =>
       return if status == 'abort'
 
-      osu.ajaxError xhr
+      onError xhr
 
 
   togglePinned: =>
@@ -527,7 +528,7 @@ export class Comment extends React.PureComponent
     .fail (xhr, status) =>
       return if status == 'abort'
 
-      osu.ajaxError xhr
+      onError xhr
 
 
   handleReplyPosted: (type) =>
@@ -588,7 +589,7 @@ export class Comment extends React.PureComponent
     .fail (xhr, status) =>
       return if status == 'abort'
 
-      osu.ajaxError xhr
+      onError xhr
 
 
   toggleNewReply: =>
@@ -622,7 +623,7 @@ export class Comment extends React.PureComponent
       return if status == 'abort'
       return $(target).trigger('ajax:error', [xhr, status]) if xhr.status == 401
 
-      osu.ajaxError xhr
+      onError xhr
 
 
   closeNewReply: =>

--- a/resources/assets/lib/components/comments-manager.coffee
+++ b/resources/assets/lib/components/comments-manager.coffee
@@ -5,6 +5,7 @@ import { route } from 'laroute'
 import { runInAction } from 'mobx'
 import { Observer } from 'mobx-react'
 import core from 'osu-core-singleton'
+import { onError } from 'utils/ajax'
 import { parseJsonNullable, storeJson } from 'utils/json'
 import { nextVal } from 'utils/seq'
 
@@ -103,7 +104,7 @@ export class CommentsManager extends React.PureComponent
     .fail (xhr, status) =>
       return if status == 'abort'
 
-      osu.ajaxError xhr
+      onError xhr
 
 
   updateSort: (_event, {sort}) =>

--- a/resources/assets/lib/contest-entry/user-entry.coffee
+++ b/resources/assets/lib/contest-entry/user-entry.coffee
@@ -5,6 +5,7 @@ import TimeWithTooltip from 'components/time-with-tooltip'
 import { route } from 'laroute'
 import * as React from 'react'
 import { button, div, i } from 'react-dom-factories'
+import { onError } from 'utils/ajax'
 
 el = React.createElement
 
@@ -21,7 +22,7 @@ export class UserEntry extends React.Component
     .done (data) =>
       $.publish 'contest:entries:update', data: data
 
-    .fail osu.ajaxError
+    .fail onError
 
   render: ->
     div className: 'contest-userentry contest-userentry--ok',

--- a/resources/assets/lib/contest-voting/voter.coffee
+++ b/resources/assets/lib/contest-voting/voter.coffee
@@ -4,7 +4,8 @@
 import { route } from 'laroute'
 import core from 'osu-core-singleton'
 import * as React from 'react'
-import { div,a,i } from 'react-dom-factories'
+import { div, a, i } from 'react-dom-factories'
+import { onError } from 'utils/ajax'
 import { createClickCallback } from 'utils/html'
 
 el = React.createElement
@@ -23,7 +24,7 @@ export class Voter extends React.Component
     .done (response) =>
       $.publish 'contest:vote:done', response: response
 
-    .fail osu.ajaxError
+    .fail onError
 
     .always =>
       $.publish 'contest:vote:end'

--- a/resources/assets/lib/core-legacy/bbcode-preview.coffee
+++ b/resources/assets/lib/core-legacy/bbcode-preview.coffee
@@ -2,6 +2,7 @@
 # See the LICENCE file in the repository root for full licence text.
 
 import { route } from 'laroute'
+import { emitError } from 'utils/ajax'
 import { pageChange } from 'utils/page-change'
 
 export default class BbcodePreview
@@ -41,7 +42,7 @@ export default class BbcodePreview
       pageChange()
       @showPreview(e)
 
-    .fail osu.emitAjaxError(target)
+    .fail emitError(target)
 
 
   showPreview: (e) =>

--- a/resources/assets/lib/core-legacy/beatmap-pack.coffee
+++ b/resources/assets/lib/core-legacy/beatmap-pack.coffee
@@ -2,6 +2,7 @@
 # See the LICENCE file in the repository root for full licence text.
 
 import { route } from 'laroute'
+import { onError } from 'utils/ajax'
 
 export default class BeatmapPack
   @initialize: ->
@@ -44,7 +45,7 @@ export default class BeatmapPack
           @packBody.innerHTML = data
           @slideDown() if @isCurrent
 
-      .fail osu.ajaxError
+      .fail onError
 
       .always =>
         @busy = false

--- a/resources/assets/lib/core-legacy/form-error.coffee
+++ b/resources/assets/lib/core-legacy/form-error.coffee
@@ -1,6 +1,8 @@
 # Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 # See the LICENCE file in the repository root for full licence text.
 
+import { onError } from 'utils/ajax'
+
 export default class FormError
   constructor: ->
     $(document).on 'ajax:error', '.js-form-error', @showError
@@ -41,7 +43,7 @@ export default class FormError
   showError: (e, xhr) =>
     data = xhr.responseJSON?.form_error
 
-    return osu.ajaxError(xhr) if !data?
+    return onError(xhr) if !data?
 
     @setError e.target, @flattenData(data)
 

--- a/resources/assets/lib/core-legacy/forum-topic-title.coffee
+++ b/resources/assets/lib/core-legacy/forum-topic-title.coffee
@@ -1,6 +1,8 @@
 # Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 # See the LICENCE file in the repository root for full licence text.
 
+import { emitError } from 'utils/ajax'
+
 export default class ForumTopicTitle
   constructor: ->
     @input = document.getElementsByClassName('js-forum-topic-title--input')
@@ -66,4 +68,4 @@ export default class ForumTopicTitle
     .fail (xhr) =>
       input.disabled = false
       @saveButton[0].disabled = false
-      osu.emitAjaxError() xhr
+      emitError() xhr

--- a/resources/assets/lib/core-legacy/forum.coffee
+++ b/resources/assets/lib/core-legacy/forum.coffee
@@ -2,6 +2,7 @@
 # See the LICENCE file in the repository root for full licence text.
 
 import core from 'osu-core-singleton'
+import { onError } from 'utils/ajax'
 import { bottomPage, formatNumber, isInputElement } from 'utils/html'
 import { hideLoadingOverlay } from 'utils/loading-overlay'
 import { pageChange } from 'utils/page-change'
@@ -335,7 +336,7 @@ export default class Forum
       link.classList.remove 'js-disabled'
     .fail (xhr) =>
       link.dataset.failed = '1'
-      osu.ajaxError xhr
+      onError xhr
 
 
   jumpToSubmit: (e) =>

--- a/resources/assets/lib/core-legacy/store-checkout.coffee
+++ b/resources/assets/lib/core-legacy/store-checkout.coffee
@@ -6,6 +6,7 @@
 import { route } from 'laroute'
 import { StorePaypal } from 'store-paypal'
 import { StoreXsolla } from 'store-xsolla'
+import { onError } from 'utils/ajax'
 import { hideLoadingOverlay, showLoadingOverlay } from 'utils/loading-overlay'
 
 export class StoreCheckout
@@ -66,4 +67,4 @@ export class StoreCheckout
 
     # TODO: less unknown error, disable button
     # TODO: handle error.message
-    osu.ajaxError(error?.xhr)
+    onError(error?.xhr)

--- a/resources/assets/lib/utils/ajax.ts
+++ b/resources/assets/lib/utils/ajax.ts
@@ -6,6 +6,10 @@ import { createClickCallback } from 'utils/html';
 
 const jqXHRProperties = ['status', 'statusText', 'readyState', 'responseText'];
 
+export function emitError(element: HTMLElement = document.body) {
+  return (xhr: JQuery.jqXHR, status: string, errorThrown: unknown) => $(element).trigger('ajax:error', [xhr, status, errorThrown]);
+}
+
 export const error = (xhr: JQuery.jqXHR, status: string, callback?: () => void) => {
   if (status === 'abort') return;
   if (core.userLogin.showOnError(xhr, callback)) return;


### PR DESCRIPTION
Use the typescript version in `ajax.onError` instead.
Convert `emitAjaxError` to typescript.


`xhrErrorMessage` to be done separately due to being a bit less straight forward with the typings