### PR TITLE
Mark recent_messages as deprecated

### DIFF
--- a/app/Http/Controllers/Chat/ChannelsController.php
+++ b/app/Http/Controllers/Chat/ChannelsController.php
@@ -282,6 +282,7 @@ class ChannelsController extends Controller
         }
 
         if (isset($channel)) {
+            // TODO: recent_messages deprecated.
             return json_item($channel, ChannelTransformer::forUser($sender), ['recent_messages.sender']);
         } else {
             abort(422, 'unknown or missing type parameter');

--- a/app/Transformers/Chat/ChannelTransformer.php
+++ b/app/Transformers/Chat/ChannelTransformer.php
@@ -25,8 +25,8 @@ class ChannelTransformer extends TransformerAbstract
     protected $availableIncludes = [
         'current_user_attributes',
         'last_message_id',
-        'last_read_id', // deprecated
-        'recent_messages',
+        'last_read_id', // TODO: deprecated
+        'recent_messages', // TODO: deprecated
         'users',
     ];
 

--- a/resources/views/docs/_structures/chat_channel.md
+++ b/resources/views/docs/_structures/chat_channel.md
@@ -34,7 +34,7 @@ icon*                   | string                                           | dis
 type                    | string                                           | see channel types below
 last_read_id*           | number?                                          | Deprecated; use `current_user_attributes.last_read_id`.
 last_message_id*        | number?                                          | `message_id` of last known message (only returned in presence responses)
-recent_messages         | ChatMessage[]?                                   | up to 50 most recent messages
+recent_messages         | ChatMessage[]?                                   | Deprecated; up to 50 most recent messages
 moderated*              | boolean                                          | user can't send message when the value is `true` (only returned in presence responses)
 users*                  | number[]?                                        | array of `user_id` that are in the channel (not included for `PUBLIC` channels)
 

--- a/resources/views/docs/info.blade.php
+++ b/resources/views/docs/info.blade.php
@@ -26,7 +26,7 @@ For a full list of changes, see the
 ## Breaking Changes
 
 ### 2022-11-11
-- `recent_messages` in [ChatChannel](#chatchannel) has been deprecated, it will be removed from [Create Channel] (#create-channel) response in the near future.
+- `recent_messages` in [ChatChannel](#chatchannel) has been deprecated, it will be removed from [Create Channel](#create-channel) response in the near future.
 
 ### 2022-09-27
 - `user` include in [Get User Scores](#get-user-scores) response has been deprecated, it will be removed in the near future.

--- a/resources/views/docs/info.blade.php
+++ b/resources/views/docs/info.blade.php
@@ -25,6 +25,9 @@ For a full list of changes, see the
 
 ## Breaking Changes
 
+### 2022-11-11
+- `recent_messages` in [ChatChannel](#chatchannel) has been deprecated, it will be removed from [Create Channel] (#create-channel) response in the near future.
+
 ### 2022-09-27
 - `user` include in [Get User Scores](#get-user-scores) response has been deprecated, it will be removed in the near future.
 


### PR DESCRIPTION
This was deprecated long ago; osu-web doesn't use it (it's not even in `ChannelJson`) and only kept around for compatibility with https://github.com/ppy/osu/blob/4bc26dbb487241e2bbae73751dbe9e93a4e427da/osu.Game/Online/API/Requests/Responses/APIChatChannel.cs#L17-L18 having a reference to it