### PR TITLE
Hot fix solo scores leaderboard when extra scores need to be fetched

### DIFF
--- a/app/Libraries/Elasticsearch/Search.php
+++ b/app/Libraries/Elasticsearch/Search.php
@@ -128,6 +128,7 @@ abstract class Search extends HasSearch implements Queryable
 
     public function getSortCursor(): ?array
     {
+        // FIXME: should cast cursor values to match sort.
         $requested = $this->params->size;
         $received = $this->response()->count();
         $total = $this->response()->total();

--- a/app/Libraries/Score/FetchDedupedScores.php
+++ b/app/Libraries/Score/FetchDedupedScores.php
@@ -31,6 +31,8 @@ class FetchDedupedScores
 
         while ($hasNext) {
             if ($nextCursor !== null) {
+                // FIXME: cursor value returned is 0/1 but elasticsearch expects false/true...
+                $nextCursor['is_legacy'] = get_bool($nextCursor['is_legacy']);
                 $search->searchAfter(array_values($nextCursor));
             }
             $search->response();


### PR DESCRIPTION
Change in #9527 means getting extra scores for deduping needs passing in a extra param in the cursor which is expected to be boolean by the value returned for the cursor is an integer....

Currently the part handling the cursor doesn't have enough info about the parameter to perform any casting.