### PR TITLE
Add missing export for type definition

### DIFF
--- a/resources/assets/lib/utils/lang.ts
+++ b/resources/assets/lib/utils/lang.ts
@@ -6,7 +6,7 @@ import { formatNumber } from 'utils/html';
 import { present } from 'utils/string';
 
 type Replacement = string | number;
-type Replacements = Partial<Record<string, Replacement>>;
+export type Replacements = Partial<Record<string, Replacement>>;
 
 export function trans(key: string, replacements: Replacements = {}, locale?: string) {
   if (!transExists(key, locale)) {


### PR DESCRIPTION
The `lang.d.ts` definition needs the type to be exported from `lang.ts` otherwise it'll treat it as `any` (but doesn't trigger any errors).