### PR TITLE
Add elasticsearch health check and replace `--wait` flag usage in `docker-compose` flow

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -57,8 +57,10 @@ services:
   notification-server:
     image: pppy/osu-notification-server
     depends_on:
-      - redis
-      - db
+      redis:
+        condition: service_healthy
+      db:
+        condition: service_healthy
     volumes:
       - .env:/app/.env
       - ./storage/oauth-public.key:/app/oauth-public.key
@@ -68,8 +70,10 @@ services:
   notification-server-dusk:
     image: pppy/osu-notification-server
     depends_on:
-      - redis
-      - db
+      redis:
+        condition: service_healthy
+      db:
+        condition: service_healthy
     volumes:
       - .env.dusk.local:/app/.env
       - ./storage/oauth-public.key:/app/oauth-public.key
@@ -93,13 +97,18 @@ services:
       # see https://github.com/docker-library/mysql/issues/663
       test: ["CMD", "mysqladmin", "ping", "-h", "127.0.0.1"]
       interval: 1s
-      timeout: 20s
-      retries: 10
+      timeout: 60s
+      start_period: 60s
 
   redis:
     image: redis:latest
     ports:
       - "${REDIS_EXTERNAL_PORT:-6379}:6379"
+    healthcheck:
+      test: ["CMD", "redis-cli", "--raw", "incr", "ping"]
+      interval: 1s
+      timeout: 60s
+      start_period: 60s
 
   elasticsearch:
     # Version must be kept up to date with library defined in: composer.json
@@ -110,6 +119,11 @@ services:
       action.auto_create_index: "false"
       discovery.type: single-node
       ES_JAVA_OPTS: "-Xms512m -Xmx512m" # less OOM on default settings.
+    healthcheck:
+      test: curl -s http://localhost:9200 >/dev/null || exit 1
+      interval: 1s
+      timeout: 60s
+      start_period: 60s
 
   nginx:
     image: nginx:latest
@@ -125,11 +139,14 @@ services:
 
   score-indexer:
     image: pppy/osu-elastic-indexer
-    command: ["queue", "--force-version", "--wait"]
+    command: ["queue", "--force-version"]
     depends_on:
-      - db
-      - elasticsearch
-      - redis
+      redis:
+        condition: service_healthy
+      db:
+        condition: service_healthy
+      elasticsearch:
+        condition: service_healthy
     environment:
       <<: *x-env
       SCHEMA: "${SCHEMA:-1}"


### PR DESCRIPTION
I have a hope of removing the `--wait` parameter from the `queue` command exposed by `osu-elastic-indexer`, but in order to remove it we need to make sure that it can be replaced with docker compose health checks.

This is the first step in ensuring that's feasible. Of note, the parameter is still being used in the github actions flow. A next step would be to change github actions to consume this compose flow instead of doing its own thing.

Local testing shows that startup order does seem to be respected. Would appreciate a second test.