### PR TITLE
Add medal unlock components

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -81,3 +81,6 @@ composer-installer
 /bootstrap/cache/
 /storage/htmlpurifier/
 /storage/paypal_auth.cache
+
+# Closed-source components
+/hush-hush-medals/

--- a/app/Http/Controllers/InterOp/UsersController.php
+++ b/app/Http/Controllers/InterOp/UsersController.php
@@ -7,37 +7,24 @@ namespace App\Http\Controllers\InterOp;
 
 use App\Exceptions\ValidationException;
 use App\Http\Controllers\Controller;
-use App\Jobs\Notifications\UserAchievementUnlock;
 use App\Libraries\UserRegistration;
-use App\Models\Achievement;
-use App\Models\Event;
+use App\Models\Beatmap;
 use App\Models\User;
+use App\Models\UserAchievement;
 use App\Transformers\CurrentUserTransformer;
-use Exception;
 
 class UsersController extends Controller
 {
     public function achievement($id, $achievementId, $beatmapId = null)
     {
-        $user = User::findOrFail($id);
-        $achievement = Achievement::findOrFail($achievementId);
+        $achievement = app('medals')->byIdOrFail($achievementId);
+        $unlocked = UserAchievement::unlock(
+            User::findOrFail($id),
+            $achievement,
+            Beatmap::find($beatmapId),
+        );
 
-        try {
-            $userAchievement = $user->userAchievements()->create([
-                'achievement_id' => $achievement->getKey(),
-                'beatmap_id' => $beatmapId,
-            ]);
-        } catch (Exception $e) {
-            if (is_sql_unique_exception($e)) {
-                return error_popup('user already unlocked the specified achievement');
-            }
-
-            throw $e;
-        }
-
-        Event::generate('achievement', compact('achievement', 'user'));
-
-        (new UserAchievementUnlock($achievement, $user))->dispatch();
+        abort_unless($unlocked, 422, 'user already unlocked the specified achievement');
 
         return $achievement->getKey();
     }

--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -14,7 +14,6 @@ use App\Libraries\Search\ForumSearch;
 use App\Libraries\Search\ForumSearchRequestParams;
 use App\Libraries\User\FindForProfilePage;
 use App\Libraries\UserRegistration;
-use App\Models\Achievement;
 use App\Models\Beatmap;
 use App\Models\BeatmapDiscussion;
 use App\Models\Country;
@@ -629,14 +628,7 @@ class UsersController extends Controller
         if (is_api_request()) {
             return $userArray;
         } else {
-            $achievements = json_collection(
-                Achievement::achievable()
-                    ->orderBy('grouping')
-                    ->orderBy('ordering')
-                    ->orderBy('progression')
-                    ->get(),
-                'Achievement'
-            );
+            $achievements = json_collection(app('medals')->all(), 'Achievement');
 
             $extras = [];
 

--- a/app/Libraries/MedalUnlockHelpers.php
+++ b/app/Libraries/MedalUnlockHelpers.php
@@ -1,0 +1,89 @@
+<?php
+
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
+declare(strict_types=1);
+
+namespace App\Libraries;
+
+use App\Listeners\MedalUnlocks\MedalUnlock;
+use Illuminate\Support\Facades\Queue;
+use ReflectionClass;
+use ReflectionException;
+use ReflectionNamedType;
+use ReflectionUnionType;
+use Symfony\Component\Finder\Finder;
+
+class MedalUnlockHelpers
+{
+    public static function discoverMedalUnlocks(): array
+    {
+        $dirs = array_filter([
+            app_path('Listeners/MedalUnlocks'),
+            base_path('hush-hush-medals/src'),
+        ], 'is_dir');
+        $files = (new Finder())->files()->name('*.php')->in($dirs);
+
+        $discoveredEvents = [];
+
+        foreach ($files as $file) {
+            $medalUnlockClass = substr($file->getRealPath(), 0, -4); // Remove ".php"
+            $medalUnlockClass = str_replace_first(app_path(), 'App', $medalUnlockClass);
+            $medalUnlockClass = str_replace_first(
+                base_path('hush-hush-medals'.DIRECTORY_SEPARATOR.'src'),
+                'App\\Listeners\\MedalUnlocks\\HushHush',
+                $medalUnlockClass,
+            );
+            $medalUnlockClass = str_replace(DIRECTORY_SEPARATOR, '\\', $medalUnlockClass);
+
+            try {
+                $medalUnlock = new ReflectionClass($medalUnlockClass);
+            } catch (ReflectionException) {
+                continue;
+            }
+
+            if (
+                !$medalUnlock->isInstantiable() ||
+                !$medalUnlock->isSubclassOf(MedalUnlock::class) ||
+                !$medalUnlock->hasProperty('event')
+            ) {
+                continue;
+            }
+
+            $eventPropertyType = $medalUnlock->getProperty('event')->getType();
+            $eventPropertyTypes = array_filter(
+                match (true) {
+                    $eventPropertyType instanceof ReflectionNamedType => [$eventPropertyType],
+                    $eventPropertyType instanceof ReflectionUnionType => $eventPropertyType->getTypes(),
+                    default => [],
+                },
+                fn (ReflectionNamedType $type) => !$type->isBuiltin(),
+            );
+
+            foreach ($eventPropertyTypes as $type) {
+                $typeName = $type->getName();
+                $discoveredEvents[$typeName] ??= [];
+                $discoveredEvents[$typeName][] = "{$medalUnlock->name}@handle";
+            }
+        }
+
+        return $discoveredEvents;
+    }
+
+    public static function registerQueueCreatePayloadHook(): void
+    {
+        Queue::createPayloadUsing(function ($connection, $queue, array $payload) {
+            $medalUnlock = $payload['displayName'];
+
+            if (str_starts_with($medalUnlock, get_class_namespace(MedalUnlock::class))) {
+                return ['data' => array_merge(
+                    $payload['data'],
+                    ['state' => $medalUnlock::getQueueableState()],
+                )];
+            }
+
+            return [];
+        });
+    }
+}

--- a/app/Libraries/Medals.php
+++ b/app/Libraries/Medals.php
@@ -1,0 +1,102 @@
+<?php
+
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
+declare(strict_types=1);
+
+namespace App\Libraries;
+
+use App\Models\Achievement;
+use App\Traits\LocallyCached;
+use Illuminate\Database\Eloquent\Collection;
+use Illuminate\Database\Eloquent\ModelNotFoundException;
+
+class Medals
+{
+    use LocallyCached;
+
+    /**
+     * Get all enabled medals.
+     */
+    public function all(): Collection
+    {
+        return $this->memoize(__FUNCTION__, function () {
+            return $this
+                ->allIncludeDisabled()
+                // From `Achievement::scopeAchievable()`
+                ->where('enabled', true)
+                ->where('slug', '<>', '');
+        });
+    }
+
+    /**
+     * Get all enabled medals keyed by ID.
+     */
+    public function allById(): Collection
+    {
+        return $this->memoize(__FUNCTION__, fn () => $this->all()->keyBy('achievement_id'));
+    }
+
+    /**
+     * Get all enabled medals keyed by slug.
+     */
+    public function allBySlug(): Collection
+    {
+        return $this->memoize(__FUNCTION__, fn () => $this->all()->keyBy('slug'));
+    }
+
+    /**
+     * Get an enabled medal by its ID.
+     */
+    public function byId(int|string|null $id): ?Achievement
+    {
+        return $this->allById()->get($id);
+    }
+
+    /**
+     * Get an enabled medal by its ID or throw an exception.
+     *
+     * @throws ModelNotFoundException
+     */
+    public function byIdOrFail(int|string|null $id): Achievement
+    {
+        return $this->byId($id)
+            ?? throw (new ModelNotFoundException())->setModel(Achievement::class, (int) $id);
+    }
+
+    /**
+     * Get a medal by its name.
+     */
+    public function byNameIncludeDisabled(string $name): ?Achievement
+    {
+        return $this->allByNameIncludeDisabled()->get($name);
+    }
+
+    /**
+     * Get an enabled medal by its slug.
+     */
+    public function bySlug(string $slug): ?Achievement
+    {
+        return $this->allBySlug()->get($slug);
+    }
+
+    private function allByNameIncludeDisabled(): Collection
+    {
+        return $this->memoize(
+            __FUNCTION__,
+            fn () => $this->allIncludeDisabled()->keyBy('name'),
+        );
+    }
+
+    private function allIncludeDisabled(): Collection
+    {
+        return $this->cachedMemoize(__FUNCTION__, function () {
+            return Achievement
+                ::orderBy('grouping')
+                ->orderBy('ordering')
+                ->orderBy('progression')
+                ->get();
+        });
+    }
+}

--- a/app/Listeners/MedalUnlocks/MedalUnlock.php
+++ b/app/Listeners/MedalUnlocks/MedalUnlock.php
@@ -1,0 +1,126 @@
+<?php
+
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
+declare(strict_types=1);
+
+namespace App\Listeners\MedalUnlocks;
+
+use App\Models\Achievement;
+use App\Models\Beatmap;
+use App\Models\User;
+use App\Models\UserAchievement;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Queue\InteractsWithQueue;
+use Illuminate\Support\Collection;
+use Illuminate\Support\Facades\DB;
+
+/**
+ * Listener for the unlock conditions of a medal.
+ *
+ * In subclasses of this type, declare an `$event` property with the types of
+ * events the unlock should listen for.
+ */
+abstract class MedalUnlock implements ShouldQueue
+{
+    use InteractsWithQueue;
+
+    public bool $afterCommit = true;
+
+    /**
+     * State recorded at queue time.
+     */
+    protected mixed $state;
+
+    /**
+     * Get the medal's slug.
+     */
+    abstract public static function getMedalSlug(): string;
+
+    /**
+     * Get additional state at queue time that should be made available at
+     * `$this->state` when handling.
+     */
+    public static function getQueueableState(): mixed
+    {
+        return null;
+    }
+
+    private static function getMedal(): ?Achievement
+    {
+        return app('medals')->bySlug(static::getMedalSlug());
+    }
+
+    /**
+     * Get the users that may be able to unlock the medal.
+     */
+    abstract protected function getApplicableUsers(): Collection|User|array;
+
+    /**
+     * Test whether this unlock should be queued for handling.
+     */
+    abstract protected function shouldHandle(): bool;
+
+    /**
+     * Test whether the given user meets the unlock conditions for the medal.
+     *
+     * This is also an appropriate time to store tracking information about
+     * the user's progress on the medal unlock, if necessary.
+     */
+    abstract protected function shouldUnlockForUser(User $user): bool;
+
+    final public function handle(object $event): void
+    {
+        if (($medal = static::getMedal()) === null) {
+            return;
+        }
+
+        $this->event = $event;
+        $this->state = $this->job->payload()['data']['state'];
+
+        $users = Collection::wrap($this->getApplicableUsers())
+            ->unique('user_id')
+            ->filter(
+                fn (User $user) =>
+                    $user
+                        ->userAchievements()
+                        ->where('achievement_id', $medal->getKey())
+                        ->doesntExist() &&
+                    $this->shouldUnlockForUser($user),
+            );
+
+        if ($users->isEmpty()) {
+            return;
+        }
+
+        DB::transaction(function () use ($medal, $users) {
+            foreach ($users as $user) {
+                UserAchievement::unlock(
+                    $user,
+                    $medal,
+                    $this->getBeatmapForUser($user),
+                );
+            }
+        });
+    }
+
+    final public function shouldQueue(object $event): bool
+    {
+        if (static::getMedal() === null) {
+            return false;
+        }
+
+        $this->event = $event;
+
+        return $this->shouldHandle();
+    }
+
+    /**
+     * Get the beatmap associated with this medal unlock for the given user.
+     */
+    protected function getBeatmapForUser(User $user): ?Beatmap
+    {
+        return null;
+    }
+}

--- a/app/Models/Event.php
+++ b/app/Models/Event.php
@@ -256,7 +256,7 @@ class Event extends Model
 
     public function parseMatchesAchievement($matches)
     {
-        $achievement = Achievement::where(['name' => $matches['achievementName']])->first();
+        $achievement = app('medals')->byNameIncludeDisabled($matches['achievementName']);
         if ($achievement === null) {
             return $this->parseFailure("unknown achievement ({$matches['achievementName']})");
         }

--- a/app/Models/UserAchievement.php
+++ b/app/Models/UserAchievement.php
@@ -5,11 +5,16 @@
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
 /**
- * @property Achievement $achievement
+ * @property-read Achievement $achievement
  * @property int $achievement_id
+ * @property-read Beatmap|null $beatmap
+ * @property int|null $beatmap_id
  * @property \Carbon\Carbon $date
- * @property User $user
+ * @property-read string $date_json
+ * @property-read User $user
  * @property int $user_id
  */
 class UserAchievement extends Model
@@ -22,14 +27,19 @@ class UserAchievement extends Model
     protected $primaryKeys = ['user_id', 'achievement_id'];
     protected $table = 'osu_user_achievements';
 
-    public function user()
-    {
-        return $this->belongsTo(User::class, 'user_id');
-    }
-
-    public function achievement()
+    public function achievement(): BelongsTo
     {
         return $this->belongsTo(Achievement::class, 'achievement_id');
+    }
+
+    public function beatmap(): BelongsTo
+    {
+        return $this->belongsTo(Beatmap::class, 'beatmap_id');
+    }
+
+    public function user(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'user_id');
     }
 
     public function getAttribute($key)
@@ -44,6 +54,7 @@ class UserAchievement extends Model
             'date_json' => $this->getJsonTimeFast($key),
 
             'achievement',
+            'beatmap',
             'user' => $this->getRelationValue($key),
         };
     }

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -12,6 +12,7 @@ use App\Libraries\ChatFilters;
 use App\Libraries\CleanHTML;
 use App\Libraries\Groups;
 use App\Libraries\LayoutCache;
+use App\Libraries\Medals;
 use App\Libraries\Mods;
 use App\Libraries\MorphMap;
 use App\Libraries\OsuAuthorize;
@@ -40,6 +41,7 @@ class AppServiceProvider extends ServiceProvider
         'clean-html' => CleanHTML::class,
         'groups' => Groups::class,
         'layout-cache' => LayoutCache::class,
+        'medals' => Medals::class,
         'mods' => Mods::class,
         'route-section' => RouteSection::class,
         'score-pins' => ScorePins::class,
@@ -62,6 +64,7 @@ class AppServiceProvider extends ServiceProvider
             app('OsuAuthorize')->resetCache();
             app('groups')->incrementResetTicker();
             app('chat-filters')->incrementResetTicker();
+            app('medals')->incrementResetTicker();
 
             Datadog::increment(
                 config('datadog-helper.prefix_web').'.queue.run',

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -13,6 +13,7 @@ use App\Libraries\CleanHTML;
 use App\Libraries\Groups;
 use App\Libraries\LayoutCache;
 use App\Libraries\Medals;
+use App\Libraries\MedalUnlockHelpers;
 use App\Libraries\Mods;
 use App\Libraries\MorphMap;
 use App\Libraries\OsuAuthorize;
@@ -75,6 +76,8 @@ class AppServiceProvider extends ServiceProvider
                 ]
             );
         });
+
+        MedalUnlockHelpers::registerQueueCreatePayloadHook();
 
         $this->app->make('translator')->setSelector(new OsuMessageSelector());
 

--- a/app/Providers/EventServiceProvider.php
+++ b/app/Providers/EventServiceProvider.php
@@ -5,6 +5,7 @@
 
 namespace App\Providers;
 
+use App\Libraries\MedalUnlockHelpers;
 use App\Listeners;
 use Illuminate\Foundation\Support\Providers\EventServiceProvider as ServiceProvider;
 
@@ -23,4 +24,9 @@ class EventServiceProvider extends ServiceProvider
         Listeners\Fulfillments\PaymentSubscribers::class,
         Listeners\Fulfillments\ValidationSubscribers::class,
     ];
+
+    protected function discoveredEvents(): array
+    {
+        return MedalUnlockHelpers::discoverMedalUnlocks();
+    }
 }

--- a/composer.json
+++ b/composer.json
@@ -60,13 +60,15 @@
   "autoload": {
     "psr-4": {
       "App\\": "app/",
+      "App\\Listeners\\MedalUnlocks\\HushHush\\": "hush-hush-medals/src/",
       "Database\\Factories\\": "database/factories/",
       "Database\\Seeders\\": "database/seeders/"
     }
   },
   "autoload-dev": {
     "psr-4": {
-      "Tests\\": "tests/"
+      "Tests\\": "tests/",
+      "Tests\\MedalUnlocks\\HushHush\\": "hush-hush-medals/tests/"
     }
   },
   "scripts": {

--- a/database/factories/AchievementFactory.php
+++ b/database/factories/AchievementFactory.php
@@ -28,6 +28,11 @@ class AchievementFactory extends Factory
 
     protected $model = Achievement::class;
 
+    public function configure(): static
+    {
+        return $this->afterCreating(fn () => app('medals')->resetCache());
+    }
+
     public function definition(): array
     {
         return [

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -59,6 +59,8 @@
           <element key="app" value="App"/>
           <element key="database/factories" value="Database\Factories"/>
           <element key="database/seeders" value="Database\Seeders"/>
+          <element key="hush-hush-medals/src" value="App\Listeners\MedalUnlocks\HushHush"/>
+          <element key="hush-hush-medals/tests" value="Tests\MedalUnlocks\HushHush"/>
           <element key="tests" value="Tests"/>
         </property>
       </properties>

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -3,11 +3,15 @@
          xsi:noNamespaceSchemaLocation="./vendor/phpunit/phpunit/phpunit.xsd"
          bootstrap="vendor/autoload.php"
          colors="true"
+         defaultTestSuite="app"
 >
     <testsuites>
-        <testsuite name="Application Test Suite">
+        <testsuite name="app">
             <directory suffix="Test.php">./tests/</directory>
             <exclude>./tests/Browser</exclude>
+        </testsuite>
+        <testsuite name="hush-hush-medals">
+            <directory suffix="Test.php">./hush-hush-medals/tests/</directory>
         </testsuite>
     </testsuites>
     <php>

--- a/tests/MedalUnlocks/MedalUnlockTestCase.php
+++ b/tests/MedalUnlocks/MedalUnlockTestCase.php
@@ -1,0 +1,129 @@
+<?php
+
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
+declare(strict_types=1);
+
+namespace Tests\MedalUnlocks;
+
+use App\Models\Achievement;
+use App\Models\Beatmap;
+use App\Models\User;
+use Illuminate\Events\CallQueuedListener;
+use Illuminate\Queue\QueueManager;
+use Illuminate\Support\Facades\Queue;
+use Illuminate\Support\Testing\Fakes\QueueFake;
+use Tests\TestCase;
+
+abstract class MedalUnlockTestCase extends TestCase
+{
+    /**
+     * The medal to test.
+     */
+    protected Achievement $medal;
+
+    /**
+     * The user that may unlock the medal.
+     */
+    protected User $user;
+
+    private QueueFake $queueFake;
+    private QueueManager $queueReal;
+
+    /**
+     * Get the medal unlock class to test.
+     */
+    abstract protected static function getMedalUnlockClass(): string;
+
+    /**
+     * Assert that the user has unlocked the medal.
+     */
+    protected function assertMedalUnlocked(bool $unlocked = true): void
+    {
+        $this->handleQueuedMedalUnlocks();
+
+        $this->assertSame(
+            $unlocked,
+            $this->user
+                ->userAchievements()
+                ->where('achievement_id', $this->medal->getKey())
+                ->exists(),
+        );
+    }
+
+    /**
+     * Assert that the user has unlocked the medal, and that the unlock is
+     * associated with the given beatmap.
+     */
+    protected function assertMedalUnlockedWithBeatmap(?Beatmap $beatmap): void
+    {
+        $this->handleQueuedMedalUnlocks();
+
+        $medal = $this->user
+            ->userAchievements()
+            ->where('achievement_id', $this->medal->getKey())
+            ->first();
+
+        $this->assertNotNull($medal);
+        $this->assertSame($beatmap?->getKey(), $medal->beatmap_id);
+    }
+
+    /**
+     * Assert that the medal unlock has been queued for handling.
+     */
+    protected function assertMedalUnlockQueued(bool $queued = true): void
+    {
+        $method = $queued ? 'assertPushed' : 'assertNotPushed';
+
+        Queue::$method(CallQueuedListener::class, function (CallQueuedListener $job) {
+            return $job->class === static::getMedalUnlockClass();
+        });
+    }
+
+    /**
+     * Reset the user's medal unlock.
+     */
+    protected function resetMedalProgress(): void
+    {
+        $this->invokeSetProperty(app('queue'), 'jobs', []);
+
+        $this->user
+            ->userAchievements()
+            ->where('achievement_id', $this->medal->getKey())
+            ->delete();
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        $this->queueReal = Queue::getFacadeRoot();
+        $this->queueFake = Queue::fake();
+
+        $this->medal = Achievement::factory()->create([
+            'slug' => static::getMedalUnlockClass()::getMedalSlug(),
+        ]);
+        $this->user = User::factory()->create();
+    }
+
+    private function handleQueuedMedalUnlocks(): void
+    {
+        $listenerJobs = Queue::pushedJobs()[CallQueuedListener::class] ?? [];
+
+        if (empty($listenerJobs)) {
+            return;
+        }
+
+        Queue::swap($this->queueReal);
+
+        foreach ($listenerJobs as $job) {
+            if ($job['job']->class === static::getMedalUnlockClass()) {
+                dispatch_sync($job['job']);
+            }
+        }
+
+        Queue::swap($this->queueFake);
+        $this->invokeSetProperty(app('queue'), 'jobs', []);
+    }
+}


### PR DESCRIPTION
- [ ] depends on #9610

this is a proposal for an interface to award medals from osu-web

each medal is a queueable event listener that extends `MedalUnlock`. basic flow is
- `$event` type-hints the events it will listen for
- `shouldHandle()` tests whether the received event is actually relevant to the medal unlock -- checks in here should be inexpensive bc it runs synchronously after the event is dispatched. if true, the handler will be queued as a job
- `getApplicableUsers()` gets the users that may unlock the medal, based on the event and any info saved at queue time (`getQueueableState()`)
- `shouldUnlockForUser()` tests whether a user will unlock the medal, if they didn't have it already

medal unlocks won't run without a corresponding entry in `osu_achievements` where `enabled`=1, so it's safe to either add the implementation before the db entry, or add a disabled db entry first and enable it after implementation.

the event-driven design is partly so medal logic is in one place, and partly so hush-hush medals can be easily dropped in from a closed-source repo and Just Work:tm:. kind of over-engineered lol but it should be easy to make lots of different kinds of medals with this. I have some random example medals & tests at https://github.com/cl8n/osu-web/tree/medal-examples and https://github.com/cl8n/osu-web-hush-hush-medals