### PR TITLE
Prevent incorrect error on simultaneous first wiki image request

### DIFF
--- a/app/Models/Wiki/Image.php
+++ b/app/Models/Wiki/Image.php
@@ -8,6 +8,7 @@ namespace App\Models\Wiki;
 use App\Exceptions\GitHubNotFoundException;
 use App\Libraries\OsuWiki;
 use Exception;
+use Illuminate\Contracts\Cache\LockTimeoutException;
 
 class Image implements WikiObject
 {
@@ -37,7 +38,7 @@ class Image implements WikiObject
     public function __construct($path)
     {
         $this->path = OsuWiki::cleanPath($path);
-        $this->cache = cache()->get($this->cacheKey());
+        $this->cache = $this->fetchFromCache();
     }
 
     public function cacheKey()
@@ -67,10 +68,23 @@ class Image implements WikiObject
             return $this;
         }
 
-        $lock = cache()->lock($this->cacheKey().':lock', 300);
+        $cache = cache();
+        $lock = $cache->lock($this->cacheKey().':lock', 300);
 
         if (!$lock->get()) {
-            return $this;
+            if ($this->cache !== null) {
+                return $this;
+            }
+
+            try {
+                $lock->block(10);
+                $lock->release();
+                $this->cache = $this->fetchFromCache();
+
+                return $this->sync($force);
+            } catch (LockTimeoutException $_e) {
+                // previous attempt is taking too long; try fetching the image anyway
+            }
         }
 
         try {
@@ -94,8 +108,13 @@ class Image implements WikiObject
             'data' => $data ?? null,
             'cached_at' => time(),
         ];
-        cache()->put($this->cacheKey(), $this->cache);
+        $cache->put($this->cacheKey(), $this->cache);
 
         return $this;
+    }
+
+    private function fetchFromCache(): ?array
+    {
+        return cache()->get($this->cacheKey());
     }
 }

--- a/app/Models/Wiki/Image.php
+++ b/app/Models/Wiki/Image.php
@@ -99,10 +99,9 @@ class Image implements WikiObject
             // do nothing and cache empty data
         } catch (Exception $e) {
             log_error($e);
+            $lock->release();
 
             return $this;
-        } finally {
-            $lock->release();
         }
 
         $this->cache = [
@@ -110,6 +109,7 @@ class Image implements WikiObject
             'cached_at' => time(),
         ];
         $cache->put($cacheKey, $this->cache);
+        $lock->release();
 
         return $this;
     }

--- a/app/Models/Wiki/Image.php
+++ b/app/Models/Wiki/Image.php
@@ -69,7 +69,8 @@ class Image implements WikiObject
         }
 
         $cache = cache();
-        $lock = $cache->lock($this->cacheKey().':lock', 300);
+        $cacheKey = $this->cacheKey();
+        $lock = $cache->lock($cacheKey.':lock', 300);
 
         if (!$lock->get()) {
             if ($this->cache !== null) {
@@ -108,7 +109,7 @@ class Image implements WikiObject
             'data' => $data ?? null,
             'cached_at' => time(),
         ];
-        $cache->put($this->cacheKey(), $this->cache);
+        $cache->put($cacheKey, $this->cache);
 
         return $this;
     }

--- a/app/Models/Wiki/Image.php
+++ b/app/Models/Wiki/Image.php
@@ -104,12 +104,15 @@ class Image implements WikiObject
             return $this;
         }
 
-        $this->cache = [
-            'data' => $data ?? null,
-            'cached_at' => time(),
-        ];
-        $cache->put($cacheKey, $this->cache);
-        $lock->release();
+        try {
+            $this->cache = [
+                'data' => $data ?? null,
+                'cached_at' => time(),
+            ];
+            $cache->put($cacheKey, $this->cache);
+        } finally {
+            $lock->release();
+        }
 
         return $this;
     }


### PR DESCRIPTION
Wait up to 10 seconds on first image load if other worker is already doing it and holding the lock.