### PR TITLE
Add support for hiding supporter event on own recent activity

### DIFF
--- a/app/Libraries/Fulfillments/SupporterTagFulfillment.php
+++ b/app/Libraries/Fulfillments/SupporterTagFulfillment.php
@@ -85,10 +85,12 @@ class SupporterTagFulfillment extends OrderFulfiller
 
         $isGift = count($gifts) !== 0;
 
-        Event::generate(
-            $this->continued ? 'userSupportAgain' : 'userSupportFirst',
-            ['user' => $donor, 'date' => $this->order->paid_at]
-        );
+        if ($items->contains(fn (OrderItem $item) => !$item->extra_data->hidden)) {
+            Event::generate(
+                $this->continued ? 'userSupportAgain' : 'userSupportFirst',
+                ['user' => $donor, 'date' => $this->order->paid_at]
+            );
+        }
 
         if (present($donor->user_email)) {
             Mail::to($donor)

--- a/app/Models/Store/ExtraDataSupporterTag.php
+++ b/app/Models/Store/ExtraDataSupporterTag.php
@@ -14,12 +14,14 @@ class ExtraDataSupporterTag extends ExtraDataBase implements JsonSerializable
     const TYPE = 'supporter-tag';
 
     public int $duration;
+    public bool $hidden;
     public int $targetId;
     public string $username;
 
     public function __construct(array $data)
     {
         $this->duration = get_int($data['duration']);
+        $this->hidden = $data['hidden'] ?? false;
         $this->targetId = get_int($data['target_id']);
         $this->username = $data['username'];
     }
@@ -28,6 +30,7 @@ class ExtraDataSupporterTag extends ExtraDataBase implements JsonSerializable
     {
         return array_merge(parent::jsonSerialize(), [
             'duration' => $this->duration,
+            'hidden' => $this->hidden,
             'target_id' => $this->targetId,
             'username' => $this->username,
         ]);

--- a/app/Models/Store/Order.php
+++ b/app/Models/Store/Order.php
@@ -706,6 +706,7 @@ class Order extends Model
     private function extraDataSupporterTag(array $orderItemParams)
     {
         $params = get_params($orderItemParams, 'extra_data', [
+            'hidden:bool',
             'target_id:int',
         ]);
 

--- a/resources/assets/less/bem/store-supporter-tag.less
+++ b/resources/assets/less/bem/store-supporter-tag.less
@@ -13,6 +13,17 @@
     width: 100%;
   }
 
+  &__options {
+    .center-content();
+    display: flex;
+    padding: 5px;
+  }
+
+  &__option {
+    text-transform: inherit;
+    margin: 0;
+  }
+
   &__user-search {
     display: grid;
     grid-gap: 5px;

--- a/resources/lang/en/store.php
+++ b/resources/lang/en/store.php
@@ -120,6 +120,8 @@ return [
 
     'supporter_tag' => [
         'gift' => 'gift to player',
+        'hide' => 'hide this gift from my activity',
+
         'require_login' => [
             '_' => 'You need to be :link to get an osu!supporter tag!',
             'link_text' => 'signed in',

--- a/resources/views/store/products/supporter-tag.blade.php
+++ b/resources/views/store/products/supporter-tag.blade.php
@@ -31,6 +31,15 @@
             !!}
         </div>
     </div>
+    <div class="store-supporter-tag__options">
+        <label class="store-supporter-tag__option">
+            @include('objects._switch', ['locals' => [
+                'checked' => false,
+                'name' => 'item[extra_data][hide]',
+            ]])
+            {{ osu_trans('store.supporter_tag.hide') }}
+        </label>
+    </div>
     <div class="store-slider">
         <div class="js-slider ui-slider ui-slider-horizontal">
             <div class="ui-slider-handle">

--- a/tests/Libraries/Fulfillments/SupporterTagFulfillmentTest.php
+++ b/tests/Libraries/Fulfillments/SupporterTagFulfillmentTest.php
@@ -11,6 +11,7 @@ use App\Libraries\Fulfillments\FulfillmentException;
 use App\Libraries\Fulfillments\SupporterTagFulfillment;
 use App\Mail\DonationThanks;
 use App\Mail\SupporterGift;
+use App\Models\Event;
 use App\Models\Store\Order;
 use App\Models\Store\OrderItem;
 use App\Models\User;
@@ -83,6 +84,9 @@ class SupporterTagFulfillmentTest extends TestCase
         $this->createDonationOrderItem($giftee1, false, false);
         $this->createDonationOrderItem($giftee2, false, false);
 
+        // TODO: should change to get the message from Event and test against that.
+        $this->expectCountChange(fn () => Event::count(), 3);
+
         $fulfiller = new SupporterTagFulfillment($this->order);
         $fulfiller->run();
 
@@ -105,6 +109,9 @@ class SupporterTagFulfillmentTest extends TestCase
         Mail::fake();
 
         $this->createDonationOrderItem($this->user, false, false);
+
+        // TODO: should change to get the message from Event and test against that.
+        $this->expectCountChange(fn () => Event::count(), 1);
 
         $fulfiller = new SupporterTagFulfillment($this->order);
         $fulfiller->run();

--- a/tests/Libraries/Fulfillments/SupporterTagFulfillmentTest.php
+++ b/tests/Libraries/Fulfillments/SupporterTagFulfillmentTest.php
@@ -100,6 +100,19 @@ class SupporterTagFulfillmentTest extends TestCase
         Mail::assertQueued(DonationThanks::class, 1);
     }
 
+    public function testMailDonateSupporterTagToSelf()
+    {
+        Mail::fake();
+
+        $this->createDonationOrderItem($this->user, false, false);
+
+        $fulfiller = new SupporterTagFulfillment($this->order);
+        $fulfiller->run();
+
+        Mail::assertNotQueued(SupporterGift::class);
+        Mail::assertQueued(DonationThanks::class, 1);
+    }
+
     public function testPartiallyFulfilledOrder()
     {
         $donor = $this->user;


### PR DESCRIPTION
- [ ] decide what actually adds events to activity

This is a bit less trivial than it sounds as it's possible to have multiple supporter tags in the same `Order`, so I'm not sure what should be the rule of when it can be hidden or not 🤔 
The current version hides only if everything in the same order is marked to be hidden.

closes #9578