### PR TITLE
Ensure correct cast type for order item extra data

### DIFF
--- a/app/Models/Store/OrderItem.php
+++ b/app/Models/Store/OrderItem.php
@@ -151,4 +151,12 @@ class OrderItem extends Model
     {
         return 'store.order_item';
     }
+
+    public function __get($key)
+    {
+        // TODO: remove this after no more things are queued with old $casts
+        $this->casts['extra_data'] = ExtraDataBase::class;
+
+        return parent::__get($key);
+    }
 }


### PR DESCRIPTION
Maybe 🤷‍♀️ Seems to work on a different test of setting casts value manually to something else and reaccessing the attribute.