### PR TITLE
Fix store line item closing tag

### DIFF
--- a/resources/views/store/objects/order.blade.php
+++ b/resources/views/store/objects/order.blade.php
@@ -40,7 +40,7 @@
                 </div>
                 <div class="order-line-items__data order-line-items__data--value">
                     {{ currency($i->subtotal()) }}
-                </td>
+                </div>
             </li>
         @endif
     @endforeach


### PR DESCRIPTION
Randomly found this weird thing 🤨

It's immediately followed by another closing tag so browser automatically fixes it (and there's no matching open tag for what it's closing).