### PR TITLE
Adjust country list in ranking page

### DIFF
--- a/app/Http/Controllers/RankingController.php
+++ b/app/Http/Controllers/RankingController.php
@@ -285,7 +285,7 @@ class RankingController extends Controller
     {
         $relation = 'statistics'.title_case($mode);
 
-        return Country::where('display', '>', 0)->whereHas($relation, function ($query) {
+        return Country::whereHas($relation, function ($query) {
             $query->where('display', true);
         })->get();
     }

--- a/resources/assets/lib/components/ranking-filter.tsx
+++ b/resources/assets/lib/components/ranking-filter.tsx
@@ -36,10 +36,6 @@ export default class RankingFilter extends React.PureComponent<Props> {
         if (core.currentUser?.country_code === a.code) return -1;
         if (core.currentUser?.country_code === b.code) return 1;
 
-        const priority = b.display - a.display;
-
-        if (priority !== 0) return priority;
-
         return a.name.localeCompare(b.name);
       });
     }


### PR DESCRIPTION
`display` column was originally for store: 0 only means it's not shipping there. It shouldn't be used to determine whether or not to show in the ranking list.

Also sort all countries except user own country alphabetically.

Resolves #8699.