### PR TITLE
Disable elasticsearch geoip downloader for docker compose

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -72,8 +72,9 @@ jobs:
 
       elasticsearch:
         env:
-          action.auto_create_index: "false"
+          action.auto_create_index: false
           discovery.type: single-node
+          ingest.geoip.downloader.enabled: false
         image: elasticsearch:7.17.6
         ports:
           - 9200:9200

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -122,9 +122,10 @@ services:
     volumes:
       - elasticsearch:/usr/share/elasticsearch/data
     environment:
-      action.auto_create_index: "false"
+      action.auto_create_index: false
       discovery.type: single-node
       ES_JAVA_OPTS: "-Xms512m -Xmx512m" # less OOM on default settings.
+      ingest.geoip.downloader.enabled: false
     healthcheck:
       test: curl -s http://localhost:9200/_cluster/health?wait_for_status=yellow >/dev/null || exit 1
       interval: 1s


### PR DESCRIPTION
Not used, so no point having elasticsearch try to update it while starting or spitting out not enough shards errors