### PR TITLE
🐛 Fix missing jpegtran binary

### DIFF
--- a/Dockerfile.deployment
+++ b/Dockerfile.deployment
@@ -26,7 +26,8 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get install -y \
     php8.0-xml \
     php8.0-zip \
     php8.0 \
-    zip
+    zip \
+    libjpeg-turbo-progs
 
 WORKDIR /app
 

--- a/Dockerfile.deployment
+++ b/Dockerfile.deployment
@@ -6,6 +6,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get install -y software-properties-common
 RUN add-apt-repository ppa:ondrej/php
 
 RUN apt-get update
+# jpegtran is not included in `jhead` dependencies in this version of Ubuntu. Revisit when upgrading/changing distro. See https://github.com/ppy/osu-web/pull/9673
 RUN DEBIAN_FRONTEND=noninteractive apt-get install -y \
     build-essential \
     curl \

--- a/Dockerfile.development
+++ b/Dockerfile.development
@@ -30,7 +30,8 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get install -y \
     php8.0-xml \
     php8.0-zip \
     php8.0 \
-    zip
+    zip \
+    libjpeg-turbo-progs
 
 RUN curl -fsSL https://deb.nodesource.com/setup_16.x | bash -
 RUN apt-get update

--- a/Dockerfile.development
+++ b/Dockerfile.development
@@ -6,6 +6,7 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get install -y software-properties-common
 RUN add-apt-repository ppa:ondrej/php
 
 RUN apt-get update
+# jpegtran is not included in `jhead` dependencies in this version of Ubuntu. Revisit when upgrading/changing distro. See https://github.com/ppy/osu-web/pull/9673
 RUN DEBIAN_FRONTEND=noninteractive apt-get install -y \
     build-essential \
     curl \


### PR DESCRIPTION
Noticed the following error in production logs:  
![image](https://user-images.githubusercontent.com/4985725/209361645-4b95be6a-5f68-4e27-bee1-3af65257ce10.png)

Curious that this never reached Sentry.

No idea what's the impact -- maybe our produced jpegs are heavier now? We surely would have heard about it from support if it directly impacted users. Also no idea if that was installed on our previous droplets.

Both `libjpeg-progs` and `libjpeg-turbo-progs` provide the `jpegtran` binary. I couldn't figure which implementation is best through this codebase and Laravel docs, but overall `libjpeg-turbo-progs` seems best.