### PR TITLE
Always skip verification for preference update

### DIFF
--- a/app/Http/Middleware/VerifyUser.php
+++ b/app/Http/Middleware/VerifyUser.php
@@ -14,6 +14,7 @@ class VerifyUser
 {
     const SKIP_VERIFICATION_ROUTES = [
         'account_controller@reissue_code' => true,
+        'account_controller@update_options' => true,
         'account_controller@verify' => true,
         'account_controller@verify_link' => true,
         'notifications_controller@endpoint' => true,


### PR DESCRIPTION
Previous fix on it only applies when `USER_POST_ACTION_VERIFICATION` was set to false (or maybe the option didn't even exist at the time).