### PR TITLE
Update commonmark conversion function call

### DIFF
--- a/app/Libraries/Markdown/OsuMarkdown.php
+++ b/app/Libraries/Markdown/OsuMarkdown.php
@@ -208,7 +208,7 @@ class OsuMarkdown
                 $this->osuExtensionConfig['block_name'],
                 $this->osuMarkdownConfig['block_modifiers'],
             );
-            $converted = $converter->convertToHtml($this->document)->getContent();
+            $converted = $converter->convert($this->document)->getContent();
             $processor = $osuExtension->processor;
 
             if ($this->osuExtensionConfig['title_from_document']) {
@@ -257,7 +257,7 @@ class OsuMarkdown
     public function toIndexable(): string
     {
         return $this->memoize(__FUNCTION__, function () {
-            return $this->getIndexableConverter()->convertToHtml($this->document)->getContent();
+            return $this->getIndexableConverter()->convert($this->document)->getContent();
         });
     }
 

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -498,7 +498,7 @@ function markdown_chat($input)
         $converter = new League\CommonMark\MarkdownConverter($environment);
     }
 
-    return $converter->convertToHtml($input)->getContent();
+    return $converter->convert($input)->getContent();
 }
 
 function markdown_plain($input)
@@ -512,7 +512,7 @@ function markdown_plain($input)
         ]);
     }
 
-    return $converter->convertToHtml($input)->getContent();
+    return $converter->convert($input)->getContent();
 }
 
 function max_offset($page, $limit)


### PR DESCRIPTION
It's been renamed to just [`convert`](https://commonmark.thephpleague.com/releases/#220---2022-01-22)