### PR TITLE
Filter missing sender before transform

### DIFF
--- a/app/Http/Controllers/Chat/Channels/MessagesController.php
+++ b/app/Http/Controllers/Chat/Channels/MessagesController.php
@@ -129,8 +129,9 @@ class MessagesController extends BaseController
 
         return [
             'messages' => json_collection($messages, new MessageTransformer()),
+            // FIXME: messages with null used should be removed from db...
             'users' => json_collection(
-                $messages->pluck('sender')->uniqueStrict('user_id')->values(),
+                $messages->pluck('sender')->filter()->uniqueStrict('user_id')->values(),
                 new UserCompactTransformer()
             ),
         ];


### PR DESCRIPTION
apparently `->whereHas('sender')` doesn't work cross database so just filter out the nulls