### PR TITLE
Throttle registration by ip network

### DIFF
--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -278,7 +278,8 @@ class UsersController extends Controller
                 return response(null, 204);
             }
 
-            $throttleKey = "registration:{$ip}";
+            $throttleIp = inet_prefixlen_start($ip, 4, 24) ?? inet_prefixlen_start($ip, 6, 56) ?? $ip;
+            $throttleKey = 'registration:'.$throttleIp;
 
             if (app(RateLimiter::class)->tooManyAttempts($throttleKey, 10)) {
                 abort(429);

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -439,16 +439,18 @@ function inet_prefixlen_start(string $inet, int $version, int $prefixlen): ?stri
     $groupCount = count($ipArray);
     for ($i = 0; $i < $groupCount; $i++) {
         $mask = $groupMask;
+        $indexStart = $i * $size;
         for ($j = 0; $j < $size; $j++) {
-            $fullIndex = $i * $size + $j;
-            // keep everything before prefixlen, remove otherwise
-            $indexMaskValue = $fullIndex < $prefixlen ? 0 : 1;
+            $fullIndex = $indexStart + $j;
+            if ($fullIndex < $prefixlen) {
+                continue;
+            }
             // shifting goes from the end, one less of size:
             // (size 8)
             // i = 0 -> shift = 7 (1000 0000)
             // i = 7 -> shift = 0 (0000 0001)
             $index = $size - $j - 1;
-            $mask ^= $indexMaskValue << $index;
+            $mask ^= 1 << $index;
         }
         // ipArray is 1-indexed
         $group = $i + 1;

--- a/config/osu.php
+++ b/config/osu.php
@@ -227,6 +227,7 @@ return [
     'user' => [
         'allow_email_login' => get_bool(env('USER_ALLOW_EMAIL_LOGIN')) ?? true,
         'allow_registration' => get_bool(env('ALLOW_REGISTRATION')) ?? true,
+        'registration_mode' => presence(env('REGISTRATION_MODE')) ?? 'client',
         'allowed_rename_groups' => explode(' ', env('USER_ALLOWED_RENAME_GROUPS', 'default')),
         'bypass_verification' => get_bool(env('USER_BYPASS_VERIFICATION')) ?? false,
         'hide_pinned_solo_scores' => get_bool(env('USER_HIDE_PINNED_SOLO_SCORES')) ?? true,

--- a/tests/HelpersTest.php
+++ b/tests/HelpersTest.php
@@ -15,6 +15,14 @@ class HelpersTest extends TestCase
         $this->assertSame($expected, class_with_modifiers($class, ...$modifiers));
     }
 
+    /**
+     * @dataProvider dataProviderForInetPrefixlenStart
+     */
+    public function testInetPrefixlenStart($inet, $version, $prefixlen, $expected)
+    {
+        $this->assertSame($expected, inet_prefixlen_start($inet, $version, $prefixlen));
+    }
+
     public function dataClassWithModifiers()
     {
         return [
@@ -40,6 +48,26 @@ class HelpersTest extends TestCase
                 ['cl', [['hello' => true, 'world' => false], ['foo' => false, 'bar' => true]], 'cl cl--hello cl--bar'],
             'mixed' =>
                 ['cl', ['hello', ['world' => true, 'foo' => false], ['bar', null]], 'cl cl--hello cl--world cl--bar'],
+        ];
+    }
+
+    public function dataProviderForInetPrefixlenStart(): array
+    {
+        return [
+            ['1.2.3.4', 4, 24, '1.2.3.0'],
+            ['1.2.3.5', 4, 31, '1.2.3.4'],
+            ['::10.0.0.3', 4, 32, null],
+            ['1:2:3:4::', 4, 24, null],
+            ['invalid', 4, 32, null],
+            ['1:2:3:4::1', 6, 64, '1:2:3:4::'],
+            ['1:2:3::1', 6, 64, '1:2:3::'],
+            ['1:2:3:4:5:6:7:8', 6, 64, '1:2:3:4::'],
+            ['1::4:5:6:7:8', 6, 64, '1:0:0:4::'],
+            ['1:2:3:4::10.0.0.1', 6, 64, '1:2:3:4::'],
+            ['1:2:3:ffff::1', 6, 56, '1:2:3:ff00::'],
+            ['::3', 6, 127, '::2'],
+            ['1.2.3.4', 6, 128, null],
+            ['invalid', 6, 128, null],
         ];
     }
 }


### PR DESCRIPTION
/24 for ipv4 and /56 for ipv6 addresses. And here's hoping the cgnats don't have ip addresses too close together 🤷 (and that they don't host too many users with single ip)

Ipv6 /56 is _usually_ the largest prefix internet providers give out to users.

@peppy please check first if it's meaningful to do this check as it's probably not all that difficult to get new ip beyond the specified prefix.