### PR TITLE
Translatable unread message label

### DIFF
--- a/resources/assets/lib/chat/message-divider.tsx
+++ b/resources/assets/lib/chat/message-divider.tsx
@@ -3,6 +3,7 @@
 
 import * as moment from 'moment';
 import * as React from 'react';
+import { trans } from 'utils/lang';
 
 interface Props {
   timestamp: string;
@@ -15,7 +16,7 @@ const MessageDividerBase = ({ timestamp, type }: Props, innerRef: React.Ref<HTML
       return (<div ref={innerRef} className='chat-conversation__day-divider'>{moment(timestamp).format('LL')}</div>);
 
     case 'UNREAD_MARKER':
-      return (<div ref={innerRef} className='chat-conversation__unread-marker' data-content='unread messages' />);
+      return (<div ref={innerRef} className='chat-conversation__unread-marker' data-content={trans('chat.unread_messages')} />);
 
     default:
       return null;

--- a/resources/lang/en/chat.php
+++ b/resources/lang/en/chat.php
@@ -8,6 +8,7 @@ return [
     'talking_in' => 'talking in :channel',
     'talking_with' => 'talking with :name',
     'title_compact' => 'chat',
+    'unread_messages' => 'unread messages',
 
     'cannot_send' => [
         'channel' => 'You cannot message this channel at this time.',


### PR DESCRIPTION
Found this in one of the ancient branches.