### PR TITLE
🔧 Enable GitHub environments settings

### DIFF
--- a/.github/workflows/pack.yml
+++ b/.github/workflows/pack.yml
@@ -62,6 +62,7 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - push_to_registry
+    environment: production
     steps:
       -
         name: Checkout
@@ -90,6 +91,7 @@ jobs:
     runs-on: ubuntu-latest
     needs:
       - push_to_registry
+    environment: staging
     steps:
       -
         name: Checkout


### PR DESCRIPTION
[GitHub environments](https://docs.github.com/en/actions/deployment/targeting-different-environments/using-environments-for-deployment) allow for per-environment secrets and protection rules, the latter being very needed for production deploys.