### PR TITLE
Split client and web registration endpoints

### DIFF
--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -211,108 +211,56 @@ class UsersController extends Controller
 
     public function store()
     {
-        if (!config('osu.user.allow_registration')) {
-            return abort(403, 'User registration is currently disabled');
+        if (config('osu.user.registration_mode') !== 'client') {
+            return response([
+                'error' => osu_trans('users.store.from_web'),
+                'url' => route('users.create'),
+            ], 403);
         }
 
-        $ip = Request::ip();
+        if (!starts_with(Request::header('User-Agent'), config('osu.client.user_agent'))) {
+            return error_popup(osu_trans('users.store.from_client'), 403);
+        }
 
-        if (IpBan::where('ip', '=', $ip)->exists()) {
-            return error_popup('Banned IP', 403);
+        return $this->storeUser(request()->all());
+    }
+
+    public function storeWeb()
+    {
+        if (config('osu.user.registration_mode') !== 'web') {
+            return error_popup(osu_trans('users.store.from_client'), 403);
         }
 
         $rawParams = request()->all();
+
+        if (captcha_enabled()) {
+            static $captchaField = 'g-recaptcha-response';
+            $token = $rawParams[$captchaField] ?? null;
+
+            $validCaptcha = NoCaptcha::verifyResponse($token);
+
+            if (!$validCaptcha) {
+                return abort(422, 'invalid captcha');
+            }
+        }
+
         $params = get_params($rawParams, 'user', [
             'password',
             'password_confirmation',
             'user_email',
             'user_email_confirmation',
-            'username',
         ], ['null_missing' => true]);
 
-        $webRegistration = config('osu.user.registration_mode') === 'web';
-        $fromClient = starts_with(Request::header('User-Agent'), config('osu.client.user_agent'));
-
-        if ($webRegistration) {
-            if ($fromClient) {
+        foreach (['user_email', 'password'] as $confirmableField) {
+            $confirmationField = "{$confirmableField}_confirmation";
+            if ($params[$confirmableField] !== $params[$confirmationField]) {
                 return response([
-                    'error' => osu_trans('users.store.from_web'),
-                    'url' => route('users.create'),
+                    'form_error' => ['user' => [$confirmationField => osu_trans('model_validation.wrong_confirmation')]],
                 ], 422);
             }
-
-            if (captcha_enabled()) {
-                static $captchaField = 'g-recaptcha-response';
-                $token = $rawParams[$captchaField] ?? null;
-
-                $validCaptcha = NoCaptcha::verifyResponse($token);
-
-                if (!$validCaptcha) {
-                    return abort(422, 'invalid captcha');
-                }
-
-                foreach (['user_email', 'password'] as $confirmableField) {
-                    $confirmationField = "{$confirmableField}_confirmation";
-                    if ($params[$confirmationField] !== $params[$confirmationField]) {
-                        return response([
-                            'form_error' => ['user' => [$confirmationField => osu_trans('model_validation.wrong_confirmation')]],
-                        ], 422);
-                    }
-                }
-            }
-        } elseif (!$fromClient) {
-            return error_popup(osu_trans('users.store.from_client'), 403);
         }
 
-        $countryCode = request_country();
-        $country = Country::find($countryCode);
-        $params['user_ip'] = $ip;
-        $params['country_acronym'] = $country === null ? '' : $country->getKey();
-
-        $registration = new UserRegistration($params);
-
-        try {
-            $registration->assertValid();
-
-            if (get_bool($rawParams['check'] ?? null)) {
-                return response(null, 204);
-            }
-
-            $throttleKey = 'registration:asn:'.app('ip2asn')->lookup($ip);
-
-            if (app(RateLimiter::class)->tooManyAttempts($throttleKey, 10)) {
-                abort(429);
-            }
-
-            $registration->save();
-            app(RateLimiter::class)->hit($throttleKey, 600);
-
-            $user = $registration->user();
-
-            if ($country === null) {
-                app('sentry')->getClient()->captureMessage(
-                    'User registered from unknown country: '.$countryCode,
-                    null,
-                    (new Scope())
-                        ->setExtra('country', $countryCode)
-                        ->setExtra('ip', $ip)
-                        ->setExtra('user_id', $user->getKey())
-                );
-            }
-
-            if ($webRegistration) {
-                $this->login($user);
-                session()->flash('popup', osu_trans('users.store.saved'));
-
-                return ujs_redirect(route('home'));
-            } else {
-                return json_item($user->fresh(), new CurrentUserTransformer());
-            }
-        } catch (ValidationException $e) {
-            return response(['form_error' => [
-                'user' => $registration->user()->validationErrors()->all(),
-            ]], 422);
-        }
+        return $this->storeUser($rawParams);
     }
 
     /**
@@ -980,5 +928,73 @@ class UsersController extends Controller
         }
 
         return $userJson;
+    }
+
+    private function storeUser(array $rawParams)
+    {
+        if (!config('osu.user.allow_registration')) {
+            return abort(403, 'User registration is currently disabled');
+        }
+
+        $ip = Request::ip();
+
+        if (IpBan::where('ip', '=', $ip)->exists()) {
+            return error_popup('Banned IP', 403);
+        }
+
+        $params = get_params($rawParams, 'user', [
+            'password',
+            'user_email',
+            'username',
+        ], ['null_missing' => true]);
+        $countryCode = request_country();
+        $country = Country::find($countryCode);
+        $params['user_ip'] = $ip;
+        $params['country_acronym'] = $country === null ? '' : $country->getKey();
+
+        $registration = new UserRegistration($params);
+
+        try {
+            $registration->assertValid();
+
+            if (get_bool($rawParams['check'] ?? null)) {
+                return response(null, 204);
+            }
+
+            $throttleKey = 'registration:asn:'.app('ip2asn')->lookup($ip);
+
+            if (app(RateLimiter::class)->tooManyAttempts($throttleKey, 10)) {
+                abort(429);
+            }
+
+            $registration->save();
+            app(RateLimiter::class)->hit($throttleKey, 600);
+
+            $user = $registration->user();
+
+            if ($country === null) {
+                app('sentry')->getClient()->captureMessage(
+                    'User registered from unknown country: '.$countryCode,
+                    null,
+                    (new Scope())
+                        ->setExtra('country', $countryCode)
+                        ->setExtra('ip', $ip)
+                        ->setExtra('user_id', $user->getKey())
+                );
+            }
+
+            if (config('osu.user.registration_mode') === 'web') {
+                $this->login($user);
+                session()->flash('popup', osu_trans('users.store.saved'));
+
+                return ujs_redirect(route('home'));
+            } else {
+                return json_item($user->fresh(), new CurrentUserTransformer());
+            }
+        } catch (ValidationException $e) {
+            return response(['form_error' => [
+                'user' => $registration->user()->validationErrors()->all(),
+            ]], 422);
+        }
     }
 }

--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -71,7 +71,7 @@ class UsersController extends Controller
 
     public function __construct()
     {
-        $this->middleware('guest', ['only' => ['create', 'store']]);
+        $this->middleware('guest', ['only' => ['create', 'store', 'storeWeb']]);
         $this->middleware('auth', ['only' => [
             'checkUsernameAvailability',
             'checkUsernameExists',

--- a/app/Http/Middleware/VerifyCsrfToken.php
+++ b/app/Http/Middleware/VerifyCsrfToken.php
@@ -19,20 +19,17 @@ class VerifyCsrfToken extends BaseVerifier
         'payments/paypal/ipn',
         'payments/shopify/callback',
         'payments/xsolla/callback',
+        'users',
     ];
 
     public function handle($request, Closure $next)
     {
-        $currentRouteData = app('route-section')->getCurrent();
-        $currentRoute = "{$currentRouteData['controller']}@{$currentRouteData['action']}";
-
-        if ($currentRoute === 'users_controller@store' && config('osu.user.registration_mode') === 'client') {
-            return $next($request);
-        }
-
         try {
             return parent::handle($request, $next);
         } catch (TokenMismatchException $e) {
+            $currentRouteData = app('route-section')->getCurrent();
+            $currentRoute = "{$currentRouteData['controller']}@{$currentRouteData['action']}";
+
             if ($currentRoute === 'sessions_controller@store') {
                 DatadogLoginAttempt::log('invalid_csrf');
             }

--- a/resources/views/users/create.blade.php
+++ b/resources/views/users/create.blade.php
@@ -8,7 +8,7 @@
     @include('layout._page_header_v4')
     <div class="osu-page osu-page--generic">
         <form
-            action="{{ route('users.store') }}"
+            action="{{ route('users.store-web') }}"
             class="simple-form simple-form--user-create js-form-error js-captcha--reset-on-error"
             data-remote="1"
             data-skip-ajax-error-popup="1"

--- a/routes/web.php
+++ b/routes/web.php
@@ -276,6 +276,7 @@ Route::group(['middleware' => ['web']], function () {
     Route::post('users/check-username-exists', 'UsersController@checkUsernameExists')->name('users.check-username-exists');
     Route::get('users/disabled', 'UsersController@disabled')->name('users.disabled');
     Route::get('users/create', 'UsersController@create')->name('users.create');
+    Route::post('users/store-web', 'UsersController@storeWeb')->name('users.store-web');
 
     Route::group(['as' => 'users.', 'prefix' => 'users/{user}'], function () {
         Route::get('card', 'UsersController@card')->name('card');

--- a/tests/Controllers/UsersControllerTest.php
+++ b/tests/Controllers/UsersControllerTest.php
@@ -50,6 +50,26 @@ class UsersControllerTest extends TestCase
         $this->assertSame($previousCount + 1, User::count());
     }
 
+    public function testStoreRegModeWeb()
+    {
+        config()->set('osu.user.registration_mode', 'web');
+        $this->expectCountChange(fn () => User::count(), 0);
+
+        $this
+            ->json('POST', route('users.store'), [
+                'user' => [
+                    'username' => 'user1',
+                    'user_email' => 'user1@example.com',
+                    'password' => 'hunter22',
+                ],
+            ], [
+                'HTTP_USER_AGENT' => config('osu.client.user_agent'),
+            ])->assertStatus(403)
+            ->assertJsonFragment([
+                'error' => osu_trans('users.store.from_web'),
+            ]);
+    }
+
     /**
      * Passing check=1 only validates user and not create.
      */
@@ -109,6 +129,57 @@ class UsersControllerTest extends TestCase
             ]);
 
         $this->assertSame($previousCount, User::count());
+    }
+
+    public function testStoreWebRegModeClient()
+    {
+        $this->expectCountChange(fn () => User::count(), 0);
+
+        $this->post(route('users.store'), [
+                'user' => [
+                    'username' => 'user1',
+                    'user_email' => 'user1@example.com',
+                    'password' => 'hunter22',
+                ],
+            ])->assertStatus(403)
+            ->assertJsonFragment([
+                'error' => osu_trans('users.store.from_client'),
+            ]);
+    }
+
+    public function testStoreWeb(): void
+    {
+        config()->set('osu.user.registration_mode', 'web');
+        $this->expectCountChange(fn () => User::count(), 1);
+
+        $this->post(route('users.store-web'), [
+                'user' => [
+                    'username' => 'user1',
+                    'user_email' => 'user1@example.com',
+                    'user_email_confirmation' => 'user1@example.com',
+                    'password' => 'hunter22',
+                    'password_confirmation' => 'hunter22',
+                ],
+            ])->assertRedirect(route('home'));
+    }
+
+    /**
+     * @dataProvider dataProviderForStoreWebInvalidParams
+     */
+    public function testStoreWebInvalidParams($username, $email, $emailConfirmation, $password, $passwordConfirmation): void
+    {
+        config()->set('osu.user.registration_mode', 'web');
+        $this->expectCountChange(fn () => User::count(), 0);
+
+        $this->post(route('users.store-web'), [
+                'user' => [
+                    'username' => $username,
+                    'user_email' => $email,
+                    'user_email_confirmation' => $emailConfirmation,
+                    'password' => $password,
+                    'password_confirmation' => $passwordConfirmation,
+                ],
+            ])->assertStatus(422);
     }
 
     public function testStoreWithCountry()
@@ -221,6 +292,28 @@ class UsersControllerTest extends TestCase
         $this
             ->get(route('api.users.show', ['user' => $user->username]))
             ->assertSuccessful();
+    }
+
+    public function dataProviderForStoreWebInvalidParams(): array
+    {
+        return [
+            ['user1', 'user@email.com', 'user@email.com', 'short', 'short'],
+            ['user1', 'user@email.com', 'user@email.com', '', ''],
+            ['user1', 'user@email.com', 'user@email.com', 'userpassword', 'userpassword1'],
+            ['user1', 'user@email.com', 'user@email.com', 'userpassword', null],
+            ['user1', 'user@email.com', 'user@email.com', null, null],
+
+            ['user1', 'notemail@.com', 'notemail@.com', 'userpassword', 'userpassword'],
+            ['user1', '', '', 'userpassword', 'userpassword'],
+            ['user1', 'user@email.com', 'user1@email.com', 'userpassword', 'userpassword'],
+            ['user1', 'user@email.com', null, 'userpassword', 'userpassword'],
+            ['user1', null, null, 'userpassword', 'userpassword'],
+
+            [null, 'user@email.com', 'user@email.com', 'userpassword', 'userpassword'],
+            ['', 'user@email.com', 'user@email.com', 'userpassword', 'userpassword'],
+            [null, 'user@email.com', 'user@email.com', null, null],
+            [null, null, null, 'userpassword', 'userpassword'],
+        ];
     }
 
     protected function setUp(): void

--- a/tests/Controllers/UsersControllerTest.php
+++ b/tests/Controllers/UsersControllerTest.php
@@ -153,14 +153,14 @@ class UsersControllerTest extends TestCase
         $this->expectCountChange(fn () => User::count(), 1);
 
         $this->post(route('users.store-web'), [
-                'user' => [
-                    'username' => 'user1',
-                    'user_email' => 'user1@example.com',
-                    'user_email_confirmation' => 'user1@example.com',
-                    'password' => 'hunter22',
-                    'password_confirmation' => 'hunter22',
-                ],
-            ])->assertRedirect(route('home'));
+            'user' => [
+                'username' => 'user1',
+                'user_email' => 'user1@example.com',
+                'user_email_confirmation' => 'user1@example.com',
+                'password' => 'hunter22',
+                'password_confirmation' => 'hunter22',
+            ],
+        ])->assertRedirect(route('home'));
     }
 
     /**
@@ -180,6 +180,24 @@ class UsersControllerTest extends TestCase
                     'password_confirmation' => $passwordConfirmation,
                 ],
             ])->assertStatus(422);
+    }
+
+    public function testStoreWebLoggedIn(): void
+    {
+        config()->set('osu.user.registration_mode', 'web');
+        $user = User::factory()->create();
+
+        $this->expectCountChange(fn () => User::count(), 0);
+
+        $this->actingAsVerified($user)->post(route('users.store-web'), [
+            'user' => [
+                'username' => 'user1',
+                'user_email' => 'user1@example.com',
+                'user_email_confirmation' => 'user1@example.com',
+                'password' => 'hunter22',
+                'password_confirmation' => 'hunter22',
+            ],
+        ])->assertRedirect('/');
     }
 
     public function testStoreWithCountry()


### PR DESCRIPTION
CSRF requirement with web registration makes it rather difficult to return correct error message.

Also add tests which discovered confirmation field check isn't actually working 👀

Although as there's already check on frontend it's probably not actually needed?