### PR TITLE
Apply markdown container styling to announcement messages

### DIFF
--- a/resources/assets/less/bem/chat-message-item.less
+++ b/resources/assets/less/bem/chat-message-item.less
@@ -11,9 +11,11 @@
   &__content {
     font-family: @font-content;
     word-break: break-word;
+    flex: 1;
 
     h1, h2, h3, h4, h5, h6 {
       font-size: revert;
+      border-bottom: 1px solid hsl(var(--hsl-b3));
     }
 
     &--action {

--- a/resources/assets/less/bem/chat-message-item.less
+++ b/resources/assets/less/bem/chat-message-item.less
@@ -11,11 +11,14 @@
   &__content {
     font-family: @font-content;
     word-break: break-word;
-    flex: 1;
 
     h1, h2, h3, h4, h5, h6 {
       font-size: revert;
       border-bottom: 1px solid hsl(var(--hsl-b3));
+    }
+
+    hr {
+      border-color: hsl(var(--hsl-b3));
     }
 
     &--action {
@@ -46,14 +49,14 @@
   }
 
   // TODO: css class instead?
-  code {
-    background: hsl(var(--hsl-b4));
-  }
+  // code {
+  //   background: hsl(var(--hsl-b4));
+  // }
 
-  pre {
-    background: hsl(var(--hsl-b4));
-    border: none;
-    color: inherit;
-  }
+  // pre {
+  //   background: hsl(var(--hsl-b4));
+  //   border: none;
+  //   color: inherit;
+  // }
 }
 

--- a/resources/assets/less/bem/chat-message-item.less
+++ b/resources/assets/less/bem/chat-message-item.less
@@ -12,15 +12,6 @@
     font-family: @font-content;
     word-break: break-word;
 
-    h1, h2, h3, h4, h5, h6 {
-      font-size: revert;
-      border-bottom: 1px solid hsl(var(--hsl-b3));
-    }
-
-    hr {
-      border-color: hsl(var(--hsl-b3));
-    }
-
     &--action {
       color: hsl(var(--hsl-l1));
       font-style: italic;
@@ -47,16 +38,5 @@
       color: red;
     }
   }
-
-  // TODO: css class instead?
-  // code {
-  //   background: hsl(var(--hsl-b4));
-  // }
-
-  // pre {
-  //   background: hsl(var(--hsl-b4));
-  //   border: none;
-  //   color: inherit;
-  // }
 }
 

--- a/resources/assets/less/bem/osu-md.less
+++ b/resources/assets/less/bem/osu-md.less
@@ -45,11 +45,11 @@
     background-color: var(--code-background-colour);
     color: @osu-colour-l1;
     border: none;
-    border-radius: 0px;
+    border-radius: 0;
 
     > code {
       border: none;
-      padding: 0px;
+      padding: 0;
     }
   }
 

--- a/resources/assets/less/bem/osu-md.less
+++ b/resources/assets/less/bem/osu-md.less
@@ -60,6 +60,11 @@
   &--chat {
     --code-background-colour: hsl(var(--hsl-b3));
     flex: 1;
+
+    h1, h2, h3, h4, h5, h6 {
+      font-size: revert;
+      border-bottom: 1px solid hsl(var(--hsl-b3));
+    }
   }
 
   &--group {

--- a/resources/assets/less/bem/osu-md.less
+++ b/resources/assets/less/bem/osu-md.less
@@ -8,11 +8,13 @@
   color: inherit;
   font-size: @font-size--wiki;
   word-wrap: break-word;
+
+  --code-background-colour: hsl(var(--hsl-b6));
   --paragraph-space: @md-paragraph-space;
 
   code {
     .default-border-radius();
-    background-color: @osu-colour-b6;
+    background-color: var(--code-background-colour);
     color: @osu-colour-l1;
     padding: 1px 4px;
   }
@@ -40,7 +42,7 @@
   }
 
   pre {
-    background-color: @osu-colour-b6;
+    background-color: var(--code-background-colour);
     color: @osu-colour-l1;
     border: none;
     border-radius: 0px;
@@ -53,6 +55,11 @@
 
   > *:last-child {
     margin-bottom: 0;
+  }
+
+  &--chat {
+    --code-background-colour: hsl(var(--hsl-b3));
+    flex: 1;
   }
 
   &--group {

--- a/resources/assets/lib/chat/message-item.tsx
+++ b/resources/assets/lib/chat/message-item.tsx
@@ -17,10 +17,11 @@ export default class MessageItem extends React.Component<Props> {
     return (
       <div className={classWithModifiers('chat-message-item', { sending: !this.props.message.persisted })}>
         <div className='chat-message-item__entry'>
-          <span
-            dangerouslySetInnerHTML={{ __html: this.props.message.parsedContent }}
-            className={classWithModifiers('chat-message-item__content', { action: this.props.message.isAction })}
-          />
+          {this.props.message.isHtml ? (
+            <div className='osu-md osu-md--chat'>
+              {this.renderContent()}
+            </div>
+          ) : this.renderContent()}
           {!this.props.message.persisted && !this.props.message.errored &&
             <div className='chat-message-item__status'>
               <Spinner />
@@ -33,6 +34,15 @@ export default class MessageItem extends React.Component<Props> {
           }
         </div>
       </div>
+    );
+  }
+
+  private renderContent() {
+    return (
+      <span
+        className={classWithModifiers('chat-message-item__content', { action: this.props.message.isAction })}
+        dangerouslySetInnerHTML={{ __html: this.props.message.parsedContent }}
+      />
     );
   }
 }

--- a/resources/assets/lib/models/chat/message.ts
+++ b/resources/assets/lib/models/chat/message.ts
@@ -25,7 +25,6 @@ export default class Message {
 
   @observable private contentHtml?: string;
 
-  @computed
   get isHtml() {
     return this.contentHtml != null;
   }

--- a/resources/assets/lib/models/chat/message.ts
+++ b/resources/assets/lib/models/chat/message.ts
@@ -27,7 +27,7 @@ export default class Message {
 
   @computed
   get isHtml() {
-    return this.contentHtml !== null;
+    return this.contentHtml != null;
   }
 
   @computed

--- a/resources/assets/lib/models/chat/message.ts
+++ b/resources/assets/lib/models/chat/message.ts
@@ -60,5 +60,6 @@ export default class Message {
     this.messageId = json.message_id;
     this.timestamp = json.timestamp;
     this.persisted = true;
+    this.contentHtml = json.content_html;
   }
 }

--- a/resources/assets/lib/models/chat/message.ts
+++ b/resources/assets/lib/models/chat/message.ts
@@ -26,6 +26,11 @@ export default class Message {
   @observable private contentHtml?: string;
 
   @computed
+  get isHtml() {
+    return this.contentHtml !== null;
+  }
+
+  @computed
   get parsedContent() {
     return this.contentHtml ?? linkify(escape(this.content), true);
   }


### PR DESCRIPTION
Should be safe to just apply the whole `osu-md` class since chat markdown only uses a limited subset with nothing floating around 🤔 