### PR TITLE
Fix mod background styling

### DIFF
--- a/resources/assets/less/bem/mod.less
+++ b/resources/assets/less/bem/mod.less
@@ -61,6 +61,8 @@
     .full-size();
     background-image: var(--type-bg);
     background-size: contain;
+    background-position: center;
+    background-repeat: no-repeat;
     content: '';
     display: var(--generic-display);
 


### PR DESCRIPTION
Resolves #9765. Kind of. The label will be too large in cases where the element size is in wrong proportion (due to flexbox sizing etc).

There are more problems with rendering many mods but those are for another time...