### PR TITLE
Add icons to chat conversation list headers

### DIFF
--- a/resources/css/bem/chat-conversation-list-item.less
+++ b/resources/css/bem/chat-conversation-list-item.less
@@ -25,7 +25,6 @@
   @media @mobile {
     margin-left: 0;
     padding-left: 0;
-    flex-shrink: 0;
   }
 
   &--selected {

--- a/resources/css/bem/chat-conversation-list.less
+++ b/resources/css/bem/chat-conversation-list.less
@@ -16,19 +16,41 @@
     overflow-x: auto;
   }
 
+  &__group {
+    @media @mobile {
+      display: flex;
+    }
+  }
+
   &__header {
-    background-color: hsl(var(--hsl-b5));
+    display: flex;
+    gap: 5px;
+
+    background: hsl(var(--hsl-b5));
     color: hsl(var(--hsl-c1));
     padding: 10px 30px;
     font-size: @font-size--normal;
-    text-transform: uppercase;
     position: sticky;
     top: 0;
+    left: 0;
     z-index: 1; // keep above items
 
     @media @mobile {
-      // FIXME: no idea how to display on mobile...
+      padding: 5px;
+    }
+  }
+
+  &__header-text {
+    text-transform: uppercase;
+
+    @media @mobile {
       display: none;
+    }
+  }
+
+  &__header-icon {
+    @media @mobile {
+      align-self: center;
     }
   }
 }

--- a/resources/js/chat/conversation-list.tsx
+++ b/resources/js/chat/conversation-list.tsx
@@ -9,16 +9,28 @@ import { trans } from 'utils/lang';
 import ConversationListItem from './conversation-list-item';
 import CreateAnnouncementButton from './create-announcement-button';
 
+const icons: Record<SupportedChannelType, string> = {
+  ANNOUNCE: 'fas fa-bullhorn',
+  GROUP: 'fas fa-user-group', // just give it an icon; nothing returns this yet.
+  PM: 'fas fa-envelope',
+  PUBLIC: 'fas fa-comments',
+};
+
 function renderChannels(type: SupportedChannelType) {
   const channels = core.dataStore.channelStore.groupedChannels[type];
   if (channels.length > 0 || type === 'ANNOUNCE' && core.dataStore.chatState.canChatAnnounce) {
+    const title = trans(`chat.channels.list.title.${type}`);
+
     return (
       <React.Fragment key={type}>
-        <div className='chat-conversation-list__header'>
-          {trans(`chat.channels.list.title.${type}`)}
+        <div className='chat-conversation-list__group'>
+          <div className='chat-conversation-list__header'>
+            <span className='chat-conversation-list__header-text'>{title}</span>
+            <span className='chat-conversation-list__header-icon' title={title}><i className={icons[type]} /></span>
+          </div>
+          {channels.map((channel) => <ConversationListItem key={channel.channelId} channel={channel} />)}
+          {type === 'ANNOUNCE' && <CreateAnnouncementButton />}
         </div>
-        {channels.map((channel) => <ConversationListItem key={channel.channelId} channel={channel} />)}
-        {type === 'ANNOUNCE' && <CreateAnnouncementButton />}
         <div className='chat-conversation-list-separator' />
       </React.Fragment>
     );


### PR DESCRIPTION
Mainly for mobile because you can't see which group you're in.

For announcement and public channels, I just used the same icon as their notification icons; PM has a different icon to differentiate it without using multiple icons (I think maybe the notification icon for PMs should be updated to match?; legacy-pm has its own row in notifications so sharing the icon here shouldn't be a problem). Nothing returns group chat yet so a random icon was picked.

This also changes the sticky headers to scroll off instead of overlapping each other.