### PR TITLE
Add supported markdown guide to creating announcement UI

### DIFF
--- a/resources/css/bem-index.less
+++ b/resources/css/bem-index.less
@@ -213,6 +213,7 @@
 @import "bem/login-box";
 @import "bem/logo";
 @import "bem/love-beatmap-modal";
+@import "bem/markdown-help";
 @import "bem/medals-group";
 @import "bem/message-length-counter";
 @import "bem/mobile-menu";

--- a/resources/css/bem/link.less
+++ b/resources/css/bem/link.less
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 .link {
+  .reset-input();
   ._colour(@link-colour, @hover-colour) {
     color: @link-colour;
 

--- a/resources/css/bem/markdown-help.less
+++ b/resources/css/bem/markdown-help.less
@@ -7,6 +7,9 @@
   padding: 10px;
   border-radius: 4px;
 
+  max-height: calc(80 * var(--vh, 1vh));
+  overflow: auto;
+
   &__example {
     display: grid;
     gap: 10px;

--- a/resources/css/bem/markdown-help.less
+++ b/resources/css/bem/markdown-help.less
@@ -3,12 +3,21 @@
 
 
 .markdown-help {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+
   background: hsl(var(--hsl-b4));
-  padding: 10px;
+  padding: 15px;
   border-radius: 4px;
 
   max-height: calc(80 * var(--vh, 1vh));
   overflow: auto;
+
+  &__buttons {
+    display: flex;
+    justify-content: flex-end;
+  }
 
   &__example {
     display: grid;
@@ -18,7 +27,12 @@
     border-radius: 4px;
     box-shadow: 0 1px 3px rgb(0 0 0 / 25%);
     padding: 10px;
-    margin: 10px;
     background: hsl(var(--hsl-b6));
+  }
+
+  &__examples {
+    display: flex;
+    flex-direction: column;
+    gap: 10px;
   }
 }

--- a/resources/css/bem/markdown-help.less
+++ b/resources/css/bem/markdown-help.less
@@ -1,0 +1,21 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
+
+.markdown-help {
+  background: hsl(var(--hsl-b4));
+  padding: 10px;
+  border-radius: 4px;
+
+  &__example {
+    display: grid;
+    gap: 10px;
+    grid-template-columns: 1fr 1fr;
+
+    border-radius: 4px;
+    box-shadow: 0 1px 3px rgb(0 0 0 / 25%);
+    padding: 10px;
+    margin: 10px;
+    background: hsl(var(--hsl-b6));
+  }
+}

--- a/resources/js/chat/create-announcement.tsx
+++ b/resources/js/chat/create-announcement.tsx
@@ -104,8 +104,9 @@ export default class CreateAnnouncement extends React.Component<Props> {
               <BusySpinner busy={this.model.lookingUpUsers} />
             </div>
           </InputContainer>
-          <MarkdownHelp />
           <InputContainer
+            extras={<MarkdownHelp />}
+            for='chat-form-message'
             labelKey='chat.form.labels.message'
             maxLength={maxLengths.message}
             model={this.model}
@@ -116,6 +117,7 @@ export default class CreateAnnouncement extends React.Component<Props> {
               autoComplete='off'
               className='chat-form__input chat-form__input--box'
               defaultValue={this.model.inputs.message}
+              id='chat-form-message'
               name='message'
               onBlur={this.handleBlur}
               onChange={this.handleInput}

--- a/resources/js/chat/create-announcement.tsx
+++ b/resources/js/chat/create-announcement.tsx
@@ -12,6 +12,7 @@ import { isInputKey, maxLengths } from 'models/chat/create-announcement';
 import core from 'osu-core-singleton';
 import * as React from 'react';
 import { trans } from 'utils/lang';
+import MarkdownHelp from './markdown-help';
 
 type Props = Record<string, never>;
 
@@ -103,6 +104,7 @@ export default class CreateAnnouncement extends React.Component<Props> {
               <BusySpinner busy={this.model.lookingUpUsers} />
             </div>
           </InputContainer>
+          <MarkdownHelp />
           <InputContainer
             labelKey='chat.form.labels.message'
             maxLength={maxLengths.message}

--- a/resources/js/chat/markdown-help.tsx
+++ b/resources/js/chat/markdown-help.tsx
@@ -5,6 +5,7 @@ import Modal from 'components/modal';
 import { action, makeObservable, observable } from 'mobx';
 import { observer } from 'mobx-react';
 import * as React from 'react';
+import { trans } from 'utils/lang';
 
 const examples = [
   {
@@ -108,7 +109,18 @@ export default class MarkdownHelp extends React.Component<Record<string, never>>
           <Modal onClose={this.toggle}>
             <div className='markdown-help'>
               <div className='osu-md osu-md--chat'>
-                {examples.map((example, index) => <React.Fragment key={index}>{renderExample(example)}</React.Fragment>)}
+                <div className='markdown-help__examples'>
+                  {examples.map((example, index) => <React.Fragment key={index}>{renderExample(example)}</React.Fragment>)}
+                </div>
+              </div>
+              <div className='markdown-help__buttons'>
+                <button
+                  className='btn-osu-big btn-osu-big--rounded-thin'
+                  onClick={this.toggle}
+                  type='button'
+                >
+                  {trans('common.buttons.close')}
+                </button>
               </div>
             </div>
           </Modal>

--- a/resources/js/chat/markdown-help.tsx
+++ b/resources/js/chat/markdown-help.tsx
@@ -103,7 +103,7 @@ export default class MarkdownHelp extends React.Component<Record<string, never>>
           className='link'
           onClick={this.toggle}
         >
-          Supported Markdown
+          {trans('chat.markdown_supported')}
         </button>
         {this.showingModal && (
           <Modal onClose={this.toggle}>

--- a/resources/js/chat/markdown-help.tsx
+++ b/resources/js/chat/markdown-help.tsx
@@ -1,0 +1,124 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
+import Modal from 'components/modal';
+import { action, makeObservable, observable } from 'mobx';
+import { observer } from 'mobx-react';
+import * as React from 'react';
+
+const examples = [
+  {
+    markdown: '# Heading 1',
+    html: <h1>Heading 1</h1>,
+  },
+  {
+    markdown: '## Heading 2',
+    html: <h2>Heading 2</h2>,
+  },
+  {
+    markdown: '### Heading 3',
+    html: <h3>Heading 3</h3>,
+  },
+  {
+    markdown: '**bold** and *emphasis*',
+    html: <><strong>bold</strong> and <em>emphasis</em></>,
+  },
+  {
+    markdown: '[links](https://osu.ppy.sh)',
+    html: <a href='https://osu.ppy.sh'>links</a>,
+  },
+  {
+    markdown: <>
+      1. ordered<br />
+      1. list
+    </>,
+    html: <ol>
+      <li>ordered</li>
+      <li>list</li>
+    </ol>,
+  },
+  {
+    markdown: <>
+      - unordered<br />
+      - list
+    </>,
+    html: <ul>
+      <li>unordered</li>
+      <li>list</li>
+    </ul>,
+  },
+  {
+    markdown: '> quote',
+    html: <blockquote><p>quote</p></blockquote>,
+  },
+  {
+    markdown: <>
+      ```<br />
+      code<br />
+      blocks<br />
+      ```
+    </>,
+    html: <pre>
+      <code>
+        code{'\n'}
+        blocks
+      </code>
+    </pre>,
+  },
+  {
+    markdown: '`inline block`',
+    html: <code>inline block</code>,
+  },
+];
+
+interface Example {
+  html: React.ReactNode;
+  markdown: React.ReactNode;
+}
+
+function renderExample({ html, markdown }: Example) {
+  return (
+    <div className='markdown-help__example'>
+      <div>{markdown}</div>
+      <div>{html}</div>
+    </div>
+  );
+}
+
+@observer
+export default class MarkdownHelp extends React.Component<Record<string, never>> {
+  @observable showingModal = false;
+
+  constructor(props: Record<string, never>) {
+    super(props);
+
+    makeObservable(this);
+  }
+
+  render() {
+    return (
+      <>
+        <button
+          className='link'
+          onClick={this.toggle}
+        >
+          Supported Markdown
+        </button>
+        {this.showingModal && (
+          <Modal onClose={this.toggle}>
+            <div className='markdown-help'>
+              <div className='osu-md osu-md--chat'>
+                {examples.map((example, index) => <React.Fragment key={index}>{renderExample(example)}</React.Fragment>)}
+              </div>
+            </div>
+          </Modal>
+        )}
+      </>
+    );
+  }
+
+  @action
+  private toggle = () => {
+    this.showingModal = !this.showingModal;
+  };
+}

--- a/resources/js/components/input-container.tsx
+++ b/resources/js/components/input-container.tsx
@@ -8,6 +8,7 @@ import { trans } from 'utils/lang';
 import MessageLengthCounter from './message-length-counter';
 
 interface CommonProps {
+  extras?: React.ReactNode;
   for?: string;
   labelKey?: string;
   modifiers?: Modifiers;
@@ -34,7 +35,10 @@ const InputContainer = observer(<T extends string>(props: React.PropsWithChildre
     <label className={classWithModifiers('input-container', { error }, props.modifiers)} htmlFor={props.for}>
       {props.labelKey != null && (
         <div className='input-container__label'>
-          {trans(props.labelKey)}
+          <span>
+            {trans(props.labelKey)}
+            {props.extras != null && <span> {props.extras}</span>}
+          </span>
           {props.model != null && props.maxLength != null && (
             <MessageLengthCounter maxLength={props.maxLength} message={props.model.inputs[props.name]} />
           )}

--- a/resources/lang/en/chat.php
+++ b/resources/lang/en/chat.php
@@ -5,6 +5,7 @@
 
 return [
     'loading_users' => 'loading users...',
+    'markdown_supported' => '(markdown supported)',
     'talking_in' => 'talking in :channel',
     'talking_with' => 'talking with :name',
     'title_compact' => 'chat',


### PR DESCRIPTION
Adds a button 
![image](https://user-images.githubusercontent.com/1694544/214047953-946a29fb-d0e3-4851-8ba6-47c8dc50a69b.png)

that pops up a guide for the markdown that is supported
![image](https://user-images.githubusercontent.com/1694544/214048066-867e7df5-ae67-4e87-b314-bfc142044301.png)

Not sure it should be a wiki page instead or pull markdown from somewhere else (or if this kind of input guide would be useful in other places) 🤔 
Draft because this is largely a PoC 👀 

Could use some ideas for the formatting of the display @arflyte 