### PR TITLE
Fix supporter tag duration not applying properly

### DIFF
--- a/app/Libraries/Fulfillments/ApplySupporterTag.php
+++ b/app/Libraries/Fulfillments/ApplySupporterTag.php
@@ -5,7 +5,6 @@
 
 namespace App\Libraries\Fulfillments;
 
-use App\Models\Store\OrderItem;
 use App\Models\User;
 use App\Models\UserDonation;
 use Carbon\Carbon;

--- a/app/Libraries/Fulfillments/ApplySupporterTag.php
+++ b/app/Libraries/Fulfillments/ApplySupporterTag.php
@@ -17,10 +17,8 @@ class ApplySupporterTag extends OrderItemFulfillment
 {
     private int $amount;
     private int $duration;
-    private ?User $donor;
-    private int $donorId;
-    private ?User $target;
-    private int $targetId;
+    private User $donor;
+    private User $target;
 
     public function cancelledTransactionId()
     {

--- a/tests/Libraries/Fulfillments/SupporterTagFulfillmentTest.php
+++ b/tests/Libraries/Fulfillments/SupporterTagFulfillmentTest.php
@@ -79,7 +79,7 @@ class SupporterTagFulfillmentTest extends TestCase
         Mail::fake();
 
         // prevent factory from generating user_sig
-        $giftee1 = User::factory()->create(['osu_subscriptionexpiry' => Carbon::today()->copy(), 'user_sig' => '']);
+        $giftee1 = User::factory()->create(['osu_subscriptionexpiry' => Carbon::today(), 'user_sig' => '']);
         $giftee2 = User::factory()->create(['user_sig' => '']);
 
         // This also tests multiple gifts only send 1 mail/event each
@@ -92,7 +92,7 @@ class SupporterTagFulfillmentTest extends TestCase
         $this->expectCountChange(fn () => Event::where('user_id', $this->user->getKey())->count(), $hidden ? 0 : 1);
 
         // Also test multiple tags in same run to same user get applied properly.
-        $expectedExpiry = $giftee1->osu_subscriptionexpiry->copy()->addMonthsNoOverflow(2);
+        $expectedExpiry = $giftee1->osu_subscriptionexpiry->addMonthsNoOverflow(2);
 
         (new SupporterTagFulfillment($this->order))->run();
 

--- a/tests/Libraries/Fulfillments/SupporterTagFulfillmentTest.php
+++ b/tests/Libraries/Fulfillments/SupporterTagFulfillmentTest.php
@@ -78,7 +78,8 @@ class SupporterTagFulfillmentTest extends TestCase
     {
         Mail::fake();
 
-        $giftee1 = User::factory()->create(['user_sig' => '']); // prevent factory from generating user_sig
+        // prevent factory from generating user_sig
+        $giftee1 = User::factory()->create(['osu_subscriptionexpiry' => Carbon::today()->copy(), 'user_sig' => '']);
         $giftee2 = User::factory()->create(['user_sig' => '']);
 
         // This also tests multiple gifts only send 1 mail/event each
@@ -90,7 +91,12 @@ class SupporterTagFulfillmentTest extends TestCase
         $this->expectCountChange(fn () => Event::where('user_id', $giftee2->getKey())->count(), 1);
         $this->expectCountChange(fn () => Event::where('user_id', $this->user->getKey())->count(), $hidden ? 0 : 1);
 
+        // Also test multiple tags in same run to same user get applied properly.
+        $expectedExpiry = $giftee1->osu_subscriptionexpiry->copy()->addMonthsNoOverflow(2);
+
         (new SupporterTagFulfillment($this->order))->run();
+
+        $this->assertTrue($expectedExpiry->equalTo($giftee1->fresh()->osu_subscriptionexpiry));
 
         Mail::assertQueued(SupporterGift::class, function ($mail) use ($giftee1, $giftee2) {
             $params = $this->invokeProperty($mail, 'params');


### PR DESCRIPTION
When the order has multiple tags to the same user.

Turns out there was actually a reason the user lookup wasn't done in the constructor 💦 