### PR TITLE
Restore missing report-form-select-options css

### DIFF
--- a/resources/css/bem-index.less
+++ b/resources/css/bem-index.less
@@ -306,6 +306,7 @@
 @import "bem/ranking-select-options";
 @import "bem/rankings-beatmapsets";
 @import "bem/report-form";
+@import "bem/report-form-select-options";
 @import "bem/score-beatmap";
 @import "bem/score-buttons";
 @import "bem/score-dial";

--- a/resources/css/bem/report-form-select-options.less
+++ b/resources/css/bem/report-form-select-options.less
@@ -1,0 +1,8 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
+.report-form-select-options {
+  .select-options(report-form-select-options);
+
+  width: 100%;
+}

--- a/resources/js/components/report-form.tsx
+++ b/resources/js/components/report-form.tsx
@@ -182,7 +182,7 @@ export default class ReportForm extends React.Component<Props> {
             <div className={`${bn}__row`}>
               <SelectOptions
                 blackout={false}
-                bn={`${bn}-select-options`}
+                bn='report-form-select-options'
                 onChange={this.handleReasonChange}
                 options={this.options}
                 selected={this.selectedReason}


### PR DESCRIPTION
this whole `${bn}` string interpolation for class names ಠ_ಠ

closes #9789