### PR TITLE
Remove force-version flag when calling starting score indexer

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -142,6 +142,7 @@ jobs:
 
       - name: Setup indices
         run: |
+          php artisan es:index-scores:set-schema --schema=1
           php artisan es:create-search-blacklist
           php artisan es:index-documents --yes
           php artisan es:index-wiki --create-only --yes

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,6 +13,7 @@ env:
   DB_HOST: 127.0.0.1
   ES_SOLO_SCORES_HOST: http://localhost:9200
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  SCHEMA: 1
   NOTIFICATION_ENDPOINT: ws://127.0.0.1:2345
   OSU_INSTALL_DEV: 1
   OSU_USE_SYSTEM_COMPOSER: 1
@@ -142,7 +143,7 @@ jobs:
 
       - name: Setup indices
         run: |
-          php artisan es:index-scores:set-schema --schema=1
+          php artisan es:index-scores:set-schema --schema=${SCHEMA}
           php artisan es:create-search-blacklist
           php artisan es:index-documents --yes
           php artisan es:index-wiki --create-only --yes

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -52,6 +52,8 @@ services:
     depends_on:
       db:
         condition: service_healthy
+      elasticsearch:
+        condition: service_healthy
 
   beatmap-difficulty-lookup-cache:
     image: pppy/osu-beatmap-difficulty-lookup-cache

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -148,7 +148,7 @@ services:
 
   score-indexer:
     image: pppy/osu-elastic-indexer
-    command: ["queue", "watch", "--force-version"]
+    command: ["queue", "watch"]
     depends_on:
       redis:
         condition: service_healthy

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -54,6 +54,8 @@ services:
         condition: service_healthy
       elasticsearch:
         condition: service_healthy
+      redis:
+        condition: service_healthy
 
   beatmap-difficulty-lookup-cache:
     image: pppy/osu-beatmap-difficulty-lookup-cache


### PR DESCRIPTION
We're looking at remove the `--force-version` flag from the score indexer ppy/osu-elastic-indexer#137; github actions can just set the version with `run` before the tests.

~~This still has the issue for with docker compose where the score index isn't aliased after the docker containers start and has to be done separately (which is what `force-version` got around)~~

Tries to set the score indexer schema version when a fresh migration is run so the score indexer can setup the alias for it.
Uses a loop in case the score indexer hasn't finished starting yet - the alternative is `healthcheck` on score-indexer which needs more things installed into the image as well as parsing the output, so I just went with adding it to the migration command.