### PR TITLE
Support timestamp type for supporter expiration time column

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -2362,7 +2362,9 @@ class User extends Model implements AfterCommit, AuthenticatableContract, HasLoc
 
         return $value === null
             ? null
-            : Carbon::createFromFormat('Y-m-d H:i:s', "{$value} 00:00:00");
+            : (strlen($value) === 10
+                ? Carbon::createFromFormat('Y-m-d H:i:s', "{$value} 00:00:00")
+                : $this->getTimeFast($value));
     }
 
     private function getOsuPlaystyle()


### PR DESCRIPTION
@peppy please merge this beforehand if we're going ahead with timestamp datatype update for the `osu_subscriptionexpiry` column. This should handle either type of column.