### PR TITLE
Fairer duration for supporter tags

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -736,11 +736,6 @@ class User extends Model implements AfterCommit, AuthenticatableContract, HasLoc
         $this->attributes['user_colour'] = ltrim($value, '#');
     }
 
-    public function setOsuSubscriptionexpiryAttribute($value)
-    {
-        $this->attributes['osu_subscriptionexpiry'] = $value?->format('Y-m-d');
-    }
-
     public function getAttribute($key)
     {
         return match ($key) {
@@ -816,16 +811,18 @@ class User extends Model implements AfterCommit, AuthenticatableContract, HasLoc
             // float
             'user_timezone' => (float) $this->getRawAttribute($key),
 
-            // datetime
+            // datetime but unix timestamp
             'user_lastmark',
             'user_lastpost_time',
             'user_lastvisit',
             'user_regdate' => Carbon::createFromTimestamp($this->getRawAttribute($key)),
 
+            // datetime
+            'osu_subscriptionexpiry' => $this->getTimeFast($key),
+
             // custom cast
             'displayed_last_visit' => $this->getDisplayedLastVisit(),
             'osu_playstyle' => $this->getOsuPlaystyle(),
-            'osu_subscriptionexpiry' => $this->getOsuSubscriptionexpiry(),
             'playmode' => $this->getPlaymode(),
             'user_avatar' => $this->getUserAvatar(),
             'user_colour' => $this->getUserColour(),
@@ -2354,18 +2351,6 @@ class User extends Model implements AfterCommit, AuthenticatableContract, HasLoc
     private function getDisplayedLastVisit()
     {
         return $this->hide_presence ? null : $this->user_lastvisit;
-    }
-
-    private function getOsuSubscriptionexpiry()
-    {
-        $column = 'osu_subscriptionexpiry';
-        $value = $this->getRawAttribute($column);
-
-        return $value === null
-            ? null
-            : (strlen($value) === 10
-                ? Carbon::createFromFormat('Y-m-d H:i:s', "{$value} 00:00:00")
-                : $this->getTimeFast($column));
     }
 
     private function getOsuPlaystyle()

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -2358,13 +2358,14 @@ class User extends Model implements AfterCommit, AuthenticatableContract, HasLoc
 
     private function getOsuSubscriptionexpiry()
     {
-        $value = $this->getRawAttribute('osu_subscriptionexpiry');
+        $column = 'osu_subscriptionexpiry';
+        $value = $this->getRawAttribute($column);
 
         return $value === null
             ? null
             : (strlen($value) === 10
                 ? Carbon::createFromFormat('Y-m-d H:i:s', "{$value} 00:00:00")
-                : $this->getTimeFast($value));
+                : $this->getTimeFast($column));
     }
 
     private function getOsuPlaystyle()

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -2362,7 +2362,9 @@ class User extends Model implements AfterCommit, AuthenticatableContract, HasLoc
 
         return $value === null
             ? null
-            : Carbon::createFromFormat('Y-m-d H:i:s', "{$value} 00:00:00");
+            : (strlen($value) === 10
+                ? Carbon::createFromFormat('Y-m-d H:i:s', "{$value} 00:00:00")
+                : $this->getTimeFast($value));
     }
 
     private function getOsuPlaystyle()

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -7,6 +7,7 @@ declare(strict_types=1);
 
 namespace Database\Factories;
 
+use App\Libraries\Fulfillments\ApplySupporterTag;
 use App\Models\Country;
 use App\Models\User;
 use App\Models\UserAccountHistory;
@@ -76,7 +77,10 @@ class UserFactory extends Factory
 
     public function supporter()
     {
-        return $this->state(['osu_subscriber' => true, 'osu_subscriptionexpiry' => now()->addMonthsNoOverflow(1)]);
+        return $this->state([
+            'osu_subscriber' => true,
+            'osu_subscriptionexpiry' => ApplySupporterTag::addDuration(now()->floorSecond(), 1),
+        ]);
     }
 
     public function tournamentBanned()

--- a/database/migrations/2023_01_30_080509_use_datetime_for_supporter_expiry.php
+++ b/database/migrations/2023_01_30_080509_use_datetime_for_supporter_expiry.php
@@ -1,0 +1,27 @@
+<?php
+
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('phpbb_users', function (Blueprint $table) {
+            $table->datetime('osu_subscriptionexpiry')->nullable()->change();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('phpbb_users', function (Blueprint $table) {
+            $table->date('osu_subscriptionexpiry')->nullable()->change();
+        });
+    }
+};

--- a/tests/Libraries/Fulfillments/SupporterTagFulfillmentTest.php
+++ b/tests/Libraries/Fulfillments/SupporterTagFulfillmentTest.php
@@ -7,6 +7,7 @@ declare(strict_types=1);
 
 namespace Tests\Libraries\Fulfillments;
 
+use App\Libraries\Fulfillments\ApplySupporterTag;
 use App\Libraries\Fulfillments\FulfillmentException;
 use App\Libraries\Fulfillments\SupporterTagFulfillment;
 use App\Mail\DonationThanks;
@@ -28,28 +29,28 @@ class SupporterTagFulfillmentTest extends TestCase
     public function testDonateSupporterTagToSelf()
     {
         $donor = $this->user;
-        $expectedExpiry = $donor->osu_subscriptionexpiry->copy()->addMonthsNoOverflow(1);
+        $expectedExpiry = ApplySupporterTag::addDuration($donor->osu_subscriptionexpiry, 1);
         $this->createDonationOrderItem($this->user, false, false);
 
         (new SupporterTagFulfillment($this->order))->run();
 
         $donor->refresh();
         $this->assertTrue($donor->osu_subscriber);
-        $this->assertTrue($expectedExpiry->equalTo($donor->osu_subscriptionexpiry));
+        $this->assertEqualsUpToMinute($expectedExpiry, $donor->osu_subscriptionexpiry);
         $this->assertSame(2, $donor->osu_featurevotes);
     }
 
     public function testDonateSupporterTagToOthers()
     {
-        $today = Carbon::today();
+        $now = Carbon::now();
 
         $donor = $this->user;
         $giftee = User::factory()->create([
             'osu_featurevotes' => 0,
-            'osu_subscriptionexpiry' => $today->copy(),
+            'osu_subscriptionexpiry' => $now->copy(),
             'user_sig' => '',
         ]);
-        $expectedExpiry = $giftee->osu_subscriptionexpiry->copy()->addMonthsNoOverflow(1);
+        $expectedExpiry = ApplySupporterTag::addDuration($giftee->osu_subscriptionexpiry, 1);
 
         $this->createDonationOrderItem($giftee, false, false);
 
@@ -63,8 +64,8 @@ class SupporterTagFulfillmentTest extends TestCase
         $this->assertTrue($giftee->osu_subscriber);
 
         // donor's expiry should not change.
-        $this->assertTrue($expectedExpiry->equalTo($giftee->osu_subscriptionexpiry));
-        $this->assertTrue($today->equalTo($donor->osu_subscriptionexpiry));
+        $this->assertEqualsUpToMinute($expectedExpiry, $giftee->osu_subscriptionexpiry);
+        $this->assertEqualsUpToMinute($now, $donor->osu_subscriptionexpiry);
 
         // votes go to donor.
         $this->assertSame(2, $donor->osu_featurevotes);
@@ -79,7 +80,7 @@ class SupporterTagFulfillmentTest extends TestCase
         Mail::fake();
 
         // prevent factory from generating user_sig
-        $giftee1 = User::factory()->create(['osu_subscriptionexpiry' => Carbon::today(), 'user_sig' => '']);
+        $giftee1 = User::factory()->create(['osu_subscriptionexpiry' => Carbon::now(), 'user_sig' => '']);
         $giftee2 = User::factory()->create(['user_sig' => '']);
 
         // This also tests multiple gifts only send 1 mail/event each
@@ -92,11 +93,11 @@ class SupporterTagFulfillmentTest extends TestCase
         $this->expectCountChange(fn () => Event::where('user_id', $this->user->getKey())->count(), $hidden ? 0 : 1);
 
         // Also test multiple tags in same run to same user get applied properly.
-        $expectedExpiry = $giftee1->osu_subscriptionexpiry->addMonthsNoOverflow(1)->addMonthsNoOverflow(1);
+        $expectedExpiry = ApplySupporterTag::addDuration($giftee1->osu_subscriptionexpiry, 2);
 
         (new SupporterTagFulfillment($this->order))->run();
 
-        $this->assertTrue($expectedExpiry->equalTo($giftee1->fresh()->osu_subscriptionexpiry));
+        $this->assertEqualsUpToMinute($expectedExpiry, $giftee1->fresh()->osu_subscriptionexpiry);
 
         Mail::assertQueued(SupporterGift::class, function ($mail) use ($giftee1, $giftee2) {
             $params = $this->invokeProperty($mail, 'params');
@@ -144,7 +145,7 @@ class SupporterTagFulfillmentTest extends TestCase
     public function testPartiallyFulfilledOrder()
     {
         $donor = $this->user;
-        $expectedExpiry = $donor->osu_subscriptionexpiry->copy()->addMonthsNoOverflow(1);
+        $expectedExpiry = ApplySupporterTag::addDuration($donor->osu_subscriptionexpiry, 1);
 
         // consider the first item as processed
         $this->createDonationOrderItem($this->user, false, true);
@@ -155,7 +156,7 @@ class SupporterTagFulfillmentTest extends TestCase
         $donor->refresh();
         // Should only apply one supporter tag.
         $this->assertTrue($donor->osu_subscriber);
-        $this->assertTrue($expectedExpiry->equalTo($donor->osu_subscriptionexpiry));
+        $this->assertEqualsUpToMinute($expectedExpiry, $donor->osu_subscriptionexpiry);
         $this->assertSame(2, $donor->osu_featurevotes);
     }
 
@@ -172,27 +173,20 @@ class SupporterTagFulfillmentTest extends TestCase
         $donor->refresh();
         // Should not apply any supporter tags
         $this->assertFalse($donor->osu_subscriber);
-        $this->assertTrue($expectedExpiry->equalTo($donor->osu_subscriptionexpiry));
+        $this->assertEqualsUpToMinute($expectedExpiry, $donor->osu_subscriptionexpiry);
         $this->assertSame(0, $donor->osu_featurevotes);
     }
 
     public function testRevokeDonateSupporterTagToSelf()
     {
-        $today = Carbon::today();
+        $now = Carbon::now();
 
         $donor = $this->user;
         $donor->update([
             'osu_featurevotes' => 2,
             'osu_subscriber' => true,
-            'osu_subscriptionexpiry' => $today->copy()->addMonthsNoOverflow(1),
+            'osu_subscriptionexpiry' => ApplySupporterTag::addDuration($now->copy(), 1),
         ]);
-
-        // workaround date insanity during testing
-        $expectedExpiry = $today->copy();
-        $insane = $today->day > $donor->osu_subscriptionexpiry->endOfMonth()->day;
-        if ($insane) {
-            $expectedExpiry = $today->day($donor->osu_subscriptionexpiry->endOfMonth()->day);
-        }
 
         $this->createDonationOrderItem($this->user, false, true);
 
@@ -200,20 +194,20 @@ class SupporterTagFulfillmentTest extends TestCase
 
         $donor->refresh();
 
-        $this->assertTrue($expectedExpiry->equalTo($donor->osu_subscriptionexpiry));
+        $this->assertEqualsUpToMinute($now, $donor->osu_subscriptionexpiry);
         $this->assertSame(0, $donor->osu_featurevotes);
         $this->assertFalse($donor->osu_subscriber);
     }
 
     public function testPartiallyRevokedOrder()
     {
-        $today = Carbon::today();
+        $now = Carbon::now();
 
         $donor = $this->user;
         $donor->update([
             'osu_featurevotes' => 4,
             'osu_subscriber' => true,
-            'osu_subscriptionexpiry' => $today->copy()->addMonthsNoOverflow(2),
+            'osu_subscriptionexpiry' => ApplySupporterTag::addDuration($now->copy(), 2),
         ]);
 
         $oldExpiry = $donor->osu_subscriptionexpiry;
@@ -226,20 +220,20 @@ class SupporterTagFulfillmentTest extends TestCase
         $donor->refresh();
 
         // there should be 1 month left.
-        $this->assertTrue($oldExpiry->subMonthsNoOverflow(1)->equalTo($donor->osu_subscriptionexpiry));
+        $this->assertEqualsUpToMinute(ApplySupporterTag::addDuration($oldExpiry, -1), $donor->osu_subscriptionexpiry);
         $this->assertSame(2, $donor->osu_featurevotes);
         $this->assertTrue($donor->osu_subscriber);
     }
 
     public function testAlreadyRevokedOrder()
     {
-        $today = Carbon::today();
+        $now = Carbon::now();
 
         $donor = $this->user;
         $donor->update([
             'osu_featurevotes' => 4,
             'osu_subscriber' => true,
-            'osu_subscriptionexpiry' => $today->copy()->addMonthsNoOverflow(2),
+            'osu_subscriptionexpiry' => ApplySupporterTag::addDuration($now->copy(), 2),
         ]);
 
         $this->createDonationOrderItem($this->user, true, true);
@@ -249,29 +243,29 @@ class SupporterTagFulfillmentTest extends TestCase
 
         $donor->refresh();
 
-        $this->assertTrue($today->copy()->addMonthsNoOverflow(2)->equalTo($donor->osu_subscriptionexpiry));
+        $this->assertEqualsUpToMinute(ApplySupporterTag::addDuration($now->copy(), 2), $donor->osu_subscriptionexpiry);
         $this->assertSame(4, $donor->osu_featurevotes);
         $this->assertTrue($donor->osu_subscriber);
     }
 
     public function testDonateSupporterTagAfterExpired()
     {
-        $today = Carbon::today();
+        $now = Carbon::now();
 
         $donor = $this->user;
         $donor->update([
             'osu_subscriber' => true,
-            'osu_subscriptionexpiry' => $today->copy()->subYears(1),
+            'osu_subscriptionexpiry' => $now->copy()->subYears(1),
         ]);
 
-        $expectedExpiry = $today->copy()->addMonthsNoOverflow(1);
+        $expectedExpiry = ApplySupporterTag::addDuration($now->copy(), 1);
         $this->createDonationOrderItem($this->user, false, false);
 
         (new SupporterTagFulfillment($this->order))->run();
 
         $donor->refresh();
         $this->assertTrue($donor->osu_subscriber);
-        $this->assertTrue($expectedExpiry->equalTo($donor->osu_subscriptionexpiry));
+        $this->assertEqualsUpToMinute($expectedExpiry, $donor->osu_subscriptionexpiry);
         $this->assertSame(2, $donor->osu_featurevotes);
     }
 
@@ -311,7 +305,7 @@ class SupporterTagFulfillmentTest extends TestCase
 
         $this->user = User::factory()->create([
             'osu_featurevotes' => 0,
-            'osu_subscriptionexpiry' => Carbon::today(),
+            'osu_subscriptionexpiry' => Carbon::now(),
         ]);
 
         $this->order = factory(Order::class)->states('paid')->create([
@@ -358,5 +352,10 @@ class SupporterTagFulfillmentTest extends TestCase
                 'username' => $user->username,
             ],
         ]);
+    }
+
+    private function assertEqualsUpToMinute(Carbon $expected, Carbon $actual): void
+    {
+        $this->assertEquals($expected->copy()->floorMinutes(1), $actual->copy()->floorMinutes(1));
     }
 }

--- a/tests/Libraries/Fulfillments/SupporterTagFulfillmentTest.php
+++ b/tests/Libraries/Fulfillments/SupporterTagFulfillmentTest.php
@@ -356,6 +356,6 @@ class SupporterTagFulfillmentTest extends TestCase
 
     private function assertEqualsUpToMinute(Carbon $expected, Carbon $actual): void
     {
-        $this->assertEquals($expected->copy()->floorMinutes(1), $actual->copy()->floorMinutes(1));
+        $this->assertTrue($expected->diffInMinutes($actual, false) < 2);
     }
 }


### PR DESCRIPTION
1 month is now 730 hours.

depends on:
- [x] #9808 (required before migration)
- [x] migrate the column in production and add entry `2023_01_30_080509_use_datetime_for_supporter_expiry`