### PR TITLE
Remove unused interface fields

### DIFF
--- a/resources/js/interfaces/user-multiplayer-history-json.ts
+++ b/resources/js/interfaces/user-multiplayer-history-json.ts
@@ -1,8 +1,6 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
-import BeatmapJson from './beatmap-json';
-import BeatmapsetJson from './beatmapset-json';
 import RoomJson from './room-json';
 
 export type MultiplayerTypeGroup = 'playlists' | 'realtime';
@@ -16,8 +14,6 @@ type RoomJsonIncludes =
 export type EndpointRoomJson = RoomJson & Required<Pick<RoomJson, RoomJsonIncludes>>;
 
 export default interface UserMultiplayerHistoryJson {
-  beatmaps: BeatmapJson[];
-  beatmapsets: BeatmapsetJson[];
   cursor_string: string | null;
   rooms: EndpointRoomJson[];
   type_group: MultiplayerTypeGroup;


### PR DESCRIPTION
It's removed when its functionality was replaced `current_playlist_item`.