### PR TITLE
Adjust wordings for first support event entry

### DIFF
--- a/resources/lang/en/events.php
+++ b/resources/lang/en/events.php
@@ -15,7 +15,7 @@ return [
     'rank' => '<strong><em>:user</em></strong> achieved rank #:rank on <em>:beatmap</em> (:mode)',
     'rank_lost' => '<strong><em>:user</em></strong> has lost first place on <em>:beatmap</em> (:mode)',
     'user_support_again' => '<strong>:user</strong> has once again chosen to support osu! - thanks for your generosity!',
-    'user_support_first' => '<strong>:user</strong> has become an osu!supporter - thanks for your generosity!',
+    'user_support_first' => '<strong>:user</strong> has supported osu! - thanks for your generosity!',
     'user_support_gift' => '<strong>:user</strong> has received the gift of osu!supporter!',
     'username_change' => '<strong>:previousUsername</strong> has changed their username to <strong><em>:user</em></strong>!',
 


### PR DESCRIPTION
It was originally linking to the user actually getting supporter tag but the current one just link to whoever purchased the support (probably for the better).

Resolves #9683.