### PR TITLE
Hide delete beatmap button for moderators

### DIFF
--- a/app/Libraries/OsuAuthorize.php
+++ b/app/Libraries/OsuAuthorize.php
@@ -556,10 +556,6 @@ class OsuAuthorize
             return 'ok';
         }
 
-        if (!$beatmapset->isScoreable() && $user->isModerator()) {
-            return 'ok';
-        }
-
         return 'unauthorized';
     }
 


### PR DESCRIPTION
Missing some logging and mailing (and silencing) that exist in bot command version.

...it's still visible for admins though.

It may be put back if someone bothered to move those additional stuff to osu-web but for now 🤷‍♀️

Resolves #9774.