### PR TITLE
Update to php 8.1

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -27,7 +27,7 @@ jobs:
         uses: shivammathur/setup-php@v2
         with:
           tools: composer:v2
-          php-version: '8.0'
+          php-version: '8.1'
 
       - name: Get composer cache directory
         id: composercache

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -96,7 +96,7 @@ jobs:
   tests:
     strategy:
       matrix:
-        php: ['8.0']
+        php: ['8.1']
     name: Tests
     runs-on: ubuntu-latest
     steps:

--- a/Dockerfile.deployment
+++ b/Dockerfile.deployment
@@ -13,20 +13,20 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get install -y \
     git \
     jhead \
     nginx \
-    php8.0-common \
-    php8.0-curl \
-    php8.0-ds \
-    php8.0-gd \
-    php8.0-intl \
-    php8.0-mbstring \
-    php8.0-mysql \
-    php8.0-redis \
-    php8.0-sqlite3 \
-    php8.0-swoole \
-    php8.0-tokenizer \
-    php8.0-xml \
-    php8.0-zip \
-    php8.0 \
+    php8.1-common \
+    php8.1-curl \
+    php8.1-ds \
+    php8.1-gd \
+    php8.1-intl \
+    php8.1-mbstring \
+    php8.1-mysql \
+    php8.1-redis \
+    php8.1-sqlite3 \
+    php8.1-swoole \
+    php8.1-tokenizer \
+    php8.1-xml \
+    php8.1-zip \
+    php8.1 \
     zip \
     libjpeg-turbo-progs
 

--- a/Dockerfile.development
+++ b/Dockerfile.development
@@ -17,20 +17,20 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get install -y \
     libnss3 \
     mysql-client \
     netcat-openbsd \
-    php8.0-common \
-    php8.0-curl \
-    php8.0-ds \
-    php8.0-gd \
-    php8.0-intl \
-    php8.0-mbstring \
-    php8.0-mysql \
-    php8.0-redis \
-    php8.0-sqlite3 \
-    php8.0-swoole \
-    php8.0-tokenizer \
-    php8.0-xml \
-    php8.0-zip \
-    php8.0 \
+    php8.1-common \
+    php8.1-curl \
+    php8.1-ds \
+    php8.1-gd \
+    php8.1-intl \
+    php8.1-mbstring \
+    php8.1-mysql \
+    php8.1-redis \
+    php8.1-sqlite3 \
+    php8.1-swoole \
+    php8.1-tokenizer \
+    php8.1-xml \
+    php8.1-zip \
+    php8.1 \
     zip \
     libjpeg-turbo-progs
 

--- a/composer.json
+++ b/composer.json
@@ -8,6 +8,12 @@
     "email": "support@ppy.sh",
     "issues": "https://github.com/ppy/osu-web/issues"
   },
+  "repositories": [
+    {
+      "type": "vcs",
+      "url": "https://github.com/nanaya/xsolla-sdk-php"
+    }
+  ],
   "require": {
     "anhskohbo/no-captcha": "^3.2",
     "chaseconey/laravel-datadog-helper": ">=1.2.0",
@@ -40,7 +46,7 @@
     "sentry/sentry-laravel": "^2.8",
     "symfony/yaml": "*",
     "tightenco/ziggy": ">=0.8.1",
-    "xsolla/xsolla-sdk-php": ">=4.2.0"
+    "xsolla/xsolla-sdk-php": "dev-php81"
   },
   "require-dev": {
     "beyondcode/laravel-query-detector": "*",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "04e11618f2a72815f3de1849829f2139",
+    "content-hash": "1b887e8e6926179b86a0c3dff4e82dd8",
     "packages": [
         {
             "name": "anhskohbo/no-captcha",
@@ -11220,24 +11220,24 @@
         },
         {
             "name": "xsolla/xsolla-sdk-php",
-            "version": "v4.2.0",
+            "version": "dev-php81",
             "source": {
                 "type": "git",
-                "url": "https://github.com/xsolla/xsolla-sdk-php.git",
-                "reference": "07729c112547f84fe2d6f21e2fc5cc9f316f01ad"
+                "url": "https://github.com/nanaya/xsolla-sdk-php.git",
+                "reference": "106c3104f1cdd4b6bfeba0dd56864269eb76f44b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/xsolla/xsolla-sdk-php/zipball/07729c112547f84fe2d6f21e2fc5cc9f316f01ad",
-                "reference": "07729c112547f84fe2d6f21e2fc5cc9f316f01ad",
+                "url": "https://api.github.com/repos/nanaya/xsolla-sdk-php/zipball/106c3104f1cdd4b6bfeba0dd56864269eb76f44b",
+                "reference": "106c3104f1cdd4b6bfeba0dd56864269eb76f44b",
                 "shasum": ""
             },
             "require": {
                 "ext-curl": "*",
                 "ext-json": "*",
-                "guzzlehttp/guzzle": "~6.0",
-                "php": "^7.3|~8.0.0",
-                "symfony/http-foundation": "~2.3 || ~3.0 || ~4.0 || ~5.0"
+                "guzzlehttp/guzzle": "~6.0 || ~7.0",
+                "php": "^7.3|^8.0",
+                "symfony/http-foundation": "~2.3 || ~3.0 || ~4.0 || ~5.0 || ~6.0"
             },
             "require-dev": {
                 "friendsofphp/php-cs-fixer": "~2.13",
@@ -11251,7 +11251,11 @@
                     "Xsolla\\SDK\\": "src"
                 }
             },
-            "notification-url": "https://packagist.org/downloads/",
+            "autoload-dev": {
+                "psr-4": {
+                    "Xsolla\\SDK\\Tests\\": "tests"
+                }
+            },
             "license": [
                 "MIT"
             ],
@@ -11265,13 +11269,13 @@
                 "xsolla"
             ],
             "support": {
-                "docs": "https://developers.xsolla.com",
                 "email": "integration@xsolla.com",
                 "issues": "https://github.com/xsolla/xsolla-sdk-php/issues",
+                "docs": "https://developers.xsolla.com",
                 "source": "https://github.com/xsolla/xsolla-sdk-php/releases"
             },
             "abandoned": true,
-            "time": "2021-05-12T07:56:37+00:00"
+            "time": "2023-02-15T06:54:26+00:00"
         }
     ],
     "packages-dev": [
@@ -13777,7 +13781,9 @@
     ],
     "aliases": [],
     "minimum-stability": "stable",
-    "stability-flags": [],
+    "stability-flags": {
+        "xsolla/xsolla-sdk-php": 20
+    },
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": [],


### PR DESCRIPTION
Upgrading to laravel 9 turned out to be a bit more annoying than expected so this can go in first instead. As additional bonus we may be able to just jump directly to 10 instead with this.

I'm not updating php specification in composer because notification and thumbnailer servers' php need to be updated separately. It'll be done as soon as it's deployed so I don't bother keeping old version in test matrix.

I'll update the branch protection rule accordingly once this pr is approved 👀 