### PR TITLE
Fix calling explode() on null deprecation

### DIFF
--- a/app/Http/Controllers/ChangelogController.php
+++ b/app/Http/Controllers/ChangelogController.php
@@ -204,7 +204,7 @@ class ChangelogController extends Controller
     {
         $token = config('osu.changelog.github_token');
 
-        $signatureHeader = explode('=', request()->header('X-Hub-Signature'));
+        $signatureHeader = explode('=', request()->header('X-Hub-Signature') ?? '');
 
         if (count($signatureHeader) !== 2) {
             abort(422, 'invalid signature header');

--- a/app/Http/Controllers/Passport/AuthorizationController.php
+++ b/app/Http/Controllers/Passport/AuthorizationController.php
@@ -62,7 +62,7 @@ class AuthorizationController extends PassportAuthorizationController
     {
         $params = $request->getQueryParams();
         $scopes = $this->normalizeScopes(
-            explode(' ', $params['scope'] ?? null)
+            explode(' ', $params['scope'] ?? '')
         );
 
         // temporary non-persisted token to validate with.

--- a/app/Libraries/Search/BeatmapsetSearchRequestParams.php
+++ b/app/Libraries/Search/BeatmapsetSearchRequestParams.php
@@ -242,7 +242,7 @@ class BeatmapsetSearchRequestParams extends BeatmapsetSearchParams
 
     private function parseSort(?string $value): void
     {
-        $array = explode('_', $value);
+        $array = explode('_', $value ?? '');
         $this->sortField = $array[0];
         $this->sortOrder = $array[1] ?? null;
 


### PR DESCRIPTION
Probably missed some of the more hidden ones..or the ones that look non-null but actually could be null 🤔 