### PR TITLE
Fix page change event triggered before page load

### DIFF
--- a/resources/js/components/header-v4.tsx
+++ b/resources/js/components/header-v4.tsx
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 import HeaderLink from 'interfaces/header-link';
+import core from 'osu-core-singleton';
 import * as React from 'react';
 import { classWithModifiers, Modifiers, urlPresence } from 'utils/css';
 import { parseJson } from 'utils/json';
@@ -52,8 +53,16 @@ export default class HeaderV4 extends React.Component<Props> {
     linksBreadcrumb: false,
   };
 
+  private cancelSyncHeight?: () => void;
+
   componentDidMount() {
-    $.publish('osu:page:change');
+    this.cancelSyncHeight = core.reactTurbolinks.runAfterPageLoad(() => {
+      $.publish('sync-height:force');
+    });
+  }
+
+  componentWillUnmount() {
+    this.cancelSyncHeight?.();
   }
 
   render() {

--- a/resources/js/core-legacy/forum.coffee
+++ b/resources/js/core-legacy/forum.coffee
@@ -64,6 +64,8 @@ export default class Forum
 
 
   topicMeta: ->
+    # FIXME: this should probably use document instead of newBody as
+    # everything else in this class use document.
     newBody.querySelector('.js-forum--topic-meta')?.dataset
 
 


### PR DESCRIPTION
Mainly in core-legacy/forum where for some reason one of its function (topicMeta) uses newBody when the rest of it uses currently displayed document.

Resolves #9869. (going to user profile from a forum topic show)