### PR TITLE
Separate ipv4 and ipv6 lookup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -83,5 +83,5 @@ composer-installer
 /storage/htmlpurifier/
 /storage/paypal_auth.cache
 
-/database/ip2asn.idx
-/database/ip2asn.tsv
+/database/ip2asn/*.idx
+/database/ip2asn/*.tsv

--- a/app/Libraries/Ip.php
+++ b/app/Libraries/Ip.php
@@ -1,0 +1,14 @@
+<?php
+
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
+declare(strict_types=1);
+
+namespace App\Libraries;
+
+enum Ip: string
+{
+    case V4 = 'v4';
+    case V6 = 'v6';
+}

--- a/app/Libraries/Ip2Asn.php
+++ b/app/Libraries/Ip2Asn.php
@@ -8,43 +8,60 @@ declare(strict_types=1);
 namespace App\Libraries;
 
 use Exception;
+use WeakMap;
 
 class Ip2Asn
 {
-    private $dbFh;
-    private string $index;
-    private int $count;
+    private WeakMap $dbFh;
+    private WeakMap $index;
+    private WeakMap $count;
 
     public function __construct()
     {
-        $this->dbFh = fopen(Ip2AsnUpdater::getDbPath(), 'r');
-        $index = file_get_contents(Ip2AsnUpdater::getIndexPath());
-        if ($this->dbFh === false || $index === false) {
-            throw new Exception('failed opening ip2asn database or index');
-        }
-        $this->index = $index;
+        $this->dbFh = new WeakMap();
+        $this->index = new WeakMap();
+        $this->count = new WeakMap();
 
-        // 4 bytes per entry (int32)
-        $this->count = strlen($this->index) / 4;
+        foreach (Ip::cases() as $version) {
+            $this->dbFh[$version] = fopen(Ip2AsnUpdater::getDbPath($version), 'r');
+            $index = file_get_contents(Ip2AsnUpdater::getIndexPath($version));
+            if ($this->dbFh[$version] === false || $index === false) {
+                throw new Exception("failed opening ip2asn {$version} database or index");
+            }
+            $this->index[$version] = $index;
+
+            // 4 bytes per entry (int32)
+            $this->count[$version] = strlen($this->index[$version]) / 4;
+        }
     }
 
     public function lookup(string $ip): string
     {
-        $start = 0;
-        $end = $this->count - 1;
-        $search = inet_pton($this->prefixIPv4($ip));
-
-        if ($search === false) {
-            return '0';
+        switch (true) {
+            case filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV4) !== false:
+                return $this->lookupByVersion(Ip::V4, $ip);
+            case filter_var($ip, FILTER_VALIDATE_IP, FILTER_FLAG_IPV6) !== false:
+                return $this->lookupByVersion(Ip::V6, $ip);
         }
+
+        return '0';
+    }
+
+    private function lookupByVersion(Ip $version, string $ip): string
+    {
+        $dbFh = $this->dbFh[$version];
+        $index = $this->index[$version];
+        $start = 0;
+        $end = $this->count[$version] - 1;
+        $search = inet_pton($ip);
 
         while ($start <= $end) {
             $current = (int) (($start + $end) / 2);
-            $loc = unpack('l', substr($this->index, $current * 4, 4))[1];
-            fseek($this->dbFh, $loc);
-            $row = fgets($this->dbFh);
+            $loc = unpack('l', substr($index, $current * 4, 4))[1];
+            fseek($dbFh, $loc);
+            $row = fgets($dbFh);
             $data = explode("\t", $row, 4);
-            $compare = inet_pton($this->prefixIPv4($data[1]));
+            $compare = inet_pton($data[1]);
             $asn = $data[2];
             if ($compare === $search) {
                 return $asn;
@@ -57,15 +74,5 @@ class Ip2Asn
         }
 
         return $lastInnerSearchAsn ?? $asn;
-    }
-
-    /**
-     * Prefix IPv4 so it's sortable as IPv6
-     */
-    private function prefixIPv4(string $ip): string
-    {
-        return strpos($ip, ':') === false
-            ? "::{$ip}"
-            : $ip;
     }
 }

--- a/app/Libraries/Ip2Asn.php
+++ b/app/Libraries/Ip2Asn.php
@@ -12,15 +12,15 @@ use WeakMap;
 
 class Ip2Asn
 {
+    private WeakMap $count;
     private WeakMap $dbFh;
     private WeakMap $index;
-    private WeakMap $count;
 
     public function __construct()
     {
+        $this->count = new WeakMap();
         $this->dbFh = new WeakMap();
         $this->index = new WeakMap();
-        $this->count = new WeakMap();
 
         foreach (Ip::cases() as $version) {
             $this->dbFh[$version] = fopen(Ip2AsnUpdater::getDbPath($version), 'r');

--- a/docker/development/prepare.sh
+++ b/docker/development/prepare.sh
@@ -69,7 +69,7 @@ if [ ! -f .docker/.my.cnf ]; then
     cp .docker/.my.cnf.example .docker/.my.cnf
 fi
 
-if [ ! -f database/ip2asn.tsv ]; then
+if [ ! -f database/ip2asn/v6.tsv ]; then
     _run artisan ip2asn:update
 fi
 


### PR DESCRIPTION
The combined table contains `::` - `::1` entry which is in incorrect order when combined with ipv4 as it ends at `::ffff:ffff` (`::255.255.255.255`) after conversion.

Also technically converted ipv4s should be prefixed with `::ffff:0:` (or `::ffff:`) instead of `::`.

I don't know where to put enums 🤔  (should it be in `App\Enums` or something)