### PR TITLE
Run octane as correct user in docker

### DIFF
--- a/docker/development/entrypoint.sh
+++ b/docker/development/entrypoint.sh
@@ -42,7 +42,7 @@ _migrate() {
 }
 
 _octane() {
-  exec /app/artisan octane:start --host=0.0.0.0 "$@"
+  _rexec /app/artisan octane:start --host=0.0.0.0 "$@"
 }
 
 _schedule() {


### PR DESCRIPTION
`exec` runs things as root.