### PR TITLE
🔧 Add docker tag in production deploy dispatch payload

### DIFF
--- a/.github/workflows/pack.yml
+++ b/.github/workflows/pack.yml
@@ -74,6 +74,7 @@ jobs:
           token: ${{ secrets.KUBERNETES_CONFIG_REPO_ACCESS_TOKEN }}
           repository: ppy/osu-kubernetes-config
           event-type: osu-web-deploy
+          client-payload: '{ "dockerTag": "${{ github.ref_name }}" }'
       -
         name: Create Sentry release
         uses: getsentry/action-release@v1


### PR DESCRIPTION
Adds a payload containing a `dockerTag` variable to be consumed by the osu-web production deploy workflow in the `osu-kubernetes-config` repository.