### PR TITLE
Clean up beatmap pack rendering

### DIFF
--- a/app/Http/Controllers/BeatmapPacksController.php
+++ b/app/Http/Controllers/BeatmapPacksController.php
@@ -32,30 +32,19 @@ class BeatmapPacksController extends Controller
     {
         $query = BeatmapPack::default();
 
-        if (!ctype_digit($idOrTag)) {
-            $pack = $query->where('tag', $idOrTag)->firstOrFail();
+        if (ctype_digit($idOrTag)) {
+            $pack = $query->findOrFail($idOrTag);
 
-            return ujs_redirect(route('packs.show', $pack));
+            return ujs_redirect(route('packs.show', ['pack' => $pack->tag]));
         }
 
-        $pack = $query->findOrFail($idOrTag);
-
-        return ext_view('packs.show', $this->packData($pack));
-    }
-
-    public function raw($id)
-    {
-        $pack = BeatmapPack::default()->findOrFail($id);
-
-        return ext_view('packs.raw', $this->packData($pack));
-    }
-
-    private function packData($pack)
-    {
+        $pack = $query->where('tag', $idOrTag)->firstOrFail();
         $mode = Beatmap::modeStr($pack->playmode ?? 0);
-        $sets = $pack->beatmapsets()->select()->get();
+        $sets = $pack->beatmapsets;
         $userCompletionData = $pack->userCompletionData(Auth::user());
 
-        return compact('mode', 'pack', 'sets', 'userCompletionData');
+        $view = request('format') === 'raw' ? 'packs.raw' : 'packs.show';
+
+        return ext_view($view, compact('mode', 'pack', 'sets', 'userCompletionData'));
     }
 }

--- a/app/Http/Controllers/BeatmapPacksController.php
+++ b/app/Http/Controllers/BeatmapPacksController.php
@@ -35,7 +35,7 @@ class BeatmapPacksController extends Controller
         if (ctype_digit($idOrTag)) {
             $pack = $query->findOrFail($idOrTag);
 
-            return ujs_redirect(route('packs.show', ['pack' => $pack->tag]));
+            return ujs_redirect(route('packs.show', $pack));
         }
 
         $pack = $query->where('tag', $idOrTag)->firstOrFail();

--- a/app/Models/BeatmapPack.php
+++ b/app/Models/BeatmapPack.php
@@ -72,6 +72,11 @@ class BeatmapPack extends Model
         );
     }
 
+    public function getRouteKeyName(): string
+    {
+        return 'tag';
+    }
+
     public function userCompletionData($user)
     {
         if ($user !== null) {

--- a/app/Models/BeatmapPack.php
+++ b/app/Models/BeatmapPack.php
@@ -62,12 +62,14 @@ class BeatmapPack extends Model
 
     public function beatmapsets()
     {
-        $setsTable = (new Beatmapset())->getTable();
-        $itemsTable = (new BeatmapPackItem())->getTable();
-
-        return Beatmapset::query()
-            ->join($itemsTable, "{$itemsTable}.beatmapset_id", '=', "{$setsTable}.beatmapset_id")
-            ->where("{$itemsTable}.pack_id", '=', $this->pack_id);
+        return $this->hasManyThrough(
+            Beatmapset::class,
+            BeatmapPackItem::class,
+            'pack_id',
+            'beatmapset_id',
+            null,
+            'beatmapset_id',
+        );
     }
 
     public function userCompletionData($user)

--- a/resources/js/core-legacy/beatmap-pack.coffee
+++ b/resources/js/core-legacy/beatmap-pack.coffee
@@ -10,7 +10,7 @@ export default class BeatmapPack
 
   constructor: (rootElement) ->
     @el = rootElement
-    @packId = rootElement.dataset.packId
+    @packTag = rootElement.dataset.packTag
     @packBody = @el.querySelector('.js-accordion__item-body')
     @expander = @el.querySelector('.js-accordion__item-header')
     @busy = false
@@ -19,11 +19,11 @@ export default class BeatmapPack
     $('.js-accordion').on 'beatmappack:clicked', @onClick
     $(@expander).on 'click', (event) =>
       event.preventDefault()
-      $(@el).trigger 'beatmappack:clicked', @packId
+      $(@el).trigger 'beatmappack:clicked', @packTag
 
-  onClick: (e, id) =>
+  onClick: (e, tag) =>
     e.stopPropagation()
-    if @isCurrent || @packId != id
+    if @isCurrent || @packTag != tag
       @close()
     else
       @open()
@@ -39,7 +39,7 @@ export default class BeatmapPack
       @slideDown() if @isCurrent
     else
       @busy = true
-      @getBeatmapPackItem(@packId)
+      @getBeatmapPackItem(@packTag)
       .done (data) =>
         @nextFrame =>
           @packBody.innerHTML = data
@@ -59,8 +59,8 @@ export default class BeatmapPack
       $(@el).removeClass('js-accordion__item--expanded')
 
   # TODO: move out.
-  getBeatmapPackItem: (packId) ->
-    $.get route('packs.raw', pack: packId)
+  getBeatmapPackItem: (packTag) ->
+    $.get route('packs.show', pack: packTag, format: 'raw')
 
   slideDown: =>
     @packBody.style.height = ''

--- a/resources/views/packs/_header.blade.php
+++ b/resources/views/packs/_header.blade.php
@@ -13,7 +13,7 @@
     if (isset($pack)) {
         $links[] = [
             'title' => $pack->name,
-            'url' => route('packs.show', ['pack' => $pack->tag]),
+            'url' => route('packs.show', $pack),
         ];
     }
 @endphp

--- a/resources/views/packs/_header.blade.php
+++ b/resources/views/packs/_header.blade.php
@@ -13,7 +13,7 @@
     if (isset($pack)) {
         $links[] = [
             'title' => $pack->name,
-            'url' => route('packs.show', $pack),
+            'url' => route('packs.show', ['pack' => $pack->tag]),
         ];
     }
 @endphp

--- a/resources/views/packs/index.blade.php
+++ b/resources/views/packs/index.blade.php
@@ -19,11 +19,11 @@
 
         <div class="beatmap-packs js-accordion">
             @foreach ($packs as $pack)
-                <div class="beatmap-pack js-beatmap-pack js-accordion__item" data-pack-id="{{ $pack->getKey() }}">
-                    <a href="{{ route('packs.show', $pack) }}" class="beatmap-pack__header js-accordion__item-header">
+                <div class="beatmap-pack js-beatmap-pack js-accordion__item" data-pack-tag="{{ $pack->tag }}">
+                    <a href="{{ route('packs.show', ['pack' => $pack->tag]) }}" class="beatmap-pack__header js-accordion__item-header">
                         <div class="beatmap-pack__name">{{ $pack->name }}</div>
                         <div class="beatmap-pack__details">
-                            <span class="beatmap-pack__date">{{ $pack->date->formatLocalized('%Y-%m-%d') }}</span>
+                            <span class="beatmap-pack__date">{{ json_date($pack->date) }}</span>
                             <span class="beatmap-pack__author">by </span>
                             <span class="beatmap-pack__author beatmap-pack__author--bold">{{ $pack->author }}</span>
                         </div>

--- a/resources/views/packs/index.blade.php
+++ b/resources/views/packs/index.blade.php
@@ -20,7 +20,7 @@
         <div class="beatmap-packs js-accordion">
             @foreach ($packs as $pack)
                 <div class="beatmap-pack js-beatmap-pack js-accordion__item" data-pack-tag="{{ $pack->tag }}">
-                    <a href="{{ route('packs.show', ['pack' => $pack->tag]) }}" class="beatmap-pack__header js-accordion__item-header">
+                    <a href="{{ route('packs.show', $pack) }}" class="beatmap-pack__header js-accordion__item-header">
                         <div class="beatmap-pack__name">{{ $pack->name }}</div>
                         <div class="beatmap-pack__details">
                             <span class="beatmap-pack__date">{{ json_date($pack->date) }}</span>

--- a/resources/views/packs/raw.blade.php
+++ b/resources/views/packs/raw.blade.php
@@ -2,14 +2,19 @@
     Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
     See the LICENCE file in the repository root for full licence text.
 --}}
-
-
+@php
+    $currentUser = Auth::user();
+@endphp
 <div class="beatmap-pack-description">
-    @if(Auth::check())
-        <a href="{{ $pack->url }}"
-            class="beatmap-pack-download__link">{{ osu_trans('beatmappacks.show.download') }}</a>
-    @else
+    @if($currentUser === null)
         {!! require_login('beatmappacks.require_login._', 'beatmappacks.require_login.link_text') !!}
+    @else
+        <a
+            href="{{ $pack->url }}"
+            class="beatmap-pack-download__link"
+        >
+            {{ osu_trans('beatmappacks.show.download') }}
+        </a>
     @endif
 </div>
 @if ($pack->no_diff_reduction)
@@ -29,8 +34,8 @@
                   title="{{ $cleared ? osu_trans('beatmappacks.show.item.cleared') : osu_trans('beatmappacks.show.item.not_cleared') }}"
             ></span>
             <a href="{{ route('beatmapsets.show', ['beatmapset' => $set->getKey()]) }}" class="beatmap-pack-items__link">
-                <span class="beatmap-pack-items__artist">{{ $set->getDisplayArtist(auth()->user()) }}</span>
-                <span class="beatmap-pack-items__title"> - {{ $set->getDisplayTitle(auth()->user()) }}</span>
+                <span class="beatmap-pack-items__artist">{{ $set->getDisplayArtist($currentUser) }}</span>
+                <span class="beatmap-pack-items__title"> - {{ $set->getDisplayTitle($currentUser) }}</span>
             </a>
     @endforeach
 </ul>

--- a/resources/views/packs/raw.blade.php
+++ b/resources/views/packs/raw.blade.php
@@ -3,7 +3,10 @@
     See the LICENCE file in the repository root for full licence text.
 --}}
 @php
+    use Ds\Set;
+
     $currentUser = Auth::user();
+    $userCompletedBeatmapIds = new Set($userCompletionData['beatmapset_ids']);
 @endphp
 <div class="beatmap-pack-description">
     @if($currentUser === null)
@@ -27,10 +30,11 @@
 <ul class="beatmap-pack-items">
     @foreach ($sets as $set)
         @php
-            $cleared = in_array($set->getKey(), $userCompletionData['beatmapset_ids'], true)
+            $cleared = $userCompletedBeatmapIds->contains($set->getKey());
+            $iconClass = class_with_modifiers('beatmap-pack-items__icon', ['cleared' => $cleared]);
         @endphp
         <li class="beatmap-pack-items__set">
-            <span class="fal fa-extra-mode-{{$mode}} beatmap-pack-items__icon {{ $cleared ? 'beatmap-pack-items__icon--cleared' : '' }}"
+            <span class="fal fa-extra-mode-{{ $mode }} {{ $iconClass }}"
                   title="{{ $cleared ? osu_trans('beatmappacks.show.item.cleared') : osu_trans('beatmappacks.show.item.not_cleared') }}"
             ></span>
             <a href="{{ route('beatmapsets.show', ['beatmapset' => $set->getKey()]) }}" class="beatmap-pack-items__link">

--- a/resources/views/packs/show.blade.php
+++ b/resources/views/packs/show.blade.php
@@ -10,10 +10,10 @@
     <div class="osu-page">
         <div class="beatmap-packs">
             <div class="beatmap-pack beatmap-pack--expanded">
-                <a href="{{ route('packs.show', $pack) }}" class="beatmap-pack__header">
+                <a href="{{ route('packs.show', ['pack' => $pack->tag]) }}" class="beatmap-pack__header">
                     <div class="beatmap-pack__name">{{ $pack->name }}</div>
                     <div class="beatmap-pack__details">
-                        <span class="beatmap-pack__date">{{ $pack->date->formatLocalized('%Y-%m-%d') }}</span>
+                        <span class="beatmap-pack__date">{{ json_date($pack->date) }}</span>
                         <span class="beatmap-pack__author">by </span>
                         <span class="beatmap-pack__author beatmap-pack__author--bold">{{ $pack->author }}</span>
                     </div>

--- a/resources/views/packs/show.blade.php
+++ b/resources/views/packs/show.blade.php
@@ -10,7 +10,7 @@
     <div class="osu-page">
         <div class="beatmap-packs">
             <div class="beatmap-pack beatmap-pack--expanded">
-                <a href="{{ route('packs.show', ['pack' => $pack->tag]) }}" class="beatmap-pack__header">
+                <a href="{{ route('packs.show', $pack) }}" class="beatmap-pack__header">
                     <div class="beatmap-pack__name">{{ $pack->name }}</div>
                     <div class="beatmap-pack__details">
                         <span class="beatmap-pack__date">{{ json_date($pack->date) }}</span>

--- a/routes/web.php
+++ b/routes/web.php
@@ -36,7 +36,6 @@ Route::group(['middleware' => ['web']], function () {
         Route::resource('artists/tracks', 'ArtistTracksController', ['only' => 'show']);
 
         Route::resource('packs', 'BeatmapPacksController', ['only' => ['index', 'show']]);
-        Route::get('packs/{pack}/raw', 'BeatmapPacksController@raw')->name('packs.raw');
 
         Route::group(['as' => 'beatmaps.', 'prefix' => '{beatmap}'], function () {
             Route::get('scores/users/{user}', 'BeatmapsController@userScore');

--- a/tests/Browser/SanityTest.php
+++ b/tests/Browser/SanityTest.php
@@ -430,9 +430,6 @@ class SanityTest extends DuskTestCase
                 'locale' => 'en',
                 'path' => 'Terms',
             ],
-            'packs.show' => [
-                'pack' => self::$scaffolding['pack']->tag,
-            ],
             'wiki.image' => [
                 'path' => 'shared/mode/osu.png',
             ],
@@ -453,7 +450,7 @@ class SanityTest extends DuskTestCase
                 static::output($params[$paramName]." \e[30;1m(override)\e[0m\n");
             } else {
                 if (isset(self::$scaffolding[$paramName])) {
-                    $params[$paramName] = self::$scaffolding[$paramName]->getKey();
+                    $params[$paramName] = self::$scaffolding[$paramName]->getRouteKey();
                     static::output($params[$paramName]."\n");
                 } else {
                     static::output("\e[30;1m¯\_(ツ)_/¯\e[0m\n");

--- a/tests/Browser/SanityTest.php
+++ b/tests/Browser/SanityTest.php
@@ -430,6 +430,9 @@ class SanityTest extends DuskTestCase
                 'locale' => 'en',
                 'path' => 'Terms',
             ],
+            'packs.show' => [
+                'pack' => self::$scaffolding['pack']->tag,
+            ],
             'wiki.image' => [
                 'path' => 'shared/mode/osu.png',
             ],

--- a/tests/Browser/ScaffoldDummy.php
+++ b/tests/Browser/ScaffoldDummy.php
@@ -19,6 +19,11 @@ class ScaffoldDummy
         return $this->value;
     }
 
+    public function getRouteKey(): string
+    {
+        return $this->getKey();
+    }
+
     public function forceDelete()
     {
         return true;


### PR DESCRIPTION
- add proper habtm between pack and set
- default to tag instead of id for url parameter
- combine show and raw endpoint
- use json date formatting as formatLocalized is deprecated in php 8.1
- cache current user variable
- lookup completion data with Set

Also looked into using tag for "primary key" but the join and sort columns still depend on id.