### PR TITLE
Adjust user type column handling

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -505,7 +505,7 @@ class User extends Model implements AfterCommit, AuthenticatableContract, HasLoc
         }
 
         if (!$findAll) {
-            $user->where('user_type', 0)->where('user_warnings', 0);
+            $user->default();
         }
 
         $user = $user->first();

--- a/database/migrations/2015_01_01_133337_base_tables.php
+++ b/database/migrations/2015_01_01_133337_base_tables.php
@@ -1394,7 +1394,7 @@ class BaseTables extends Migration
             $table->collation = 'utf8_bin';
 
             $table->mediumIncrements('user_id');
-            $table->boolean('user_type')->default(0);
+            $table->tinyInteger('user_type')->default(0);
             $table->mediumInteger('group_id')->unsigned()->default(2);
             $column = $table->mediumText('user_permissions');
             $column->collation = 'utf8_bin';


### PR DESCRIPTION
- use existing scope
- use correct type (2 means ignore, 3 means "founder")

Saw this when messing around with user type.