### PR TITLE
Update mod definitions

### DIFF
--- a/database/mods.json
+++ b/database/mods.json
@@ -401,6 +401,10 @@
           {
             "Name": "always_play_tail_sample",
             "Type": "boolean"
+          },
+          {
+            "Name": "fade_hit_circle_early",
+            "Type": "boolean"
           }
         ],
         "IncompatibleMods": [
@@ -1369,7 +1373,7 @@
       {
         "Acronym": "RX",
         "Name": "Relax",
-        "Description": "No ninja-like spinners, demanding drumrolls or unexpected katu's.",
+        "Description": "No ninja-like spinners, demanding drumrolls or unexpected katus.",
         "Type": "Automation",
         "Settings": [],
         "IncompatibleMods": [


### PR DESCRIPTION
Most importantly, includes the new "Fade out hit circles earlier" setting for classic mod. The setting is out in a lazer release, so deployment should probably be expedited.

Addresses https://github.com/ppy/osu/discussions/22779.