### PR TITLE
Always show limited beatmap availability info

### DIFF
--- a/resources/js/beatmapsets-show/header.tsx
+++ b/resources/js/beatmapsets-show/header.tsx
@@ -238,7 +238,7 @@ export default class Header extends React.Component<Props> {
   };
 
   private renderAvailabilityInfo() {
-    if (core.currentUser == null || !downloadLimited(this.controller.beatmapset)) return;
+    if (!downloadLimited(this.controller.beatmapset)) return;
 
     let label: string;
     let href: string | null;


### PR DESCRIPTION
Less confusion for when the page being checked as guest.