### PR TITLE
Fix alignment of page tabs

### DIFF
--- a/resources/css/bem/page-tabs.less
+++ b/resources/css/bem/page-tabs.less
@@ -2,12 +2,12 @@
 // See the LICENCE file in the repository root for full licence text.
 
 .page-tabs {
-  --gutter: 10px;
   --border-size: 5px;
   --tab-hover-border-colour: transparent;
   --tab-active-border-colour: @osu-colour-h1;
 
   display: flex;
+  gap: 20px;
   width: 100%;
   justify-content: center;
   margin-bottom: 1px;
@@ -28,23 +28,21 @@
 
   &--follows {
     max-width: max-content;
-    align-items: flex-start;
-    margin: 0 calc(-1 * var(--gutter)) 10px;
+    margin: 0 0 10px;
     --border-size: 2px;
     --tab-hover-border-colour: var(--tab-active-border-colour);
 
     &::before {
       background-image: none;
       background-color: hsl(var(--hsl-d2));
-      width: calc(100% - (var(--gutter) * 2));
+      width: 100%;
       height: var(--border-size);
-      left: var(--gutter);
       top: calc(100% - var(--border-size));
     }
   }
 
   &__tab {
-    margin: 0 var(--gutter);
+    margin: 0;
     padding: 5px 0;
     border-bottom: var(--border-size) solid transparent;
 


### PR DESCRIPTION
- use gap
- stretch-align the items in follows (not sure why it's flex-start)

Resolves #7047