### PR TITLE
Allow searching beatmap by difficulty owner

### DIFF
--- a/config/schemas/beatmapsets.json
+++ b/config/schemas/beatmapsets.json
@@ -87,6 +87,9 @@
           "total_length": {
             "type": "long"
           },
+          "user_id": {
+            "type": "long"
+          },
           "version": {
             "type": "text"
           }


### PR DESCRIPTION
Resolves #7627. Partial username match isn't supported. Username with space in it must currently be specified using id. The same with username which consists of only numbers.

- [x] depends on #9953
- [x] depends on #9956
- [x] reindex after merging