### PR TITLE
Prioritise accept-language header for api endpoint

### DIFF
--- a/app/Http/Kernel.php
+++ b/app/Http/Kernel.php
@@ -21,7 +21,7 @@ class Kernel extends HttpKernel
     protected $middlewareGroups = [
         'api' => [
             Middleware\AuthApi::class,
-            Middleware\SetLocale::class,
+            Middleware\SetLocaleApi::class,
             Middleware\CheckUserBanStatus::class,
         ],
         'web' => [

--- a/app/Http/Middleware/SetLocale.php
+++ b/app/Http/Middleware/SetLocale.php
@@ -46,8 +46,7 @@ class SetLocale
 
     private function localeFromHeader(Request $request): string
     {
-        $accept = $request->server('HTTP_ACCEPT_LANGUAGE');
-        $parser = new Parser($accept);
+        $parser = new Parser($request->server('HTTP_ACCEPT_LANGUAGE'));
 
         return $parser->languageRegionCompatibleFrom(config('app.available_locales')) ?? config('app.fallback_locale');
     }

--- a/app/Http/Middleware/SetLocale.php
+++ b/app/Http/Middleware/SetLocale.php
@@ -24,24 +24,31 @@ class SetLocale
      */
     public function handle(Request $request, Closure $next)
     {
-        if (Auth::check()) {
-            $locale = Auth::user()->user_lang;
-        } else {
-            $locale = presence($request->cookie('locale'));
-        }
+        $this->setLocale(
+            Auth::user()?->user_lang ?? presence($request->cookie('locale')),
+            $request,
+        );
 
-        $locale = get_valid_locale($locale);
+        return $next($request);
+    }
 
-        if ($locale === null) {
-            $accept = $request->server('HTTP_ACCEPT_LANGUAGE');
-            $parser = new Parser($accept);
-            $locale = $parser->languageRegionCompatibleFrom(config('app.available_locales')) ?? config('app.fallback_locale');
+    protected function setLocale(?string $locale, Request $request): void
+    {
+        if ($locale !== null) {
+            $locale = get_valid_locale($locale);
         }
+        $locale ??= $this->localeFromHeader($request);
 
         App::setLocale($locale);
         // Carbon setLocale normalizes the locale
         Carbon::setLocale($locale);
+    }
 
-        return $next($request);
+    private function localeFromHeader(Request $request): string
+    {
+        $accept = $request->server('HTTP_ACCEPT_LANGUAGE');
+        $parser = new Parser($accept);
+
+        return $parser->languageRegionCompatibleFrom(config('app.available_locales')) ?? config('app.fallback_locale');
     }
 }

--- a/app/Http/Middleware/SetLocaleApi.php
+++ b/app/Http/Middleware/SetLocaleApi.php
@@ -1,0 +1,27 @@
+<?php
+
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
+declare(strict_types=1);
+
+namespace App\Http\Middleware;
+
+use Auth;
+use Closure;
+use Illuminate\Http\Request;
+
+class SetLocaleApi extends SetLocale
+{
+    public function handle(Request $request, Closure $next)
+    {
+        $acceptLanguage = $request->server('HTTP_ACCEPT_LANGUAGE');
+        if ($acceptLanguage === null || $acceptLanguage === '*') {
+            $locale = Auth::user()?->user_lang;
+        }
+
+        $this->setLocale($locale ?? null, $request);
+
+        return $next($request);
+    }
+}

--- a/resources/views/docs/info.md.blade.php
+++ b/resources/views/docs/info.md.blade.php
@@ -104,3 +104,7 @@ Version | Status
 ------- | ---------------------------------------------------------------
 v2      | current _(not yet public, consider unstable and expect breaking changes)_
 v1      | _legacy api provided by the old site, will be deprecated soon_
+
+## Language
+
+Language for the response is determined by `Accept-Language` header when specified. Specifying `*` or not setting the header will set the language to user configured language when accessing API as a user.


### PR DESCRIPTION
Different behaviour added for `*` so it can be used when the http client enforces the header.

Resolves #8113.