### PR TITLE
Various fixes for download page

### DIFF
--- a/app/Http/Controllers/HomeController.php
+++ b/app/Http/Controllers/HomeController.php
@@ -64,13 +64,7 @@ class HomeController extends Controller
             'windows_x64' => osu_trans('home.download.os_version_or_later', ['os_version' => 'Windows 8.1']).' (x64)',
         ];
 
-        $httpHeaders = [];
-        // format headers to what Agent is expecting
-        foreach (request()->headers->all() as $key => $values) {
-            $headerKey = 'HTTP_'.strtoupper(strtr($key, '-', '_'));
-            $httpHeaders[$headerKey] = $values[0];
-        }
-        $agent = new Agent($httpHeaders);
+        $agent = new Agent(Request::server());
 
         $platform = match (true) {
             // Try matching most likely platform first

--- a/app/Http/Controllers/HomeController.php
+++ b/app/Http/Controllers/HomeController.php
@@ -56,8 +56,7 @@ class HomeController extends Controller
 
     public function getDownload()
     {
-        static $lazerPlatformNames;
-        $lazerPlatformNames ??= [
+        $lazerPlatformNames = [
             'android' => osu_trans('home.download.os_version_or_later', ['os_version' => 'Android 5']),
             'ios' => osu_trans('home.download.os_version_or_later', ['os_version' => 'iOS 13.4']),
             'linux_x64' => 'Linux (x64)',

--- a/resources/css/bem/btn-osu-big.less
+++ b/resources/css/bem/btn-osu-big.less
@@ -148,7 +148,7 @@
     transition: background-position 120ms;
 
     flex: none;
-    width: 240px;
+    min-width: 240px;
     padding: 10px;
     margin-bottom: 5px;
     line-height: 1;


### PR DESCRIPTION
- Use correct locale for download page platform names
  - using static means the content doesn't change between requests
- Simpler header passing
  - the original headers are stored in a different place
- Allow button to expand on locales with longer text
  - for example in japanese