### PR TITLE
Fix editing beatmap discussion post on modding profile

### DIFF
--- a/app/Http/Controllers/BeatmapDiscussionPostsController.php
+++ b/app/Http/Controllers/BeatmapDiscussionPostsController.php
@@ -172,7 +172,7 @@ class BeatmapDiscussionPostsController extends Controller
         // TODO: return post + relevant updates only; currently returns both to simplify handling in the beatmap-discussions component.
         return [
             'post' => json_item($post, new BeatmapDiscussionPostTransformer()),
-            'beatmapset' => $post->beatmapset->defaultDiscussionJson()
+            'beatmapset' => $post->beatmapset->defaultDiscussionJson(),
         ];
     }
 }

--- a/app/Http/Controllers/BeatmapDiscussionPostsController.php
+++ b/app/Http/Controllers/BeatmapDiscussionPostsController.php
@@ -161,6 +161,7 @@ class BeatmapDiscussionPostsController extends Controller
             try {
                 $document = json_decode($params['message'], true);
                 Review::update($post->beatmapDiscussion, $document, auth()->user());
+                $post->refresh();
             } catch (\Exception $e) {
                 throw new ModelNotSavedException($e->getMessage());
             }
@@ -168,7 +169,7 @@ class BeatmapDiscussionPostsController extends Controller
             $post->fill($params)->saveOrExplode();
         }
 
-        // TODO: return post only; currently returns both to simplify handling in the beatmap-discussions component.
+        // TODO: return post + relevant updates only; currently returns both to simplify handling in the beatmap-discussions component.
         return [
             'post' => json_item($post, new BeatmapDiscussionPostTransformer()),
             'beatmapset' => $post->beatmapset->defaultDiscussionJson()

--- a/app/Http/Controllers/BeatmapDiscussionPostsController.php
+++ b/app/Http/Controllers/BeatmapDiscussionPostsController.php
@@ -15,6 +15,7 @@ use App\Models\BeatmapDiscussionPost;
 use App\Models\Beatmapset;
 use App\Models\BeatmapsetWatch;
 use App\Models\User;
+use App\Transformers\BeatmapDiscussionPostTransformer;
 
 /**
  * @group Beatmapset Discussions
@@ -167,6 +168,10 @@ class BeatmapDiscussionPostsController extends Controller
             $post->fill($params)->saveOrExplode();
         }
 
-        return $post->beatmapset->defaultDiscussionJson();
+        // TODO: return post only; currently returns both to simplify handling in the beatmap-discussions component.
+        return [
+            'post' => json_item($post, new BeatmapDiscussionPostTransformer()),
+            'beatmapset' => $post->beatmapset->defaultDiscussionJson()
+        ];
     }
 }

--- a/resources/js/beatmap-discussions-history/main.coffee
+++ b/resources/js/beatmap-discussions-history/main.coffee
@@ -21,6 +21,7 @@ export class Main extends React.PureComponent
 
     @eventId = "beatmapset-discussions-history-#{nextVal()}"
     @cache = {}
+    @reviewsConfig = Object.assign({}, props.reviewsConfig, disableInsert: true)
     @state = JSON.parse(props.container.dataset.discussionsState ? null)
     @restoredState = @state?
 
@@ -88,7 +89,7 @@ export class Main extends React.PureComponent
     beatmaps = @beatmaps()
     beatmapsets = @beatmapsets()
 
-    el ReviewEditorConfigContext.Provider, value: @props.reviewsConfig,
+    el ReviewEditorConfigContext.Provider, value: @reviewsConfig,
       el DiscussionsContext.Provider, value: @discussions(),
         el BeatmapsetsContext.Provider, value: beatmapsets,
           el BeatmapsContext.Provider, value: beatmaps,

--- a/resources/js/beatmap-discussions-history/main.coffee
+++ b/resources/js/beatmap-discussions-history/main.coffee
@@ -57,8 +57,8 @@ export class Main extends React.PureComponent
 
     # don't assign null/undefined to state key
     newState = {}
-    newState.updatedDiscussions = updatedDiscussions if updatedDiscussions?
-    newState.updatedRelatedDiscussions = updatedRelatedDiscussions if updatedRelatedDiscussions?
+    newState.discussions = updatedDiscussions if updatedDiscussions?
+    newState.relatedDiscussions = updatedRelatedDiscussions if updatedRelatedDiscussions?
 
     @setState newState
 

--- a/resources/js/beatmap-discussions-history/main.coffee
+++ b/resources/js/beatmap-discussions-history/main.coffee
@@ -21,7 +21,7 @@ export class Main extends React.PureComponent
 
     @eventId = "beatmapset-discussions-history-#{nextVal()}"
     @cache = {}
-    @reviewsConfig = Object.assign({}, props.reviewsConfig, disableInsert: true)
+    @reviewsConfig = Object.assign({}, props.reviewsConfig, disableNewEmbeds: true)
     @state = JSON.parse(props.container.dataset.discussionsState ? null)
     @restoredState = @state?
 

--- a/resources/js/beatmap-discussions/editor-insertion-menu.tsx
+++ b/resources/js/beatmap-discussions/editor-insertion-menu.tsx
@@ -14,6 +14,7 @@ import { SlateContext } from './slate-context';
 
 interface Props {
   currentBeatmap: BeatmapExtendedJson | null;
+  disableNewEmbeds?: boolean;
 }
 
 export class EditorInsertionMenu extends React.Component<Props> {
@@ -228,6 +229,9 @@ export class EditorInsertionMenu extends React.Component<Props> {
       case 'praise':
       case 'problem':
       case 'suggestion':
+        if (this.props.disableNewEmbeds) {
+          return null;
+        }
         icon = discussionTypeIcons[type];
         break;
       case 'paragraph':

--- a/resources/js/beatmap-discussions/editor.tsx
+++ b/resources/js/beatmap-discussions/editor.tsx
@@ -298,7 +298,7 @@ export default class Editor extends React.Component<Props, State> {
             >
               <div ref={this.scrollContainerRef} className={`${editorClass}__input-area`}>
                 <EditorToolbar ref={this.toolbarRef} />
-                {!this.context.disableInsert && <EditorInsertionMenu ref={this.insertMenuRef} currentBeatmap={this.props.currentBeatmap} />}
+                {<EditorInsertionMenu ref={this.insertMenuRef} currentBeatmap={this.props.currentBeatmap} disableNewEmbeds={this.context.disableNewEmbeds} />}
                 <DraftsContext.Provider value={this.cache.draftEmbeds || []}>
                   <Editable
                     decorate={this.decorateTimestamps}
@@ -469,7 +469,7 @@ export default class Editor extends React.Component<Props, State> {
     const { insertData, normalizeNode } = editor;
 
     editor.insertData = (data) => {
-      if (insideEmbed(this.slateEditor)) {
+      if (insideEmbed(this.slateEditor) || this.context.disableNewEmbeds) {
         editor.insertText(data.getData('text/plain'));
       } else {
         insertData(data);

--- a/resources/js/beatmap-discussions/editor.tsx
+++ b/resources/js/beatmap-discussions/editor.tsx
@@ -298,7 +298,7 @@ export default class Editor extends React.Component<Props, State> {
             >
               <div ref={this.scrollContainerRef} className={`${editorClass}__input-area`}>
                 <EditorToolbar ref={this.toolbarRef} />
-                <EditorInsertionMenu ref={this.insertMenuRef} currentBeatmap={this.props.currentBeatmap} />
+                {!this.context.disableInsert && <EditorInsertionMenu ref={this.insertMenuRef} currentBeatmap={this.props.currentBeatmap} />}
                 <DraftsContext.Provider value={this.cache.draftEmbeds || []}>
                   <Editable
                     decorate={this.decorateTimestamps}

--- a/resources/js/beatmap-discussions/post.tsx
+++ b/resources/js/beatmap-discussions/post.tsx
@@ -12,10 +12,9 @@ import StringWithComponent from 'components/string-with-component';
 import TimeWithTooltip from 'components/time-with-tooltip';
 import { UserLink } from 'components/user-link';
 import BeatmapExtendedJson from 'interfaces/beatmap-extended-json';
-import BeatmapsetDiscussionJson from 'interfaces/beatmapset-discussion-json';
-import { BeatmapsetDiscussionMessagePostJson } from 'interfaces/beatmapset-discussion-post-json';
+import BeatmapsetDiscussionJson, { BeatmapsetDiscussionJsonForShow } from 'interfaces/beatmapset-discussion-json';
+import BeatmapsetDiscussionPostJson, { BeatmapsetDiscussionMessagePostJson } from 'interfaces/beatmapset-discussion-post-json';
 import BeatmapsetExtendedJson from 'interfaces/beatmapset-extended-json';
-import { BeatmapsetWithDiscussionsJson } from 'interfaces/beatmapset-json';
 import UserJson from 'interfaces/user-json';
 import { route } from 'laroute';
 import { isEqual } from 'lodash';
@@ -35,6 +34,11 @@ import DiscussionMessageLengthCounter from './discussion-message-length-counter'
 import { UserCard } from './user-card';
 
 const bn = 'beatmap-discussion-post';
+
+interface DiscussionPostUpdateResponse {
+  beatmapset: BeatmapsetDiscussionJsonForShow;
+  post: BeatmapsetDiscussionPostJson;
+}
 
 interface Props {
   beatmap: BeatmapExtendedJson | null;
@@ -58,7 +62,7 @@ export default class Post extends React.Component<Props> {
   private readonly reviewEditorRef = React.createRef<Editor>();
   @observable private textareaMinHeight = '0';
   private readonly textareaRef = React.createRef<HTMLTextAreaElement>();
-  @observable private xhr: JQuery.jqXHR<BeatmapsetWithDiscussionsJson> | null = null;
+  @observable private xhr: JQuery.jqXHR<DiscussionPostUpdateResponse> | null = null;
 
   @computed
   private get canEdit() {
@@ -465,9 +469,9 @@ export default class Post extends React.Component<Props> {
       method: 'PUT',
     });
 
-    this.xhr.done((beatmapset) => runInAction(() => {
+    this.xhr.done((response) => runInAction(() => {
       this.editing = false;
-      $.publish('beatmapsetDiscussions:update', { beatmapset });
+      $.publish('beatmapsetDiscussions:update', response);
     }))
       .fail(onError)
       .always(action(() => this.xhr = null));

--- a/resources/js/interfaces/review-editor-config-json.ts
+++ b/resources/js/interfaces/review-editor-config-json.ts
@@ -2,5 +2,6 @@
 // See the LICENCE file in the repository root for full licence text.
 
 export default interface ReviewEditorConfigJson {
+  disableInsert?: boolean;
   max_blocks: number;
 }

--- a/resources/js/interfaces/review-editor-config-json.ts
+++ b/resources/js/interfaces/review-editor-config-json.ts
@@ -2,6 +2,6 @@
 // See the LICENCE file in the repository root for full licence text.
 
 export default interface ReviewEditorConfigJson {
-  disableInsert?: boolean;
+  disableNewEmbeds?: boolean;
   max_blocks: number;
 }

--- a/resources/js/modding-profile/main.coffee
+++ b/resources/js/modding-profile/main.coffee
@@ -46,7 +46,7 @@ export class Main extends React.PureComponent
     @cache = {}
     @tabs = React.createRef()
     @pages = React.createRef()
-    @reviewsConfig = Object.assign({}, props.reviewsConfig, disableInsert: true)
+    @reviewsConfig = Object.assign({}, props.reviewsConfig, disableNewEmbeds: true)
     @state = JSON.parse(props.container.dataset.profilePageState ? null)
     @restoredState = @state?
 

--- a/resources/js/modding-profile/main.coffee
+++ b/resources/js/modding-profile/main.coffee
@@ -46,6 +46,7 @@ export class Main extends React.PureComponent
     @cache = {}
     @tabs = React.createRef()
     @pages = React.createRef()
+    @reviewsConfig = Object.assign({}, props.reviewsConfig, disableInsert: true)
     @state = JSON.parse(props.container.dataset.profilePageState ? null)
     @restoredState = @state?
 
@@ -141,7 +142,7 @@ export class Main extends React.PureComponent
   render: =>
     profileOrder = @state.profileOrder
 
-    el ReviewEditorConfigContext.Provider, value: @props.reviewsConfig,
+    el ReviewEditorConfigContext.Provider, value: @reviewsConfig,
       el DiscussionsContext.Provider, value: @discussions(),
         el BeatmapsetsContext.Provider, value: @beatmapsets(),
           el BeatmapsContext.Provider, value: @beatmaps(),

--- a/resources/js/modding-profile/main.coffee
+++ b/resources/js/modding-profile/main.coffee
@@ -19,6 +19,7 @@ import DetailBar from 'profile-page/detail-bar'
 import headerLinks from 'profile-page/header-links'
 import * as React from 'react'
 import { a, button, div, i, span } from 'react-dom-factories'
+import { updateDiscussionsWithPost } from 'utils/beatmapset-discussion-helper'
 import { bottomPage } from 'utils/html'
 import { jsonClone } from 'utils/json'
 import { pageChange } from 'utils/page-change'
@@ -99,31 +100,22 @@ export class Main extends React.PureComponent
 
     # update posts
     existingPostIndex = @state.posts.findIndex (x) -> x.id == post.id
-    existingPosts = jsonClone(@state.posts)
 
     if existingPostIndex > -1
-      existingPost = existingPosts[existingPostIndex]
+      updatedPosts = jsonClone(@state.posts)
+      existingPost = updatedPosts[existingPostIndex]
 
       # merge with any existing data added from anywhere else.
-      existingPosts[existingPostIndex] = Object.assign({}, existingPost, post)
+      updatedPosts[existingPostIndex] = Object.assign({}, existingPost, post)
 
     # update if in discussion.starting_post
-    existingDiscussions = null
-    existingDiscussionIndex = @state.discussions.findIndex (x) -> x.id == post.beatmapset_discussion_id
+    updatedDiscussions = updateDiscussionsWithPost(@state.discussions, post)
 
-    if existingDiscussionIndex > -1
-      existingDiscussion = @state.discussions[existingDiscussionIndex]
+    @cache = {}
 
-      if existingDiscussion.starting_post.id == post.id
-        existingDiscussions = jsonClone(@state.discussions)
-        existingDiscussion.starting_post = Object.assign({}, existingDiscussion.starting_post, post)
-        existingDiscussions[existingDiscussionIndex] = existingDiscussion
-        @cache = {}
-
-    newState =
-      posts: existingPosts
-
-    newState.discussions = existingDiscussions if existingDiscussions?
+    newState = {}
+    newState.posts = updatedPosts if updatedPosts?
+    newState.discussions = updatedDiscussions if updatedDiscussions?
 
     @setState newState
 

--- a/resources/js/utils/beatmapset-discussion-helper.ts
+++ b/resources/js/utils/beatmapset-discussion-helper.ts
@@ -417,6 +417,24 @@ export function stateFromDiscussion(discussion: BeatmapsetDiscussionJson) {
   };
 }
 
+export function updateDiscussionsWithPost(discussions: BeatmapsetDiscussionJsonForBundle[], post: BeatmapsetDiscussionPostJson) {
+  const existingDiscussionIndex = discussions.findIndex((x) => x.id === post.beatmapset_discussion_id);
+  let updatedDiscussions: BeatmapsetDiscussionJson[] | null = null;
+
+  if (existingDiscussionIndex > -1) {
+    const existingDiscussion = discussions[existingDiscussionIndex];
+
+    if (existingDiscussion.starting_post.id === post.id) {
+      updatedDiscussions = [...discussions];
+      existingDiscussion.starting_post = { ...existingDiscussion.starting_post, ...post };
+      updatedDiscussions[existingDiscussionIndex] = existingDiscussion;
+    }
+  }
+
+  return updatedDiscussions;
+}
+
+
 export function validMessageLength(message?: string | null, isTimeline = false) {
   if (!message?.length) return false;
 


### PR DESCRIPTION
Only update the post when editing a beatmap discussion post on the modding profile page instead of adding more discussions from the beatmapset onto the page 👀 

Also disables the UI for adding new discussions in reviews when editing from the modding profile and discussion history page since it doesn't seem to make sense to be able to add more without the context of the beatmap itself...?

This is largely a workaround until we can properly refactor the top-level handling on the beatmap discussions component itself.