### PR TITLE
Cleanup header nav styling

### DIFF
--- a/resources/css/bem/header-nav-v4.less
+++ b/resources/css/bem/header-nav-v4.less
@@ -4,7 +4,7 @@
 .header-nav-v4 {
   @_top: header-nav-v4;
   @header-nav-gap: 10px;
-  --header-nav-item-padding-y: 4px;
+  --header-nav-item-padding-y: 10px;
 
   list-style: none;
   display: none;
@@ -23,10 +23,6 @@
 
   &--breadcrumb {
     display: flex;
-
-    @media @mobile {
-      --header-nav-item-padding-y: 10px;
-    }
   }
 
   &--list {

--- a/resources/css/bem/header-nav-v4.less
+++ b/resources/css/bem/header-nav-v4.less
@@ -3,70 +3,59 @@
 
 .header-nav-v4 {
   @_top: header-nav-v4;
-  @_gutter-x: 5px;
-  @_gutter-x-list: 10px;
-  @_gutter-y: 4px;
-  @_gutter-y-desktop: 15px;
+  --header-nav-item-padding-y: 4px;
+
   list-style: none;
   display: none;
   flex-wrap: wrap;
-  margin: 0 -@_gutter-x;
-  padding: (10px - @_gutter-y) 0;
+  gap: 10px;
+  margin: 0;
+  padding: 0;
   font-size: @font-size--normal;
   position: relative;
 
   @media @desktop {
+    --header-nav-item-padding-y: 15px;
     font-size: @font-size--title-small;
-    padding-top: 0;
-    padding-bottom: 0;
     display: flex;
   }
 
   &--breadcrumb {
     display: flex;
+
+    @media @mobile {
+      --header-nav-item-padding-y: 10px;
+    }
   }
 
   &--list {
-    margin-left: -@_gutter-x-list;
-    margin-right: -@_gutter-x-list;
+    gap: 20px;
 
     &::before {
       content: '';
       position: absolute;
-      left: @_gutter-x-list;
       bottom: 0;
-      width: calc(100% - (@_gutter-x-list * 2));
+      width: 100%;
       height: 1px;
-      background-color: @osu-colour-h1;
+      background-color: hsl(var(--hsl-h1));
     }
   }
 
   &__item {
-    margin: 0;
-    padding: @_gutter-y @_gutter-x;
     display: flex; // remove space between ::before and content
     align-items: baseline;
-
-    @media @desktop {
-      padding-top: 0;
-      padding-bottom: 0;
-    }
 
     .@{_top}--breadcrumb & + &::before {
       .fas();
       content: "\f105"; // fa-angle-right
 
-      padding-right: (@_gutter-x * 2);
-    }
-
-    .@{_top}--list & {
-      padding-left: @_gutter-x-list;
-      padding-right: @_gutter-x-list;
+      padding-right: $gap;
     }
   }
 
   &__link {
     position: relative;
+    padding: var(--header-nav-item-padding-y) 0;
 
     &::before {
       display: none;
@@ -74,9 +63,6 @@
     }
 
     @media @desktop {
-      padding-top: @_gutter-y-desktop;
-      padding-bottom: @_gutter-y-desktop;
-
       &::before {
         content: '';
         position: absolute;
@@ -84,7 +70,7 @@
         height: 5px;
         width: 100%;
         border-radius: 10000px;
-        background-color: @osu-colour-h1;
+        background-color: hsl(var(--hsl-h1));
         z-index: @z-index--header-nav-v4-active;
         transition: inherit;
         display: block;
@@ -112,12 +98,4 @@
       }
     }
   }
-
-  &__text {
-    @media @desktop {
-      padding-top: @_gutter-y-desktop;
-      padding-bottom: @_gutter-y-desktop;
-    }
-  }
-
 }

--- a/resources/css/bem/header-nav-v4.less
+++ b/resources/css/bem/header-nav-v4.less
@@ -98,4 +98,8 @@
       }
     }
   }
+
+  &__text {
+    padding: var(--header-nav-item-padding-y) 0;
+  }
 }

--- a/resources/css/bem/header-nav-v4.less
+++ b/resources/css/bem/header-nav-v4.less
@@ -3,12 +3,13 @@
 
 .header-nav-v4 {
   @_top: header-nav-v4;
+  @header-nav-gap: 10px;
   --header-nav-item-padding-y: 4px;
 
   list-style: none;
   display: none;
   flex-wrap: wrap;
-  gap: 10px;
+  gap: @header-nav-gap;
   margin: 0;
   padding: 0;
   font-size: @font-size--normal;
@@ -49,7 +50,7 @@
       .fas();
       content: "\f105"; // fa-angle-right
 
-      padding-right: $gap;
+      padding-right: @header-nav-gap;
     }
   }
 


### PR DESCRIPTION
Something I came across while borrowing the nav for the markdown editor.

Switch to using `gap` instead of margin/padding offsetting