### PR TITLE
Increase number of beatmap packs per page

### DIFF
--- a/app/Http/Controllers/BeatmapPacksController.php
+++ b/app/Http/Controllers/BeatmapPacksController.php
@@ -12,7 +12,7 @@ use Request;
 
 class BeatmapPacksController extends Controller
 {
-    private const PER_PAGE = 20;
+    private const PER_PAGE = 100;
 
     public function index()
     {

--- a/resources/css/bem/beatmap-pack.less
+++ b/resources/css/bem/beatmap-pack.less
@@ -39,7 +39,7 @@
   &__header {
     .link-plain();
     .link-white();
-    padding: @beatmappack-listing--gutter;
+    padding: 15px @beatmappack-listing--gutter;
     background-color: @osu-colour-b3;
     display: flex;
 


### PR DESCRIPTION
Not really solving #2761 but should help reducing number of pages to browse through. Reduces padding a bit so it's quite too long.