### PR TITLE
Fix running multiple octane instances at the same time

### DIFF
--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -143,9 +143,10 @@ class AppServiceProvider extends ServiceProvider
             fn ($app) => $app->bound(Server::class) ? new SwooleTaskDispatcher() : new SequentialTaskDispatcher()
         );
 
-        if ($this->app->environment('testing')) {
+        $env = $this->app->environment();
+        if ($env === 'testing' || $env === 'dusk.local') {
             // This is needed for testing with Dusk.
-            $this->app->register('\App\Providers\AdditionalDuskServiceProvider');
+            $this->app->register(AdditionalDuskServiceProvider::class);
 
             // This is for testing after commit broadcastable events.
             $this->app->singleton(BroadcastsPendingForTests::class, fn () => new BroadcastsPendingForTests());

--- a/config/octane.php
+++ b/config/octane.php
@@ -213,4 +213,5 @@ return [
 
     'max_execution_time' => 180,
 
+    'state_file' => presence(env('OCTANE_STATE_FILE')) ?? storage_path('logs/octane-server-state.json'),
 ];


### PR DESCRIPTION
Customisable octane state path and recognise `dusk.local` env as it's what the dusk octane would be started under. It's needed because octane doesn't seem to respect any changes to `APP_ENV` in the `.env` file so when the test replaces `.env` file with the dusk one which has `APP_ENV=testing`, the actual env stays at whatever it originally started as (usually `local`). Apparently reported two years ago at laravel/dusk#949 and no update since.