### PR TITLE
Clean up ES index after PHPUnit test on GitHub Action

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -151,7 +151,11 @@ jobs:
       - name: Run PHPUnit
         run: ./bin/phpunit.sh
 
-      # TODO: workaround things (beatmaps) being indexed during test above and not cleaned up
+      # TODO: workaround things (beatmaps) being indexed during test above and not cleaned up.
+      # This results in:
+      # 1. ranked beatmapset with null approved date being indexed
+      # 2. ES then returns Long.MIN_VALUE for null dates cursor
+      # 3. and finally ES parser fails when parsing the Long.MIN_VALUE back when passed as cursor
       - name: Clean indexes
         run: php artisan es:index-documents --yes
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -151,6 +151,10 @@ jobs:
       - name: Run PHPUnit
         run: ./bin/phpunit.sh
 
+      # TODO: workaround things (beatmaps) being indexed during test above and not cleaned up
+      - name: Clean indexes
+        run: php artisan es:index-documents --yes
+
       - name: Run Dusk
         run: ./bin/run_dusk.sh
 


### PR DESCRIPTION
It's two different bugs ಠ_ಠ

- beatmap indexing added to the model's `afterCommit` a while back unintentionally fills up es
- es returning cursor itself can't actually parse (for null timestamps `Long.MAX_VALUE`/`MIN_VALUE`)