### PR TITLE
Fix running test in docker

### DIFF
--- a/.env.dusk.local.example
+++ b/.env.dusk.local.example
@@ -1,8 +1,8 @@
 APP_KEY=
 APP_ENV=testing
 
-APP_URL=http://nginx
-NOTIFICATION_ENDPOINT=/home/notifications/feed-dusk
+APP_URL=http://localhost:8000
+NOTIFICATION_ENDPOINT=ws://notification-server-dusk:2345
 
 DB_DATABASE=osu_test
 DB_DATABASE_CHAT=osu_chat_test

--- a/.env.testing.example
+++ b/.env.testing.example
@@ -1,4 +1,3 @@
-DB_DATABASE=osu_test
 DB_DATABASE_CHAT=osu_chat_test
 DB_DATABASE_MP=osu_mp_test
 DB_DATABASE_STORE=osu_store_test
@@ -6,6 +5,7 @@ DB_DATABASE_UPDATES=osu_updates_test
 DB_DATABASE_CHARTS=osu_charts_test
 
 # match with docker-compose.yml
+DB_DATABASE=osu_test
 ES_INDEX_PREFIX=test_
 SCHEMA=test
 

--- a/.env.testing.example
+++ b/.env.testing.example
@@ -5,6 +5,8 @@ DB_DATABASE_STORE=osu_store_test
 DB_DATABASE_UPDATES=osu_updates_test
 DB_DATABASE_CHARTS=osu_charts_test
 
+# match with docker-compose.yml
 ES_INDEX_PREFIX=test_
+SCHEMA=test
 
 PAYMENT_SANDBOX=true

--- a/SETUP.md
+++ b/SETUP.md
@@ -319,6 +319,7 @@ bin/run_dusk.sh
 or if using Docker:
 
 ```
+# `compose exec` doesn't work here due to port conflict with dev instance
 docker compose run --rm php test browser
 ```
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ version: '3.4'
 
 x-env: &x-env
   APP_KEY: "${APP_KEY}"
-  BEATMAPS_DIFFICULTY_CACHE_SERVER_URL: http://beatmap-difficulty-lookup-cache:5000
+  BEATMAPS_DIFFICULTY_CACHE_SERVER_URL: http://beatmap-difficulty-lookup-cache
   BROADCAST_DRIVER: redis
   CACHE_DRIVER: redis
   DB_CONNECTION_STRING: Server=db;Database=osu;Uid=osuweb;
@@ -159,6 +159,23 @@ services:
     environment:
       <<: *x-env
       SCHEMA: "${SCHEMA:-1}"
+
+  score-indexer-test:
+    image: pppy/osu-elastic-indexer
+    command: ["queue", "watch", "--force-version"]
+    depends_on:
+      redis:
+        condition: service_healthy
+      db:
+        condition: service_healthy
+      elasticsearch:
+        condition: service_healthy
+    environment:
+      <<: *x-env
+      DB_CONNECTION_STRING: Server=db;Database=osu_test;Uid=osuweb;
+      # match with .env.testing.example
+      ES_INDEX_PREFIX: test_
+      SCHEMA: test
 
 volumes:
   database:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -172,8 +172,8 @@ services:
         condition: service_healthy
     environment:
       <<: *x-env
-      DB_CONNECTION_STRING: Server=db;Database=osu_test;Uid=osuweb;
       # match with .env.testing.example
+      DB_CONNECTION_STRING: Server=db;Database=osu_test;Uid=osuweb;
       ES_INDEX_PREFIX: test_
       SCHEMA: test
 

--- a/docker/development/entrypoint.sh
+++ b/docker/development/entrypoint.sh
@@ -62,11 +62,18 @@ _test() {
     fi
 
     case "$command" in
-        browser) _rexec php /app/artisan dusk --verbose "$@";;
+        browser) _test_browser "$@";;
         js) _rexec yarn karma start --single-run --browsers ChromeHeadless "$@";;
         phpunit) _rexec ./bin/phpunit.sh "$@";;
     esac
 }
+
+_test_browser() {
+    export APP_ENV=dusk.local
+    export OCTANE_STATE_FILE=/app/storage/logs/octane-server-state-dusk.json
+    _rexec ./bin/run_dusk.sh --verbose "$@"
+}
+
 
 _watch() {
     _run yarn --network-timeout 100000

--- a/docker/development/entrypoint.sh
+++ b/docker/development/entrypoint.sh
@@ -71,7 +71,7 @@ _test() {
 _test_browser() {
     export APP_ENV=dusk.local
     export OCTANE_STATE_FILE=/app/storage/logs/octane-server-state-dusk.json
-    _rexec ./bin/run_dusk.sh --verbose "$@"
+    _rexec ./bin/run_dusk.sh "$@"
 }
 
 


### PR DESCRIPTION
Reusing dev octane doesn't work for dusk. Additionally prevent the new octane instance from overwriting existing octane state.

~~Removed verbose logging while at it.~~ Wait no it's also defined in run_dusk.sh ಠ_ಠ maybe for another time