### PR TITLE
Remove type in timestamp tooltip

### DIFF
--- a/resources/js/beatmap-discussions/editor-discussion-component.tsx
+++ b/resources/js/beatmap-discussions/editor-discussion-component.tsx
@@ -262,10 +262,7 @@ export default class EditorDiscussionComponent extends React.Component<Props> {
     const classMods = canEdit ? [] : ['read-only'];
 
     const timestampTooltipType = this.props.element.beatmapId != null ? 'diff' : 'all-diff';
-
-    const timestampTooltip = trans(`beatmaps.discussions.review.embed.timestamp.${timestampTooltipType}`, {
-      type: trans(`beatmaps.discussions.message_type.${this.discussionType()}`),
-    });
+    const timestampTooltip = trans(`beatmaps.discussions.review.embed.timestamp.${timestampTooltipType}`);
 
     const deleteButton =
       (

--- a/resources/js/beatmap-discussions/editor-discussion-component.tsx
+++ b/resources/js/beatmap-discussions/editor-discussion-component.tsx
@@ -262,7 +262,10 @@ export default class EditorDiscussionComponent extends React.Component<Props> {
     const classMods = canEdit ? [] : ['read-only'];
 
     const timestampTooltipType = this.props.element.beatmapId != null ? 'diff' : 'all-diff';
-    const timestampTooltip = trans(`beatmaps.discussions.review.embed.timestamp.${timestampTooltipType}`);
+    const timestampTooltip = trans(`beatmaps.discussions.review.embed.timestamp.${timestampTooltipType}`, {
+      // TODO: remove after translations are updated without the key
+      type: trans(`beatmaps.discussions.message_type.${this.discussionType()}`),
+    });
 
     const deleteButton =
       (

--- a/resources/lang/en/beatmaps.php
+++ b/resources/lang/en/beatmaps.php
@@ -106,7 +106,7 @@ return [
                 'unsaved' => 'Unsaved',
                 'timestamp' => [
                     'all-diff' => 'Posts on "All difficulties" can\'t be timestamped.',
-                    'diff' => 'If this :type starts with a timestamp, it will be shown under Timeline.',
+                    'diff' => 'If this post starts with a timestamp, it will be shown under Timeline.',
                 ],
             ],
             'insert-block' => [


### PR DESCRIPTION
Resolves #6193. Technically people translating this could've done this themselves ("If this post (:type)") but looking again the English version seems kind of weird anyway with capitalised type. And it already says "Posts" for All difficulties tooltip.