### PR TITLE
Adjust beatmap page margin and add tags overflow

### DIFF
--- a/resources/css/bem/beatmapset-header.less
+++ b/resources/css/bem/beatmapset-header.less
@@ -2,29 +2,30 @@
 // See the LICENCE file in the repository root for full licence text.
 
 .beatmapset-header {
-  @header-height: 350px;
+  display: grid;
+  gap: 20px;
+  padding: 10px @gutter-beatmapset 0;
+  min-height: 350px;
+  position: relative;
 
-  .default-box-shadow();
+  @media @desktop {
+    padding: 20px @gutter-beatmapset-desktop 0;
+    grid-template-columns: 1fr @beatmapset-float-box-width;
+  }
 
   &__box {
     display: flex;
     flex-direction: column;
 
-    padding: 20px 10px 25px;
     position: relative;
 
     &--main {
-      align-self: stretch;
-      min-width: 0;
-
       @media @desktop {
-        flex: 1;
+        padding-bottom: 25px;
       }
     }
 
     &--stats {
-      padding-bottom: 0;
-      align-self: stretch;
       justify-content: space-between;
     }
   }
@@ -37,20 +38,6 @@
     display: flex;
     flex-wrap: wrap;
     margin-top: 10px;
-  }
-
-  &__content {
-    display: flex;
-    flex-direction: column;
-    padding: 0 30px;
-    min-height: @header-height;
-    position: relative;
-
-    @media @desktop {
-      align-items: flex-end;
-      flex-direction: row;
-    }
-
   }
 
   &__availability-info {
@@ -69,6 +56,7 @@
   &__cover {
     --border-radius: 0;
     .light-header-overlay();
+    display: contents;
   }
 
   &__details-text {

--- a/resources/css/bem/beatmapset-info.less
+++ b/resources/css/bem/beatmapset-info.less
@@ -3,11 +3,9 @@
 
 .beatmapset-info {
   @_top: beatmapset-info;
-  @min-height: 220px;
-  @max-height: 320px;
+  @min-height: 200px;
+  @max-height: 300px;
   @box-margin--top: 15px;
-  @header-margin--top: 15px;
-  @header-margin--bottom: 5px;
 
   font-size: @font-size--normal;
 
@@ -16,51 +14,28 @@
 
   padding: 10px @gutter-beatmapset 0;
   background-color: hsl(var(--hsl-b4));
+  -webkit-overflow-scrolling: touch;
 
   @media @desktop {
     padding: 15px @gutter-beatmapset-desktop 0;
-    min-height: @min-height;
-    max-height: @max-height;
     grid-template-columns: 1fr 175px @beatmapset-float-box-width;
   }
 
   &__box {
-    &--description {
-      min-width: 0;
-      display: flex;
-      flex-direction: column;
-      position: relative;
-    }
+    min-width: 0;
+    display: flex;
+    flex-direction: column;
+    position: relative;
+    padding-top: 10px;
 
-    &--meta {
-      position: relative;
-
-      @media @desktop {
-        overflow: hidden;
-        margin-bottom: 10px;
-      }
-    }
-  }
-
-  &__description {
-    -webkit-overflow-scrolling: touch;
-    overflow-y: auto;
-    padding-right: 10px;
-
-    // to prevent overflow from extending container box
     @media @desktop {
-      .full-size();
-    }
-    @media @mobile {
+      min-height: @min-height;
       max-height: @max-height;
     }
-  }
 
-  &__description-container {
-    min-height: 0;
-    max-height: @max-height;
-    flex: 1;
-    position: relative;
+    &--success-rate {
+      padding-top: 0;
+    }
   }
 
   &__edit-button {
@@ -77,13 +52,25 @@
     }
   }
 
-  &__half-box {
+  &__row {
     display: flex;
+    flex-direction: column;
+    padding-top: 5px;
+    padding-bottom: 10px;
+
+    &--half {
+      flex-direction: row;
+    }
+
+    &--value-overflow {
+      padding-bottom: 0;
+      min-height: 0;
+    }
   }
 
   &__half-entry {
-    flex: 1;
-    max-width: 50%;
+    flex: none;
+    width: 50%;
   }
 
   &__header {
@@ -92,10 +79,19 @@
     font-weight: bold;
     font-style: normal;
     padding: 0;
-    margin: @header-margin--top 0 @header-margin--bottom;
+    margin: 0 0 5px;
   }
 
   &__link {
     overflow-wrap: break-word;
+  }
+
+  &__value-overflow {
+    min-height: 0;
+    max-height: @max-height;
+    flex: 1;
+
+    overflow-y: auto;
+    padding-bottom: 10px;
   }
 }

--- a/resources/css/bem/beatmapset-info.less
+++ b/resources/css/bem/beatmapset-info.less
@@ -10,26 +10,22 @@
   @header-margin--bottom: 5px;
 
   font-size: @font-size--normal;
-  color: white;
 
-  display: flex;
-  flex-direction: column;
+  display: grid;
+  gap: 20px;
 
-  padding: 0 30px 0;
+  padding: 10px @gutter-beatmapset 0;
   background-color: hsl(var(--hsl-b4));
 
   @media @desktop {
-    flex-direction: row;
+    padding: 15px @gutter-beatmapset-desktop 0;
     min-height: @min-height;
     max-height: @max-height;
+    grid-template-columns: 1fr 175px @beatmapset-float-box-width;
   }
 
   &__box {
-    margin: @box-margin--top 10px 0;
-    flex: none;
-
     &--description {
-      flex: 1;
       min-width: 0;
       display: flex;
       flex-direction: column;
@@ -40,15 +36,8 @@
       position: relative;
 
       @media @desktop {
-        width: 175px;
         overflow: hidden;
         margin-bottom: 10px;
-      }
-    }
-
-    &--success-rate {
-      @media @desktop {
-        width: @beatmapset-float-box-width;
       }
     }
   }

--- a/resources/css/bem/beatmapset-stats.less
+++ b/resources/css/bem/beatmapset-stats.less
@@ -2,12 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 .beatmapset-stats {
-  color: #fff;
   font-size: 12px;
-
-  @media @desktop {
-    width: @beatmapset-float-box-width;
-  }
 
   &__elapsed-bar {
     position: absolute;

--- a/resources/js/beatmapsets-show/header.tsx
+++ b/resources/js/beatmapsets-show/header.tsx
@@ -92,117 +92,115 @@ export default class Header extends React.Component<Props> {
 
     return (
       <div className='beatmapset-header'>
-        <div className='beatmapset-header__content'>
-          <div className='beatmapset-header__cover'>
-            <BeatmapsetCover
-              beatmapset={this.controller.beatmapset}
-              forceShowVisual // check already covered by parent component
-              modifiers='full'
-              size='cover'
-            />
-          </div>
+        <div className='beatmapset-header__cover'>
+          <BeatmapsetCover
+            beatmapset={this.controller.beatmapset}
+            forceShowVisual // check already covered by parent component
+            modifiers='full'
+            size='cover'
+          />
+        </div>
 
-          <div className='beatmapset-header__box beatmapset-header__box--main'>
-            <div className='beatmapset-header__beatmap-picker-box'>
-              <BeatmapPicker controller={this.controller} />
+        <div className='beatmapset-header__box beatmapset-header__box--main'>
+          <div className='beatmapset-header__beatmap-picker-box'>
+            <BeatmapPicker controller={this.controller} />
 
-              {this.renderBeatmapVersion()}
+            {this.renderBeatmapVersion()}
 
-              <div>
-                <span className='beatmapset-header__value' title={trans('beatmapsets.show.stats.playcount')}>
-                  <span className='beatmapset-header__value-icon'><span className='fas fa-play-circle' /></span>
-                  <span className='beatmapset-header__value-name'>{formatNumber(this.controller.beatmapset.play_count)}</span>
-                </span>
+            <div>
+              <span className='beatmapset-header__value' title={trans('beatmapsets.show.stats.playcount')}>
+                <span className='beatmapset-header__value-icon'><span className='fas fa-play-circle' /></span>
+                <span className='beatmapset-header__value-name'>{formatNumber(this.controller.beatmapset.play_count)}</span>
+              </span>
 
-                {this.controller.beatmapset.status === 'pending' &&
-                  <span className='beatmapset-header__value' title={trans('beatmapsets.show.stats.nominations')}>
-                    <span className='beatmapset-header__value-icon'><span className='fas fa-thumbs-up' /></span>
-                    <span className='beatmapset-header__value-name'>
-                      {formatNumber(this.controller.beatmapset.nominations_summary.current)}
-                    </span>
-                  </span>
-                }
-
-                <span
-                  ref={this.favouriteIconRef}
-                  className={classWithModifiers('beatmapset-header__value', { 'has-favourites': this.controller.beatmapset.favourite_count > 0 })}
-                  onMouseOver={this.onEnterFavouriteIcon}
-                  onTouchStart={this.onEnterFavouriteIcon}
-                >
-                  <span className='beatmapset-header__value-icon'>
-                    <span className='fas fa-heart' />
-                  </span>
+              {this.controller.beatmapset.status === 'pending' &&
+                <span className='beatmapset-header__value' title={trans('beatmapsets.show.stats.nominations')}>
+                  <span className='beatmapset-header__value-icon'><span className='fas fa-thumbs-up' /></span>
                   <span className='beatmapset-header__value-name'>
-                    {formatNumber(this.controller.beatmapset.favourite_count)}
+                    {formatNumber(this.controller.beatmapset.nominations_summary.current)}
                   </span>
                 </span>
-              </div>
-            </div>
-
-            <span className='beatmapset-header__details-text beatmapset-header__details-text--title'>
-              <a
-                className='beatmapset-header__details-text-link'
-                href={route('beatmapsets.index', { q: getTitle(this.controller.beatmapset) })}
-              >
-                {getTitle(this.controller.beatmapset)}
-              </a>
-              <BeatmapsetBadge
-                beatmapset={this.controller.beatmapset}
-                type='nsfw'
-              />
-              <BeatmapsetBadge
-                beatmapset={this.controller.beatmapset}
-                type='spotlight'
-              />
-            </span>
-
-            <span className='beatmapset-header__details-text beatmapset-header__details-text--artist'>
-              <a
-                className='beatmapset-header__details-text-link'
-                href={route('beatmapsets.index', { q: getArtist(this.controller.beatmapset) })}
-              >
-                {getArtist(this.controller.beatmapset)}
-              </a>
-              <BeatmapsetBadge
-                beatmapset={this.controller.beatmapset}
-                type='featured_artist'
-              />
-            </span>
-
-            <BeatmapsetMapping beatmapset={this.controller.beatmapset} />
-
-            {this.renderAvailabilityInfo()}
-
-            <div className='beatmapset-header__buttons'>
-              {core.currentUser != null &&
-                <BigButton
-                  icon={favouriteButton.icon}
-                  modifiers={['beatmapset-header-square', `beatmapset-header-square-${favouriteButton.action}`]}
-                  props={{
-                    onClick: this.onClickFavourite,
-                    title: trans(`beatmapsets.show.details.${favouriteButton.action}`),
-                  }}
-                />
               }
 
-              {this.renderDownloadButtons()}
-              {this.renderLoginButton()}
+              <span
+                ref={this.favouriteIconRef}
+                className={classWithModifiers('beatmapset-header__value', { 'has-favourites': this.controller.beatmapset.favourite_count > 0 })}
+                onMouseOver={this.onEnterFavouriteIcon}
+                onTouchStart={this.onEnterFavouriteIcon}
+              >
+                <span className='beatmapset-header__value-icon'>
+                  <span className='fas fa-heart' />
+                </span>
+                <span className='beatmapset-header__value-name'>
+                  {formatNumber(this.controller.beatmapset.favourite_count)}
+                </span>
+              </span>
+            </div>
+          </div>
 
-              {!this.controller.beatmapset.is_scoreable && core.currentUser != null && core.currentUser.id !== this.controller.beatmapset.user_id &&
-                <div className='beatmapset-header__more'>
-                  <div className='btn-circle btn-circle--page-toggle btn-circle--page-toggle-detail'>
-                    <BeatmapsetMenu beatmapset={this.controller.beatmapset} />
-                  </div>
+          <span className='beatmapset-header__details-text beatmapset-header__details-text--title'>
+            <a
+              className='beatmapset-header__details-text-link'
+              href={route('beatmapsets.index', { q: getTitle(this.controller.beatmapset) })}
+            >
+              {getTitle(this.controller.beatmapset)}
+            </a>
+            <BeatmapsetBadge
+              beatmapset={this.controller.beatmapset}
+              type='nsfw'
+            />
+            <BeatmapsetBadge
+              beatmapset={this.controller.beatmapset}
+              type='spotlight'
+            />
+          </span>
+
+          <span className='beatmapset-header__details-text beatmapset-header__details-text--artist'>
+            <a
+              className='beatmapset-header__details-text-link'
+              href={route('beatmapsets.index', { q: getArtist(this.controller.beatmapset) })}
+            >
+              {getArtist(this.controller.beatmapset)}
+            </a>
+            <BeatmapsetBadge
+              beatmapset={this.controller.beatmapset}
+              type='featured_artist'
+            />
+          </span>
+
+          <BeatmapsetMapping beatmapset={this.controller.beatmapset} />
+
+          {this.renderAvailabilityInfo()}
+
+          <div className='beatmapset-header__buttons'>
+            {core.currentUser != null &&
+              <BigButton
+                icon={favouriteButton.icon}
+                modifiers={['beatmapset-header-square', `beatmapset-header-square-${favouriteButton.action}`]}
+                props={{
+                  onClick: this.onClickFavourite,
+                  title: trans(`beatmapsets.show.details.${favouriteButton.action}`),
+                }}
+              />
+            }
+
+            {this.renderDownloadButtons()}
+            {this.renderLoginButton()}
+
+            {!this.controller.beatmapset.is_scoreable && core.currentUser != null && core.currentUser.id !== this.controller.beatmapset.user_id &&
+              <div className='beatmapset-header__more'>
+                <div className='btn-circle btn-circle--page-toggle btn-circle--page-toggle-detail'>
+                  <BeatmapsetMenu beatmapset={this.controller.beatmapset} />
                 </div>
-              }
-            </div>
+              </div>
+            }
           </div>
+        </div>
 
-          <div className='beatmapset-header__box beatmapset-header__box--stats'>
-            {this.renderStatusBar()}
+        <div className='beatmapset-header__box beatmapset-header__box--stats'>
+          {this.renderStatusBar()}
 
-            <Stats controller={this.controller} />
-          </div>
+          <Stats controller={this.controller} />
         </div>
       </div>
     );

--- a/resources/js/beatmapsets-show/info.tsx
+++ b/resources/js/beatmapsets-show/info.tsx
@@ -85,17 +85,10 @@ export default class Info extends React.Component<Props> {
   render() {
     const tags = this.controller.beatmapset.tags
       .split(' ')
-      .filter(present)
-      .slice(0, 21);
-
-    const tagsOverload = tags.length === 21;
-
-    if (tagsOverload) {
-      tags.pop();
-    }
+      .filter(present);
 
     return (
-      <div className='beatmapset-info'>
+      <div className='beatmapset-info u-fancy-scrollbar'>
         {this.isEditingDescription &&
           <Modal onClose={this.handleCloseDescriptionEditor}>
             <div className='osu-page'>
@@ -116,16 +109,16 @@ export default class Info extends React.Component<Props> {
           </Modal>
         }
 
-        <div className='beatmapset-info__box beatmapset-info__box--description'>
+        <div className='beatmapset-info__box'>
           {this.withEditDescription && this.renderEditDescriptionButton()}
 
-          <h3 className='beatmapset-info__header'>
-            {trans('beatmapsets.show.info.description')}
-          </h3>
+          <div className='beatmapset-info__row beatmapset-info__row--value-overflow'>
+            <h3 className='beatmapset-info__header'>
+              {trans('beatmapsets.show.info.description')}
+            </h3>
 
-          <div className='beatmapset-info__description-container u-fancy-scrollbar'>
             <div
-              className='beatmapset-info__description'
+              className='beatmapset-info__value-overflow'
               dangerouslySetInnerHTML={{
                 __html: this.controller.beatmapset.description.description ?? '',
               }}
@@ -133,11 +126,11 @@ export default class Info extends React.Component<Props> {
           </div>
         </div>
 
-        <div className='beatmapset-info__box beatmapset-info__box--meta'>
+        <div className='beatmapset-info__box'>
           {this.withEditMetadata && this.renderEditMetadataButton()}
 
           {this.nominators.length > 0 &&
-            <>
+            <div className='beatmapset-info__row'>
               <h3 className='beatmapset-info__header'>
                 {trans('beatmapsets.show.info.nominators')}
               </h3>
@@ -152,11 +145,11 @@ export default class Info extends React.Component<Props> {
                   </React.Fragment>
                 ))}
               </div>
-            </>
+            </div>
           }
 
           {present(this.controller.beatmapset.source) &&
-            <>
+            <div className='beatmapset-info__row'>
               <h3 className='beatmapset-info__header'>
                 {trans('beatmapsets.show.info.source')}
               </h3>
@@ -166,10 +159,10 @@ export default class Info extends React.Component<Props> {
               >
                 {this.controller.beatmapset.source}
               </a>
-            </>
+            </div>
           }
 
-          <div className='beatmapset-info__half-box'>
+          <div className='beatmapset-info__row beatmapset-info__row--half'>
             <div className='beatmapset-info__half-entry'>
               <h3 className='beatmapset-info__header'>
                 {trans('beatmapsets.show.info.genre')}
@@ -196,11 +189,11 @@ export default class Info extends React.Component<Props> {
           </div>
 
           {tags.length > 0 &&
-            <>
+            <div className='beatmapset-info__row beatmapset-info__row--value-overflow'>
               <h3 className='beatmapset-info__header'>
                 {trans('beatmapsets.show.info.tags')}
               </h3>
-              <div>
+              <div className='beatmapset-info__value-overflow'>
                 {tags.map((tag, i) => (
                   <React.Fragment key={`${tag}-${i}`}>
                     <a
@@ -212,9 +205,8 @@ export default class Info extends React.Component<Props> {
                     {' '}
                   </React.Fragment>
                 ))}
-                {tagsOverload && '...'}
               </div>
-            </>
+            </div>
           }
         </div>
 


### PR DESCRIPTION
I was looking at #8787 figuring might as well merge that instead of waiting for the new design but then realized that the page margin is wrong on mobile and description box is done in a rather interesting way (and also missing bottom padding and has right padding for some reason).

This includes the change to overflow tags but shares style with description overflow instead of its own style (and without `__box` in `__box`).

I just remembered why the description is done that way - it's so the box doesn't expand when expanding spoiler box. It's already expanding everywhere else though so I think it's fine here as well.