### PR TITLE
Disable editing beatmap discussion post on user modding profile

### DIFF
--- a/resources/js/beatmap-discussions-history/main.coffee
+++ b/resources/js/beatmap-discussions-history/main.coffee
@@ -33,53 +33,8 @@ export class Main extends React.PureComponent
         relatedDiscussions: props.relatedDiscussions
 
 
-  componentDidMount: =>
-    $.subscribe "beatmapsetDiscussions:update.#{@eventId}", @discussionUpdate
-    $(document).on "ajax:success.#{@eventId}", '.js-beatmapset-discussion-update', @ujsDiscussionUpdate
-
-
   componentWillUnmount: =>
-    $.unsubscribe ".#{@eventId}"
-    $(window).off ".#{@eventId}"
-
     $(window).stop()
-
-
-  discussionUpdate: (_e, options) =>
-    {beatmapset} = options
-    return unless beatmapset?
-
-    discussions = [@state.discussions...]
-    users = [@state.users...]
-    relatedDiscussions = [@state.relatedDiscussions...]
-
-    discussionIds = _.map discussions, 'id'
-    userIds = _.map users, 'id'
-
-    # Due to the entire hierarchy of discussions being sent back when a post is updated (instead of just the modified post),
-    #   we need to iterate over each discussion and their posts to extract the updates we want.
-    _.each beatmapset.discussions, (newDiscussion) ->
-      if discussionIds.includes(newDiscussion.id)
-        discussion = _.find discussions, id: newDiscussion.id
-        discussions = _.reject discussions, id: newDiscussion.id
-        newDiscussion = _.merge(discussion, newDiscussion)
-        # The discussion list shows discussions started by the current user, so it can be assumed that the first post is theirs
-        newDiscussion.starting_post = newDiscussion.posts[0]
-        discussions.push(newDiscussion)
-      else
-        relatedDiscussions.push(newDiscussion)
-
-    _.each beatmapset.related_users, (newUser) ->
-      if userIds.includes(newUser.id)
-        users = _.reject users, id: newUser.id
-
-      users.push(newUser)
-
-    @cache.users = @cache.discussions = @cache.beatmaps = @cache.beatmapsets = @state.relatedDiscussions = null
-    @setState
-      discussions: _.reverse(_.sortBy(discussions, (d) -> Date.parse(d.starting_post.created_at)))
-      users: users
-      relatedDiscussions: relatedDiscussions
 
 
   discussions: =>
@@ -147,8 +102,3 @@ export class Main extends React.PureComponent
       @cache.users[null] = @cache.users[undefined] = deletedUser.toJson()
 
     @cache.users
-
-
-  ujsDiscussionUpdate: (_e, data) =>
-    # to allow ajax:complete to be run
-    Timeout.set 0, => @discussionUpdate(null, beatmapset: data)

--- a/resources/js/beatmap-discussions-history/main.coffee
+++ b/resources/js/beatmap-discussions-history/main.coffee
@@ -136,7 +136,7 @@ export class Main extends React.PureComponent
                       currentUser: currentUser
                       beatmapset: beatmapsets[discussion.beatmapset_id]
                       isTimelineVisible: false
-                      visible: false
+                      readonly: true
                       showDeleted: true
                       preview: true
 

--- a/resources/js/beatmap-discussions/discussion.tsx
+++ b/resources/js/beatmap-discussions/discussion.tsx
@@ -31,6 +31,7 @@ interface PropsBase {
   currentBeatmap: BeatmapExtendedJson | null;
   isTimelineVisible: boolean;
   parentDiscussion?: BeatmapsetDiscussionJson | null;
+  readonly: boolean;
   readPostIds?: Set<number>;
   showDeleted: boolean;
   users: Partial<Record<number | string, UserJson>>;
@@ -66,6 +67,7 @@ export class Discussion extends React.Component<Props> {
   static contextType = DiscussionsStateContext;
   static defaultProps = {
     preview: false,
+    readonly: false,
   };
 
   declare context: React.ContextType<typeof DiscussionsStateContext>;
@@ -227,6 +229,7 @@ export class Discussion extends React.Component<Props> {
         discussion={this.props.discussion}
         post={post}
         read={this.isRead(post)}
+        readonly={this.props.readonly}
         resolvedSystemPostId={this.resolvedSystemPostId}
         type={type}
         user={user}

--- a/resources/js/beatmap-discussions/post.tsx
+++ b/resources/js/beatmap-discussions/post.tsx
@@ -260,6 +260,8 @@ export default class Post extends React.Component<Props> {
   }
 
   private renderKudosuAction(op: 'allow' | 'deny') {
+    if (this.props.readonly) return null;
+
     return (
       <a
         className={`js-beatmapset-discussion-update ${bn}__action ${bn}__action--button`}

--- a/resources/js/beatmap-discussions/post.tsx
+++ b/resources/js/beatmap-discussions/post.tsx
@@ -63,8 +63,6 @@ export default class Post extends React.Component<Props> {
 
   @computed
   private get canEdit() {
-    if (this.props.readonly) return false;
-
     return this.isAdmin
       || (!downloadLimited(this.props.beatmapset)
         && this.isOwn
@@ -74,15 +72,13 @@ export default class Post extends React.Component<Props> {
   }
 
   private get canDelete() {
-    if (this.props.readonly) return false;
-
     return this.props.type === 'discussion'
       ? this.props.discussion.current_user_attributes?.can_destroy
       : this.canModerate || this.canEdit;
   }
 
   private get canModerate() {
-    return !this.props.readonly && canModeratePosts();
+    return canModeratePosts();
   }
 
   @computed
@@ -260,8 +256,6 @@ export default class Post extends React.Component<Props> {
   }
 
   private renderKudosuAction(op: 'allow' | 'deny') {
-    if (this.props.readonly) return null;
-
     return (
       <a
         className={`js-beatmapset-discussion-update ${bn}__action ${bn}__action--button`}
@@ -390,43 +384,48 @@ export default class Post extends React.Component<Props> {
               valueAsUrl
             />
           </span>
-          {this.canEdit && (
-            <button
-              className={`${bn}__action ${bn}__action--button`}
-              onClick={this.editStart}
-            >
-              {trans('beatmaps.discussions.edit')}
-            </button>
-          )}
 
-          {this.deleteModel.deleted_at == null && this.canDelete && (
-            <a
-              className={`js-beatmapset-discussion-update ${bn}__action ${bn}__action--button`}
-              data-confirm={trans('common.confirmation')}
-              data-method='DELETE'
-              data-remote
-              href={this.deleteHref('destroy')}
-            >
-              {trans('beatmaps.discussions.delete')}
-            </a>
-          )}
+          {!this.props.readonly && (
+            <>
+              {this.canEdit && (
+                <button
+                  className={`${bn}__action ${bn}__action--button`}
+                  onClick={this.editStart}
+                >
+                  {trans('beatmaps.discussions.edit')}
+                </button>
+              )}
 
-          {this.deleteModel.deleted_at != null && this.canModerate && (
-            <a
-              className={`js-beatmapset-discussion-update ${bn}__action ${bn}__action--button`}
-              data-confirm={trans('common.confirmation')}
-              data-method='POST'
-              data-remote
-              href={this.deleteHref('restore')}
-            >
-              {trans('beatmaps.discussions.restore')}
-            </a>
-          )}
+              {this.deleteModel.deleted_at == null && this.canDelete && (
+                <a
+                  className={`js-beatmapset-discussion-update ${bn}__action ${bn}__action--button`}
+                  data-confirm={trans('common.confirmation')}
+                  data-method='DELETE'
+                  data-remote
+                  href={this.deleteHref('destroy')}
+                >
+                  {trans('beatmaps.discussions.delete')}
+                </a>
+              )}
 
-          {this.props.type === 'discussion' && this.props.discussion.current_user_attributes?.can_moderate_kudosu && (
-            this.props.discussion.can_grant_kudosu
-              ? this.renderKudosuAction('deny')
-              : this.props.discussion.kudosu_denied && this.renderKudosuAction('allow')
+              {this.deleteModel.deleted_at != null && this.canModerate && (
+                <a
+                  className={`js-beatmapset-discussion-update ${bn}__action ${bn}__action--button`}
+                  data-confirm={trans('common.confirmation')}
+                  data-method='POST'
+                  data-remote
+                  href={this.deleteHref('restore')}
+                >
+                  {trans('beatmaps.discussions.restore')}
+                </a>
+              )}
+
+              {this.props.type === 'discussion' && this.props.discussion.current_user_attributes?.can_moderate_kudosu && (
+                this.props.discussion.can_grant_kudosu
+                  ? this.renderKudosuAction('deny')
+                  : this.props.discussion.kudosu_denied && this.renderKudosuAction('allow')
+              )}
+            </>
           )}
 
           {this.canReport && (

--- a/resources/js/modding-profile/discussions.tsx
+++ b/resources/js/modding-profile/discussions.tsx
@@ -66,6 +66,7 @@ export default class Discussions extends React.Component<Props> {
           discussion={discussion}
           isTimelineVisible={false}
           preview
+          readonly
           showDeleted
           users={this.props.users}
         />

--- a/resources/js/modding-profile/main.coffee
+++ b/resources/js/modding-profile/main.coffee
@@ -66,8 +66,6 @@ export class Main extends React.PureComponent
   componentDidMount: =>
     $.subscribe "user:update.#{@eventId}", @userUpdate
     $.subscribe "profile:page:jump.#{@eventId}", @pageJump
-    $.subscribe "beatmapsetDiscussions:update.#{@eventId}", @discussionUpdate
-    $(document).on "ajax:success.#{@eventId}", '.js-beatmapset-discussion-update', @ujsDiscussionUpdate
     $(window).on "scroll.#{@eventId}", @pageScan
 
     pageChange()
@@ -84,53 +82,10 @@ export class Main extends React.PureComponent
   componentWillUnmount: =>
     $.unsubscribe ".#{@eventId}"
     $(window).off ".#{@eventId}"
-    $(document).off ".#{@eventId}"
 
     $(window).stop()
     Timeout.clear @modeScrollTimeout
     @disposers.forEach (disposer) => disposer?()
-
-
-  discussionUpdate: (_e, options) =>
-    {beatmapset} = options
-    return unless beatmapset?
-
-    discussions = @state.discussions
-    posts = @state.posts
-    users = @state.users
-
-    discussionIds = _.map discussions, 'id'
-    postIds = _.map posts, 'id'
-    userIds = _.map users, 'id'
-
-    # Due to the entire hierarchy of discussions being sent back when a post is updated (instead of just the modified post),
-    #   we need to iterate over each discussion and their posts to extract the updates we want.
-    _.each beatmapset.discussions, (newDiscussion) ->
-      if discussionIds.includes(newDiscussion.id)
-        discussion = _.find discussions, id: newDiscussion.id
-        discussions = _.reject discussions, id: newDiscussion.id
-        newDiscussion = _.merge(discussion, newDiscussion)
-
-      newDiscussion.starting_post = newDiscussion.posts[0]
-      discussions.push(newDiscussion)
-
-      _.each newDiscussion.posts, (newPost) ->
-        if postIds.includes(newPost.id)
-          post = _.find posts, id: newPost.id
-          posts = _.reject posts, id: newPost.id
-          posts.push(_.merge(post, newPost))
-
-    _.each beatmapset.related_users, (newUser) ->
-      if userIds.includes(newUser.id)
-        users = _.reject users, id: newUser.id
-
-      users.push(newUser)
-
-    @cache.users = @cache.discussions = @cache.userDiscussions = @cache.beatmaps = @cache.beatmapsets = null
-    @setState
-      discussions: _.reverse(_.sortBy(discussions, (d) -> Date.parse(d.starting_post.created_at)))
-      posts: _.reverse(_.sortBy(posts, (p) -> Date.parse(p.created_at)))
-      users: users
 
 
   discussions: =>
@@ -354,8 +309,3 @@ export class Main extends React.PureComponent
       @cache.userDiscussions = _.filter @state.discussions, (d) => d.user_id == @state.user.id
 
     @cache.userDiscussions
-
-
-  ujsDiscussionUpdate: (_e, data) =>
-    # to allow ajax:complete to be run
-    Timeout.set 0, => @discussionUpdate(null, beatmapset: data)

--- a/resources/js/modding-profile/posts.coffee
+++ b/resources/js/modding-profile/posts.coffee
@@ -58,12 +58,8 @@ export class Posts extends React.Component
                       users: @props.users
                       user: @props.users[post.user_id]
                       read: true
+                      readonly: true
                       lastEditor: @props.users[post.last_editor_id] ? @props.users[null] if post.last_editor_id?
-                      # FIXME: These permissions are more restrictive than the correct ones in discussion
-                      # because they don't have the right data to check.
-                      canBeEdited: currentUser.is_admin
-                      canBeDeleted: canModerate
-                      canBeRestored: canModerate
                       currentUser: currentUser
             a
               key: 'show-more'


### PR DESCRIPTION
Simpler alternative to #9969

Essentially disables modification on pages that can't really handle the entire discussion response properly.