### PR TITLE
Localise suffixed number format

### DIFF
--- a/app/helpers.php
+++ b/app/helpers.php
@@ -1714,18 +1714,18 @@ function clamp($number, $min, $max)
 }
 
 // e.g. 100634983048665 -> 100.63 trillion
-function suffixed_number_format($number)
+function suffixed_number_format(float|int $number, ?string $locale = null): string
 {
-    $suffixes = ['', 'k', 'million', 'billion', 'trillion']; // TODO: localize
-    $k = 1000;
+    $locale ??= App::getLocale();
 
-    if ($number < $k) {
-        return $number;
+    static $formatters = [];
+
+    if (!isset($formatters[$locale])) {
+        $formatters[$locale] = new NumberFormatter($locale, NumberFormatter::PADDING_POSITION);
+        $formatters[$locale]->setAttribute(NumberFormatter::FRACTION_DIGITS, 2);
     }
 
-    $i = floor(log($number) / log($k));
-
-    return number_format($number / pow($k, $i), 2).' '.$suffixes[$i];
+    return $formatters[$locale]->format($number);
 }
 
 function suffixed_number_format_tag($number)

--- a/resources/js/components/beatmapset-panel.tsx
+++ b/resources/js/components/beatmapset-panel.tsx
@@ -100,7 +100,7 @@ const StatsItem = ({ icon, title, type, value }: StatsItemProps) => (
     <span className='beatmapset-panel__stats-item-icon'>
       <i className={`fa-fw ${icon}`} />
     </span>
-    <span>{formatNumberSuffixed(value, undefined, { maximumFractionDigits: 1, minimumFractionDigits: 0 })}</span>
+    <span>{formatNumberSuffixed(value)}</span>
   </div>
 );
 

--- a/resources/js/components/comment.coffee
+++ b/resources/js/components/comment.coffee
@@ -443,7 +443,7 @@ export class Comment extends React.PureComponent
       onClick: @voteToggle
       disabled: @state.postingVote || !@props.comment.canVote
       span className: 'comment-vote__text',
-        "+#{formatNumberSuffixed(@props.comment.votesCount, null, maximumFractionDigits: 1)}"
+        "+#{formatNumberSuffixed(@props.comment.votesCount)}"
       if @state.postingVote
         span className: 'comment-vote__spinner', el Spinner
       hover

--- a/resources/js/utils/html.ts
+++ b/resources/js/utils/html.ts
@@ -7,7 +7,6 @@ import { urlPresence } from './css';
 
 const byteSuffixes = ['B', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'];
 const kilo = 1000;
-const numberSuffixes = ['', 'k', 'm', 'b', 't'];
 
 export function bottomPage() {
   return bottomPageDistance() === 0;
@@ -85,25 +84,17 @@ export function formatNumber(num: number, precision?: number, options?: Intl.Num
   return num.toLocaleString(locale ?? window.currentLocale, options);
 }
 
-export function formatNumberSuffixed(num?: number, precision?: number, options?: Intl.NumberFormatOptions) {
-  if (num == null) return;
+const defaultSuffixedNumberOptions = {
+  maximumFractionDigits: 1,
+  minimumFractionDigits: 0,
+  notation: 'compact',
+} as const;
+const defaultSuffixedNumberFormatter = new Intl.NumberFormat(window.currentLocale, defaultSuffixedNumberOptions);
 
-  const format = (n: number) => {
-    options ??= {};
-
-    if (precision != null) {
-      options.minimumFractionDigits = precision;
-      options.maximumFractionDigits = precision;
-    }
-
-    return n.toLocaleString('en', options);
-  };
-
-  if (num < kilo) return format(num);
-
-  const i = Math.min(numberSuffixes.length - 1, Math.floor(Math.log(num) / Math.log(kilo)));
-
-  return `${format(num / Math.pow(kilo, i))}${numberSuffixes[i]}`;
+export function formatNumberSuffixed(num?: number) {
+  return num == null
+    ? undefined
+    : defaultSuffixedNumberFormatter.format(num);
 }
 
 export function htmlElementOrNull(thing: unknown) {


### PR DESCRIPTION
As it turned out ICU already have the relevant formatting (of course they do). It's shortened to M/B/T on the php side but I think it's fine. It's already shortened on javascript side.

Resolves #4192.