### PR TITLE
Update mod definitions

### DIFF
--- a/database/mods.json
+++ b/database/mods.json
@@ -1330,6 +1330,22 @@
         "ValidForMultiplayerAsFreeMod": true
       },
       {
+        "Acronym": "SG",
+        "Name": "Single Tap",
+        "Description": "One key for dons, one key for kats.",
+        "Type": "Conversion",
+        "Settings": [],
+        "IncompatibleMods": [
+          "AT",
+          "CN",
+          "RX"
+        ],
+        "RequiresConfiguration": false,
+        "UserPlayable": true,
+        "ValidForMultiplayer": true,
+        "ValidForMultiplayerAsFreeMod": true
+      },
+      {
         "Acronym": "AT",
         "Name": "Autoplay",
         "Description": "Watch a perfect automated play through the song.",
@@ -1340,6 +1356,7 @@
           "SD",
           "PF",
           "AC",
+          "SG",
           "CN",
           "RX",
           "AS"
@@ -1360,6 +1377,7 @@
           "SD",
           "PF",
           "AC",
+          "SG",
           "AT",
           "CN",
           "RX",
@@ -1381,6 +1399,7 @@
           "SD",
           "PF",
           "AC",
+          "SG",
           "AT",
           "CN"
         ],


### PR DESCRIPTION
Adds support for the new "Single Tap" taiko mod, and therefore closes one part of https://github.com/ppy/osu/issues/23014.

Mod in question is live with the latest releases so again one to potentially expedite.

---

Missed one again... :( Doing this one by hand still because it's faster than trying to get the automatic flow in place (#9942).