### PR TITLE
Enforce wrapping of beatmap difficulty name

### DIFF
--- a/resources/css/bem/beatmapset-header.less
+++ b/resources/css/bem/beatmapset-header.less
@@ -98,6 +98,7 @@
   &__diff-name {
     font-size: 17px;
     font-weight: 600;
+    overflow-wrap: anywhere;
 
     color: hsl(var(--hsl-c1));
 


### PR DESCRIPTION
There's a different problem of things moving around when hovering around difficulties with vastly different length but solving that is a lot more annoying.

Resolves #10057.