### PR TITLE
Use factory method for generic discussion markdown renderer

### DIFF
--- a/resources/js/beatmap-discussions/discussion-message.tsx
+++ b/resources/js/beatmap-discussions/discussion-message.tsx
@@ -7,7 +7,7 @@ import remarkBreaks from 'remark-breaks';
 import autolink from 'remark-plugins/autolink';
 import disableConstructs, { DisabledType } from 'remark-plugins/disable-constructs';
 import ImageLink from './image-link';
-import { emphasisRenderer, linkRenderer, listItemRenderer, paragraphRenderer, strongRenderer, transformLinkUri } from './renderers';
+import { createRenderer, linkRenderer, transformLinkUri } from './renderers';
 
 interface Props {
   markdown: string;
@@ -21,11 +21,11 @@ export default class DiscussionMessage extends React.Component<Props> {
         className='osu-md osu-md--discussions'
         components={{
           a: linkRenderer,
-          em: emphasisRenderer,
+          em: createRenderer('em'),
           img: ImageLink,
-          li: listItemRenderer,
-          p: paragraphRenderer,
-          strong: strongRenderer,
+          li: createRenderer('li'),
+          p: createRenderer('p'),
+          strong: createRenderer('strong'),
         }}
         remarkPlugins={[autolink, [disableConstructs, { type: this.props.type }], remarkBreaks]}
         transformLinkUri={transformLinkUri}

--- a/resources/js/beatmap-discussions/plain-text-preview.tsx
+++ b/resources/js/beatmap-discussions/plain-text-preview.tsx
@@ -29,7 +29,7 @@ export function linkRenderer(astProps: ReactMarkdownProps & React.DetailedHTMLPr
 }
 
 function textRenderer(astProps: ReactMarkdownProps & React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>) {
-  return <>{astProps.children.map(timestampDecorator)}</>;
+  return <>{astProps.children?.map(timestampDecorator)}</>;
 }
 
 export default class PlainTextPreview extends React.Component<Props> {

--- a/resources/js/beatmap-discussions/renderers.tsx
+++ b/resources/js/beatmap-discussions/renderers.tsx
@@ -9,9 +9,10 @@ import { openBeatmapEditor } from 'utils/url';
 
 export const LinkContext = React.createContext({ inLink: false });
 
-// FIXME: use a factory
-export function emphasisRenderer(astProps: ReactMarkdownProps & React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>) {
-  return <em>{astProps.children.map(timestampDecorator)}</em>;
+export function createRenderer(ElementType: React.ElementType) {
+  return function defaultRenderer(astProps: ReactMarkdownProps & React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>) {
+    return <ElementType>{astProps.children?.map(timestampDecorator)}</ElementType>;
+  };
 }
 
 export function linkRenderer(astProps: ReactMarkdownProps & React.DetailedHTMLProps<React.AnchorHTMLAttributes<HTMLAnchorElement>, HTMLAnchorElement>) {
@@ -24,18 +25,6 @@ export function linkRenderer(astProps: ReactMarkdownProps & React.DetailedHTMLPr
       </LinkContext.Provider>
     </>
   );
-}
-
-export function listItemRenderer(astProps: ReactMarkdownProps & React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>) {
-  return <li>{astProps.children?.map(timestampDecorator)}</li>;
-}
-
-export function paragraphRenderer(astProps: ReactMarkdownProps & React.DetailedHTMLProps<React.HTMLAttributes<HTMLParagraphElement>, HTMLParagraphElement>) {
-  return <p>{astProps.children.map(timestampDecorator)}</p>;
-}
-
-export function strongRenderer(astProps: ReactMarkdownProps & React.DetailedHTMLProps<React.HTMLAttributes<HTMLElement>, HTMLElement>) {
-  return <strong>{astProps.children.map(timestampDecorator)}</strong>;
 }
 
 export function timestampDecorator(reactNode: React.ReactNode) {


### PR DESCRIPTION
Also `children` actually resolves to `ReactNode[] & ReactNode` and since `ReactNode` also includes `null | undefined`, it means `children` is `nullable` but the typecheck doesn't pick it up:

```typescript
type Foo = number | null;

function bar(arg: Foo[] & Foo) {
  // doesn't register that arg can be null 
  return arg.map((x) => x);
}
```

The downside is this creates a new instance of the function every time but I guess we could cache it if needed? 🤷 