### PR TITLE
Unify handling of model-based form error response

### DIFF
--- a/app/Exceptions/ModelNotSavedException.php
+++ b/app/Exceptions/ModelNotSavedException.php
@@ -5,9 +5,26 @@
 
 namespace App\Exceptions;
 
+use Exception;
+use Illuminate\Http\Response;
+
 // This is used for model's saveOrExplode
 class ModelNotSavedException extends SilencedException
 {
+    public static function makeResponse(?Exception $e, array $modelFields): Response
+    {
+        $json = [
+            'error' => $e?->getMessage(),
+            'form_error' => [],
+        ];
+
+        foreach ($modelFields as $field => $model) {
+            $json['form_error'][$field] = $model->validationErrors()->all();
+        }
+
+        return response($json, 422);
+    }
+
     public function getStatusCode()
     {
         return 422;

--- a/app/Http/Controllers/AccountController.php
+++ b/app/Http/Controllers/AccountController.php
@@ -140,7 +140,7 @@ class AccountController extends Controller
         try {
             $user->fill($params)->saveOrExplode();
         } catch (ModelNotSavedException $e) {
-            return $this->errorResponse($user, $e);
+            return ModelNotSavedException::makeResponse($e, compact('user'));
         }
 
         return json_item($user, new CurrentUserTransformer());
@@ -165,7 +165,7 @@ class AccountController extends Controller
 
             return response([], 204);
         } else {
-            return $this->errorResponse($user);
+            return ModelNotSavedException::makeResponse(null, compact('user'));
         }
     }
 
@@ -240,7 +240,10 @@ class AccountController extends Controller
                 $user->profileCustomization()->fill($profileParams)->saveOrExplode();
             }
         } catch (ModelNotSavedException $e) {
-            return $this->errorResponse($user, $e);
+            return ModelNotSavedException::makeResponse($e, [
+                'user' => $user,
+                'user_profile_customization' => $user->profileCustomization(),
+            ]);
         }
 
         return json_item($user, new CurrentUserTransformer());
@@ -262,7 +265,7 @@ class AccountController extends Controller
 
             return response([], 204);
         } else {
-            return $this->errorResponse($user);
+            return ModelNotSavedException::makeResponse(null, compact('user'));
         }
     }
 
@@ -290,13 +293,5 @@ class AccountController extends Controller
     public function reissueCode()
     {
         return UserVerification::fromCurrentRequest()->reissue();
-    }
-
-    private function errorResponse($user, $exception = null)
-    {
-        return response([
-            'form_error' => ['user' => $user->validationErrors()->all()],
-            'error' => optional($exception)->getMessage(),
-        ], 422);
     }
 }

--- a/app/Http/Controllers/InterOp/UsersController.php
+++ b/app/Http/Controllers/InterOp/UsersController.php
@@ -5,6 +5,7 @@
 
 namespace App\Http\Controllers\InterOp;
 
+use App\Exceptions\ModelNotSavedException;
 use App\Exceptions\ValidationException;
 use App\Http\Controllers\Controller;
 use App\Libraries\UserRegistration;
@@ -59,9 +60,9 @@ class UsersController extends Controller
 
             return json_item($registration->user()->fresh(), new CurrentUserTransformer());
         } catch (ValidationException $ex) {
-            return response(['form_error' => [
-                'user' => $registration->user()->validationErrors()->all(),
-            ]], 422);
+            return ModelNotSavedException::makeResponse($ex, [
+                'user' => $registration->user(),
+            ]);
         }
     }
 }

--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -982,9 +982,9 @@ class UsersController extends Controller
                 return json_item($user->fresh(), new CurrentUserTransformer());
             }
         } catch (ValidationException $e) {
-            return response(['form_error' => [
-                'user' => $registration->user()->validationErrors()->all(),
-            ]], 422);
+            return ModelNotSavedException::makeResponse($e, [
+                'user' => $registration->user(),
+            ]);
         }
     }
 }


### PR DESCRIPTION
I thought of handling the exception right with the exception itself but there's nowhere to pass the model field name to the exception.

Also apparently errors on `user_profile_customization` in `Account#updateOptions` weren't included at all.