### PR TITLE
Revoke OAuth tokens in multiple batches for user reset session

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -1773,7 +1773,10 @@ class User extends Model implements AfterCommit, AuthenticatableContract, HasLoc
     public function resetSessions(): void
     {
         SessionStore::destroy($this->getKey());
-        $this->tokens()->with('refreshToken')->get()->each->revokeRecursive();
+        $this
+            ->tokens()
+            ->with('refreshToken')
+            ->chunkById(1000, fn ($tokens) => $tokens->each->revokeRecursive());
     }
 
     public function title(): ?string


### PR DESCRIPTION
There was a problem with deleting some ten of thousands tokens recently and this should alleviate it. There may still be problem with the actual process taking a while but that'll be for another day.