### PR TITLE
Fix js transExists incorrectly checking fallback locale

### DIFF
--- a/resources/js/notification-maps/message.ts
+++ b/resources/js/notification-maps/message.ts
@@ -39,7 +39,7 @@ export function formatMessage(item: Notification, compact = false) {
   }
 
   const emptyKey = `${key}_empty`;
-  if (item.details.content == null && transExists(emptyKey)) {
+  if (item.details.content == null && transExists(emptyKey, window.fallbackLocale)) {
     key = emptyKey;
   }
 

--- a/resources/js/utils/lang.tsx
+++ b/resources/js/utils/lang.tsx
@@ -73,11 +73,16 @@ export function transChoice(key: string, count: number, replacements: Replacemen
 
 // Handles case where crowdin fills in untranslated key with empty string.
 export function transExists(key: string, locale?: string) {
+  locale ??= window.currentLocale;
+  window.Lang.setFallback(locale);
+
   const translated = window.Lang.get(key, undefined, locale);
+  const ret = present(translated) && translated !== key;
 
-  return present(translated) && translated !== key;
+  window.Lang.setFallback(window.fallbackLocale);
+
+  return ret;
 }
-
 
 // re-export Lang so we can use our version of the types;
 // default export doesn't support declaration https://github.com/microsoft/TypeScript/issues/14080


### PR DESCRIPTION
Explicitly pass fallbackLocale for checking existence of dynamically generated key.