### PR TITLE
Add workflow for semi-automated mod definition updates

### DIFF
--- a/.github/workflows/update-mod-definitions.yml
+++ b/.github/workflows/update-mod-definitions.yml
@@ -1,0 +1,68 @@
+name: Update mod definitions
+on:
+  workflow_dispatch:
+    inputs:
+      ref:
+        type: string
+        description: The name of the ref to check out. Will default to latest `master`.
+
+jobs:
+  update-mod-definitions:
+    name: Update mod definitions
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout ppy/osu-web
+      uses: actions/checkout@v3
+      with:
+        path: osu-web
+
+    - name: Install .NET 6.0.x
+      uses: actions/setup-dotnet@v3
+      with:
+        dotnet-version: "6.0.x"
+
+    - name: Checkout ppy/osu
+      uses: actions/checkout@v3
+      with:
+        repository: ppy/osu
+        ref: ${{ github.event.inputs.ref }}
+        path: osu
+
+    - name: Store ppy/osu commit hash
+      id: store-osu-hash
+      run: echo commit-hash=`git rev-parse HEAD` >> "$GITHUB_OUTPUT"
+      working-directory: ./osu
+
+    - name: Checkout ppy/osu-tools
+      uses: actions/checkout@v3
+      with:
+        repository: ppy/osu-tools
+        path: osu-tools
+
+    - name: Setup local game checkout for tools
+      run: ./UseLocalOsu.sh
+      working-directory: ./osu-tools
+
+    - name: Regenerate mod definitions
+      run: dotnet run --project PerformanceCalculator -- mods > ../osu-web/database/mods.json
+      working-directory: ./osu-tools
+
+    - name: Check if anything changed
+      id: check-changes
+      # by default, github runs `bash -e`, which will stop the run script below if `git diff` returns nonzero.
+      # to circumvent this, we turn that option off, since we want the first command to fail gracefully and store its exit code.
+      shell: bash {0}
+      run: |
+        git diff --exit-code
+        echo "has-changes=$?" >> "$GITHUB_OUTPUT"
+      working-directory: ./osu-web
+
+    - name: Create pull request with changes
+      if: ${{ steps.check-changes.outputs.has-changes == '1' }}
+      uses: peter-evans/create-pull-request@v5
+      with:
+        title: Update mod definitions
+        body: "This PR has been auto-generated to update the mod definitions to match ppy/osu@${{ steps.store-osu-hash.outputs.commit-hash }}."
+        branch: update-mod-definitions
+        commit-message: Update mod definitions
+        path: osu-web


### PR DESCRIPTION
This PR is supposed to be the starting point for https://github.com/ppy/osu-web/issues/9942. The goal here is to be able to automate the generation of `database/mods.json`, so that once new client releases drop, the process of updating the mod definitions is made much easier on the web side.

Right now, the workflow is written to be dispatched manually. What this means, is that to start it, you have to go to the "Actions" tab, choose the "Update mod definitions workflow", and fill the argument:

![1683109459](https://user-images.githubusercontent.com/20418176/235893617-e4585a46-2387-4238-9434-18eae6b63508.png)

This part is probably not what we want, and is why I'm opening this as draft, to try and gauge what we *would* want. One idea in the issue was to coordinate the workflow such that `ppy/osu` signals `ppy/osu-web` on every new release by way of a `repository_dispatch` event, but this would require an extra workflow on the `ppy/osu` side and possibly issuance of a new personal access token. Notably, `ppy/osu` can't create the PR on the web side itself.

This was tested to work on my fork. See the following runs:

- [Run 1](https://github.com/bdach/osu-web/actions/runs/4870886979/jobs/8687174369): Wherein I specified the latest release tag when dispatching the workflow; this meant that the mod definitions were up to date, so no PR was opened (note that the "Create pull request with changes" step did not execute).
- [Run 2](https://github.com/bdach/osu-web/actions/runs/4870905479): Wherein I specified nothing, which ends up being latest `master`, and so, since on the game side we've merged a new mod since the last release, this resulted in [this PR](https://github.com/bdach/osu-web/pull/2) being opened.

@ThePooN cc'ing you here, since @peppy said in stream chat that you may have an opinion as to where and when this thing should run.