### PR TITLE
Fix new beatmap discussion pinning when switching tabs

### DIFF
--- a/resources/js/beatmap-discussions/main.coffee
+++ b/resources/js/beatmap-discussions/main.coffee
@@ -150,6 +150,7 @@ export class Main extends React.PureComponent
                   beatmaps: @beatmaps()
                   currentBeatmap: @currentBeatmap()
                   currentUser: @state.currentUser
+                  innerRef: @newDiscussionRef
                   pinned: @state.pinnedNewDiscussion
                   setPinned: @setPinnedNewDiscussion
                   stickTo: @modeSwitcherRef
@@ -378,7 +379,6 @@ export class Main extends React.PureComponent
 
     newState.callback = =>
       $.publish 'beatmapset-discussions:highlight', discussionId: discussion.id
-
 
       attribute = if postId? then "data-post-id='#{postId}'" else "data-id='#{id}'"
       target = $(".js-beatmap-discussion-jump[#{attribute}]")

--- a/resources/js/beatmap-discussions/new-discussion.tsx
+++ b/resources/js/beatmap-discussions/new-discussion.tsx
@@ -135,6 +135,7 @@ export class NewDiscussion extends React.Component<Props> {
   }
 
   componentDidMount() {
+    this.updateStickToHeight();
     // watching for height changes on the stickTo element to handle horizontal scrollbars when they appear.
     $(window).on('resize', this.updateStickToHeight);
     this.disposers.add(core.reactTurbolinks.runAfterPageLoad(action(() => this.mounted = true)));

--- a/resources/js/beatmap-discussions/new-review.tsx
+++ b/resources/js/beatmap-discussions/new-review.tsx
@@ -19,6 +19,7 @@ interface Props {
   beatmapset: BeatmapsetExtendedJson;
   currentBeatmap: BeatmapExtendedJson;
   currentUser: UserJson;
+  innerRef: React.RefObject<HTMLDivElement>;
   pinned?: boolean;
   setPinned?: (sticky: boolean) => void;
   stickTo?: React.RefObject<HTMLDivElement>;
@@ -73,7 +74,7 @@ export default class NewReview extends React.Component<Props> {
     return (
       <div className={classWithModifiers(floatClass, { pinned: this.props.pinned })} style={{ top: this.cssTop }}>
         <div className={`${floatClass}__floatable ${floatClass}__floatable--pinned`}>
-          <div className={`${floatClass}__content`}>
+          <div ref={this.props.innerRef} className={`${floatClass}__content`}>
             <div className='osu-page osu-page--small'>
               <div className='beatmap-discussion-new'>
                 <div className='page-title'>

--- a/resources/js/beatmap-discussions/new-review.tsx
+++ b/resources/js/beatmap-discussions/new-review.tsx
@@ -57,6 +57,7 @@ export default class NewReview extends React.Component<Props> {
   }
 
   componentDidMount(): void {
+    this.updateStickToHeight();
     // watching for height changes on the stickTo element to handle horizontal scrollbars when they appear.
     $(window).on('resize', this.updateStickToHeight);
     this.disposers.add(core.reactTurbolinks.runAfterPageLoad(action(() => this.mounted = true)));

--- a/resources/js/beatmap-discussions/new-review.tsx
+++ b/resources/js/beatmap-discussions/new-review.tsx
@@ -73,7 +73,7 @@ export default class NewReview extends React.Component<Props> {
 
     return (
       <div className={classWithModifiers(floatClass, { pinned: this.props.pinned })} style={{ top: this.cssTop }}>
-        <div className={`${floatClass}__floatable ${floatClass}__floatable--pinned`}>
+        <div className={`${floatClass}__floatable`}>
           <div ref={this.props.innerRef} className={`${floatClass}__content`}>
             <div className='osu-page osu-page--small'>
               <div className='beatmap-discussion-new'>


### PR DESCRIPTION
- Fix dying when jumping to a review from non-review discussion while the new-discussion element is pinned.
- Fix the pinned position of element when switching discussion tabs.