### PR TITLE
Fix incorrect user state on navigation

### DIFF
--- a/resources/js/osu-core.ts
+++ b/resources/js/osu-core.ts
@@ -127,8 +127,12 @@ export default class OsuCore {
 
   readonly updateCurrentUser = () => {
     // Remove from DOM so only new data is parsed on navigation.
-    window.currentUser = parseJsonNullable('json-current-user', true) ?? { id: undefined };
-    this.setCurrentUser(window.currentUser);
+    const currentUser = parseJsonNullable<typeof window.currentUser>('json-current-user', true);
+
+    if (currentUser != null) {
+      window.currentUser = currentUser;
+      this.setCurrentUser(window.currentUser);
+    }
   };
 
   private readonly onCurrentUserUpdate = (event: unknown, user: CurrentUserJson) => {


### PR DESCRIPTION
Only update current user state if the json exists otherwise going back will reset to guest as the json is removed on initial read.

Resolves #10179.