### PR TITLE
Add multiplayer option to disable score multiplier

### DIFF
--- a/app/Models/Multiplayer/Room.php
+++ b/app/Models/Multiplayer/Room.php
@@ -43,6 +43,7 @@ use Illuminate\Database\Eloquent\SoftDeletes;
  * @property string $type
  * @property string $queue_mode
  * @property bool $auto_skip
+ * @property bool $no_score_multiplier
  */
 class Room extends Model
 {
@@ -81,6 +82,7 @@ class Room extends Model
     ];
     protected $casts = [
         'auto_skip' => 'boolean',
+        'no_score_multiplier' => 'boolean',
         'ends_at' => 'datetime',
         'password' => PresentString::class,
         'starts_at' => 'datetime',
@@ -508,6 +510,7 @@ class Room extends Model
             'queue_mode',
             'auto_start_duration:int',
             'auto_skip:bool',
+            'no_score_multiplier:bool'
         ], ['null_missing' => true]);
 
         $this->fill([
@@ -518,6 +521,7 @@ class Room extends Model
             'queue_mode' => $params['queue_mode'],
             'auto_start_duration' => $params['auto_start_duration'],
             'auto_skip' => $params['auto_skip'] ?? false,
+            'no_score_multiplier' => $params['no_score_multiplier'] ?? false,
             'user_id' => $host->getKey(),
         ]);
 

--- a/app/Transformers/Multiplayer/RoomTransformer.php
+++ b/app/Transformers/Multiplayer/RoomTransformer.php
@@ -41,6 +41,7 @@ class RoomTransformer extends TransformerAbstract
             'has_password' => $room->password !== null,
             'queue_mode' => $room->queue_mode,
             'auto_skip' => $room->auto_skip,
+            'no_score_multiplier' => $room->no_score_multiplier
         ];
     }
 

--- a/database/migrations/2023_05_11_000000_add_no_score_multiplier_to_multiplayer_rooms.php
+++ b/database/migrations/2023_05_11_000000_add_no_score_multiplier_to_multiplayer_rooms.php
@@ -1,0 +1,35 @@
+<?php
+
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+class AddNoScoreMultiplierToMultiplayerRooms extends Migration
+{
+    /**
+     * Run the migrations.
+     *
+     * @return void
+     */
+    public function up()
+    {
+        Schema::table('multiplayer_rooms', function (Blueprint $table) {
+            $table->boolean('no_score_multiplier')->after('auto_skip')->default(false);
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     *
+     * @return void
+     */
+    public function down()
+    {
+        Schema::table('multiplayer_rooms', function (Blueprint $table) {
+            $table->dropColumn('no_score_multiplier');
+        });
+    }
+}


### PR DESCRIPTION
This feature spans across osu, osu-server-spectator and osu-web projects. This should be merged only when all PRs are approved.

[main osu PR](https://github.com/ppy/osu/pull/23510)

# Changes

This PR adds a migration to add `no_score_multiplier` column to `multiplayer_rooms` table. I basically just followed how `auto_skip` was added in the past.