### PR TITLE
Fix incorrect weight on negative offset

### DIFF
--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -685,7 +685,7 @@ class UsersController extends Controller
             abort(404);
         }
 
-        $this->offset = get_int(Request::input('offset')) ?? 0;
+        $this->offset = max(0, get_int(Request::input('offset')) ?? 0);
 
         if ($this->offset >= $this->maxResults) {
             $this->perPage = 0;


### PR DESCRIPTION
Offset can't go below 0 - it'll just be offset 0 anyway. Additionally, `pow(0.95, -100000)` results in INF, causing `json_encode` to fail.