### PR TITLE
Limit users who can edit online tags

### DIFF
--- a/app/Http/Controllers/BeatmapsetsController.php
+++ b/app/Http/Controllers/BeatmapsetsController.php
@@ -277,21 +277,26 @@ class BeatmapsetsController extends Controller
             'genre_id:int',
             'language_id:int',
             'nsfw:bool',
-            'tags:string',
         ]);
-
-        $offsetParams = get_params($params, 'beatmapset', [
-            'offset:int',
-        ]);
-
-        $updateParams = array_merge($metadataParams, $offsetParams);
 
         if (count($metadataParams) > 0) {
             priv_check('BeatmapsetMetadataEdit', $beatmapset)->ensureCan();
         }
 
-        if (count($offsetParams) > 0) {
+        $updateParams = [
+            ...$metadataParams,
+            ...get_params($params, 'beatmapset', [
+                'offset:int',
+                'tags:string',
+            ]),
+        ];
+
+        if (array_key_exists('offset', $updateParams)) {
             priv_check('BeatmapsetOffsetEdit')->ensureCan();
+        }
+
+        if (array_key_exists('tags', $updateParams)) {
+            priv_check('BeatmapsetTagsEdit')->ensureCan();
         }
 
         if (count($updateParams) > 0) {

--- a/app/Libraries/OsuAuthorize.php
+++ b/app/Libraries/OsuAuthorize.php
@@ -887,6 +887,17 @@ class OsuAuthorize
         return 'unauthorized';
     }
 
+    public function checkBeatmapsetTagsEdit(?User $user): string
+    {
+        $this->ensureLoggedIn($user);
+
+        if ($user->isModerator()) {
+            return 'ok';
+        }
+
+        return 'unauthorized';
+    }
+
     /**
      * @param User|null $user
      * @return string

--- a/app/Transformers/BeatmapsetCompactTransformer.php
+++ b/app/Transformers/BeatmapsetCompactTransformer.php
@@ -138,6 +138,7 @@ class BeatmapsetCompactTransformer extends TransformerAbstract
             'can_delete' => !$beatmapset->isScoreable() && priv_check('BeatmapsetDelete', $beatmapset)->can(),
             'can_edit_metadata' => priv_check('BeatmapsetMetadataEdit', $beatmapset)->can(),
             'can_edit_offset' => priv_check('BeatmapsetOffsetEdit')->can(),
+            'can_edit_tags' => priv_check('BeatmapsetTagsEdit')->can(),
             'can_hype' => $hypeValidation['result'],
             'can_hype_reason' => $hypeValidation['message'] ?? null,
             'can_love' => $beatmapset->isLoveable() && priv_check('BeatmapsetLove')->can(),

--- a/resources/js/beatmapsets-show/metadata-editor.tsx
+++ b/resources/js/beatmapsets-show/metadata-editor.tsx
@@ -46,6 +46,10 @@ export default class MetadataEditor extends React.Component<Props> {
     return this.controller.beatmapset.current_user_attributes.can_edit_offset;
   }
 
+  private get canEditTags() {
+    return this.controller.beatmapset.current_user_attributes.can_edit_tags;
+  }
+
   constructor(props: Props) {
     super(props);
 
@@ -117,19 +121,21 @@ export default class MetadataEditor extends React.Component<Props> {
           </div>
         </label>
 
-        <label className='simple-form__row'>
-          <div className='simple-form__label'>
-            {trans('beatmapsets.show.info.tags')}
-          </div>
+        {this.canEditTags &&
+          <label className='simple-form__row'>
+            <div className='simple-form__label'>
+              {trans('beatmapsets.show.info.tags')}
+            </div>
 
-          <textarea
-            className='simple-form__input'
-            maxLength={1000}
-            name='beatmapset[tags]'
-            onChange={this.setTags}
-            value={this.tags}
-          />
-        </label>
+            <textarea
+              className='simple-form__input'
+              maxLength={1000}
+              name='beatmapset[tags]'
+              onChange={this.setTags}
+              value={this.tags}
+            />
+          </label>
+        }
 
         {this.canEditOffset &&
           <label className='simple-form__row'>
@@ -202,7 +208,7 @@ export default class MetadataEditor extends React.Component<Props> {
         language_id: this.languageId,
         nsfw: this.nsfw,
         offset: this.canEditOffset ? getInt(this.offset) : undefined,
-        tags: this.tags,
+        tags: this.canEditTags ? this.tags : undefined,
       } },
       method: 'PATCH',
     });

--- a/resources/js/interfaces/beatmapset-json.ts
+++ b/resources/js/interfaces/beatmapset-json.ts
@@ -50,6 +50,7 @@ export interface CurrentUserAttributes {
   can_delete: boolean;
   can_edit_metadata: boolean;
   can_edit_offset: boolean;
+  can_edit_tags: boolean;
   can_hype: boolean;
   can_hype_reason: string;
   can_love: boolean;


### PR DESCRIPTION
Reduces confusion on what it currently actually does. May be reverted once the tags are updated in client as well.

- [x] confirm this has the correct permission check (gmt, nat) <sub>[deja vu](https://www.youtube.com/watch?v=tNF05-A1xY0)</sub>