### PR TITLE
Add anchor for legacy API settings

### DIFF
--- a/resources/views/accounts/edit.blade.php
+++ b/resources/views/accounts/edit.blade.php
@@ -164,7 +164,7 @@
         @include('accounts._edit_oauth')
     </div>
 
-    <div class="osu-page">
+    <div class="osu-page" id="legacy-api">
         @include('accounts._edit_legacy_api')
     </div>
 @endsection


### PR DESCRIPTION
So I can link better from the old site as we turn things off.