### PR TITLE
Stop post edit counter after 64k

### DIFF
--- a/app/Models/Forum/Post.php
+++ b/app/Models/Forum/Post.php
@@ -377,10 +377,10 @@ class Post extends Model implements AfterCommit, Indexable, Traits\ReportableInt
 
         // record edit history
         if ($this->exists && $this->isDirty('post_text')) {
-            $this->fill([
-                'post_edit_time' => Carbon::now(),
-                'post_edit_count' => DB::raw('post_edit_count + 1'),
-            ]);
+            $this->post_edit_time = Carbon::now();
+            if ($this->post_edit_count < 64000) {
+                $this->post_edit_count = DB::raw('post_edit_count + 1');
+            }
         }
 
         return parent::save($options);


### PR DESCRIPTION
Resolves #10196. The second most edited post is at just a bit over 10k so there's not much point increasing the column size.