### PR TITLE
Remove redundant button disabling parameter

### DIFF
--- a/resources/js/beatmap-discussions/nominator.tsx
+++ b/resources/js/beatmap-discussions/nominator.tsx
@@ -208,7 +208,7 @@ export class Nominator extends React.Component<Props> {
           {isHybrid ? this.renderModalContentHybrid() : this.renderModalContentNormal()}
           <div className={`${bn}__buttons`}>
             <BigButton
-              disabled={(isHybrid && this.selectedModes.length < 1) || this.loading}
+              disabled={isHybrid && this.selectedModes.length < 1}
               icon='fas fa-thumbs-up'
               isBusy={this.loading}
               props={{

--- a/resources/js/beatmap-discussions/subscribe.tsx
+++ b/resources/js/beatmap-discussions/subscribe.tsx
@@ -39,7 +39,6 @@ export class Subscribe extends React.Component<Props> {
   render() {
     return (
       <BigButton
-        disabled={this.busy}
         icon={this.isWatching ? 'fas fa-eye-slash' : 'fas fa-eye'}
         isBusy={this.busy}
         modifiers='full'

--- a/resources/js/components/big-button.tsx
+++ b/resources/js/components/big-button.tsx
@@ -30,6 +30,10 @@ export default class BigButton extends React.Component<Props> {
     props: {},
   };
 
+  get disabled() {
+    return this.props.disabled || this.props.isBusy;
+  }
+
   get text() {
     if (this.props.text == null) {
       return null;
@@ -45,13 +49,13 @@ export default class BigButton extends React.Component<Props> {
   }
 
   render() {
-    let blockClass = classWithModifiers('btn-osu-big', this.props.modifiers, { disabled: this.props.disabled });
+    let blockClass = classWithModifiers('btn-osu-big', this.props.modifiers, { disabled: this.disabled });
     if (this.props.extraClasses != null) {
       blockClass += ` ${this.props.extraClasses.join(' ')}`;
     }
 
     if (present(this.props.href)) {
-      if (this.props.disabled) {
+      if (this.disabled) {
         return (
           <span className={blockClass} {...this.props.props}>
             {this.renderChildren()}
@@ -73,7 +77,7 @@ export default class BigButton extends React.Component<Props> {
     return (
       <button
         className={blockClass}
-        disabled={this.props.disabled}
+        disabled={this.disabled}
         type={this.props.isSubmit ? 'submit' : 'button'}
         {...this.props.props}
       >

--- a/resources/js/components/comment-editor.tsx
+++ b/resources/js/components/comment-editor.tsx
@@ -157,7 +157,7 @@ export default class CommentEditor extends React.Component<Props> {
             ? (
               <div className={`${bn}__footer-item`}>
                 <BigButton
-                  disabled={this.posting || !this.isValid}
+                  disabled={!this.isValid}
                   isBusy={this.posting}
                   modifiers='comment-editor'
                   props={{ onClick: this.post }}

--- a/resources/js/legacy-api-key/details.tsx
+++ b/resources/js/legacy-api-key/details.tsx
@@ -91,7 +91,6 @@ export default class Details extends React.Component<Props> {
             text={trans(`legacy_api_key.view.${this.keyVisible ? 'hide' : 'show'}`)}
           />
           <BigButton
-            disabled={this.props.controller.isDeleting}
             icon='fas fa-trash'
             isBusy={this.props.controller.isDeleting}
             modifiers={['account-edit', 'danger', 'settings-oauth']}

--- a/resources/js/legacy-irc-key/details.tsx
+++ b/resources/js/legacy-irc-key/details.tsx
@@ -85,7 +85,6 @@ export default class Details extends React.Component<Props> {
             text={trans(`legacy_irc_key.view.${this.keyVisible ? 'hide' : 'show'}`)}
           />
           <BigButton
-            disabled={this.props.controller.isDeleting}
             icon='fas fa-trash'
             isBusy={this.props.controller.isDeleting}
             modifiers={['account-edit', 'danger', 'settings-oauth']}

--- a/resources/js/oauth/authorized-client.tsx
+++ b/resources/js/oauth/authorized-client.tsx
@@ -39,7 +39,7 @@ export class AuthorizedClient extends React.Component<Props> {
         </div>
         <div>
           <BigButton
-            disabled={client.isRevoking || client.revoked}
+            disabled={client.revoked}
             icon={client.revoked ? 'fas fa-ban' : 'fas fa-trash'}
             isBusy={client.isRevoking}
             modifiers={['account-edit', 'danger', 'settings-oauth']}

--- a/resources/js/oauth/own-client.tsx
+++ b/resources/js/oauth/own-client.tsx
@@ -56,7 +56,7 @@ export class OwnClient extends React.Component<Props> {
             text={trans('common.buttons.edit')}
           />
           <BigButton
-            disabled={client.isRevoking || client.revoked}
+            disabled={client.revoked}
             icon={client.revoked ? 'fas fa-ban' : 'fas fa-trash'}
             isBusy={client.isRevoking}
             modifiers={['account-edit', 'danger', 'settings-oauth']}


### PR DESCRIPTION
The `disabled` are all either redundant with `isBusy` or include larger test which covers the same thing. This removes the need to copy the check for the former.