### PR TITLE
Require being in a channel to report chat message

### DIFF
--- a/app/Models/UserReport.php
+++ b/app/Models/UserReport.php
@@ -7,6 +7,7 @@ namespace App\Models;
 
 use App\Exceptions\ValidationException;
 use App\Libraries\MorphMap;
+use App\Models\Chat\Message;
 use App\Models\Score\Best;
 use App\Models\Score\Best\Model as BestModel;
 use App\Traits\Validatable;
@@ -135,6 +136,15 @@ class UserReport extends Model
             $this->validationErrors()->add(
                 'reason',
                 '.no_ranked_beatmapset'
+            );
+        }
+
+        if ($this->reportable instanceof Message
+            && !$this->reportable->channel->hasUser($this->reporter)
+        ) {
+            $this->validationErrors()->add(
+                'reportable',
+                '.not_in_channel'
             );
         }
 

--- a/app/Models/UserReport.php
+++ b/app/Models/UserReport.php
@@ -139,7 +139,8 @@ class UserReport extends Model
             );
         }
 
-        if ($this->reportable instanceof Message
+        if (
+            $this->reportable instanceof Message
             && !$this->reportable->channel->hasUser($this->reporter)
         ) {
             $this->validationErrors()->add(

--- a/app/Models/UserReport.php
+++ b/app/Models/UserReport.php
@@ -141,6 +141,7 @@ class UserReport extends Model
 
         if (
             $this->reportable instanceof Message
+            && $this->reportable->channel->isHideable()
             && !$this->reportable->channel->hasUser($this->reporter)
         ) {
             $this->validationErrors()->add(

--- a/resources/lang/en/model_validation.php
+++ b/resources/lang/en/model_validation.php
@@ -175,6 +175,7 @@ return [
 
     'user_report' => [
         'no_ranked_beatmapset' => 'Ranked beatmaps cannot be reported',
+        'not_in_channel' => 'You\'re not in this channel.',
         'reason_not_valid' => ':reason is not valid for this report type.',
         'self' => "You can't report yourself!",
     ],

--- a/tests/Models/UserReportTest.php
+++ b/tests/Models/UserReportTest.php
@@ -127,7 +127,6 @@ class UserReportTest extends TestCase
         $reporter = User::factory()->create();
 
         if ($class === Message::class) {
-            $reportable->channel->addUser($reporter);
             $this->expectCountChange(fn () => UserReport::count(), 1);
         } else {
             $this->expectException(ValidationException::class);
@@ -159,9 +158,6 @@ class UserReportTest extends TestCase
     {
         $reportable = static::makeReportable($class);
         $reporter = User::factory()->create();
-        if ($reportable instanceof Message) {
-            $reportable->channel->addUser($reporter);
-        }
 
         $query = UserReport::whereMorphedTo('reportable', $reportable);
         $this->expectCountChange(fn () => $query->count(), 1, 'reportable query');
@@ -188,9 +184,6 @@ class UserReportTest extends TestCase
     {
         $reportable = static::makeReportable($class);
         $reporter = User::factory()->create();
-        if ($reportable instanceof Message) {
-            $reportable->channel->addUser($reporter);
-        }
 
         $report = $reportable->reportBy($reporter, static::reportParams());
 


### PR DESCRIPTION
Seems weird to be able to report messages without being in a channel 👀 
(also apparently there's legit use-case for allowing reports without being in a channel)