### PR TITLE
Adjust `cannot_nominate` wording (playmode -> game mode)

### DIFF
--- a/resources/lang/en/beatmaps.php
+++ b/resources/lang/en/beatmaps.php
@@ -176,7 +176,7 @@ return [
 
     'nominations' => [
         'already_nominated' => 'You\'ve already nominated this beatmap.',
-        'cannot_nominate' => 'You cannot nominate this beatmap playmode.',
+        'cannot_nominate' => 'You cannot nominate this beatmap game mode.',
         'delete' => 'Delete',
         'delete_own_confirm' => 'Are you sure? The beatmap will be deleted and you will be redirected back to your profile.',
         'delete_other_confirm' => 'Are you sure? The beatmap will be deleted and you will be redirected back to the user\'s profile.',


### PR DESCRIPTION
As per https://osu.ppy.sh/wiki/en/Game_mode the official wording is game mode, playmode is only used internally in code.