### PR TITLE
Fix forward slash escaping when printing route:convert to console

### DIFF
--- a/app/Console/Commands/RouteConvert.php
+++ b/app/Console/Commands/RouteConvert.php
@@ -78,7 +78,7 @@ class RouteConvert extends Command
         }
 
         if (!$written) {
-            $this->line(json_encode($this->routeScopesHelper->toArray(), JSON_PRETTY_PRINT));
+            $this->line(json_encode($this->routeScopesHelper->toArray(), JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
         }
     }
 }

--- a/app/Libraries/RouteScopesHelper.php
+++ b/app/Libraries/RouteScopesHelper.php
@@ -126,6 +126,6 @@ class RouteScopesHelper
 
     public function toJson(string $filename)
     {
-        file_put_contents($filename, str_replace('\/', '/', json_encode($this->toArray(), JSON_PRETTY_PRINT)."\n"));
+        file_put_contents($filename, json_encode($this->toArray(), JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES)."\n");
     }
 }


### PR DESCRIPTION
Shouldn't be escaped; also, apparently `JSON_UNESCAPED_SLASHES` exists 🤔 