### PR TITLE
Support new Discord username format

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -2278,7 +2278,7 @@ class User extends Model implements AfterCommit, AuthenticatableContract, HasLoc
             // This is a basic check and not 100% compliant to Discord's spec, only validates that input:
             // - is a 2-32 char username (excluding chars @#:)
             // - (if ending with # char) ends with a # and 4-digit discriminator
-            if (!preg_match('/^[^@#:]{2,32}(#\d{4})?$/i', $this->user_discord)) {
+            if (!preg_match('/^([^@#:]{2,32}#\d{4}|[\w.]{2,32})$/i', $this->user_discord)) {
                 $this->validationErrors()->add('user_discord', '.invalid_discord');
             }
         }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -2277,8 +2277,8 @@ class User extends Model implements AfterCommit, AuthenticatableContract, HasLoc
         if ($this->isDirty('user_jabber') && present($this->user_discord)) {
             // This is a basic check and not 100% compliant to Discord's spec, only validates that input:
             // - is a 2-32 char username (excluding chars @#:)
-            // - ends with a # and 4-digit discriminator
-            if (!preg_match('/^[^@#:]{2,32}#\d{4}$/i', $this->user_discord)) {
+            // - (if ending with # char) ends with a # and 4-digit discriminator
+            if (!preg_match('/^[^@#:]{2,32}(#\d{4})?$/i', $this->user_discord)) {
                 $this->validationErrors()->add('user_discord', '.invalid_discord');
             }
         }

--- a/resources/js/profile-page/links.tsx
+++ b/resources/js/profile-page/links.tsx
@@ -39,7 +39,7 @@ interface Props {
 const linkMapping: Record<LinkKey, (user: UserExtendedJson) => LinkProps> = {
   discord: (user: UserExtendedJson) => ({
     icon: 'fab fa-discord',
-    text: <ClickToCopy showIcon value={user.discord ?? ''} />,
+    text: <ClickToCopy showIcon value={user.discord ? (/^[^@#:]{2,32}$/i.test(user.discord) ? `@${user.discord}` : user.discord) : ''} />,
   }),
   interests: (user: UserExtendedJson) => ({
     icon: 'far fa-heart',

--- a/resources/js/profile-page/links.tsx
+++ b/resources/js/profile-page/links.tsx
@@ -39,7 +39,7 @@ interface Props {
 const linkMapping: Record<LinkKey, (user: UserExtendedJson) => LinkProps> = {
   discord: (user: UserExtendedJson) => ({
     icon: 'fab fa-discord',
-    text: <ClickToCopy showIcon value={user.discord ? (/^[^@#:]{2,32}$/i.test(user.discord) ? `@${user.discord}` : user.discord) : ''} />,
+    text: <ClickToCopy showIcon value={user.discord ?? ''} />,
   }),
   interests: (user: UserExtendedJson) => ({
     icon: 'far fa-heart',


### PR DESCRIPTION
Closes #10257 
Due to the rollout that may take months, I've added the ability to use either a pomelo or discriminator Discord username/tag.

**Here are some screenshots of how it will display:**
- If discriminator is present
![chrome_x7pbUU25OP](https://github.com/ppy/osu-web/assets/17349626/1eb0661b-d816-4f4c-9220-12513f7a468a)

- If no discriminator is present (pomelo, prefixes with "@")
![chrome_lLZnpoEgEr](https://github.com/ppy/osu-web/assets/17349626/cd6b225c-3c2c-4cee-92b4-d6b24beeaba8)

Validation still exists, it either must be a full discriminator or not have one at all...
![chrome_kmbywhMX1F](https://github.com/ppy/osu-web/assets/17349626/020fff96-47aa-42b0-a23e-7010625c96d9)
