### PR TITLE
fix: Invalid endpoint for v1 in docs

### DIFF
--- a/resources/views/docs/info.md.blade.php
+++ b/resources/views/docs/info.md.blade.php
@@ -106,8 +106,8 @@ This is combined with the base endpoint to determine where requests should be se
 
 URL                             | Status
 ------------------------------- | ---------------------------------------------------------------
-https://osu.ppy.sh/api/v2/      | current
-https://osu.ppy.sh/api/         | _legacy api provided by the old site, will be deprecated soon_
+{{ config('app.url') }}/api/v2/      | current
+{{ config('app.url') }}/api/         | _legacy api provided by the old site, will be deprecated soon_
 
 ## Language
 

--- a/resources/views/docs/info.md.blade.php
+++ b/resources/views/docs/info.md.blade.php
@@ -100,18 +100,14 @@ For a full list of changes, see the
 
 # Endpoint
 
-## Base URL
-
-The base URL is: `{{ config('app.url') }}/api/[version]/`
-
-## API Versions
+## Base URL and API Versions
 
 This is combined with the base endpoint to determine where requests should be sent.
 
-Version | Status
-------- | ---------------------------------------------------------------
-v2      | current
-v1      | _legacy api provided by the old site, will be deprecated soon_
+URL                             | Status
+------------------------------- | ---------------------------------------------------------------
+https://osu.ppy.sh/api/v2/      | current
+https://osu.ppy.sh/api/         | _legacy api provided by the old site, will be deprecated soon_
 
 ## Language
 


### PR DESCRIPTION
The base url for the v1 api is https://osu.ppy.sh/api/, not https://osu.ppy.sh/api/v1.

I'm not sure what would be the best way to fix this in the docs, tried my best.