### PR TITLE
Fix error when searching for favourited beatmaps as guest

### DIFF
--- a/app/Libraries/Search/BeatmapsetSearch.php
+++ b/app/Libraries/Search/BeatmapsetSearch.php
@@ -346,8 +346,10 @@ class BeatmapsetSearch extends RecordSearch
                 $query->must(['match' => ['beatmaps.approved' => Beatmapset::STATES['loved']]]);
                 break;
             case 'favourites':
-                $favs = model_pluck($this->params->user->favouriteBeatmapsets(), 'beatmapset_id', Beatmapset::class);
-                $query->must(['ids' => ['values' => $favs]]);
+                if ($this->params->user !== null) {
+                    $favs = model_pluck($this->params->user->favouriteBeatmapsets(), 'beatmapset_id', Beatmapset::class);
+                }
+                $query->must(['ids' => ['values' => $favs ?? []]]);
                 $queryForFilter = $mainQuery;
                 break;
             case 'qualified':


### PR DESCRIPTION
When `BEATMAPSET_GUEST_ADVANCED_SEARCH` is enabled.