### PR TITLE
Always show timestamp in discussion page timeline

### DIFF
--- a/resources/css/bem/beatmap-discussion-timestamp.less
+++ b/resources/css/bem/beatmap-discussion-timestamp.less
@@ -15,6 +15,10 @@
   align-items: center;
 
   display: flex;
+  position: sticky;
+  // 36px is page-extra-tabs height on desktop.
+  // This doesn't work when the new discussion box is visible.
+  top: calc(var(--navbar-height) + 36px);
 
   &__icons {
     display: flex;

--- a/resources/css/bem/page-extra-tabs.less
+++ b/resources/css/bem/page-extra-tabs.less
@@ -3,13 +3,8 @@
 
 .page-extra-tabs {
   position: sticky;
-  --navbar-height: @navbar-height;
   // 1px overlap with navbar to prevent possible gap in some cases.
   // Reference: https://bugs.chromium.org/p/chromium/issues/detail?id=1261852
   top: calc(var(--navbar-height) - 1px);
   z-index: @z-index--page-extra-tabs;
-
-  @media @desktop {
-    --navbar-height: @nav2-height--pinned;
-  }
 }

--- a/resources/css/layout.less
+++ b/resources/css/layout.less
@@ -53,6 +53,11 @@
   --forum-bg: hsl(var(--hsl-h1));
   --forum-text: @link-color;
   --forum-text: @link-hover-color;
+
+  --navbar-height: @navbar-height;
+  @media @desktop {
+    --navbar-height: @nav2-height--pinned;
+  }
 }
 
 html, body {


### PR DESCRIPTION
There's no telling when new design will happen so this should make do in the meantime. It doesn't work when new discussion box is being pinned but getting that to work would involve updating the js side which is being refactored so it's not happening here 🤷‍♀️

Resolves #1394. There's also #2382 but it seems to be a different issue requesting full timeline to be anchored somewhere.