### PR TITLE
Disable xdebug coverage in GitHub Action

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -125,6 +125,7 @@ jobs:
           extensions: redis, swoole
           tools: composer:v2
           php-version: ${{ matrix.php }}
+          coverage: none
 
       - name: Get composer cache directory
         id: composercache


### PR DESCRIPTION
disables xdebug coverage on tests to speedup action