### PR TITLE
Disable xdebug coverage in GitHub Action (lint)

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -28,6 +28,7 @@ jobs:
         with:
           tools: composer:v2
           php-version: '8.1'
+          coverage: none
 
       - name: Get composer cache directory
         id: composercache


### PR DESCRIPTION
improve phpcs run time disabling xdebug on github action