### PR TITLE
Fix navigation incorrectly triggered when dialog is visible

### DIFF
--- a/resources/js/core-legacy/forum.coffee
+++ b/resources/js/core-legacy/forum.coffee
@@ -3,6 +3,7 @@
 
 import core from 'osu-core-singleton'
 import { onError } from 'utils/ajax'
+import { blackoutVisible } from 'utils/blackout'
 import { bottomPage, formatNumber, isInputElement } from 'utils/html'
 import { hideLoadingOverlay } from 'utils/loading-overlay'
 import { pageChange } from 'utils/page-change'
@@ -202,7 +203,7 @@ export default class Forum
     true
 
   keyboardNavigation: (e) =>
-    return if isInputElement(e.target) or not @_postsCounter.length
+    return if isInputElement(e.target) || e.target.closest('[role=dialog]')? || blackoutVisible() || @_postsCounter.length == 0
 
     e.preventDefault()
 

--- a/resources/js/utils/blackout.ts
+++ b/resources/js/utils/blackout.ts
@@ -19,3 +19,9 @@ export function blackoutToggle(state: boolean, opacity?: number) {
     fadeToggle(el, state);
   }
 }
+
+export function blackoutVisible() {
+  const el = document.querySelector('.js-blackout');
+
+  return el instanceof HTMLElement && el.style.opacity !== '';
+}


### PR DESCRIPTION
Resolves #4115. I feel preventing event from bubbling out of the dialog dom in the first place would be better but that's for another day I guess 🤔 