### PR TITLE
Workaround invalid legacy match game ruleset

### DIFF
--- a/app/Models/LegacyMatch/Game.php
+++ b/app/Models/LegacyMatch/Game.php
@@ -122,7 +122,11 @@ class Game extends Model
 
     private function getRulesetId(): int
     {
-        $gameRulesetId = $this->getRawAttribute('play_mode') ?? Beatmap::MODES['osu'];
+        $gameRulesetId = $this->getRawAttribute('play_mode');
+        // There are some entries with invalid ruleset id.
+        if ($gameRulesetId === null || Beatmap::modeStr($gameRulesetId) === null) {
+            $gameRulesetId = Beatmap::MODES['osu'];
+        }
         $beatmapRulesetId = $this->beatmap?->playmode;
 
         // ruleset set at this model is incorrect when playing ruleset


### PR DESCRIPTION
Apparently it's a thing.

- [ ] maybe not needed as it'll be fixed at the backend