### PR TITLE
Always set time for beatmapset query to utc

### DIFF
--- a/app/Libraries/Search/BeatmapsetQueryParser.php
+++ b/app/Libraries/Search/BeatmapsetQueryParser.php
@@ -108,7 +108,7 @@ class BeatmapsetQueryParser
             $startTime = Carbon::create($m['year'], $m['month'], $m['day'], 0, 0, 0, 'UTC');
             $endTimeFunction = 'addDays';
         } else {
-            $startTime = parse_time_to_carbon($value);
+            $startTime = parse_time_to_carbon($value)?->utc();
             $endTimeFunction = 'addSeconds';
         }
 

--- a/tests/Libraries/Search/BeatmapsetQueryParserTest.php
+++ b/tests/Libraries/Search/BeatmapsetQueryParserTest.php
@@ -50,8 +50,8 @@ class BeatmapsetQueryParserTest extends TestCase
             ['ranked=2018/05', ['keywords' => null, 'options' => ['ranked' => ['gte' => '2018-05-01T00:00:00+00:00', 'lt' => '2018-06-01T00:00:00+00:00']]]],
             ['ranked=2018.05.01', ['keywords' => null, 'options' => ['ranked' => ['gte' => '2018-05-01T00:00:00+00:00', 'lt' => '2018-05-02T00:00:00+00:00']]]],
             ['ranked>2018/05/01', ['keywords' => null, 'options' => ['ranked' => ['gte' => '2018-05-02T00:00:00+00:00']]]],
-            ['ranked>="2020-07-21 12:30:30 +09:00"', ['keywords' => null, 'options' => ['ranked' => ['gte' => '2020-07-21T12:30:30+09:00']]]],
-            ['ranked="2020-07-21 12:30:30 +09:00"', ['keywords' => null, 'options' => ['ranked' => ['gte' => '2020-07-21T12:30:30+09:00', 'lt' => '2020-07-21T12:30:31+09:00']]]],
+            ['ranked>="2020-07-21 12:30:30 +09:00"', ['keywords' => null, 'options' => ['ranked' => ['gte' => '2020-07-21T03:30:30+00:00']]]],
+            ['ranked="2020-07-21 12:30:30 +09:00"', ['keywords' => null, 'options' => ['ranked' => ['gte' => '2020-07-21T03:30:30+00:00', 'lt' => '2020-07-21T03:30:31+00:00']]]],
             ['ranked="invalid date format"', ['keywords' => 'ranked="invalid date format"', 'options' => []]],
 
             // multiple options


### PR DESCRIPTION
Otherwise `11/04-2016` ended up being parsed to having timezone of -20:16 and rejected by elasticsearch.

(this change doesn't fix it to parse to year 2016 but still better than having exploding elasticsearch)