### PR TITLE
Remove redundant isNew attribute

### DIFF
--- a/app/Models/Multiplayer/Room.php
+++ b/app/Models/Multiplayer/Room.php
@@ -597,7 +597,7 @@ class Room extends Model
 
         return $this->getConnection()->transaction(function () use ($user, $playlistItem) {
             $agg = UserScoreAggregate::new($user, $this);
-            if ($agg->isNew) {
+            if ($agg->wasRecentlyCreated) {
                 // sanity; if the object isn't saved, laravel will increment the entire table.
                 if (!$this->exists) {
                     $this->save();

--- a/app/Models/Multiplayer/UserScoreAggregate.php
+++ b/app/Models/Multiplayer/UserScoreAggregate.php
@@ -43,8 +43,6 @@ class UserScoreAggregate extends Model
     ];
     protected $table = 'multiplayer_rooms_high';
 
-    public $isNew = false;
-
     public static function getPlaylistItemUserHighScore(Score $score)
     {
         return PlaylistItemUserHighScore::firstOrNew([
@@ -87,7 +85,6 @@ class UserScoreAggregate extends Model
         $obj = static::lookupOrDefault($user, $room);
 
         if (!$obj->exists) {
-            $obj->isNew = true;
             $obj->save(); // force a save now to avoid being trolled later.
             $obj->recalculate();
         }

--- a/tests/Models/Multiplayer/RoomTest.php
+++ b/tests/Models/Multiplayer/RoomTest.php
@@ -103,6 +103,22 @@ class RoomTest extends TestCase
         $room->startPlay($user, $playlistItem);
     }
 
+    public function testStartPlay(): void
+    {
+        $user = User::factory()->create();
+        $room = Room::factory()->create();
+        $playlistItem = PlaylistItem::factory()->create(['room_id' => $room]);
+
+        $this->expectCountChange(fn () => $room->participant_count, 1);
+        $this->expectCountChange(fn () => $room->userHighScores()->count(), 1);
+        $this->expectCountChange(fn () => $room->scores()->count(), 1);
+
+        $room->startPlay($user, $playlistItem);
+        $room->refresh();
+
+        $this->assertSame($user->getKey(), $room->scores()->last()->user_id);
+    }
+
     public function testMaxAttemptsReached()
     {
         $user = User::factory()->create();


### PR DESCRIPTION
Laravel already have the exactly same attribute just with different name.