### PR TITLE
Fix bucket name for solo score replays

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -69,6 +69,8 @@ SLACK_ENDPOINT=https://myconan.net/null/
 # S3_BASE_URL=
 # S3_MINI_URL=
 
+# S3_SOLO_REPLAY_BUCKET=solo-scores-replays
+
 # S3_AVATAR_KEY=
 # S3_AVATAR_SECRET=
 # S3_AVATAR_REGION=

--- a/config/filesystems.php
+++ b/config/filesystems.php
@@ -102,7 +102,7 @@ return [
             'key' => env('S3_KEY'),
             'secret' => env('S3_SECRET'),
             'region' => env('S3_REGION'),
-            'bucket' => 'solo-scores-replays',
+            'bucket' => presence(env('S3_SOLO_REPLAY_BUCKET')) ?? 'solo-scores-replays',
         ],
     ],
 

--- a/config/filesystems.php
+++ b/config/filesystems.php
@@ -102,7 +102,7 @@ return [
             'key' => env('S3_KEY'),
             'secret' => env('S3_SECRET'),
             'region' => env('S3_REGION'),
-            'bucket' => 'solo-scores-replay',
+            'bucket' => 'solo-scores-replays',
         ],
     ],
 


### PR DESCRIPTION
It was missing an `s`. I also made it configurable while at it.