### PR TITLE
Allow guest user to view Playlist scores

### DIFF
--- a/app/Http/Controllers/Multiplayer/Rooms/Playlist/ScoresController.php
+++ b/app/Http/Controllers/Multiplayer/Rooms/Playlist/ScoresController.php
@@ -21,7 +21,7 @@ class ScoresController extends BaseController
 {
     public function __construct()
     {
-        $this->middleware('auth');
+        $this->middleware('auth', ['except' => ['index']]);
         $this->middleware('require-scopes:public', ['only' => ['index']]);
     }
 

--- a/tests/api_routes.json
+++ b/tests/api_routes.json
@@ -723,7 +723,6 @@
         "middlewares": [
             "App\\Http\\Middleware\\ThrottleRequests:1200,1,api:",
             "App\\Http\\Middleware\\RequireScopes",
-            "Illuminate\\Auth\\Middleware\\Authenticate",
             "App\\Http\\Middleware\\RequireScopes:public"
         ],
         "scopes": [


### PR DESCRIPTION
There's an explicit `if ($user !== null)` check when looking up the user score and it returns `null` if there's no user, but the middleware wasn't updated to not require `auth` and therefore always requires a user, so I'm not sure what's actually supposed to be going on here 🤔 