### PR TITLE
Add link to osu.js API wrapper

### DIFF
--- a/resources/views/docs/info.md.blade.php
+++ b/resources/views/docs/info.md.blade.php
@@ -25,6 +25,7 @@ Below is a list of some language-specific wrappers maintained by the community. 
 - [ossapi](https://github.com/circleguard/ossapi) (python)
 - [aiosu](https://github.com/NiceAesth/aiosu) (python)
 - [rosu-v2](https://github.com/MaxOhn/rosu-v2) (rust)
+- [osu.js](https://github.com/L-Mario564/osu.js) (javascript/typescript)
 
 # Changelog
 


### PR DESCRIPTION
I maintain a JS/TS API wrapper called osu.js that supports API v1 and v2 and would like to see it added to the current list of API wrappers.

[Repository](https://github.com/L-Mario564/osu.js)