### PR TITLE
Add osu.py to list of API wrappers on the docs

### DIFF
--- a/resources/views/docs/info.md.blade.php
+++ b/resources/views/docs/info.md.blade.php
@@ -24,6 +24,7 @@ Below is a list of some language-specific wrappers maintained by the community. 
 
 - [ossapi](https://github.com/circleguard/ossapi) (python)
 - [aiosu](https://github.com/NiceAesth/aiosu) (python)
+- [osu.py](https://github.com/sheppsu/osu.py) (python)
 - [rosu-v2](https://github.com/MaxOhn/rosu-v2) (rust)
 
 # Changelog


### PR DESCRIPTION
Hi, I'm the developer of [osu.py](https://github.com/sheppsu/osu.py), a purely Python API wrapper for specifically v2 of the osu api. I regularly update the library and actively seek to improve it. Was wondering if I could get it added onto the list of API wrappers on the docs.