### PR TITLE
Fix saving new user playlist high score

### DIFF
--- a/app/Models/Multiplayer/PlaylistItemUserHighScore.php
+++ b/app/Models/Multiplayer/PlaylistItemUserHighScore.php
@@ -61,11 +61,11 @@ class PlaylistItemUserHighScore extends Model
 
     public function updateWithScore(Score $score): void
     {
-        $this->update([
+        $this->fill([
             'accuracy' => $score->accuracy,
             'pp' => $score->pp,
             'score_id' => $score->getKey(),
             'total_score' => $score->total_score,
-        ]);
+        ])->save();
     }
 }


### PR DESCRIPTION
"Updating" nonexistent record is noop in laravel because apparently it previously updates the whole table instead (laravel/framework#12083) (ha ha ha) and then updated to be noop because filling the model and saving it as requested makes too much sense.