### PR TITLE
Fix escaping in invalid imagemap

### DIFF
--- a/app/Libraries/BBCodeFromDB.php
+++ b/app/Libraries/BBCodeFromDB.php
@@ -134,7 +134,8 @@ class BBCodeFromDB
         return preg_replace_callback(
             '#(\[imagemap\].+?\[/imagemap\]\n?)#',
             function ($m) {
-                return preg_replace_callback(
+                $unescaped = html_entity_decode_better(BBCodeForDB::extraUnescape($m[1]));
+                $parsed = preg_replace_callback(
                     '#\[imagemap\]\n(?<imageUrl>https?://.+)\n(?<links>(?:(?:[0-9.]+ ){4}(?:\#|https?://[^\s]+|mailto:[^\s]+)(?: .*)?\n)+)\[/imagemap\]\n?#',
                     function ($map) {
                         $links = array_map(
@@ -173,8 +174,10 @@ class BBCodeFromDB
 
                         return tag('div', ['class' => 'imagemap'], $imageHtml.$linksHtml);
                     },
-                    html_entity_decode_better(BBCodeForDB::extraUnescape($m[1])),
+                    $unescaped,
                 );
+
+                return $parsed === $unescaped ? $m[1] : $parsed;
             },
             $text,
         );

--- a/tests/Libraries/bbcode_examples/imagemap.html
+++ b/tests/Libraries/bbcode_examples/imagemap.html
@@ -11,6 +11,4 @@
     <a class="imagemap__link" href="https://osu.ppy.sh/users/2" style="left:40%;top:50%;width:60%;height:70%;" title=""></a>
 </div>
 <br />
-[imagemap]<br />
-https://assets.ppy.sh/osu-web-test-resources/placeholder-1280x720.jpg<br />
-[/imagemap]
+[imagemap]https://assets.ppy.sh/osu-web-test-resources/placeholder-1280x720.jpg[/imagemap]

--- a/tests/Libraries/bbcode_examples/imagemap_invalid_content_escape.base.txt
+++ b/tests/Libraries/bbcode_examples/imagemap_invalid_content_escape.base.txt
@@ -1,0 +1,3 @@
+[imagemap]
+<strong>
+[/imagemap]

--- a/tests/Libraries/bbcode_examples/imagemap_invalid_content_escape.db.txt
+++ b/tests/Libraries/bbcode_examples/imagemap_invalid_content_escape.db.txt
@@ -1,0 +1,1 @@
+[imagemap]&#10;&lt;strong&gt;&#10;[/imagemap]

--- a/tests/Libraries/bbcode_examples/imagemap_invalid_content_escape.html
+++ b/tests/Libraries/bbcode_examples/imagemap_invalid_content_escape.html
@@ -1,0 +1,1 @@
+[imagemap]&lt;strong&gt;[/imagemap]


### PR DESCRIPTION
The other fix fixed the problem globally while this one is doing the right thing for this specific tag without relying on the global cleaner (which turned out was disabled).