### PR TITLE
Add helper to create user group events based on existing models

### DIFF
--- a/database/factories/UserGroupEventFactory.php
+++ b/database/factories/UserGroupEventFactory.php
@@ -11,6 +11,7 @@ use App\Models\Beatmap;
 use App\Models\Group;
 use App\Models\User;
 use App\Models\UserGroupEvent;
+use Illuminate\Support\ItemNotFoundException;
 
 class UserGroupEventFactory extends Factory
 {
@@ -70,5 +71,23 @@ class UserGroupEventFactory extends Factory
                 default => User::factory(),
             },
         ];
+    }
+
+    public function withRandomExistingModels(): static
+    {
+        return $this->state([
+            'actor_id' => User::inRandomOrder()->first(),
+            'group_id' => function () {
+                return app('groups')->all()->random()
+                    ?? throw new ItemNotFoundException();
+            },
+            'user_id' => fn (array $attr) => match ($attr['type']) {
+                UserGroupEvent::GROUP_ADD,
+                UserGroupEvent::GROUP_REMOVE,
+                UserGroupEvent::GROUP_RENAME => null,
+
+                default => User::inRandomOrder()->firstOrFail(),
+            },
+        ]);
     }
 }

--- a/database/factories/UserGroupEventFactory.php
+++ b/database/factories/UserGroupEventFactory.php
@@ -76,11 +76,8 @@ class UserGroupEventFactory extends Factory
     public function withRandomExistingModels(): static
     {
         return $this->state([
-            'actor_id' => User::inRandomOrder()->first(),
-            'group_id' => function () {
-                return app('groups')->all()->random()
-                    ?? throw new ItemNotFoundException();
-            },
+            'actor_id' => fn () => User::inRandomOrder()->first(),
+            'group_id' => fn () => app('groups')->all()->random() ?? throw new ItemNotFoundException(),
             'user_id' => fn (array $attr) => match ($attr['type']) {
                 UserGroupEvent::GROUP_ADD,
                 UserGroupEvent::GROUP_REMOVE,


### PR DESCRIPTION
this was a helpful extension to `UserGroupEventFactory` while working on the group history page, but I don't see any use for it in tests or anything. wasn't sure if I should include it so put it in separate PR

- [x] depends on #9488