### PR TITLE
Add `ProfileBanner` `image@2x` field to api docs

### DIFF
--- a/resources/views/docs/_structures/user_compact.md
+++ b/resources/views/docs/_structures/user_compact.md
@@ -83,8 +83,8 @@ Field         | Type        | Description
 --------------|-------------|------------
 id            | number      | |
 tournament_id | number      | |
-image         | string      | |
-image@2x      | string      | |
+image         | string?     | |
+image@2x      | string?     | |
 
 <div id="usercompact-rankhighest" data-unique="usercompact-rankhighest"></div>
 

--- a/resources/views/docs/_structures/user_compact.md
+++ b/resources/views/docs/_structures/user_compact.md
@@ -84,6 +84,7 @@ Field         | Type        | Description
 id            | number      | |
 tournament_id | number      | |
 image         | string      | |
+image@2x      | string      | |
 
 <div id="usercompact-rankhighest" data-unique="usercompact-rankhighest"></div>
 


### PR DESCRIPTION
Wasn't added in https://github.com/ppy/osu-web/pull/9861.