### PR TITLE
Rename "permanent" bans to "indefinite"

### DIFF
--- a/resources/js/profile-page/account-standing.tsx
+++ b/resources/js/profile-page/account-standing.tsx
@@ -56,7 +56,7 @@ const ColumnLength = ({ history }: ColumnProps) => {
   if (history.type === 'restriction' || history.permanent) {
     return (
       <div className={`${bn}__action ${bn}__action--restriction`}>
-        {trans('users.show.extra.account_standing.recent_infringements.length_permanent')}
+        {trans('users.show.extra.account_standing.recent_infringements.length_indefinite')}
       </div>
     );
   }

--- a/resources/lang/en/users.php
+++ b/resources/lang/en/users.php
@@ -387,7 +387,7 @@ return [
                     'date' => 'date',
                     'action' => 'action',
                     'length' => 'length',
-                    'length_permanent' => 'Permanent',
+                    'length_indefinite' => 'Indefinite',
                     'description' => 'description',
                     'actor' => 'by :username',
 


### PR DESCRIPTION
closes #10417, I've also let this affect restrictions as well since the same wording logic applies