### PR TITLE
Clean up views on database refresh

### DIFF
--- a/app/Console/Commands/MigrateFreshAllCommand.php
+++ b/app/Console/Commands/MigrateFreshAllCommand.php
@@ -34,6 +34,7 @@ class MigrateFreshAllCommand extends FreshCommand
             $this->warn($database);
             $this->call('db:wipe', [
                 '--database' => $database,
+                '--drop-views' => true,
             ]);
         }
 


### PR DESCRIPTION
Fixes error when running fresh migration on database without `2017_02_13_013536_delete_contest_vote_aggregates_view` applied.