### PR TITLE
Remove the Laravel Mix docs link in SETUP.md

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -223,8 +223,6 @@ php artisan tinker
 
 ## Generating assets
 
-Using Laravel's [Mix](https://laravel.com/docs/10.x/mix).
-
 ```bash
 # build assets (should be done automatically if using docker)
 yarn run development

--- a/SETUP.md
+++ b/SETUP.md
@@ -223,7 +223,7 @@ php artisan tinker
 
 ## Generating assets
 
-Using Laravel's [Mix](https://laravel.com/docs/6.x/mix).
+Using Laravel's [Mix](https://laravel.com/docs/10.x/mix).
 
 ```bash
 # build assets (should be done automatically if using docker)


### PR DESCRIPTION
It confused me because this version is not used now