### PR TITLE
Add api endpoint for new score show and download routes

### DIFF
--- a/app/Http/Controllers/ScoresController.php
+++ b/app/Http/Controllers/ScoresController.php
@@ -30,14 +30,14 @@ class ScoresController extends Controller
         $shouldRedirect = !is_api_request() && !from_app_url();
         if ($id === null) {
             if ($shouldRedirect) {
-                return ujs_redirect(route('scores.show', ['score' => $rulesetOrSoloId]));
+                return ujs_redirect(route('scores.show', ['rulesetOrScore' => $rulesetOrSoloId]));
             }
             $soloScore = SoloScore::where('has_replay', true)->findOrFail($rulesetOrSoloId);
 
             $score = $soloScore->legacyScore() ?? $soloScore;
         } else {
             if ($shouldRedirect) {
-                return ujs_redirect(route('scores.show-legacy', ['score' => $id, 'mode' => $rulesetOrSoloId]));
+                return ujs_redirect(route('scores.show', ['rulesetOrScore' => $rulesetOrSoloId, 'score' => $id]));
             }
             // don't limit downloading replays of restricted users for review purpose
             $score = ScoreBest::getClass($rulesetOrSoloId)
@@ -63,6 +63,11 @@ class ScoresController extends Controller
         return response()->streamDownload(function () use ($file) {
             echo $file;
         }, $this->makeReplayFilename($score), $responseHeaders);
+    }
+
+    public function downloadLegacy($ruleset, $id)
+    {
+        return $this->download($ruleset, $id);
     }
 
     public function show($rulesetOrSoloId, $legacyId = null)

--- a/app/Models/Score/Best/Model.php
+++ b/app/Models/Score/Best/Model.php
@@ -145,7 +145,7 @@ abstract class Model extends BaseModel implements Traits\ReportableInterface
 
     public function url(): string
     {
-        return route('scores.show-legacy', ['mode' => $this->getMode(), 'score' => $this->getKey()]);
+        return route('scores.show', ['rulesetOrScore' => $this->getMode(), 'score' => $this->getKey()]);
     }
 
     public function userRank($options)

--- a/app/Models/Solo/Score.php
+++ b/app/Models/Solo/Score.php
@@ -228,7 +228,7 @@ class Score extends Model implements Traits\ReportableInterface
 
     public function url(): string
     {
-        return route('scores.show', $this);
+        return route('scores.show', ['rulesetOrScore' => $this->getKey()]);
     }
 
     public function userRank(?array $params = null): int

--- a/resources/js/utils/score-helper.ts
+++ b/resources/js/utils/score-helper.ts
@@ -109,12 +109,12 @@ export function scoreDownloadUrl(score: SoloScoreJson) {
 
 export function scoreUrl(score: SoloScoreJson) {
   if (score.type === 'solo_score') {
-    return route('scores.show', { score: score.id });
+    return route('scores.show', { rulesetOrScore: score.id });
   }
 
   if (score.best_id != null) {
-    return route('scores.show-legacy', {
-      mode: rulesetName(score.ruleset_id),
+    return route('scores.show', {
+      rulesetOrScore: rulesetName(score.ruleset_id),
       score: score.best_id,
     });
   }

--- a/resources/js/utils/score-helper.ts
+++ b/resources/js/utils/score-helper.ts
@@ -99,7 +99,7 @@ export function scoreDownloadUrl(score: SoloScoreJson) {
 
   if (score.best_id != null) {
     return route('scores.download-legacy', {
-      mode: rulesetName(score.ruleset_id),
+      rulesetOrScore: rulesetName(score.ruleset_id),
       score: score.best_id,
     });
   }

--- a/routes/web.php
+++ b/routes/web.php
@@ -102,15 +102,11 @@ Route::group(['middleware' => ['web']], function () {
     Route::resource('beatmapsets', 'BeatmapsetsController', ['only' => ['destroy', 'index', 'show', 'update']]);
 
     Route::group(['prefix' => 'scores', 'as' => 'scores.'], function () {
-        // make sure it's matched before {mode}/{score}
         Route::get('{score}/download', 'ScoresController@download')->name('download');
+        Route::get('{rulesetOrScore}/{score}/download', 'ScoresController@downloadLegacy')->name('download-legacy');
 
-        Route::group(['prefix' => '{mode}'], function () {
-            Route::get('{score}/download', 'ScoresController@download')->name('download-legacy');
-            Route::get('{score}', 'ScoresController@show')->name('show-legacy');
-        });
+        Route::get('{rulesetOrScore}/{score?}', 'ScoresController@show')->name('show');
     });
-    Route::resource('scores', 'ScoresController', ['only' => ['show']]);
 
     Route::delete('score-pins', 'ScorePinsController@destroy')->name('score-pins.destroy');
     Route::put('score-pins', 'ScorePinsController@reorder')->name('score-pins.reorder');
@@ -485,9 +481,11 @@ Route::group(['as' => 'api.', 'prefix' => 'api', 'middleware' => ['api', Throttl
 
         Route::apiResource('seasonal-backgrounds', 'SeasonalBackgroundsController', ['only' => ['index']]);
 
-        Route::group(['prefix' => 'scores/{mode}', 'as' => 'scores.'], function () {
+        Route::group(['prefix' => 'scores', 'as' => 'scores.'], function () {
             Route::get('{score}/download', 'ScoresController@download')->middleware(ThrottleRequests::getApiThrottle('scores_download'))->name('download');
-            Route::get('{score}', 'ScoresController@show')->name('show');
+            Route::get('{rulesetOrScore}/{score}/download', 'ScoresController@downloadLegacy')->middleware(ThrottleRequests::getApiThrottle('scores_download'))->name('download-legacy');
+
+            Route::get('{rulesetOrScore}/{score?}', 'ScoresController@show')->name('show');
         });
 
         // Beatmapsets

--- a/tests/Browser/SanityTest.php
+++ b/tests/Browser/SanityTest.php
@@ -430,6 +430,10 @@ class SanityTest extends DuskTestCase
             'changelog.show' => [
                 'changelog' => self::$scaffolding['build']->version,
             ],
+            'scores.show' => [
+                'rulesetOrScore' => static::$scaffolding['score']->getMode(),
+                'score' => static::$scaffolding['score']->getKey(),
+            ],
             'legal' => [
                 'locale' => 'en',
                 'path' => 'Terms',

--- a/tests/Browser/SanityTest.php
+++ b/tests/Browser/SanityTest.php
@@ -430,6 +430,10 @@ class SanityTest extends DuskTestCase
             'changelog.show' => [
                 'changelog' => self::$scaffolding['build']->version,
             ],
+            'scores.download-legacy' => [
+                'rulesetOrScore' => static::$scaffolding['score']->getMode(),
+                'score' => static::$scaffolding['score']->getKey(),
+            ],
             'scores.show' => [
                 'rulesetOrScore' => static::$scaffolding['score']->getMode(),
                 'score' => static::$scaffolding['score']->getKey(),

--- a/tests/Controllers/ScoresControllerTest.php
+++ b/tests/Controllers/ScoresControllerTest.php
@@ -90,7 +90,7 @@ class ScoresControllerTest extends TestCase
                 'GET',
                 route('scores.download-legacy', $this->params())
             )
-            ->assertRedirect(route('scores.show-legacy', $this->params()));
+            ->assertRedirect(route('scores.show', $this->params()));
 
         $this
             ->actingAs($this->user)
@@ -99,7 +99,7 @@ class ScoresControllerTest extends TestCase
                 'GET',
                 route('scores.download-legacy', $this->params())
             )
-            ->assertRedirect(route('scores.show-legacy', $this->params()));
+            ->assertRedirect(route('scores.show', $this->params()));
     }
 
     public function testDownloadInvalidMode()
@@ -108,7 +108,7 @@ class ScoresControllerTest extends TestCase
             ->actingAs($this->user)
             ->json(
                 'GET',
-                route('scores.download-legacy', ['mode' => 'nope', 'score' => $this->score->getKey()])
+                route('scores.download-legacy', ['rulesetOrScore' => 'nope', 'score' => $this->score->getKey()])
             )
             ->assertStatus(302);
     }
@@ -143,7 +143,7 @@ class ScoresControllerTest extends TestCase
     private function params()
     {
         return [
-            'mode' => $this->score->getMode(),
+            'rulesetOrScore' => $this->score->getMode(),
             'score' => $this->score->getKey(),
         ];
     }

--- a/tests/api_routes.json
+++ b/tests/api_routes.json
@@ -528,6 +528,22 @@
         "scopes": []
     },
     {
+        "uri": "api/v2/events",
+        "methods": [
+            "GET",
+            "HEAD"
+        ],
+        "controller": "App\\Http\\Controllers\\EventsController@index",
+        "middlewares": [
+            "App\\Http\\Middleware\\ThrottleRequests:1200,1,api:",
+            "App\\Http\\Middleware\\RequireScopes",
+            "App\\Http\\Middleware\\RequireScopes:public"
+        ],
+        "scopes": [
+            "public"
+        ]
+    },
+    {
         "uri": "api/v2/forums/topics/{topic}/reply",
         "methods": [
             "POST"
@@ -826,7 +842,7 @@
         "scopes": []
     },
     {
-        "uri": "api/v2/scores/{mode}/{score}/download",
+        "uri": "api/v2/scores/{score}/download",
         "methods": [
             "GET",
             "HEAD"
@@ -844,7 +860,25 @@
         ]
     },
     {
-        "uri": "api/v2/scores/{mode}/{score}",
+        "uri": "api/v2/scores/{rulesetOrScore}/{score}/download",
+        "methods": [
+            "GET",
+            "HEAD"
+        ],
+        "controller": "App\\Http\\Controllers\\ScoresController@downloadLegacy",
+        "middlewares": [
+            "App\\Http\\Middleware\\ThrottleRequests:1200,1,api:",
+            "App\\Http\\Middleware\\RequireScopes",
+            "App\\Http\\Middleware\\ThrottleRequests:10,1,api-scores-download:",
+            "Illuminate\\Auth\\Middleware\\Authenticate",
+            "App\\Http\\Middleware\\RequireScopes:public"
+        ],
+        "scopes": [
+            "public"
+        ]
+    },
+    {
+        "uri": "api/v2/scores/{rulesetOrScore}/{score?}",
         "methods": [
             "GET",
             "HEAD"
@@ -1191,21 +1225,5 @@
             "App\\Http\\Middleware\\RequireScopes"
         ],
         "scopes": []
-    },
-    {
-        "uri": "api/v2/events",
-        "methods": [
-            "GET",
-            "HEAD"
-        ],
-        "controller": "App\\Http\\Controllers\\EventsController@index",
-        "middlewares": [
-            "App\\Http\\Middleware\\ThrottleRequests:1200,1,api:",
-            "App\\Http\\Middleware\\RequireScopes",
-            "App\\Http\\Middleware\\RequireScopes:public"
-        ],
-        "scopes": [
-            "public"
-        ]
     }
 ]


### PR DESCRIPTION
Download action stays separate because I can't figure out how to have optional parameter in the middle without leaving extra slash when optional parameter is empty.