### PR TITLE
Remove filtering multiplayer rooms by route path parameter

### DIFF
--- a/app/Http/Controllers/Multiplayer/RoomsController.php
+++ b/app/Http/Controllers/Multiplayer/RoomsController.php
@@ -26,7 +26,7 @@ class RoomsController extends BaseController
      * ---
      *
      * @queryParam limit Maximum number of results. No-example
-     * @queryParam mode Filter mode; `all`, `ended`, `participated`, `owned`. Defaults to active rooms only if not sepcified. No-example
+     * @queryParam mode Filter mode; `active` (default), `all`, `ended`, `participated`, `owned`. No-example
      * @queryParam season_id Season ID to return Rooms from. No-example
      * @queryParam sort Sort order; `ended`, `created`. No-example
      * @queryParam type_group `playlists` (default) or `realtime`. No-example

--- a/app/Http/Controllers/Multiplayer/RoomsController.php
+++ b/app/Http/Controllers/Multiplayer/RoomsController.php
@@ -18,6 +18,19 @@ class RoomsController extends BaseController
         $this->middleware('require-scopes:public', ['only' => ['index', 'leaderboard', 'show']]);
     }
 
+    /**
+     * Get Multiplayer Rooms
+     *
+     * Returns a list of multiplayer rooms.
+     *
+     * ---
+     *
+     * @queryParam limit Maximum number of results. No-example
+     * @queryParam mode Filter mode; `all`, `ended`, `participated`, `owned`. Defaults to active rooms only if not sepcified. No-example
+     * @queryParam season_id Season ID to return Rooms from. No-example
+     * @queryParam sort Sort order; `ended`, `created`. No-example
+     * @queryParam type_group `playlists` (default) or `realtime`. No-example
+     */
     public function index()
     {
         $apiVersion = api_version();

--- a/app/Http/Controllers/Multiplayer/RoomsController.php
+++ b/app/Http/Controllers/Multiplayer/RoomsController.php
@@ -23,8 +23,6 @@ class RoomsController extends BaseController
      *
      * Returns a list of multiplayer rooms.
      *
-     * ---
-     *
      * @group Multiplayer
      *
      * @queryParam limit Maximum number of results. No-example

--- a/app/Http/Controllers/Multiplayer/RoomsController.php
+++ b/app/Http/Controllers/Multiplayer/RoomsController.php
@@ -25,6 +25,8 @@ class RoomsController extends BaseController
      *
      * ---
      *
+     * @group Multiplayer
+     *
      * @queryParam limit Maximum number of results. No-example
      * @queryParam mode Filter mode; `active` (default), `all`, `ended`, `participated`, `owned`. No-example
      * @queryParam season_id Season ID to return Rooms from. No-example

--- a/routes/web.php
+++ b/routes/web.php
@@ -468,8 +468,9 @@ Route::group(['as' => 'api.', 'prefix' => 'api', 'middleware' => ['api', Throttl
         });
         Route::resource('matches', 'MatchesController', ['only' => ['index', 'show']]);
 
+        Route::resource('reports', 'ReportsController', ['only' => ['store']]);
+
         Route::group(['as' => 'rooms.', 'prefix' => 'rooms'], function () {
-            Route::get('{mode?}', 'Multiplayer\RoomsController@index')->name('index')->where('mode', 'owned|participated|ended');
             Route::put('{room}/users/{user}', 'Multiplayer\RoomsController@join')->name('join');
             Route::delete('{room}/users/{user}', 'Multiplayer\RoomsController@part')->name('part');
             Route::get('{room}/leaderboard', 'Multiplayer\RoomsController@leaderboard');
@@ -479,9 +480,7 @@ Route::group(['as' => 'api.', 'prefix' => 'api', 'middleware' => ['api', Throttl
             });
         });
 
-        Route::resource('reports', 'ReportsController', ['only' => ['store']]);
-
-        Route::apiResource('rooms', 'Multiplayer\RoomsController', ['only' => ['show', 'store']]);
+        Route::apiResource('rooms', 'Multiplayer\RoomsController', ['only' => ['index', 'show', 'store']]);
 
         Route::apiResource('seasonal-backgrounds', 'SeasonalBackgroundsController', ['only' => ['index']]);
 

--- a/tests/api_routes.json
+++ b/tests/api_routes.json
@@ -528,6 +528,22 @@
         "scopes": []
     },
     {
+        "uri": "api/v2/events",
+        "methods": [
+            "GET",
+            "HEAD"
+        ],
+        "controller": "App\\Http\\Controllers\\EventsController@index",
+        "middlewares": [
+            "App\\Http\\Middleware\\ThrottleRequests:1200,1,api:",
+            "App\\Http\\Middleware\\RequireScopes",
+            "App\\Http\\Middleware\\RequireScopes:public"
+        ],
+        "scopes": [
+            "public"
+        ]
+    },
+    {
         "uri": "api/v2/forums/topics/{topic}/reply",
         "methods": [
             "POST"
@@ -640,21 +656,17 @@
         ]
     },
     {
-        "uri": "api/v2/rooms/{mode?}",
+        "uri": "api/v2/reports",
         "methods": [
-            "GET",
-            "HEAD"
+            "POST"
         ],
-        "controller": "App\\Http\\Controllers\\Multiplayer\\RoomsController@index",
+        "controller": "App\\Http\\Controllers\\ReportsController@store",
         "middlewares": [
             "App\\Http\\Middleware\\ThrottleRequests:1200,1,api:",
             "App\\Http\\Middleware\\RequireScopes",
-            "Illuminate\\Auth\\Middleware\\Authenticate",
-            "App\\Http\\Middleware\\RequireScopes:public"
+            "Illuminate\\Auth\\Middleware\\Authenticate"
         ],
-        "scopes": [
-            "public"
-        ]
+        "scopes": []
     },
     {
         "uri": "api/v2/rooms/{room}/users/{user}",
@@ -771,17 +783,21 @@
         "scopes": []
     },
     {
-        "uri": "api/v2/reports",
+        "uri": "api/v2/rooms",
         "methods": [
-            "POST"
+            "GET",
+            "HEAD"
         ],
-        "controller": "App\\Http\\Controllers\\ReportsController@store",
+        "controller": "App\\Http\\Controllers\\Multiplayer\\RoomsController@index",
         "middlewares": [
             "App\\Http\\Middleware\\ThrottleRequests:1200,1,api:",
             "App\\Http\\Middleware\\RequireScopes",
-            "Illuminate\\Auth\\Middleware\\Authenticate"
+            "Illuminate\\Auth\\Middleware\\Authenticate",
+            "App\\Http\\Middleware\\RequireScopes:public"
         ],
-        "scopes": []
+        "scopes": [
+            "public"
+        ]
     },
     {
         "uri": "api/v2/rooms",
@@ -1191,21 +1207,5 @@
             "App\\Http\\Middleware\\RequireScopes"
         ],
         "scopes": []
-    },
-    {
-        "uri": "api/v2/events",
-        "methods": [
-            "GET",
-            "HEAD"
-        ],
-        "controller": "App\\Http\\Controllers\\EventsController@index",
-        "middlewares": [
-            "App\\Http\\Middleware\\ThrottleRequests:1200,1,api:",
-            "App\\Http\\Middleware\\RequireScopes",
-            "App\\Http\\Middleware\\RequireScopes:public"
-        ],
-        "scopes": [
-            "public"
-        ]
     }
 ]


### PR DESCRIPTION
closes #10491

Added some basic docs for `@queryParam` so I don't have to keep digging for it; `category` is omitted due to being deprecated.