### PR TITLE
Remove sticky header from forum topic log

### DIFF
--- a/resources/views/forum/topics/logs/index.blade.php
+++ b/resources/views/forum/topics/logs/index.blade.php
@@ -7,7 +7,6 @@
 ])
 
 @section('content')
-    @include('forum.topics._floating_header')
     @include('forum._header', [
         'additionalLinks' => [
             [


### PR DESCRIPTION
It never worked due to missing reference tag but then again there isn't much point in having the header on this page anyway as there's no infinite scrolling involved.