### PR TITLE
Highlight new top rank (1-50) in event

### DIFF
--- a/resources/js/profile-page/parse-event.tsx
+++ b/resources/js/profile-page/parse-event.tsx
@@ -1,11 +1,13 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+import StringWithComponent from 'components/string-with-component';
 import EventJson from 'interfaces/event-json';
 import core from 'osu-core-singleton';
 import * as React from 'react';
 import { Modifiers } from 'utils/css';
-import { trans } from 'utils/lang';
+import { formatNumber } from 'utils/html';
+import { trans, transExists } from 'utils/lang';
 import { switchNever } from 'utils/switch-never';
 import AchievementBadge from './achievement-badge';
 
@@ -91,16 +93,31 @@ export default function parseEvent(event: EventJson, modifiers: Modifiers): { ba
         },
       };
 
-    case 'rank':
+    case 'rank': {
+      const rankNumber = formatNumber(event.rank);
+      // TODO: remove check after all languages are updated to have both `rank` and `value.rank`.
+      let rank: React.ReactNode = transExists('events.rank') && !transExists('events.value.rank')
+        ? rankNumber
+        : (
+          <StringWithComponent
+            mappings={{ rank: rankNumber }}
+            pattern={trans('events.value.rank')}
+          />
+        );
+      if (event.rank <= 50) {
+        rank = <strong>{rank}</strong>;
+      }
+
       return {
         badge: <div className={`score-rank score-rank--${event.scoreRank}`} />,
         mappings: {
           beatmap: <em><a href={event.beatmap.url}>{event.beatmap.title}</a></em>,
           mode: trans(`beatmaps.mode.${event.mode}`),
-          rank: event.rank,
+          rank,
           user: <strong><em><a href={event.user.url}>{event.user.username}</a></em></strong>,
         },
       };
+    }
 
     case 'rankLost':
       return {

--- a/resources/lang/en/events.php
+++ b/resources/lang/en/events.php
@@ -12,7 +12,7 @@ return [
     'beatmapset_update' => '<strong><em>:user</em></strong> has updated the beatmap "<em>:beatmapset</em>"',
     'beatmapset_upload' => '<strong><em>:user</em></strong> has submitted a new beatmap ":beatmapset"',
     'empty' => "This user hasn't done anything notable recently!",
-    'rank' => '<strong><em>:user</em></strong> achieved rank #:rank on <em>:beatmap</em> (:mode)',
+    'rank' => ':user achieved :rank on :beatmap (:mode)',
     'rank_lost' => '<strong><em>:user</em></strong> has lost first place on <em>:beatmap</em> (:mode)',
     'user_support_again' => '<strong>:user</strong> has once again chosen to support osu! - thanks for your generosity!',
     'user_support_first' => '<strong>:user</strong> has supported osu! - thanks for your generosity!',
@@ -24,5 +24,9 @@ return [
         'loved' => 'loved',
         'qualified' => 'qualified',
         'ranked' => 'ranked',
+    ],
+
+    'value' => [
+        'rank' => 'rank #:rank',
     ],
 ];


### PR DESCRIPTION
Resolves #8877?

It's just a `<strong>` and no font resize. But the current legacy css doesn't have specific styling either and I can't find reference to the original `epicN` classes.

Also the bold is not quite visible 🤷 

![](https://s.myconan.tk/2023/08/firefox_2023-08-29_14-53-06.png)