### PR TITLE
Fix beatmap discussion jump to anchor position

### DIFF
--- a/resources/css/bem/beatmap-discussion-post.less
+++ b/resources/css/bem/beatmap-discussion-post.less
@@ -11,8 +11,8 @@
 
   @_content-gutter-base: 15px;
 
-  scroll-margin-top: var(--scroll-margin-top, 36px);
   transition: background-color .1s ease-in-out;
+  margin: 10px 0;
 
   &--deleted {
     opacity: 0.5;
@@ -107,8 +107,9 @@
   }
 
   &__content {
+    overflow-anchor: none;
     display: flex;
-    padding: 10px @_content-gutter-base;
+    padding: 0 @_content-gutter-base;
     flex-direction: column;
     flex: none;
     min-width: 0;

--- a/resources/css/bem/beatmap-discussion-post.less
+++ b/resources/css/bem/beatmap-discussion-post.less
@@ -11,6 +11,7 @@
 
   @_content-gutter-base: 15px;
 
+  scroll-margin-top: var(--scroll-margin-top, 36px);
   transition: background-color .1s ease-in-out;
 
   &--deleted {

--- a/resources/css/bem/beatmap-discussion-post.less
+++ b/resources/css/bem/beatmap-discussion-post.less
@@ -12,6 +12,8 @@
   @_content-gutter-base: 15px;
 
   transition: background-color .1s ease-in-out;
+  // margin here instead of padding on __content to make Chrome anchor when images above load in.
+  // even 1 px margin is enough to fix the shifting.
   margin: 10px 0;
 
   &--deleted {
@@ -20,6 +22,7 @@
 
   &--discussion {
     min-width: 0;
+    margin: 0;
 
     @media @desktop {
       flex: 1;

--- a/resources/css/bem/beatmap-discussion.less
+++ b/resources/css/bem/beatmap-discussion.less
@@ -10,6 +10,7 @@
   --base-bg: hsl(var(--hsl-b4));
   .own-layer();
   display: flex;
+  scroll-margin-top: var(--scroll-margin-top, 36px);
 
   &--deleted {
     opacity: 0.5;

--- a/resources/css/bem/beatmap-discussion.less
+++ b/resources/css/bem/beatmap-discussion.less
@@ -3,14 +3,12 @@
 
 .beatmap-discussion {
   @_top: beatmap-discussion;
-
   @_top-padding-y: 10px;
   @_top-padding-x: 15px;
 
   --base-bg: hsl(var(--hsl-b4));
   .own-layer();
   display: flex;
-  scroll-margin-top: var(--scroll-margin-top, 36px);
 
   &--deleted {
     opacity: 0.5;
@@ -63,6 +61,7 @@
     // hightlighted will override ::after
     &::before {
       @media @mobile {
+        overflow-anchor: none;
         content: '';
         position: absolute;
         right: 0;
@@ -142,6 +141,7 @@
   }
 
   &__timestamp {
+    overflow-anchor: none;
     flex: none;
 
     // hopefully enough for type and resolve status icons.
@@ -154,6 +154,7 @@
   }
 
   &__top {
+    overflow-anchor: none;
     background-color: @osu-colour-b3;
     display: grid;
     grid-template-areas: "user actions" "message message";

--- a/resources/css/bem/beatmap-discussion.less
+++ b/resources/css/bem/beatmap-discussion.less
@@ -187,7 +187,6 @@
   }
 
   &__top-actions {
-    overflow-anchor: none;
     grid-area: actions;
     display: flex;
     align-items: center;
@@ -195,7 +194,6 @@
   }
 
   &__top-message {
-    overflow-anchor: none;
     grid-area: message;
     margin: 0 @_top-padding-x @_top-padding-y;
 
@@ -207,7 +205,6 @@
   }
 
   &__top-user {
-    overflow-anchor: none;
     margin-top: @_top-padding-y;
     margin-left: @_top-padding-x;
 

--- a/resources/css/bem/beatmap-discussion.less
+++ b/resources/css/bem/beatmap-discussion.less
@@ -154,7 +154,6 @@
   }
 
   &__top {
-    overflow-anchor: none;
     background-color: @osu-colour-b3;
     display: grid;
     grid-template-areas: "user actions" "message message";
@@ -188,6 +187,7 @@
   }
 
   &__top-actions {
+    overflow-anchor: none;
     grid-area: actions;
     display: flex;
     align-items: center;
@@ -195,6 +195,7 @@
   }
 
   &__top-message {
+    overflow-anchor: none;
     grid-area: message;
     margin: 0 @_top-padding-x @_top-padding-y;
 
@@ -206,6 +207,7 @@
   }
 
   &__top-user {
+    overflow-anchor: none;
     margin-top: @_top-padding-y;
     margin-left: @_top-padding-x;
 

--- a/resources/css/bem/beatmap-discussions.less
+++ b/resources/css/bem/beatmap-discussions.less
@@ -49,6 +49,7 @@
   &__mode-circle {
     .circle(@_mode-circle-diameter);
     background-color: @_timeline-colour;
+    overflow-anchor: none;
   }
 
   &__mode-text {

--- a/resources/css/bem/beatmap-discussions.less
+++ b/resources/css/bem/beatmap-discussions.less
@@ -57,6 +57,7 @@
   }
 
   &__timeline-line {
+    overflow-anchor: none;
     position: absolute;
     top: (@_discussions-vertical-padding + @_mode-circle-diameter / 2);
     left: @_discussions-horizontal-padding;

--- a/resources/css/layout.less
+++ b/resources/css/layout.less
@@ -55,6 +55,8 @@
   --forum-text: @link-hover-color;
 
   --navbar-height: @navbar-height;
+  --scroll-padding-top: var(--scroll-padding-top-base);
+  --scroll-padding-top-base: calc(var(--navbar-height) + 1em);
   @media @desktop {
     --navbar-height: @nav2-height--pinned;
   }
@@ -65,12 +67,8 @@ html, body {
 }
 
 html {
-  scroll-padding-top: calc(@nav2-height--pinned + 1em);
+  scroll-padding-top: var(--scroll-padding-top);
   scroll-padding-bottom: 1em;
-
-  @media @mobile {
-    scroll-padding-top: calc(@navbar-height + 1em);
-  }
 }
 
 body {

--- a/resources/css/layout.less
+++ b/resources/css/layout.less
@@ -55,8 +55,8 @@
   --forum-text: @link-hover-color;
 
   --navbar-height: @navbar-height;
-  --scroll-padding-top: var(--scroll-padding-top-base);
-  --scroll-padding-top-base: calc(var(--navbar-height) + 1em);
+  --scroll-padding-top: calc(var(--navbar-height) + 1em + var(--scroll-padding-top-extra, 0px));
+
   @media @desktop {
     --navbar-height: @nav2-height--pinned;
   }

--- a/resources/js/beatmap-discussions/discussion.tsx
+++ b/resources/js/beatmap-discussions/discussion.tsx
@@ -134,8 +134,7 @@ export class Discussion extends React.Component<Props> {
 
     return (
       <div
-        className={`${topClasses} js-beatmap-discussion-jump`}
-        data-id={this.props.discussion.id}
+        className={`${topClasses}`}
         onClick={this.handleSetHighlight}
         style={{
           '--discussion-colour': `var(--beatmapset-discussion-colour--${this.props.discussion.message_type})`,
@@ -144,8 +143,8 @@ export class Discussion extends React.Component<Props> {
         <div className={`${bn}__timestamp hidden-xs`}>
           {this.renderTimestamp()}
         </div>
-
-        <div className={`${bn}__discussion`}>
+        {/* jump is here instead of the top to have the margin on the element so that Chrome will anchor properly when an image lazy loads. */}
+        <div className={`${bn}__discussion js-beatmap-discussion-jump`} data-id={this.props.discussion.id}>
           <div
             className={`${bn}__top`}
             style={groupColour(group)}

--- a/resources/js/beatmap-discussions/discussions.tsx
+++ b/resources/js/beatmap-discussions/discussions.tsx
@@ -124,7 +124,7 @@ export class Discussions extends React.Component<Props> {
   render() {
     return (
       <div className='osu-page osu-page--small osu-page--full'>
-        <div className={bn}>
+        <div className={`${bn} js-beatmap-discussions`}>
           <div className='page-title'>
             {trans('beatmaps.discussions.title')}
           </div>

--- a/resources/js/beatmap-discussions/main.coffee
+++ b/resources/js/beatmap-discussions/main.coffee
@@ -381,14 +381,19 @@ export class Main extends React.PureComponent
       $.publish 'beatmapset-discussions:highlight', discussionId: discussion.id
 
       attribute = if postId? then "data-post-id='#{postId}'" else "data-id='#{id}'"
-      target = $(".js-beatmap-discussion-jump[#{attribute}]")
+      target = document.querySelector(".js-beatmap-discussion-jump[#{attribute}]")
 
-      return if target.length == 0
+      return unless target? && @modeSwitcherRef.current? && @newDiscussionRef.current?
 
-      offsetTop = target.offset().top - @modeSwitcherRef.current.getBoundingClientRect().height
-      offsetTop -= @newDiscussionRef.current.getBoundingClientRect().height if @state.pinnedNewDiscussion
+      margin = @modeSwitcherRef.current.getBoundingClientRect().height
+      margin += @newDiscussionRef.current.getBoundingClientRect().height if @state.pinnedNewDiscussion
 
-      $(window).stop().scrollTo core.stickyHeader.scrollOffset(offsetTop), 500
+      document.documentElement.style.setProperty '--scroll-margin-top', "#{margin}px"
+
+      # avoid smooth scrolling to avoid triggering lazy loaded images.
+      # FIXME: Safari still has the issue where images just out of view get loaded and push the page down
+      # because it doesn't anchor the scroll position.
+      target.scrollIntoView behavior: 'instant', block: 'start', inline: 'nearest'
 
     @update null, newState
 

--- a/resources/js/beatmap-discussions/main.coffee
+++ b/resources/js/beatmap-discussions/main.coffee
@@ -99,6 +99,8 @@ export class Main extends React.PureComponent
     $.unsubscribe ".#{@eventId}"
     $(document).off ".#{@eventId}"
 
+    document.documentElement.style.removeProperty '--scroll-padding-top'
+
     Timeout.clear(timeout) for _name, timeout of @timeouts
     xhr?.abort() for _name, xhr of @xhr
     @disposers.forEach (disposer) => disposer?()
@@ -388,8 +390,8 @@ export class Main extends React.PureComponent
       margin = @modeSwitcherRef.current.getBoundingClientRect().height
       margin += @newDiscussionRef.current.getBoundingClientRect().height if @state.pinnedNewDiscussion
 
-      discussionsElement = document.querySelector('.js-beatmap-discussions')
-      discussionsElement?.style.setProperty '--scroll-margin-top', "#{margin}px"
+      # Update scroll-padding instead of adding scroll-margin, otherwise it doesn't anchor in the right place.
+      document.documentElement.style.setProperty '--scroll-padding-top', "calc(var(--scroll-padding-top-base) + #{Math.floor(margin)}px)"
 
       # avoid smooth scrolling to avoid triggering lazy loaded images.
       # FIXME: Safari still has the issue where images just out of view get loaded and push the page down

--- a/resources/js/beatmap-discussions/main.coffee
+++ b/resources/js/beatmap-discussions/main.coffee
@@ -388,7 +388,8 @@ export class Main extends React.PureComponent
       margin = @modeSwitcherRef.current.getBoundingClientRect().height
       margin += @newDiscussionRef.current.getBoundingClientRect().height if @state.pinnedNewDiscussion
 
-      document.documentElement.style.setProperty '--scroll-margin-top', "#{margin}px"
+      discussionsElement = document.querySelector('.js-beatmap-discussions')
+      discussionsElement?.style.setProperty '--scroll-margin-top', "#{margin}px"
 
       # avoid smooth scrolling to avoid triggering lazy loaded images.
       # FIXME: Safari still has the issue where images just out of view get loaded and push the page down

--- a/resources/js/beatmap-discussions/main.coffee
+++ b/resources/js/beatmap-discussions/main.coffee
@@ -99,7 +99,7 @@ export class Main extends React.PureComponent
     $.unsubscribe ".#{@eventId}"
     $(document).off ".#{@eventId}"
 
-    document.documentElement.style.removeProperty '--scroll-padding-top'
+    document.documentElement.style.removeProperty '--scroll-padding-top-extra'
 
     Timeout.clear(timeout) for _name, timeout of @timeouts
     xhr?.abort() for _name, xhr of @xhr
@@ -391,7 +391,7 @@ export class Main extends React.PureComponent
       margin += @newDiscussionRef.current.getBoundingClientRect().height if @state.pinnedNewDiscussion
 
       # Update scroll-padding instead of adding scroll-margin, otherwise it doesn't anchor in the right place.
-      document.documentElement.style.setProperty '--scroll-padding-top', "calc(var(--scroll-padding-top-base) + #{Math.floor(margin)}px)"
+      document.documentElement.style.setProperty '--scroll-padding-top-extra', "#{Math.floor(margin)}px"
 
       # avoid smooth scrolling to avoid triggering lazy loaded images.
       # FIXME: Safari still has the issue where images just out of view get loaded and push the page down


### PR DESCRIPTION
Something like this, maybe? 🤔 
Uses native `scrollIntoView` function ~~and `scroll-margin`~~; `instant` scroll avoids triggering lazy loaded images except when the image is close to the current view position. Chrome and Firefox should still handle it fine since they support scroll anchoring, Safari will still jump, not sure about Edge. The default of `auto` won't work because Safari just takes it to mean `smooth` even on load....

Updating `scroll-padding` instead of adding `scroll-margin` to the elements as it doesn't seem to use the correct position to offset of layout shift when images get loaded in.
Moved some of the element `padding` to `margin` otherwise Chrome still anchors to the wrong position 🤨 (also noticed some of the element structure could be updated to better handle it, but that's a problem for another time? 👀 )

fixes #10496 (unless you're Safari and doesn't scroll anchor)