### PR TITLE
Fix old and legacy link markdown parsing errors 

### DIFF
--- a/resources/js/remark-plugins/legacy-link/micromark.ts
+++ b/resources/js/remark-plugins/legacy-link/micromark.ts
@@ -54,7 +54,9 @@ function tokenize(effects: Effects, ok: State, nok: State) {
     if (code === codes.space) {
       if (foundUrl) {
         effects.exit('legacyLinkUrl');
+        effects.enter('legacyLinkSpace');
         effects.consume(code);
+        effects.exit('legacyLinkSpace');
         effects.enter('legacyLinkTitle');
         effects.enter('chunkString', { contentType: 'string' });
 
@@ -82,7 +84,9 @@ function tokenize(effects: Effects, ok: State, nok: State) {
         if (foundTitle) {
           effects.exit('chunkString');
           effects.exit('legacyLinkTitle');
+          effects.enter('legacyLinkClose');
           effects.consume(code);
+          effects.exit('legacyLinkClose');
           effects.exit('legacyLink');
 
           return ok(code);

--- a/resources/js/remark-plugins/old-link/micromark.ts
+++ b/resources/js/remark-plugins/old-link/micromark.ts
@@ -56,7 +56,9 @@ function tokenize(effects: Effects, ok: State, nok: State) {
       if (foundUrl) {
         if (openBrackets === 0) {
           effects.exit('oldLinkUrl');
+          effects.enter('oldLinkUrlClose');
           effects.consume(code);
+          effects.exit('oldLinkUrlClose');
           effects.exit('oldLink');
 
           return ok(code);
@@ -78,7 +80,9 @@ function tokenize(effects: Effects, ok: State, nok: State) {
 
   function consumeUrlStart(code: Code): State | void {
     if (code === codes.leftSquareBracket) {
+      effects.enter('oldLinkUrlOpen');
       effects.consume(code);
+      effects.exit('oldLinkUrlOpen');
       effects.enter('oldLinkUrl');
 
       return consumeUrl;
@@ -101,7 +105,9 @@ function tokenize(effects: Effects, ok: State, nok: State) {
         if (foundTitle) {
           effects.exit('chunkString');
           effects.exit('oldLinkTitle');
+          effects.enter('oldLinkTitleClose');
           effects.consume(code);
+          effects.exit('oldLinkTitleClose');
 
           return consumeUrlStart;
         } else {


### PR DESCRIPTION
Apparently, `consume` isn't allowed immediately following `exit`, and, triggers assertion failures in the dev version of `micromark` which webpack 5 will use by default for development builds - production does not include `assert`s; performance of dev builds with assertions enabled is another issue.

I decided to go with the simplest fix which is wrapping `consume`s following an `exit` with a dummy effect that only contains the value consumed.