### PR TITLE
Add 2x image url to user badge

### DIFF
--- a/app/Transformers/UserBadgeTransformer.php
+++ b/app/Transformers/UserBadgeTransformer.php
@@ -17,8 +17,8 @@ class UserBadgeTransformer extends TransformerAbstract
         return [
             'awarded_at' => json_time($badge->awarded),
             'description' => $badge->description,
-            'image_url' => $imageUrl,
             'image@2x_url' => $image2xUrl,
+            'image_url' => $imageUrl,
             'url' => $badge->url,
         ];
     }

--- a/app/Transformers/UserBadgeTransformer.php
+++ b/app/Transformers/UserBadgeTransformer.php
@@ -11,14 +11,14 @@ class UserBadgeTransformer extends TransformerAbstract
 {
     public function transform(UserBadge $badge)
     {
-        $image_url = $badge->imageUrl();
-        $image2x_url = retinaify($image_url);
+        $imageUrl = $badge->imageUrl();
+        $image2xUrl = retinaify($image_url);
 
         return [
             'awarded_at' => json_time($badge->awarded),
             'description' => $badge->description,
-            'image_url' => $image_url,
-            'image@2x_url' => $image2x_url,
+            'image_url' => $imageUrl,
+            'image@2x_url' => $image2xUrl,
             'url' => $badge->url,
         ];
     }

--- a/app/Transformers/UserBadgeTransformer.php
+++ b/app/Transformers/UserBadgeTransformer.php
@@ -11,10 +11,14 @@ class UserBadgeTransformer extends TransformerAbstract
 {
     public function transform(UserBadge $badge)
     {
+        $image_url = $badge->imageUrl();
+        $image2x_url = retinaify($image_url);
+
         return [
             'awarded_at' => json_time($badge->awarded),
             'description' => $badge->description,
-            'image_url' => $badge->imageUrl(),
+            'image_url' => $image_url,
+            'image@2x_url' => $image2x_url,
             'url' => $badge->url,
         ];
     }

--- a/app/Transformers/UserBadgeTransformer.php
+++ b/app/Transformers/UserBadgeTransformer.php
@@ -12,7 +12,7 @@ class UserBadgeTransformer extends TransformerAbstract
     public function transform(UserBadge $badge)
     {
         $imageUrl = $badge->imageUrl();
-        $image2xUrl = retinaify($image_url);
+        $image2xUrl = retinaify($imageUrl);
 
         return [
             'awarded_at' => json_time($badge->awarded),

--- a/resources/js/interfaces/user-badge-json.ts
+++ b/resources/js/interfaces/user-badge-json.ts
@@ -4,7 +4,7 @@
 export default interface UserBadgeJson {
   awarded_at: string;
   description: string;
-  image_url: string;
   'image@2x_url': string;
+  image_url: string;
   url: string;
 }

--- a/resources/js/interfaces/user-badge-json.ts
+++ b/resources/js/interfaces/user-badge-json.ts
@@ -5,5 +5,6 @@ export default interface UserBadgeJson {
   awarded_at: string;
   description: string;
   image_url: string;
+  'image@2x_url': string;
   url: string;
 }

--- a/resources/views/docs/_structures/user.md
+++ b/resources/views/docs/_structures/user.md
@@ -62,6 +62,7 @@
       "awarded_at": "2015-01-01T00:00:00+00:00",
       "description": "Test badge",
       "image_url": "https://assets.ppy.sh/profile-badges/test.png",
+      "image@2x_url": "https://assets.ppy.sh/profile-badges/test@2x.png",
       "url": ""
     }
   ],

--- a/resources/views/docs/_structures/user.md
+++ b/resources/views/docs/_structures/user.md
@@ -61,8 +61,8 @@
     {
       "awarded_at": "2015-01-01T00:00:00+00:00",
       "description": "Test badge",
-      "image_url": "https://assets.ppy.sh/profile-badges/test.png",
       "image@2x_url": "https://assets.ppy.sh/profile-badges/test@2x.png",
+      "image_url": "https://assets.ppy.sh/profile-badges/test.png",
       "url": ""
     }
   ],

--- a/resources/views/docs/_structures/user_compact.md
+++ b/resources/views/docs/_structures/user_compact.md
@@ -112,9 +112,10 @@ type        | string    | `note`, `restriction`, or `silence`.
 
 ### UserBadge
 
-Field       | Type      | Description
-------------|-----------|------------
-awarded_at  | Timestamp | |
-description | string    | |
-image_url   | string    | |
-url         | string    | |
+Field        | Type      | Description
+-------------|-----------|------------
+awarded_at   | Timestamp | |
+description  | string    | |
+image@2x_url | string    | |
+image_url    | string    | |
+url          | string    | |


### PR DESCRIPTION
Resolve #10434

~~I'm not sure if naming the new field as `image@2x` and duplicating `image_url` as `image` would be better or not.~~