### PR TITLE
Fix slow query when looking up messages beyond backlog limit

### DIFF
--- a/app/Http/Controllers/Chat/Channels/MessagesController.php
+++ b/app/Http/Controllers/Chat/Channels/MessagesController.php
@@ -8,6 +8,7 @@ namespace App\Http\Controllers\Chat\Channels;
 use App\Http\Controllers\Chat\Controller as BaseController;
 use App\Libraries\Chat;
 use App\Models\Chat\Channel;
+use App\Models\Chat\Message;
 use App\Transformers\Chat\MessageTransformer;
 use App\Transformers\UserCompactTransformer;
 
@@ -111,7 +112,7 @@ class MessagesController extends BaseController
         }
 
         $messages = $channel
-            ->filteredMessages()
+            ->messages()
             ->with(['channel', 'sender'])
             ->limit($limit);
 
@@ -126,6 +127,8 @@ class MessagesController extends BaseController
 
             $messages = $messages->orderBy('message_id', 'desc')->get()->reverse();
         }
+
+        $messages = Message::filterBacklogs($channel, $messages);
 
         if (!$returnObject) {
             return json_collection(

--- a/app/Models/Chat/Channel.php
+++ b/app/Models/Chat/Channel.php
@@ -263,19 +263,6 @@ class Channel extends Model
         return $this->hasMany(Message::class);
     }
 
-    public function filteredMessages()
-    {
-        $messages = $this->messages();
-
-        if ($this->isPublic()) {
-            $messages = $messages->where('timestamp', '>', Carbon::now()->subHours(config('osu.chat.public_backlog_limit')));
-        }
-
-        // TODO: additional message filtering
-
-        return $messages;
-    }
-
     public function userChannels()
     {
         return $this->hasMany(UserChannel::class);

--- a/app/Models/Chat/Message.php
+++ b/app/Models/Chat/Message.php
@@ -8,6 +8,8 @@ namespace App\Models\Chat;
 use App\Models\Traits\Reportable;
 use App\Models\Traits\ReportableInterface;
 use App\Models\User;
+use Carbon\Carbon;
+use Illuminate\Support\Collection;
 
 /**
  * @property Channel $channel
@@ -22,6 +24,24 @@ use App\Models\User;
 class Message extends Model implements ReportableInterface
 {
     use Reportable;
+
+    public static function filterBacklogs(Channel $channel, Collection $messages): Collection
+    {
+        if (!$channel->isPublic()) {
+            return $messages;
+        }
+
+        $minTimestamp = json_time(Carbon::now()->subHours(config('osu.chat.public_backlog_limit')));
+        $ret = [];
+
+        foreach ($messages as $message) {
+            if ($message->timestamp_json > $minTimestamp) {
+                $ret[] = $message;
+            }
+        }
+
+        return collect($ret);
+    }
 
     public ?string $uuid = null;
 

--- a/app/Transformers/Chat/ChannelTransformer.php
+++ b/app/Transformers/Chat/ChannelTransformer.php
@@ -6,6 +6,7 @@
 namespace App\Transformers\Chat;
 
 use App\Models\Chat\Channel;
+use App\Models\Chat\Message;
 use App\Models\User;
 use App\Transformers\TransformerAbstract;
 

--- a/app/Transformers/Chat/ChannelTransformer.php
+++ b/app/Transformers/Chat/ChannelTransformer.php
@@ -78,14 +78,17 @@ class ChannelTransformer extends TransformerAbstract
     public function includeRecentMessages(Channel $channel)
     {
         if ($channel->exists) {
-            $messages = $channel
-                ->filteredMessages()
-                // assumes sender will be included by the Message transformer
-                ->with('sender')
-                ->orderBy('message_id', 'desc')
-                ->limit(50)
-                ->get()
-                ->reverse();
+            $messages = Message::filterBacklogs(
+                $channel,
+                $channel
+                    ->messages()
+                    // assumes sender will be included by the Message transformer
+                    ->with('sender')
+                    ->orderBy('message_id', 'desc')
+                    ->limit(50)
+                    ->get()
+                    ->reverse(),
+            );
         } else {
             $messages = [];
         }


### PR DESCRIPTION
A combination of low id and high timestamp means the query spends a lot of time searching for nonexistent messages.

Resolves #10510.