### PR TITLE
Remove unnecessary beatmap discussion wrapper

### DIFF
--- a/resources/css/bem/beatmap-discussions.less
+++ b/resources/css/bem/beatmap-discussions.less
@@ -13,14 +13,6 @@
   display: flex;
   flex-direction: column;
 
-  &__discussion {
-    .own-layer();
-
-    @media @mobile {
-      overflow-x: auto;
-    }
-  }
-
   &__discussions {
     padding: @_discussions-vertical-padding @_discussions-horizontal-padding;
     background-color: @osu-colour-b5;

--- a/resources/js/beatmap-discussions/discussions.tsx
+++ b/resources/js/beatmap-discussions/discussions.tsx
@@ -172,18 +172,17 @@ export class Discussions extends React.Component<Props> {
     const parentDiscussion = discussion.parent_id != null ? this.props.currentDiscussions.byFilter.total.reviews[discussion.parent_id] : null;
 
     return (
-      <React.Fragment key={discussion.id}>
-        <Discussion
-          beatmapset={this.props.beatmapset}
-          currentBeatmap={this.props.currentBeatmap}
-          discussion={discussion}
-          isTimelineVisible={this.isTimelineVisible}
-          parentDiscussion={parentDiscussion}
-          readPostIds={this.props.readPostIds}
-          showDeleted={this.props.showDeleted}
-          users={this.props.users}
-        />
-      </React.Fragment>
+      <Discussion
+        key={discussion.id}
+        beatmapset={this.props.beatmapset}
+        currentBeatmap={this.props.currentBeatmap}
+        discussion={discussion}
+        isTimelineVisible={this.isTimelineVisible}
+        parentDiscussion={parentDiscussion}
+        readPostIds={this.props.readPostIds}
+        showDeleted={this.props.showDeleted}
+        users={this.props.users}
+      />
     );
   };
 

--- a/resources/js/beatmap-discussions/discussions.tsx
+++ b/resources/js/beatmap-discussions/discussions.tsx
@@ -172,10 +172,7 @@ export class Discussions extends React.Component<Props> {
     const parentDiscussion = discussion.parent_id != null ? this.props.currentDiscussions.byFilter.total.reviews[discussion.parent_id] : null;
 
     return (
-      <div
-        key={discussion.id}
-        className={`${bn}__discussion`}
-      >
+      <React.Fragment key={discussion.id}>
         <Discussion
           beatmapset={this.props.beatmapset}
           currentBeatmap={this.props.currentBeatmap}
@@ -186,7 +183,7 @@ export class Discussions extends React.Component<Props> {
           showDeleted={this.props.showDeleted}
           users={this.props.users}
         />
-      </div>
+      </React.Fragment>
     );
   };
 

--- a/resources/views/beatmap_discussion_posts/_item.blade.php
+++ b/resources/views/beatmap_discussion_posts/_item.blade.php
@@ -7,7 +7,7 @@
     $beatmapset = $post->beatmapDiscussion->beatmapset;
 @endphp
 
-<div class="beatmap-discussions__discussion beatmapset-activities__discussion-post">
+<div class="beatmapset-activities__discussion-post">
     <div class="beatmap-discussion beatmap-discussion--single beatmapset-activities__post-grow">
         <div class="beatmap-discussion-timestamp__icons-container">
             <div class="beatmap-discussion-timestamp__icons">

--- a/resources/views/beatmap_discussions/_item.blade.php
+++ b/resources/views/beatmap_discussions/_item.blade.php
@@ -12,7 +12,7 @@
       'suggestion' => 'far fa-circle',
     ];
 @endphp
-<div class="beatmap-discussions__discussion beatmapset-activities__discussion-post">
+<div class="beatmapset-activities__discussion-post">
     <div class="beatmap-discussion beatmap-discussion--single beatmapset-activities__post-grow{{ $discussion->trashed() ? ' beatmap-discussion--deleted' : ''}}">
         <div class="beatmap-discussion-timestamp__icons-container">
             <div class="beatmap-discussion-timestamp__icons">


### PR DESCRIPTION
Remove creating an necessary layer (immediate `beatmap-discussion` child element already is own layer); the overflow also doesn't do anything anymore.
There's a different overflow/overlap problem which `overflow-x` here doesn't fix, anyway.