### PR TITLE
Add default scope for solo score

### DIFF
--- a/app/Models/Solo/Score.php
+++ b/app/Models/Solo/Score.php
@@ -101,6 +101,11 @@ class Score extends Model implements Traits\ReportableInterface
         return $this->belongsTo(User::class, 'user_id');
     }
 
+    public function scopeDefault(Builder $query): Builder
+    {
+        return $query->whereHas('beatmap.beatmapset');
+    }
+
     /**
      * This should match the one used in osu-elastic-indexer.
      */


### PR DESCRIPTION
Split off #9427 and #9438 so I can separate both PR without conflicting with each other. Not used anywhere but it's similar to legacy score model.