### PR TITLE
Remove mobx-react-devtools

### DIFF
--- a/package.json
+++ b/package.json
@@ -118,7 +118,6 @@
     "karma-sourcemap-loader": "^0.3.8",
     "karma-typescript": "^5.5.3",
     "karma-webpack": "^5.0.0",
-    "mobx-react-devtools": "^6.0.3",
     "webpack-build-notifier": "^2.3.0"
   },
   "resolutions": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -5625,11 +5625,6 @@ mkdirp@^1.0.3, mkdirp@^1.0.4:
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
   integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
 
-mobx-react-devtools@^6.0.3:
-  version "6.1.1"
-  resolved "https://registry.yarnpkg.com/mobx-react-devtools/-/mobx-react-devtools-6.1.1.tgz#a462b944085cf11ff96fc937d12bf31dab4c8984"
-  integrity sha512-nc5IXLdEUFLn3wZal65KF3/JFEFd+mbH4KTz/IG5BOPyw7jo8z29w/8qm7+wiCyqVfUIgJ1gL4+HVKmcXIOgqA==
-
 mobx-react-lite@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/mobx-react-lite/-/mobx-react-lite-3.2.0.tgz#331d7365a6b053378dfe9c087315b4e41c5df69f"


### PR DESCRIPTION
1. it's been deprecated
2. we don't even initialize it anywhere 👀 
3. mobx 6 doesn't even support it