### PR TITLE
Workaround beatmap discussions reply box having wrong background colour

### DIFF
--- a/resources/css/bem/beatmap-discussion-post.less
+++ b/resources/css/bem/beatmap-discussion-post.less
@@ -30,6 +30,10 @@
   }
 
   &--new-reply {
+    // use padding because this section is a different background colour to the parent
+    // and fortunately doesn't need an anchor.
+    margin: 0;
+    padding: 10px 0;
     background-color: @osu-colour-b5;
     border-radius: 0 0 @border-radius-base @border-radius-base;
   }


### PR DESCRIPTION
closes #10536

Will do for now since the reply area doesn't have a jump so it doesn't need to use `margin`