### PR TITLE
Speed up assets building on non-native platform

### DIFF
--- a/Dockerfile.deployment
+++ b/Dockerfile.deployment
@@ -1,19 +1,18 @@
-FROM debian:11
+FROM --platform=$BUILDPLATFORM debian:11 as buildenv
 
-RUN apt update
-RUN DEBIAN_FRONTEND=noninteractive apt install -y apt-transport-https lsb-release ca-certificates curl
+RUN apt-get update
+RUN DEBIAN_FRONTEND=noninteractive apt-get install -y apt-transport-https lsb-release ca-certificates curl gnupg
 
-RUN curl -sSLo /usr/share/keyrings/deb.sury.org-php.gpg https://packages.sury.org/php/apt.gpg
+RUN curl -fsSLo /usr/share/keyrings/deb.sury.org-php.gpg https://packages.sury.org/php/apt.gpg
 RUN echo "deb [signed-by=/usr/share/keyrings/deb.sury.org-php.gpg] https://packages.sury.org/php/ $(lsb_release -sc) main" > /etc/apt/sources.list.d/php.list
 
-RUN curl -fsSL https://deb.nodesource.com/setup_16.x | bash -
+RUN curl -fsSL https://deb.nodesource.com/gpgkey/nodesource-repo.gpg.key | gpg --dearmor -o /usr/share/keyrings/nodesource.gpg
+RUN echo "deb [signed-by=/usr/share/keyrings/nodesource.gpg] https://deb.nodesource.com/node_16.x nodistro main" > /etc/apt/sources.list.d/nodesource.list
 
-RUN apt update
-RUN DEBIAN_FRONTEND=noninteractive apt install -y \
+RUN apt-get update
+RUN DEBIAN_FRONTEND=noninteractive apt-get install -y \
     build-essential \
     git \
-    jhead \
-    nginx \
     nodejs \
     php8.2 \
     php8.2-common \
@@ -38,18 +37,48 @@ WORKDIR /app
 RUN curl -L "https://getcomposer.org/download/latest-2.x/composer.phar" > /usr/local/bin/composer && chmod 755 /usr/local/bin/composer
 
 COPY composer.json composer.lock ./
-RUN composer install --no-autoloader --no-dev
+RUN composer install --no-dev --no-scripts
 
 COPY package.json yarn.lock ./
 RUN yarn --prod --ignore-optional --frozen-lockfile
+
+
+FROM debian:11 as runenv
+
+RUN apt-get update
+RUN DEBIAN_FRONTEND=noninteractive apt-get install -y apt-transport-https lsb-release ca-certificates curl
+
+RUN curl -sSLo /usr/share/keyrings/deb.sury.org-php.gpg https://packages.sury.org/php/apt.gpg
+RUN echo "deb [signed-by=/usr/share/keyrings/deb.sury.org-php.gpg] https://packages.sury.org/php/ $(lsb_release -sc) main" > /etc/apt/sources.list.d/php.list
+
+RUN apt-get update
+RUN DEBIAN_FRONTEND=noninteractive apt-get install -y \
+    jhead \
+    nginx \
+    php8.2 \
+    php8.2-common \
+    php8.2-curl \
+    php8.2-ds \
+    php8.2-gd \
+    php8.2-intl \
+    php8.2-mbstring \
+    php8.2-mysql \
+    php8.2-redis \
+    php8.2-sqlite3 \
+    php8.2-swoole \
+    php8.2-tokenizer \
+    php8.2-xml \
+    php8.2-zip
 
 RUN rm -f /var/log/nginx/access.log /var/log/nginx/error.log && \
     ln -s /dev/stdout /var/log/nginx/access.log && \
     ln -s /dev/stderr /var/log/nginx/error.log
 
+
+FROM buildenv as build
+
 COPY . .
 RUN mkdir -p bootstrap/cache storage/logs storage/framework/cache storage/framework/views storage/framework/sessions public/uploads public/uploads-avatar public/uploads-replay
-RUN composer dump-autoload
 
 ARG APP_URL
 ARG DOCS_URL
@@ -60,8 +89,16 @@ RUN php artisan scribe:generate
 
 RUN rm -rf node_modules
 
+RUN composer dump-autoload
+
 ARG GIT_SHA
 RUN printf "%s" "$GIT_SHA" > version
+
+
+FROM runenv as run
+
+COPY --from=build /app /app
+WORKDIR /app
 
 RUN useradd -m osuweb
 RUN chown -R osuweb /var/lib/nginx bootstrap/cache storage


### PR DESCRIPTION
...by building it natively.

Other changes include switching back to `apt-get` because `apt` apparently shouldn't be used for scripting and updating node installation to the current supported method.

The final build doesn't have a lot of things like node or even composer. I think it should work fine without them?

Build log: https://github.com/nanaya/osu-web/actions/runs/6171056504/job/16748549037
Build result: https://hub.docker.com/layers/nanaya/osu-web/master/images/sha256-437563725df4e7c0255fa4b148181965dbedb2e2affb372ac24d61c8670c83a9