### PR TITLE
Add type guard to string.present

### DIFF
--- a/resources/js/utils/string.ts
+++ b/resources/js/utils/string.ts
@@ -5,6 +5,6 @@ export function presence(value?: string | null) {
   return present(value) ? value : null;
 }
 
-export function present(value?: string | null) {
+export function present(value?: string | null): value is string {
   return value != null && value !== '';
 }


### PR DESCRIPTION
Implicitly makes the return type of `presence` `string | null` which it should be instead of `string | null | undefined`