### PR TITLE
Use beatmap max combo column value if available

### DIFF
--- a/app/Models/Beatmap.php
+++ b/app/Models/Beatmap.php
@@ -276,8 +276,15 @@ class Beatmap extends Model implements AfterCommit
 
     public function maxCombo()
     {
-        if (!$this->convert && array_key_exists('attrib_max_combo', $this->attributes)) {
-            return $this->attributes['attrib_max_combo'];
+        if (!$this->convert) {
+            $rowMaxCombo = $this->getRawAttribute('max_combo');
+
+            if ($rowMaxCombo > 0) {
+                return $rowMaxCombo;
+            }
+            if (array_key_exists('attrib_max_combo', $this->attributes)) {
+                return $this->attributes['attrib_max_combo'];
+            }
         }
 
         if ($this->relationLoaded('baseMaxCombo')) {

--- a/app/Models/Beatmap.php
+++ b/app/Models/Beatmap.php
@@ -277,7 +277,7 @@ class Beatmap extends Model implements AfterCommit
     public function maxCombo()
     {
         if (!$this->convert) {
-            $rowMaxCombo = $this->getRawAttribute('max_combo');
+            $rowMaxCombo = $this->max_combo;
 
             if ($rowMaxCombo > 0) {
                 return $rowMaxCombo;


### PR DESCRIPTION
The osu-web portion of #10566. Should be safe to deploy anytime as it'll only be used if not 0.