### PR TITLE
Fix page scrolling when typing into new discussions text box 

### DIFF
--- a/resources/js/beatmap-discussions/main.coffee
+++ b/resources/js/beatmap-discussions/main.coffee
@@ -359,6 +359,7 @@ export class Main extends React.PureComponent
 
 
   handleNewDiscussionFocus: =>
+    # Bug with position: sticky and scroll-padding: https://bugs.chromium.org/p/chromium/issues/detail?id=1466472
     document.documentElement.style.removeProperty '--scroll-padding-top-extra'
 
 

--- a/resources/js/beatmap-discussions/main.coffee
+++ b/resources/js/beatmap-discussions/main.coffee
@@ -164,6 +164,7 @@ export class Main extends React.PureComponent
                   currentDiscussions: @currentDiscussions()
                   innerRef: @newDiscussionRef
                   mode: @state.currentMode
+                  onFocus: @handleNewDiscussionFocus
                   pinned: @state.pinnedNewDiscussion
                   setPinned: @setPinnedNewDiscussion
                   stickTo: @modeSwitcherRef
@@ -355,6 +356,10 @@ export class Main extends React.PureComponent
 
   groupedBeatmaps: (discussionSet) =>
     @cache.groupedBeatmaps ?= BeatmapHelper.group _.values(@beatmaps())
+
+
+  handleNewDiscussionFocus: =>
+    document.documentElement.style.removeProperty '--scroll-padding-top-extra'
 
 
   jumpToDiscussionByHash: =>

--- a/resources/js/beatmap-discussions/new-discussion.tsx
+++ b/resources/js/beatmap-discussions/new-discussion.tsx
@@ -45,6 +45,7 @@ interface Props {
   currentDiscussions: CurrentDiscussions;
   innerRef: React.RefObject<HTMLDivElement>;
   mode: DiscussionMode;
+  onFocus?: () => void;
   pinned: boolean;
   setPinned: (flag: boolean) => void;
   stickTo: React.RefObject<HTMLElement>;
@@ -186,7 +187,10 @@ export class NewDiscussion extends React.Component<Props> {
     }
   };
 
-  private readonly onFocus = () => this.setSticky(true);
+  private readonly onFocus = () => {
+    this.setSticky(true);
+    this.props.onFocus?.();
+  };
 
   @action
   private readonly post = (e: React.SyntheticEvent<HTMLElement>) => {

--- a/resources/js/beatmap-discussions/new-review.tsx
+++ b/resources/js/beatmap-discussions/new-review.tsx
@@ -18,6 +18,7 @@ interface Props {
   beatmapset: BeatmapsetExtendedJson;
   currentBeatmap: BeatmapExtendedJson;
   innerRef: React.RefObject<HTMLDivElement>;
+  onFocus?: () => void;
   pinned?: boolean;
   setPinned?: (sticky: boolean) => void;
   stickTo?: React.RefObject<HTMLDivElement>;
@@ -109,7 +110,10 @@ export default class NewReview extends React.Component<Props> {
     );
   }
 
-  private readonly handleFocus = () => this.setSticky(true);
+  private readonly handleFocus = () => {
+    this.setSticky(true);
+    this.props.onFocus?.();
+  };
 
   @action
   private setSticky(sticky: boolean) {


### PR DESCRIPTION
`position: sticky` and `scroll-padding` don't quite behave well together.
Typing into the text area or selecting text constantly triggers scrolling into view and the combination of `position: sticky` and `scroll-padding` makes the entire page scroll; this doesn't happen if the total `scroll-padding-top` is less vertical position where it's focusing into view (which it normally isn't). 

closes #10578