### PR TITLE
Fix multiplayer scores around query returning unmigrated entries

### DIFF
--- a/app/Models/Multiplayer/PlaylistItemUserHighScore.php
+++ b/app/Models/Multiplayer/PlaylistItemUserHighScore.php
@@ -73,6 +73,7 @@ class PlaylistItemUserHighScore extends Model
             $ret[$type] = [
                 'query' => static
                     ::cursorSort($cursorHelper, $placeholder)
+                    ->whereHas('scoreLink')
                     ->where('playlist_item_id', $scoreLink->playlist_item_id)
                     ->where('user_id', '<>', $scoreLink->user_id),
                 'cursorHelper' => $cursorHelper,


### PR DESCRIPTION
I think this should fix showUser endpoint error in some cases (by hiding those scores just like everywhere else)