### PR TITLE
Revert "Remove redundant StorageWithUrl"

### DIFF
--- a/app/Libraries/StorageWithUrl.php
+++ b/app/Libraries/StorageWithUrl.php
@@ -1,0 +1,34 @@
+<?php
+
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
+namespace App\Libraries;
+
+use Storage;
+
+class StorageWithUrl
+{
+    private string $baseUrl;
+    private $disk;
+    private string $diskName;
+
+    public function __construct($diskName = null)
+    {
+        $this->diskName = $diskName ?? config('filesystems.default');
+    }
+
+    public function url($path)
+    {
+        $this->baseUrl ??= config("filesystems.disks.{$this->diskName}.base_url");
+
+        return "{$this->baseUrl}/{$path}";
+    }
+
+    public function __call($method, $parameters)
+    {
+        $this->disk ??= Storage::disk($this->diskName);
+
+        return call_user_func_array([$this->disk, $method], $parameters);
+    }
+}

--- a/app/Models/Beatmapset.php
+++ b/app/Models/Beatmapset.php
@@ -24,13 +24,13 @@ use App\Libraries\BBCodeFromDB;
 use App\Libraries\Commentable;
 use App\Libraries\Elasticsearch\Indexable;
 use App\Libraries\ImageProcessorService;
+use App\Libraries\StorageWithUrl;
 use App\Libraries\Transactions\AfterCommit;
 use App\Traits\Memoizes;
 use App\Traits\Validatable;
 use Cache;
 use Carbon\Carbon;
 use DB;
-use Illuminate\Contracts\Filesystem\Cloud;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Relations\BelongsToMany;
 use Illuminate\Database\Eloquent\SoftDeletes;
@@ -145,7 +145,7 @@ class Beatmapset extends Model implements AfterCommit, Commentable, Indexable, T
 
     public $timestamps = false;
 
-    protected Cloud $_storage;
+    protected $_storage = null;
     protected $casts = self::CASTS;
     protected $primaryKey = 'beatmapset_id';
     protected $table = 'osu_beatmapsets';
@@ -446,7 +446,11 @@ class Beatmapset extends Model implements AfterCommit, Commentable, Indexable, T
 
     public function storage()
     {
-        return $this->_storage ??= \Storage::disk();
+        if ($this->_storage === null) {
+            $this->_storage = new StorageWithUrl();
+        }
+
+        return $this->_storage;
     }
 
     public function removeCovers()

--- a/app/Models/Traits/UserAvatar.php
+++ b/app/Models/Traits/UserAvatar.php
@@ -6,16 +6,16 @@
 namespace App\Models\Traits;
 
 use App\Libraries\ImageProcessor;
+use App\Libraries\StorageWithUrl;
 use ErrorException;
-use Illuminate\Contracts\Filesystem\Cloud;
 
 trait UserAvatar
 {
-    private Cloud $avatarStorage;
+    private $avatarStorage;
 
     public function avatarStorage()
     {
-        return $this->avatarStorage ??= \Storage::disk(config('osu.avatar.storage'));
+        return $this->avatarStorage ??= new StorageWithUrl(config('osu.avatar.storage'));
     }
 
     public function setUserAvatarAttribute($value)

--- a/app/Traits/Uploadable.php
+++ b/app/Traits/Uploadable.php
@@ -5,12 +5,12 @@
 
 namespace App\Traits;
 
-use Illuminate\Contracts\Filesystem\Cloud;
+use App\Libraries\StorageWithUrl;
 use Illuminate\Http\File;
 
 trait Uploadable
 {
-    protected Cloud $_storage;
+    protected $_storage = null;
 
     /**
      * Returns maximum size of the file in bytes. Defaults to 1 MB.
@@ -61,7 +61,11 @@ trait Uploadable
 
     public function storage()
     {
-        return $this->_storage ??= \Storage::disk();
+        if ($this->_storage === null) {
+            $this->_storage = new StorageWithUrl();
+        }
+
+        return $this->_storage;
     }
 
     public function fileDir()

--- a/config/filesystems.php
+++ b/config/filesystems.php
@@ -71,13 +71,13 @@ return [
         'local' => [
             'driver' => 'local',
             'root' => public_path().'/uploads',
-            'url' => env('APP_URL', 'http://localhost').'/uploads',
+            'base_url' => env('APP_URL', 'http://localhost').'/uploads',
         ],
 
         'local-avatar' => [
             'driver' => 'local',
             'root' => public_path().'/uploads-avatar',
-            'url' => env('APP_URL', 'http://localhost').'/uploads-avatar',
+            'base_url' => env('APP_URL', 'http://localhost').'/uploads-avatar',
         ],
 
         'local-solo-replay' => [
@@ -87,17 +87,17 @@ return [
 
         's3' => [
             ...$s3Default,
+            'base_url' => env('S3_BASE_URL'),
             'mini_url' => env('S3_MINI_URL') ?? env('S3_BASE_URL'),
-            'url' => env('S3_BASE_URL'),
         ],
 
         's3-avatar' => [
             ...$s3Default,
+            'base_url' => env('S3_AVATAR_BASE_URL'),
             'bucket' => env('S3_AVATAR_BUCKET'),
             'key' => env('S3_AVATAR_KEY'),
             'region' => env('S3_AVATAR_REGION'),
             'secret' => env('S3_AVATAR_SECRET'),
-            'url' => env('S3_AVATAR_BASE_URL'),
         ],
 
         's3-solo-replay' => [


### PR DESCRIPTION
This reverts commit b0476c1f99202b93c617a171f09fba419f9280b8.

This turned out to cause permanent additional 2MB memory usage per worker (at least on my dev) 🤷

This is also the only one I found so far which increased memory usage between 2023.1008.0 and 2023.1011.0.