### PR TITLE
Add more Opengraph headers to more pages

### DIFF
--- a/app/Http/Controllers/ArtistsController.php
+++ b/app/Http/Controllers/ArtistsController.php
@@ -120,6 +120,7 @@ class ArtistsController extends Controller
                 'tracks' => json_collection($tracks, new ArtistTrackTransformer()),
             ],
             'links' => $links,
+            'opengraph' => $artist->toOpengraph(),
         ]);
     }
 }

--- a/app/Http/Controllers/BeatmapsetsController.php
+++ b/app/Http/Controllers/BeatmapsetsController.php
@@ -98,6 +98,7 @@ class BeatmapsetsController extends Controller
             }
 
             $noindex = !$beatmapset->esShouldIndex();
+            $opengraph = $beatmapset->toOpengraph();
 
             return ext_view('beatmapsets.show', compact(
                 'beatmapset',
@@ -105,6 +106,7 @@ class BeatmapsetsController extends Controller
                 'genres',
                 'languages',
                 'noindex',
+                'opengraph',
                 'set'
             ));
         }

--- a/app/Http/Controllers/ContestsController.php
+++ b/app/Http/Controllers/ContestsController.php
@@ -42,6 +42,8 @@ class ContestsController extends Controller
             $contests = collect([$contest]);
         }
 
+        $opengraph = $contest->toOpengraph();
+
         if ($contest->isVotingStarted()) {
             if ($contest->isVotingOpen()) {
                 // TODO: add support for $contests requirement instead of at parent
@@ -56,11 +58,13 @@ class ContestsController extends Controller
                 'contestMeta' => $contest,
                 'contests' => $contests,
                 'noVoteReason' => $noVoteReason ?? null,
+                'opengraph' => $opengraph,
             ]);
         } else {
             return ext_view('contests.enter', [
                 'contestMeta' => $contest,
                 'contest' => $contests->first(),
+                'opengraph' => $opengraph,
             ]);
         }
     }

--- a/app/Http/Controllers/Forum/ForumsController.php
+++ b/app/Http/Controllers/Forum/ForumsController.php
@@ -104,12 +104,14 @@ class ForumsController extends Controller
                 ->keyBy('topic_id');
 
         $noindex = !$forum->enable_indexing;
+        $opengraph = $forum->toOpengraph();
 
         return ext_view('forum.forums.show', compact(
             'cover',
             'forum',
             'lastTopics',
             'noindex',
+            'opengraph',
             'pinnedTopics',
             'sort',
             'topicReadStatus',

--- a/app/Http/Controllers/Forum/TopicsController.php
+++ b/app/Http/Controllers/Forum/TopicsController.php
@@ -429,7 +429,7 @@ class TopicsController extends Controller
 
         $posts->last()->markRead($currentUser);
 
-        $coverModel = $topic->cover()->firstOrNew([]);
+        $coverModel = $topic->cover ?? new TopicCover();
         $coverModel->setRelation('topic', $topic);
         $cover = json_item($coverModel, new TopicCoverTransformer());
 

--- a/app/Http/Controllers/Forum/TopicsController.php
+++ b/app/Http/Controllers/Forum/TopicsController.php
@@ -437,6 +437,7 @@ class TopicsController extends Controller
 
         $featureVotes = $this->groupFeatureVotes($topic);
         $noindex = !$topic->forum->enable_indexing;
+        $opengraph = $topic->toOpengraph();
 
         return ext_view('forum.topics.show', compact(
             'canEditPoll',
@@ -449,6 +450,7 @@ class TopicsController extends Controller
             'firstPostPosition',
             'navUrls',
             'noindex',
+            'opengraph',
             'topic',
             'userCanModerate',
             'showDeleted'

--- a/app/Http/Controllers/NewsController.php
+++ b/app/Http/Controllers/NewsController.php
@@ -196,6 +196,7 @@ class NewsController extends Controller
 
         return ext_view('news.show', [
             'commentBundle' => CommentBundle::forEmbed($post),
+            'opengraph' => $post->toOpengraph(),
             'post' => $post,
             'postJson' => $postJson,
             'sidebarMeta' => $this->sidebarMeta($post),

--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -631,7 +631,7 @@ class UsersController extends Controller
             abort(404);
         }
 
-        // preload and set relation for toMetaDescription and transformer sharing data
+        // preload and set relation for opengraph header and transformer sharing data
         $user->statistics($currentMode)?->setRelation('user', $user);
 
         $userArray = $this->fillDeprecatedDuplicateFields(json_item(

--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -654,9 +654,10 @@ class UsersController extends Controller
                 'user' => $userArray,
             ];
 
-            $pageDescription = blade_safe($user->toMetaDescription(['ruleset' => $currentMode]));
 
-            return ext_view('users.show', compact('initialData', 'pageDescription', 'mode', 'user'));
+            $opengraph = $user->toOpengraph(['ruleset' => $currentMode]);
+
+            return ext_view('users.show', compact('initialData', 'mode', 'opengraph', 'user'));
         }
     }
 

--- a/app/Models/Artist.php
+++ b/app/Models/Artist.php
@@ -73,8 +73,9 @@ class Artist extends Model implements HasOpengraph
     public function toOpengraph(?array $options = []): array
     {
         return [
-            'title' => $this->name,
+            'description' => $this->description,
             'image' => $this->cover_url,
+            'title' => $this->name,
         ];
     }
 

--- a/app/Models/Artist.php
+++ b/app/Models/Artist.php
@@ -73,7 +73,7 @@ class Artist extends Model implements HasOpengraph
     public function toOpengraph(?array $options = []): array
     {
         return [
-            'description' => $this->description,
+            'description' => first_paragraph(markdown_plain($this->description)),
             'image' => $this->cover_url,
             'title' => $this->name,
         ];

--- a/app/Models/Artist.php
+++ b/app/Models/Artist.php
@@ -5,6 +5,7 @@
 
 namespace App\Models;
 
+use App\Models\Traits\HasOpengraph;
 use App\Traits\Memoizes;
 
 /**
@@ -31,7 +32,7 @@ use App\Traits\Memoizes;
  * @property string|null $website
  * @property string|null $youtube
  */
-class Artist extends Model
+class Artist extends Model implements HasOpengraph
 {
     use Memoizes;
 
@@ -67,6 +68,14 @@ class Artist extends Model
         $date = parse_time_to_carbon($this->attributes['tracks_max_created_at']);
 
         return $date !== null && $date->addMonths(1)->isFuture();
+    }
+
+    public function toOpengraph(?array $options = []): array
+    {
+        return [
+            'title' => $this->name,
+            'image' => $this->cover_url,
+        ];
     }
 
     public function url()

--- a/app/Models/Beatmapset.php
+++ b/app/Models/Beatmapset.php
@@ -1428,6 +1428,7 @@ class Beatmapset extends Model implements AfterCommit, Commentable, HasOpengraph
 
         return [
             'description' => "osu! » {$section} » {$this->artist} - {$this->title}",
+            'image' => $this->coverURL('card'),
         ];
     }
 

--- a/app/Models/Beatmapset.php
+++ b/app/Models/Beatmapset.php
@@ -25,6 +25,7 @@ use App\Libraries\Commentable;
 use App\Libraries\Elasticsearch\Indexable;
 use App\Libraries\ImageProcessorService;
 use App\Libraries\Transactions\AfterCommit;
+use App\Models\Traits\HasOpengraph;
 use App\Traits\Memoizes;
 use App\Traits\Validatable;
 use Cache;
@@ -104,7 +105,7 @@ use Illuminate\Database\QueryException;
  * @property bool $video
  * @property \Illuminate\Database\Eloquent\Collection $watches BeatmapsetWatch
  */
-class Beatmapset extends Model implements AfterCommit, Commentable, Indexable, Traits\ReportableInterface
+class Beatmapset extends Model implements AfterCommit, Commentable, HasOpengraph, Indexable, Traits\ReportableInterface
 {
     use Memoizes, SoftDeletes, Traits\CommentableDefaults, Traits\Es\BeatmapsetSearch, Traits\Reportable, Validatable;
 
@@ -1421,11 +1422,13 @@ class Beatmapset extends Model implements AfterCommit, Commentable, Indexable, T
             ]);
     }
 
-    public function toMetaDescription()
+    public function toOpengraph(?array $options = []): array
     {
         $section = osu_trans('layout.menu.beatmaps._');
 
-        return "osu! » {$section} » {$this->artist} - {$this->title}";
+        return [
+            'description' => "osu! » {$section} » {$this->artist} - {$this->title}",
+        ];
     }
 
     private function extractDescription($post)

--- a/app/Models/Beatmapset.php
+++ b/app/Models/Beatmapset.php
@@ -1425,10 +1425,12 @@ class Beatmapset extends Model implements AfterCommit, Commentable, HasOpengraph
     public function toOpengraph(?array $options = []): array
     {
         $section = osu_trans('layout.menu.beatmaps._');
+        $title = "{$this->artist} - {$this->title}"; // opengrah header always intended for guest.
 
         return [
-            'description' => "osu! » {$section} » {$this->artist} - {$this->title}",
+            'description' => "osu! » {$section} » {$title}",
             'image' => $this->coverURL('card'),
+            'title' => $title,
         ];
     }
 

--- a/app/Models/Contest.php
+++ b/app/Models/Contest.php
@@ -6,6 +6,7 @@
 namespace App\Models;
 
 use App\Exceptions\InvariantException;
+use App\Models\Traits\HasOpengraph;
 use App\Traits\Memoizes;
 use App\Transformers\ContestEntryTransformer;
 use App\Transformers\ContestTransformer;
@@ -38,7 +39,7 @@ use Exception;
  * @property \Carbon\Carbon|null $voting_ends_at
  * @property \Carbon\Carbon|null $voting_starts_at
  */
-class Contest extends Model
+class Contest extends Model implements HasOpengraph
 {
     use Memoizes;
 
@@ -328,6 +329,14 @@ class Contest extends Model
             'contest' => $contestJson,
             'userVotes' => ($this->isVotingStarted() ? $this->votesForUser($user) : []),
         ]);
+    }
+
+    public function toOpengraph(?array $options = []): array
+    {
+        return [
+            'title' => $this->name,
+            'image' => $this->header_url,
+        ];
     }
 
     public function votesForUser($user = null)

--- a/app/Models/Contest.php
+++ b/app/Models/Contest.php
@@ -334,8 +334,9 @@ class Contest extends Model implements HasOpengraph
     public function toOpengraph(?array $options = []): array
     {
         return [
-            'title' => $this->name,
+            'description' => strip_tags(markdown($this->currentDescription())),
             'image' => $this->header_url,
+            'title' => $this->name,
         ];
     }
 

--- a/app/Models/Forum/Forum.php
+++ b/app/Models/Forum/Forum.php
@@ -375,7 +375,7 @@ class Forum extends Model implements HasOpengraph
         });
     }
 
-    public function toMetaDescription()
+    public function toOpengraph(?array $options = []): array
     {
         $stack = [osu_trans('forum.title')];
         foreach ($this->forum_parents as $forumId => $forumData) {
@@ -384,13 +384,9 @@ class Forum extends Model implements HasOpengraph
 
         $stack[] = $this->forum_name;
 
-        return implode(' » ', $stack);
-    }
+        $description = implode(' » ', $stack);
 
-    public function toOpengraph(?array $options = []): array
-    {
-        return [
-            'description' => $this->toMetaDescription(),
-        ];
+        // Reminder to update Topic::toOpengraph() if these values change.
+        return compact('description');
     }
 }

--- a/app/Models/Forum/Forum.php
+++ b/app/Models/Forum/Forum.php
@@ -389,6 +389,7 @@ class Forum extends Model implements HasOpengraph
         // Reminder to update Topic::toOpengraph() if these values change.
         return [
             'description' => $description,
+            'title' => $this->forum_name,
             'image' => $this->cover?->fileUrl(),
         ];
     }

--- a/app/Models/Forum/Forum.php
+++ b/app/Models/Forum/Forum.php
@@ -5,6 +5,7 @@
 
 namespace App\Models\Forum;
 
+use App\Models\Traits\HasOpengraph;
 use App\Models\User;
 use Carbon\Carbon;
 use Illuminate\Database\Eloquent\Builder;
@@ -59,7 +60,7 @@ use Illuminate\Database\Eloquent\Builder;
  * @property \Illuminate\Database\Eloquent\Collection $subforums static
  * @property \Illuminate\Database\Eloquent\Collection $topics Topic
  */
-class Forum extends Model
+class Forum extends Model implements HasOpengraph
 {
     public $timestamps = false;
 
@@ -384,5 +385,12 @@ class Forum extends Model
         $stack[] = $this->forum_name;
 
         return implode(' » ', $stack);
+    }
+
+    public function toOpengraph(?array $options = []): array
+    {
+        return [
+            'description' => $this->toMetaDescription(),
+        ];
     }
 }

--- a/app/Models/Forum/Forum.php
+++ b/app/Models/Forum/Forum.php
@@ -387,6 +387,9 @@ class Forum extends Model implements HasOpengraph
         $description = implode(' » ', $stack);
 
         // Reminder to update Topic::toOpengraph() if these values change.
-        return compact('description');
+        return [
+            'description' => $description,
+            'image' => $this->cover?->fileUrl(),
+        ];
     }
 }

--- a/app/Models/Forum/Topic.php
+++ b/app/Models/Forum/Topic.php
@@ -13,6 +13,7 @@ use App\Libraries\Transactions\AfterCommit;
 use App\Models\Beatmapset;
 use App\Models\Log;
 use App\Models\Notification;
+use App\Models\Traits\HasOpengraph;
 use App\Models\User;
 use App\Traits\Memoizes;
 use App\Traits\Validatable;
@@ -72,7 +73,7 @@ use Illuminate\Database\QueryException;
  * @property \Illuminate\Database\Eloquent\Collection $userTracks TopicTrack
  * @property \Illuminate\Database\Eloquent\Collection $watches TopicWatch
  */
-class Topic extends Model implements AfterCommit
+class Topic extends Model implements AfterCommit, HasOpengraph
 {
     use Memoizes, Validatable;
     use SoftDeletes {
@@ -827,6 +828,13 @@ class Topic extends Model implements AfterCommit
     public function toMetaDescription()
     {
         return "{$this->forum->toMetaDescription()} » {$this->topic_title}";
+    }
+
+    public function toOpengraph(?array $options = []): array
+    {
+        return [
+            'description' => $this->toMetaDescription(),
+        ];
     }
 
     public function afterCommit()

--- a/app/Models/Forum/Topic.php
+++ b/app/Models/Forum/Topic.php
@@ -825,16 +825,12 @@ class Topic extends Model implements AfterCommit, HasOpengraph
         return strpos($this->topic_title, "[{$tag}]") !== false;
     }
 
-    public function toMetaDescription()
-    {
-        return "{$this->forum->toMetaDescription()} » {$this->topic_title}";
-    }
-
     public function toOpengraph(?array $options = []): array
     {
-        return [
-            'description' => $this->toMetaDescription(),
-        ];
+        $opengraph = $this->forum->toOpengraph();
+        $opengraph['description'] = "{$opengraph['description']} » {$this->topic_title}";
+
+        return $opengraph;
     }
 
     public function afterCommit()

--- a/app/Models/Forum/Topic.php
+++ b/app/Models/Forum/Topic.php
@@ -832,6 +832,7 @@ class Topic extends Model implements AfterCommit, HasOpengraph
         return [
             'description' => "{$forumOpengraph['description']} » {$this->topic_title}",
             'image' => $this->cover?->fileUrl() ?? $this->forum->cover?->defaultTopicCover->fileUrl(),
+            'title' => $this->topic_title,
         ];
     }
 

--- a/app/Models/Forum/Topic.php
+++ b/app/Models/Forum/Topic.php
@@ -827,10 +827,12 @@ class Topic extends Model implements AfterCommit, HasOpengraph
 
     public function toOpengraph(?array $options = []): array
     {
-        $opengraph = $this->forum->toOpengraph();
-        $opengraph['description'] = "{$opengraph['description']} » {$this->topic_title}";
+        $forumOpengraph = $this->forum->toOpengraph();
 
-        return $opengraph;
+        return [
+            'description' => "{$forumOpengraph['description']} » {$this->topic_title}",
+            'image' => $this->cover?->fileUrl() ?? $this->forum->cover?->defaultTopicCover->fileUrl(),
+        ];
     }
 
     public function afterCommit()

--- a/app/Models/NewsPost.php
+++ b/app/Models/NewsPost.php
@@ -9,6 +9,7 @@ use App\Exceptions\GitHubNotFoundException;
 use App\Libraries\Commentable;
 use App\Libraries\Markdown\OsuMarkdown;
 use App\Libraries\OsuWiki;
+use App\Models\Traits\HasOpengraph;
 use App\Traits\Memoizes;
 use Carbon\Carbon;
 use Exception;
@@ -26,7 +27,7 @@ use Exception;
  * @property \Carbon\Carbon|null $updated_at
  * @property string|null $version
  */
-class NewsPost extends Model implements Commentable, Wiki\WikiObject
+class NewsPost extends Model implements Commentable, HasOpengraph, Wiki\WikiObject
 {
     use Memoizes, Traits\CommentableDefaults, Traits\WithDbCursorHelper;
 
@@ -327,6 +328,14 @@ class NewsPost extends Model implements Commentable, Wiki\WikiObject
         $this->save();
 
         return $this;
+    }
+
+    public function toOpengraph(?array $options = []): array
+    {
+        return [
+            'title' => $this->title(),
+            'image' => $this->firstImage(true),
+        ];
     }
 
     public function pagePublishedAt()

--- a/app/Models/NewsPost.php
+++ b/app/Models/NewsPost.php
@@ -333,8 +333,9 @@ class NewsPost extends Model implements Commentable, HasOpengraph, Wiki\WikiObje
     public function toOpengraph(?array $options = []): array
     {
         return [
-            'title' => $this->title(),
+            'description' => blade_safe($this->previewText()),
             'image' => $this->firstImage(true),
+            'title' => $this->title(),
         ];
     }
 

--- a/app/Models/Traits/HasOpengraph.php
+++ b/app/Models/Traits/HasOpengraph.php
@@ -1,0 +1,13 @@
+<?php
+
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
+declare(strict_types=1);
+
+namespace App\Models\Traits;
+
+interface HasOpengraph
+{
+    public function toOpengraph(?array $options): array;
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -20,6 +20,7 @@ use App\Libraries\User\UsernamesForDbLookup;
 use App\Libraries\UsernameValidation;
 use App\Models\Forum\TopicWatch;
 use App\Models\OAuth\Client;
+use App\Models\Traits\HasOpengraph;
 use App\Traits\Memoizes;
 use App\Traits\Validatable;
 use Cache;
@@ -210,7 +211,7 @@ use Request;
  * @method static Builder eagerloadForListing()
  * @method static Builder online()
  */
-class User extends Model implements AfterCommit, AuthenticatableContract, HasLocalePreference, Indexable, Traits\ReportableInterface
+class User extends Model implements AfterCommit, AuthenticatableContract, HasLocalePreference, HasOpengraph, Indexable, Traits\ReportableInterface
 {
     use Authenticatable, HasApiTokens, Memoizes, Traits\Es\UserSearch, Traits\Reportable, Traits\UserAvatar, Traits\UserScoreable, Traits\UserStore, Validatable;
 
@@ -1845,6 +1846,15 @@ class User extends Model implements AfterCommit, AuthenticatableContract, HasLoc
         }
 
         return osu_trans('users.ogp.description._', $replacements);
+    }
+
+    public function toOpengraph(?array $options = []): array
+    {
+        return [
+            'description' => blade_safe($this->toMetaDescription($options)),
+            'image' => $this->user_avatar,
+            'title' => blade_safe(osu_trans('users.show.title', ['username' => $this->username])),
+        ];
     }
 
     public function hasProfile()

--- a/resources/views/artists/show.blade.php
+++ b/resources/views/artists/show.blade.php
@@ -20,7 +20,6 @@
 
 @extends('master', [
     'titlePrepend' => $artist->name,
-    'pageDescription' => $artist->description,
     'canonicalUrl' => $artist->url(),
 ])
 

--- a/resources/views/artists/show.blade.php
+++ b/resources/views/artists/show.blade.php
@@ -22,10 +22,6 @@
     'titlePrepend' => $artist->name,
     'pageDescription' => $artist->description,
     'canonicalUrl' => $artist->url(),
-    'opengraph' => [
-        'title' => $artist->name,
-        'image' => $artist->cover_url,
-    ],
 ])
 
 @section('content')

--- a/resources/views/beatmapsets/show.blade.php
+++ b/resources/views/beatmapsets/show.blade.php
@@ -10,7 +10,6 @@
     @endphp
 @endif
 @extends('master', [
-    'pageDescription' => $beatmapset->toMetaDescription(),
     'titlePrepend' => "{$beatmapset->getDisplayArtist(auth()->user())} - {$beatmapset->getDisplayTitle(auth()->user())}",
     'extraFooterLinks' => $extraFooterLinks ?? [],
 ])

--- a/resources/views/contests/base.blade.php
+++ b/resources/views/contests/base.blade.php
@@ -17,7 +17,6 @@
 
 @extends('master', [
     'titlePrepend' => $contestMeta->name,
-    'pageDescription' => strip_tags(markdown($contestMeta->currentDescription())),
     'canonicalUrl' => $contestMeta->url(),
 ])
 

--- a/resources/views/contests/base.blade.php
+++ b/resources/views/contests/base.blade.php
@@ -19,10 +19,6 @@
     'titlePrepend' => $contestMeta->name,
     'pageDescription' => strip_tags(markdown($contestMeta->currentDescription())),
     'canonicalUrl' => $contestMeta->url(),
-    'opengraph' => [
-        'title' => $contestMeta->name,
-        'image' => $contestMeta->header_url,
-    ],
 ])
 
 @section('content')

--- a/resources/views/forum/forums/show.blade.php
+++ b/resources/views/forum/forums/show.blade.php
@@ -4,7 +4,6 @@
 --}}
 @extends('master', [
     'bodyAdditionalClasses' => "t-forum-{$forum->categorySlug()}",
-    'pageDescription' => $forum->toMetaDescription(),
     'searchParams' => [
         'forum_id' => $forum->getKey(),
         'mode' => 'forum_post',

--- a/resources/views/forum/topics/show.blade.php
+++ b/resources/views/forum/topics/show.blade.php
@@ -5,7 +5,6 @@
 @extends('master', [
     'titlePrepend' => $topic->topic_title,
     'canonicalUrl' => route('forum.topics.show', $topic->topic_id),
-    'pageDescription' => $topic->toMetaDescription(),
 ])
 
 @php

--- a/resources/views/layout/metadata.blade.php
+++ b/resources/views/layout/metadata.blade.php
@@ -6,6 +6,8 @@
     $appUrl = config('app.url');
     $currentLocale = App::getLocale();
     $fallbackLocale = config('app.fallback_locale');
+
+    $pageDescription ??= $opengraph['description'] ?? null;
 @endphp
 <link rel="apple-touch-icon" sizes="180x180" href="{{ $appUrl }}/images/favicon/apple-touch-icon.png">
 <link rel="icon" sizes="32x32" href="{{ $appUrl }}/images/favicon/favicon-32x32.png">

--- a/resources/views/layout/metadata.blade.php
+++ b/resources/views/layout/metadata.blade.php
@@ -7,7 +7,7 @@
     $currentLocale = App::getLocale();
     $fallbackLocale = config('app.fallback_locale');
 
-    $pageDescription ??= $opengraph['description'] ?? null;
+    $opengraph['description'] ??= $opengraph['description'] ?? $pageDescription ?? null;
 @endphp
 <link rel="apple-touch-icon" sizes="180x180" href="{{ $appUrl }}/images/favicon/apple-touch-icon.png">
 <link rel="icon" sizes="32x32" href="{{ $appUrl }}/images/favicon/favicon-32x32.png">
@@ -18,30 +18,24 @@
 <meta name="theme-color" content="hsl({{ $currentHue }}, 10%, 40%)"> {{-- @osu-colour-b1 --}}
 
 <meta charset="utf-8">
-<meta name="description" content="{{ $pageDescription ?? osu_trans('layout.defaults.page_description') }}">
+<meta name="description" content="{{ $opengraph['description'] ?? osu_trans('layout.defaults.page_description') }}">
 <meta name="keywords" content="osu, peppy, ouendan, elite, beat, agents, ds, windows, game, taiko, tatsujin, simulator, sim, xna, ddr, beatmania, osu!, osume">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 
 <link rel="search" type="application/opensearchdescription+xml" title="osu! search" href="{{ config('app.url') }}/opensearch.xml">
 
-@if (isset($opengraph))
-    <meta property="og:site_name" content="osu! » {{ page_title() }}">
-    <meta property="og:type" content="website">
+<meta property="og:site_name" content="osu! » {{ page_title() }}">
+<meta property="og:type" content="website">
 
-    @if (isset($canonicalUrl))
-        <meta property="og:url" content="{{ $canonicalUrl }}">
-    @endif
-
-    @foreach ($opengraph as $key => $value)
-        @if (present($value))
-            <meta property="og:{{ $key }}" content="{{ $value }}">
-        @endif
-    @endforeach
-
-    @if (!isset($opengraph['description']) && isset($pageDescription))
-        <meta property="og:description" content="{{ $pageDescription }}">
-    @endif
+@if (isset($canonicalUrl))
+    <meta property="og:url" content="{{ $canonicalUrl }}">
 @endif
+
+@foreach ($opengraph as $key => $value)
+    @if (present($value))
+        <meta property="og:{{ $key }}" content="{{ $value }}">
+    @endif
+@endforeach
 
 @if ($noindex ?? false)
     <meta name="robots" content="noindex">

--- a/resources/views/layout/metadata.blade.php
+++ b/resources/views/layout/metadata.blade.php
@@ -27,10 +27,15 @@
 @if (isset($opengraph))
     <meta property="og:site_name" content="osu! » {{ page_title() }}">
     <meta property="og:type" content="website">
-    <meta property="og:url" content="{{ $canonicalUrl }}">
+
+    @if (isset($canonicalUrl))
+        <meta property="og:url" content="{{ $canonicalUrl }}">
+    @endif
 
     @foreach ($opengraph as $key => $value)
-        <meta property="og:{{ $key }}" content="{{ $value }}">
+        @if (present($value))
+            <meta property="og:{{ $key }}" content="{{ $value }}">
+        @endif
     @endforeach
 
     @if (!isset($opengraph['description']) && isset($pageDescription))

--- a/resources/views/layout/metadata.blade.php
+++ b/resources/views/layout/metadata.blade.php
@@ -26,10 +26,12 @@
     <meta property="og:site_name" content="osu! » {{ page_title() }}">
     <meta property="og:type" content="website">
     <meta property="og:url" content="{{ $canonicalUrl }}">
-    <meta property="og:title" content="{{ $opengraph['title'] }}">
-    <meta property="og:image" content="{{ $opengraph['image'] }}">
 
-    @if (isset($pageDescription))
+    @foreach ($opengraph as $key => $value)
+        <meta property="og:{{ $key }}" content="{{ $value }}">
+    @endforeach
+
+    @if (!isset($opengraph['description']) && isset($pageDescription))
         <meta property="og:description" content="{{ $pageDescription }}">
     @endif
 @endif

--- a/resources/views/news/show.blade.php
+++ b/resources/views/news/show.blade.php
@@ -5,7 +5,6 @@
 @extends('master', [
     'titlePrepend' => $post->title(),
     'canonicalUrl' => $post->url(),
-    'pageDescription' => blade_safe($post->previewText()),
 ])
 
 @section('content')

--- a/resources/views/news/show.blade.php
+++ b/resources/views/news/show.blade.php
@@ -2,17 +2,10 @@
     Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
     See the LICENCE file in the repository root for full licence text.
 --}}
-@php
-    $title = $post->title();
-@endphp
 @extends('master', [
-    'titlePrepend' => $title,
+    'titlePrepend' => $post->title(),
     'canonicalUrl' => $post->url(),
     'pageDescription' => blade_safe($post->previewText()),
-    'opengraph' => [
-        'title' => $title,
-        'image' => $post->firstImage(true),
-    ],
 ])
 
 @section('content')

--- a/resources/views/users/show.blade.php
+++ b/resources/views/users/show.blade.php
@@ -6,10 +6,6 @@
 @extends('master', [
     'canonicalUrl' => $user->url($mode),
     'titlePrepend' => blade_safe(str_replace(' ', '&nbsp;', e($user->username))),
-    'opengraph' => [
-        'title' => blade_safe(osu_trans('users.show.title', ['username' => $user->username])),
-        'image' => $user->user_avatar,
-    ]
 ])
 
 @section('content')


### PR DESCRIPTION
Add more opengraph headers for news, featured artists, beatmapsets, forums, contests.
Moves the previous `pageDescription` for `show` pages into opengraph info since they're always the same.
More detailed headers can be added separately.

The interface isn't really necessary at the moment other than to make linter/style checker/validators complain if not implemented 🤷 

closes #1295
closes #7652