### PR TITLE
Apidoc type consistency

### DIFF
--- a/app/Http/Controllers/BeatmapDiscussionsController.php
+++ b/app/Http/Controllers/BeatmapDiscussionsController.php
@@ -87,7 +87,7 @@ class BeatmapDiscussionsController extends Controller
      * cursor_string             | [CursorString](#cursorstring)                   | |
      * discussions               | [BeatmapsetDiscussion](#beatmapsetdiscussion)[] | List of discussions according to `sort` order.
      * included_discussions      | [BeatmapsetDiscussion](#beatmapsetdiscussion)[] | Additional discussions related to `discussions`.
-     * reviews_config.max_blocks | number                                          | Maximum number of blocks allowed in a review.
+     * reviews_config.max_blocks | integer                                         | Maximum number of blocks allowed in a review.
      * users                     | [User](#user)[]                                 | List of users associated with the discussions returned.
      *
      * @queryParam beatmap_id `id` of the [Beatmap](#beatmap).

--- a/app/Http/Controllers/BeatmapsController.php
+++ b/app/Http/Controllers/BeatmapsController.php
@@ -71,7 +71,7 @@ class BeatmapsController extends Controller
      * Attributes | [DifficultyAttributes](#beatmapdifficultyattributes)
      *
      * @urlParam beatmap integer required Beatmap id. Example: 2
-     * @bodyParam mods number|string[]|Mod[] Mod combination. Can be either a bitset of mods, array of mod acronyms, or array of mods. Defaults to no mods. Example: 1
+     * @bodyParam mods integer|string[]|Mod[] Mod combination. Can be either a bitset of mods, array of mod acronyms, or array of mods. Defaults to no mods. Example: 1
      * @bodyParam ruleset Ruleset Ruleset of the difficulty attributes. Only valid if it's the beatmap ruleset or the beatmap can be converted to the specified ruleset. Defaults to ruleset of the specified beatmap. Example: osu
      * @bodyParam ruleset_id integer The same as `ruleset` but in integer form. No-example
      *

--- a/app/Http/Controllers/BeatmapsController.php
+++ b/app/Http/Controllers/BeatmapsController.php
@@ -72,7 +72,7 @@ class BeatmapsController extends Controller
      *
      * @urlParam beatmap integer required Beatmap id. Example: 2
      * @bodyParam mods number|string[]|Mod[] Mod combination. Can be either a bitset of mods, array of mod acronyms, or array of mods. Defaults to no mods. Example: 1
-     * @bodyParam ruleset GameMode Ruleset of the difficulty attributes. Only valid if it's the beatmap ruleset or the beatmap can be converted to the specified ruleset. Defaults to ruleset of the specified beatmap. Example: osu
+     * @bodyParam ruleset Ruleset Ruleset of the difficulty attributes. Only valid if it's the beatmap ruleset or the beatmap can be converted to the specified ruleset. Defaults to ruleset of the specified beatmap. Example: osu
      * @bodyParam ruleset_id integer The same as `ruleset` but in integer form. No-example
      *
      * @response {
@@ -285,7 +285,7 @@ class BeatmapsController extends Controller
      *
      * @urlParam beatmap integer required Id of the [Beatmap](#beatmap).
      *
-     * @queryParam mode The [GameMode](#gamemode) to get scores for.
+     * @queryParam mode The [Ruleset](#ruleset) to get scores for.
      * @queryParam mods An array of matching Mods, or none // TODO.
      * @queryParam type Beatmap score ranking type // TODO.
      */
@@ -354,7 +354,7 @@ class BeatmapsController extends Controller
      *
      * @urlParam beatmap integer required Id of the [Beatmap](#beatmap).
      *
-     * @queryParam mode The [GameMode](#gamemode) to get scores for.
+     * @queryParam mode The [Ruleset](#ruleset) to get scores for.
      * @queryParam mods An array of matching Mods, or none // TODO.
      * @queryParam type Beatmap score ranking type // TODO.
      */
@@ -461,7 +461,7 @@ class BeatmapsController extends Controller
      * @urlParam beatmap integer required Id of the [Beatmap](#beatmap).
      * @urlParam user integer required Id of the [User](#user).
      *
-     * @queryParam mode The [GameMode](#gamemode) to get scores for.
+     * @queryParam mode The [Ruleset](#ruleset) to get scores for.
      * @queryParam mods An array of matching Mods, or none // TODO.
      */
     public function userScore($beatmapId, $userId)
@@ -507,7 +507,7 @@ class BeatmapsController extends Controller
      * @urlParam beatmap integer required Id of the [Beatmap](#beatmap).
      * @urlParam user integer required Id of the [User](#user).
      *
-     * @queryParam mode The [GameMode](#gamemode) to get scores for. Defaults to beatmap mode
+     * @queryParam mode The [Ruleset](#ruleset) to get scores for. Defaults to beatmap mode
      */
     public function userScoreAll($beatmapId, $userId)
     {

--- a/app/Http/Controllers/ChangelogController.php
+++ b/app/Http/Controllers/ChangelogController.php
@@ -55,8 +55,8 @@ class ChangelogController extends Controller
      * --------------|---------------------------------|------
      * builds        | [Build](#build)[]               | Includes `changelog_entries`, `changelog_entries.github_user`, and changelog entry message in requested formats.
      * search.from   | string?                         | `from` input.
-     * search.limit  | number                          | Always `21`.
-     * search.max_id | number?                         | `max_id` input.
+     * search.limit  | integer                         | Always `21`.
+     * search.max_id | integer?                        | `max_id` input.
      * search.stream | string?                         | `stream` input.
      * search.to     | string?                         | `to` input.
      * streams       | [UpdateStream](#updatestream)[] | Always contains all available streams. Includes `latest_build` and `user_count`.

--- a/app/Http/Controllers/Forum/TopicsController.php
+++ b/app/Http/Controllers/Forum/TopicsController.php
@@ -471,12 +471,12 @@ class TopicsController extends Controller
      * post   | [ForumPost](#forum-post)   | body
      *
      * @bodyParam body string required Content of the topic. Example: hello
-     * @bodyParam forum_id number required Forum to create the topic in. Example: 1
+     * @bodyParam forum_id integer required Forum to create the topic in. Example: 1
      * @bodyParam title string required Title of the topic. Example: untitled
      * @bodyParam with_poll boolean Enable this to also create poll in the topic (default: false). Example: 1
      * @bodyParam forum_topic_poll[hide_results] boolean Enable this to hide result until voting period ends (default: false). No-example
-     * @bodyParam forum_topic_poll[length_days] number Number of days for voting period. 0 means the voting will never ends (default: 0). This parameter is required if `hide_results` option is enabled. No-example
-     * @bodyParam forum_topic_poll[max_options] number Maximum number of votes each user can cast (default: 1). No-example
+     * @bodyParam forum_topic_poll[length_days] integer Number of days for voting period. 0 means the voting will never ends (default: 0). This parameter is required if `hide_results` option is enabled. No-example
+     * @bodyParam forum_topic_poll[max_options] integer Maximum number of votes each user can cast (default: 1). No-example
      * @bodyParam forum_topic_poll[options] string required Newline-separated list of voting options. BBCode is supported. Example: item A...
      * @bodyParam forum_topic_poll[title] string required Title of the poll. Example: my poll
      * @bodyParam forum_topic_poll[vote_change] boolean Enable this to allow user to change their votes (default: false). No-example

--- a/app/Http/Controllers/HomeController.php
+++ b/app/Http/Controllers/HomeController.php
@@ -166,10 +166,10 @@ class HomeController extends Controller
      *
      * #### SearchResult&lt;T>
      *
-     * Field | Type   | Description
-     * ----- | ------ | -----------
-     * data  | T[]    | |
-     * total | number | |
+     * Field | Type    | Description
+     * ----- | ------- | -----------
+     * data  | T[]     | |
+     * total | integer | |
      *
      * @queryParam mode Either `all`, `user`, or `wiki_page`. Default is `all`. Example: all
      * @queryParam query Search keyword. Example: hello

--- a/app/Http/Controllers/NewsController.php
+++ b/app/Http/Controllers/NewsController.php
@@ -28,7 +28,7 @@ class NewsController extends Controller
      * news_posts                | [NewsPost](#newspost)[]       | Includes `preview`.
      * news_sidebar.current_year | integer                       | Year of the first post's publish time, or current year if no posts returned.
      * news_sidebar.news_posts   | [NewsPost](#newspost)[]       | All posts published during `current_year`.
-     * news_sidebar.years        | number[]                      | All years during which posts have been published.
+     * news_sidebar.years        | integer[]                     | All years during which posts have been published.
      * search.limit              | integer                       | Clamped limit input.
      * search.sort               | string                        | Always `published_desc`.
      *

--- a/app/Http/Controllers/NewsController.php
+++ b/app/Http/Controllers/NewsController.php
@@ -26,10 +26,10 @@ class NewsController extends Controller
      * ------------------------- | ----------------------------- | -----
      * cursor_string             | [CursorString](#cursorstring) | |
      * news_posts                | [NewsPost](#newspost)[]       | Includes `preview`.
-     * news_sidebar.current_year | number                        | Year of the first post's publish time, or current year if no posts returned.
+     * news_sidebar.current_year | integer                       | Year of the first post's publish time, or current year if no posts returned.
      * news_sidebar.news_posts   | [NewsPost](#newspost)[]       | All posts published during `current_year`.
      * news_sidebar.years        | number[]                      | All years during which posts have been published.
-     * search.limit              | number                        | Clamped limit input.
+     * search.limit              | integer                       | Clamped limit input.
      * search.sort               | string                        | Always `published_desc`.
      *
      * <aside class="notice">

--- a/app/Http/Controllers/RankingController.php
+++ b/app/Http/Controllers/RankingController.php
@@ -111,7 +111,7 @@ class RankingController extends Controller
      *
      * Returns [Rankings](#rankings)
      *
-     * @urlParam mode string required [GameMode](#gamemode). Example: mania
+     * @urlParam mode string required [Ruleset](#ruleset). Example: mania
      * @urlParam type string required [RankingType](#rankingtype). Example: performance
      *
      * @queryParam country Filter ranking by country code. Only available for `type` of `performance`. Example: JP

--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -487,7 +487,7 @@ class UsersController extends Controller
      * @urlParam type string required Score type. Must be one of these: `best`, `firsts`, `recent`. Example: best
      *
      * @queryParam include_fails Only for recent scores, include scores of failed plays. Set to 1 to include them. Defaults to 0. Example: 0
-     * @queryParam mode [GameMode](#gamemode) of the scores to be returned. Defaults to the specified `user`'s mode. Example: osu
+     * @queryParam mode [Ruleset](#ruleset) of the scores to be returned. Defaults to the specified `user`'s mode. Example: osu
      * @queryParam limit Maximum number of results.
      * @queryParam offset Result offset for pagination. Example: 1
      *
@@ -542,7 +542,7 @@ class UsersController extends Controller
      *
      * Additionally, `statistics_rulesets` is included, containing statistics for all rulesets.
      *
-     * @urlParam mode string [GameMode](#gamemode). User default mode will be used if not specified. Example: osu
+     * @urlParam mode string [Ruleset](#ruleset). User default mode will be used if not specified. Example: osu
      *
      * @response "See User object section"
      */
@@ -615,7 +615,7 @@ class UsersController extends Controller
      * - user_achievements
      *
      * @urlParam user integer required Id or username of the user. Id lookup is prioritised unless `key` parameter is specified. Previous usernames are also checked in some cases. Example: 1
-     * @urlParam mode string [GameMode](#gamemode). User default mode will be used if not specified. Example: osu
+     * @urlParam mode string [Ruleset](#ruleset). User default mode will be used if not specified. Example: osu
      *
      * @queryParam key Type of `user` passed in url parameter. Can be either `id` or `username` to limit lookup by their respective type. Passing empty or invalid value will result in id lookup followed by username lookup if not found.
      *

--- a/resources/views/docs/_structures/beatmap.md
+++ b/resources/views/docs/_structures/beatmap.md
@@ -7,7 +7,7 @@ Field             | Type                  | Description
 beatmapset_id     | integer               | |
 difficulty_rating | float                 | |
 id                | integer               | |
-mode              | [GameMode](#gamemode) | |
+mode              | [Ruleset](#ruleset)   | |
 status            | string                | See [Rank status](#beatmapset-rank-status) for list of possible values.
 total_length      | integer               | |
 user_id           | integer               | |

--- a/resources/views/docs/_structures/beatmap_pack.md
+++ b/resources/views/docs/_structures/beatmap_pack.md
@@ -8,7 +8,7 @@ author            | string                  |
 date              | [Timestamp](#timestamp) |
 name              | string                  |
 no_diff_reduction | boolean                 | Whether difficulty reduction mods may be used to clear the pack.
-ruleset_id        | number                  |
+ruleset_id        | integer                 |
 tag               | string                  | The tag of the beatmap pack. Starts with a character representing the type (See the `Tag` column of [BeatmapPackType](#beatmappacktype)) followed by an integer.
 url               | string                  | The download url of the beatmap pack.
 
@@ -17,5 +17,5 @@ url               | string                  | The download url of the beatmap pa
 Field                               | Type                        | Description
 ----------------------------------- | --------------------------- | -----------
 beatmapsets                         | [Beatmapset](#beatmapset)[] |
-user_completion_data.beatmapset_ids | number[]                    | IDs of beatmapsets completed by the user (according to the requirements of the pack)
+user_completion_data.beatmapset_ids | integer[]                   | IDs of beatmapsets completed by the user (according to the requirements of the pack)
 user_completion_data.completed      | boolean                     | Whether all beatmapsets are completed or not

--- a/resources/views/docs/_structures/beatmap_playcount.md
+++ b/resources/views/docs/_structures/beatmap_playcount.md
@@ -4,7 +4,7 @@ Represent the playcount of a beatmap.
 
 Field             | Type                       | Description
 ----------------- | -------------------------- | -----------
-beatmap_id        | number                     | |
+beatmap_id        | integer                    | |
 beatmap           | [Beatmap](#beatmap)?       | |
 beatmapset        | [Beatmapset](#beatmapset)? | |
-count             | number                     | |
+count             | integer                    | |

--- a/resources/views/docs/_structures/beatmap_user_score.md
+++ b/resources/views/docs/_structures/beatmap_user_score.md
@@ -8,5 +8,5 @@
 
 Field    | Type              | Description
 -------- | ----------------- | --------------------------------------------------------------------
-position | number            | The position of the score within the requested beatmap ranking.
+position | integer           | The position of the score within the requested beatmap ranking.
 score    | [Score](#score)   | The details of the score.

--- a/resources/views/docs/_structures/beatmapset.md
+++ b/resources/views/docs/_structures/beatmapset.md
@@ -8,18 +8,18 @@ artist          | string                       | |
 artist_unicode  | string                       | |
 covers          | [Covers](#beatmapset-covers) | |
 creator         | string                       | |
-favourite_count | number                       | |
-id              | number                       | |
+favourite_count | integer                      | |
+id              | integer                      | |
 nsfw            | boolean                      | |
-offset          | number                       | |
-play_count      | number                       | |
+offset          | integer                      | |
+play_count      | integer                      | |
 preview_url     | string                       | |
 source          | string                       | |
 status          | string                       | |
 spotlight       | boolean                      | |
 title           | string                       | |
 title_unicode   | string                       | |
-user_id         | number                       | |
+user_id         | integer                      | |
 video           | boolean                      | |
 
 Those fields are optional.
@@ -42,7 +42,7 @@ ratings                 |                                                       
 recent_favourites       |                                                              | |
 related_users           |                                                              | |
 user                    |                                                              | |
-track_id                | number                                                       | |
+track_id                | integer                                                      | |
 
 <div id="beatmapset-covers" data-unique="beatmapset-covers"></div>
 

--- a/resources/views/docs/_structures/beatmapset_discussion.md
+++ b/resources/views/docs/_structures/beatmapset_discussion.md
@@ -5,26 +5,26 @@ Represents a Beatmapset modding discussion.
 Field                   | Type                                                     | Description
 ----------------------- | -------------------------------------------------------- | -----------
 beatmap                 | [Beatmap](#beatmap)?                                     | |
-beatmap_id              | number?                                                  | |
+beatmap_id              | integer?                                                 | |
 beatmapset              | [Beatmapset](#beatmapset)?                               | |
-beatmapset_id           | number                                                   | |
+beatmapset_id           | integer                                                  | |
 can_be_resolved         | boolean                                                  | |
 can_grant_kudosu        | boolean                                                  | |
 created_at              | [Timestamp](#timestamp)                                  | |
 current_user_attributes | [CurrentUserAttributes](#currentuserattributes)          | |
 deleted_at              | [Timestamp](#timestamp)?                                 | |
-deleted_by_id           | number?                                                  | |
-id                      | number                                                   | |
+deleted_by_id           | integer?                                                 | |
+id                      | integer                                                  | |
 kudosu_denied           | boolean                                                  | |
 last_post_at            | [Timestamp](#timestamp)                                  | |
 message_type            | [MessageType](#messagetype)                              | |
-parent_id               | number?                                                  | |
+parent_id               | integer?                                                 | |
 posts                   | [BeatmapsetDiscussionPost](#beatmapsetdiscussionpost)[]? | |
 resolved                | boolean                                                  | |
 starting_post           | [BeatmapsetDiscussionPost](#beatmapsetdiscussionpost)?   | |
-timestamp               | number?                                                  | |
+timestamp               | integer?                                                 | |
 updated_at              | [Timestamp](#timestamp)                                  | |
-user_id                 | number                                                   | |
+user_id                 | integer                                                  | |
 
 ### MessageType
 

--- a/resources/views/docs/_structures/beatmapset_discussion_post.md
+++ b/resources/views/docs/_structures/beatmapset_discussion_post.md
@@ -4,13 +4,13 @@ Represents a post in a [BeatmapsetDiscussion](#beatmapsetdiscussion).
 
 Field                    | Type                     | Description
 ------------------------ | ------------------------ | -----------
-beatmapset_discussion_id | number                   | |
+beatmapset_discussion_id | integer                  | |
 created_at               | [Timestamp](#timestamp)  | |
 deleted_at               | [Timestamp](#timestamp)? | |
-deleted_by_id            | number?                  | |
-id                       | number                   | |
-last_editor_id           | number?                  | |
+deleted_by_id            | integer?                 | |
+id                       | integer                  | |
+last_editor_id           | integer?                 | |
 message                  | string                   | |
 system                   | boolean                  | |
 updated_at               | [Timestamp](#timestamp)  | |
-user_id                  | number                   | |
+user_id                  | integer                  | |

--- a/resources/views/docs/_structures/beatmapset_discussion_vote.md
+++ b/resources/views/docs/_structures/beatmapset_discussion_vote.md
@@ -4,9 +4,9 @@ Represents a vote on a [BeatmapsetDiscussion](#beatmapsetdiscussion).
 
 Field                    | Type                         | Description
 ------------------------ | ---------------------------- | -----------
-beatmapset_discussion_id | number                       | |
+beatmapset_discussion_id | integer                      | |
 created_at               | [Timestamp](#timestamp)      | |
-id                       | number                       | |
-score                    | number                       | |
+id                       | integer                      | |
+score                    | integer                      | |
 updated_at               | [Timestamp](#timestamp)      | |
-user_id                  | number                       | |
+user_id                  | integer                      | |

--- a/resources/views/docs/_structures/beatmapset_extended.md
+++ b/resources/views/docs/_structures/beatmapset_extended.md
@@ -8,7 +8,7 @@ availability.download_disabled | boolean                      | |
 availability.more_information  | string?                      | |
 bpm                            | float                        | |
 can_be_hyped                   | boolean                      | |
-deleted_at                     | string?                      | |
+deleted_at                     | [Timestamp](#timestamp)?     | |
 discussion_enabled             | boolean                      | Deprecated, all beatmapsets now have discussion enabled. |
 discussion_locked              | boolean                      | |
 hype.current                   | integer                      | |

--- a/resources/views/docs/_structures/build.md
+++ b/resources/views/docs/_structures/build.md
@@ -20,9 +20,9 @@ Field           | Type
 ----------------|-----
 created_at      | [Timestamp](#timestamp)
 display_version | string
-id              | number
+id              | integer
 update_stream   | [UpdateStream](#updatestream)?
-users           | number
+users           | integer
 version         | string?
 youtube_id      | string?
 

--- a/resources/views/docs/_structures/changelog_entry.md
+++ b/resources/views/docs/_structures/changelog_entry.md
@@ -20,9 +20,9 @@ Field                  | Type
 -----------------------|-----
 category               | string
 created_at             | [Timestamp](#timestamp)?
-github_pull_request_id | number?
+github_pull_request_id | integer?
 github_url             | string?
-id                     | number?
+id                     | integer?
 major                  | boolean
 repository             | string?
 title                  | string?

--- a/resources/views/docs/_structures/chat_channel.md
+++ b/resources/views/docs/_structures/chat_channel.md
@@ -26,12 +26,12 @@ Represents an individual chat "channel" in the game.
 
 Field                   | Type                          | Description
 ----------------------- | ----------------------------- | ------------------
-channel_id              | number                        | |
+channel_id              | integer                       | |
 name                    | string                        | |
 description             | string?                       | |
 icon                    | string?                       | display icon for the channel
 type                    | [ChannelType](#channeltype)   | type of channel
-message_length_limit    | number                        | |
+message_length_limit    | integer                       | |
 moderated               | boolean                       | user can't send message when the value is `true`
 uuid                    | string?                       | value from requests that is relayed back to the sender.
 
@@ -40,7 +40,7 @@ Optional attributes:
 Field                   | Type                                             | Description
 ----------------------- | ------------------------------------------------ | ------------------
 current_user_attributes | [CurrentUserAttributes](#currentuserattributes)? | only present on some responses
-last_read_id            | number?                                          | Deprecated; use `current_user_attributes.last_read_id`.
-last_message_id         | number?                                          | `message_id` of last known message (only returned in presence responses)
+last_read_id            | integer?                                         | Deprecated; use `current_user_attributes.last_read_id`.
+last_message_id         | integer?                                         | `message_id` of last known message (only returned in presence responses)
 recent_messages         | ChatMessage[]?                                   | Deprecated; up to 50 most recent messages
-users                   | number[]?                                        | array of `user_id` that are in the channel (not included for `PUBLIC` channels)
+users                   | integer[]?                                       | array of `user_id` that are in the channel (not included for `PUBLIC` channels)

--- a/resources/views/docs/_structures/chat_message.md
+++ b/resources/views/docs/_structures/chat_message.md
@@ -27,12 +27,12 @@ Represents an individual Message within a [ChatChannel](#chatchannel).
 
 Field        | Type    | Description
 ------------ | ------- | ------------------------------------------------------------
-channel_id   | number  | `channel_id` of where the message was sent
+channel_id   | integer | `channel_id` of where the message was sent
 content      | string  | message content
 content_html | string? | Deprecated. Markdown message content as HTML
 is_action    | boolean | was this an action? i.e. `/me dances`
-message_id   | number  | unique identifier for message
-sender_id    | number  | `user_id` of the sender
+message_id   | integer | unique identifier for message
+sender_id    | integer | `user_id` of the sender
 timestamp    | string  | when the message was sent, ISO-8601
 type         | string  | type of message; 'action', 'markdown' or 'plain'
 uuid         | string? | message identifier originally sent by client

--- a/resources/views/docs/_structures/chat_message.md
+++ b/resources/views/docs/_structures/chat_message.md
@@ -25,17 +25,17 @@
 
 Represents an individual Message within a [ChatChannel](#chatchannel).
 
-Field        | Type    | Description
------------- | ------- | ------------------------------------------------------------
-channel_id   | integer | `channel_id` of where the message was sent
-content      | string  | message content
-content_html | string? | Deprecated. Markdown message content as HTML
-is_action    | boolean | was this an action? i.e. `/me dances`
-message_id   | integer | unique identifier for message
-sender_id    | integer | `user_id` of the sender
-timestamp    | string  | when the message was sent, ISO-8601
-type         | string  | type of message; 'action', 'markdown' or 'plain'
-uuid         | string? | message identifier originally sent by client
+Field        | Type                    | Description
+------------ | ----------------------- | ------------------------------------------------------------
+channel_id   | integer                 | `channel_id` of where the message was sent
+content      | string                  | message content
+content_html | string?                 | Deprecated. Markdown message content as HTML
+is_action    | boolean                 | was this an action? i.e. `/me dances`
+message_id   | integer                 | unique identifier for message
+sender_id    | integer                 | `user_id` of the sender
+timestamp    | [Timestamp](#timestamp) | when the message was sent, ISO-8601
+type         | string                  | type of message; 'action', 'markdown' or 'plain'
+uuid         | string?                 | message identifier originally sent by client
 
 Optional attributes:
 

--- a/resources/views/docs/_structures/comment.md
+++ b/resources/views/docs/_structures/comment.md
@@ -24,19 +24,19 @@ Represents a single comment.
 
 Field            | Type       | Description
 ---------------- | ---------- | ------------------
-commentable_id   | number     | ID of the object the comment is attached to
+commentable_id   | integer    | ID of the object the comment is attached to
 commentable_type | string     | type of object the comment is attached to
 created_at       | string     | ISO 8601 date
 deleted_at       | string?    | ISO 8601 date if the comment was deleted; null, otherwise
 edited_at        | string?    | ISO 8601 date if the comment was edited; null, otherwise
-edited_by_id     | number?    | user id of the user that edited the post; null, otherwise
-id               | number     | the ID of the comment
+edited_by_id     | integer?   | user id of the user that edited the post; null, otherwise
+id               | integer    | the ID of the comment
 legacy_name      | string?    | username displayed on legacy comments
 message          | string?    | markdown of the comment's content
 message_html     | string?    | html version of the comment's content
-parent_id        | number?    | ID of the comment's parent
+parent_id        | integer?   | ID of the comment's parent
 pinned           | boolean    | Pin status of the comment
-replies_count    | number     | number of replies to the comment
+replies_count    | integer    | integerof replies to the comment
 updated_at       | string     | ISO 8601 date
-user_id          | number     | user ID of the poster
-votes_count      | number     | number of votes
+user_id          | integer    | user ID of the poster
+votes_count      | integer    | integerof votes

--- a/resources/views/docs/_structures/comment.md
+++ b/resources/views/docs/_structures/comment.md
@@ -36,7 +36,7 @@ message          | string?                  | markdown of the comment's content
 message_html     | string?                  | html version of the comment's content
 parent_id        | integer?                 | ID of the comment's parent
 pinned           | boolean                  | Pin status of the comment
-replies_count    | integer                  | integerof replies to the comment
+replies_count    | integer                  | Number of replies to the comment
 updated_at       | [Timestamp](#timestamp)  | ISO 8601 date
 user_id          | integer                  | user ID of the poster
-votes_count      | integer                  | integerof votes
+votes_count      | integer                  | Number of votes

--- a/resources/views/docs/_structures/comment.md
+++ b/resources/views/docs/_structures/comment.md
@@ -22,21 +22,21 @@
 
 Represents a single comment.
 
-Field            | Type       | Description
----------------- | ---------- | ------------------
-commentable_id   | integer    | ID of the object the comment is attached to
-commentable_type | string     | type of object the comment is attached to
-created_at       | string     | ISO 8601 date
-deleted_at       | string?    | ISO 8601 date if the comment was deleted; null, otherwise
-edited_at        | string?    | ISO 8601 date if the comment was edited; null, otherwise
-edited_by_id     | integer?   | user id of the user that edited the post; null, otherwise
-id               | integer    | the ID of the comment
-legacy_name      | string?    | username displayed on legacy comments
-message          | string?    | markdown of the comment's content
-message_html     | string?    | html version of the comment's content
-parent_id        | integer?   | ID of the comment's parent
-pinned           | boolean    | Pin status of the comment
-replies_count    | integer    | integerof replies to the comment
-updated_at       | string     | ISO 8601 date
-user_id          | integer    | user ID of the poster
-votes_count      | integer    | integerof votes
+Field            | Type                     | Description
+---------------- | ------------------------ | ------------------
+commentable_id   | integer                  | ID of the object the comment is attached to
+commentable_type | string                   | type of object the comment is attached to
+created_at       | [Timestamp](#timestamp)  | ISO 8601 date
+deleted_at       | [Timestamp](#timestamp)? | ISO 8601 date if the comment was deleted; null, otherwise
+edited_at        | [Timestamp](#timestamp)? | ISO 8601 date if the comment was edited; null, otherwise
+edited_by_id     | integer?                 | user id of the user that edited the post; null, otherwise
+id               | integer                  | the ID of the comment
+legacy_name      | string?                  | username displayed on legacy comments
+message          | string?                  | markdown of the comment's content
+message_html     | string?                  | html version of the comment's content
+parent_id        | integer?                 | ID of the comment's parent
+pinned           | boolean                  | Pin status of the comment
+replies_count    | integer                  | integerof replies to the comment
+updated_at       | [Timestamp](#timestamp)  | ISO 8601 date
+user_id          | integer                  | user ID of the poster
+votes_count      | integer                  | integerof votes

--- a/resources/views/docs/_structures/comment_bundle.md
+++ b/resources/views/docs/_structures/comment_bundle.md
@@ -97,7 +97,7 @@ has_more_id       | integer?                              |
 included_comments | [Comment](#comment)[]                 | Related comments; e.g. parent comments and nested replies
 pinned_comments   | [Comment](#comment)[]?                | Pinned comments
 sort              | string                                | one of the [CommentSort](#commentsort) types
-top_level_count   | integer?                              | integerof comments at the top level. Not returned for replies.
+top_level_count   | integer?                              | Number of comments at the top level. Not returned for replies.
 total             | integer?                              | Total number of comments. Not retuned for replies.
 user_follow       | boolean                               | is the current user watching the comment thread?
 user_votes        | integer[]                             | IDs of the comments in the bundle the current user has upvoted

--- a/resources/views/docs/_structures/comment_bundle.md
+++ b/resources/views/docs/_structures/comment_bundle.md
@@ -93,12 +93,12 @@ commentable_meta  | [CommentableMeta](#commentablemeta)[] | ID of the object the
 comments          | [Comment](#comment)[]                 | Array of comments ordered according to `sort`;
 cursor            | [Cursor](#cursor)                     |
 has_more          | boolean                               | If there are more comments or replies available
-has_more_id       | number?                               |
+has_more_id       | integer?                              |
 included_comments | [Comment](#comment)[]                 | Related comments; e.g. parent comments and nested replies
 pinned_comments   | [Comment](#comment)[]?                | Pinned comments
 sort              | string                                | one of the [CommentSort](#commentsort) types
-top_level_count   | number?                               | Number of comments at the top level. Not returned for replies.
-total             | number?                               | Total number of comments. Not retuned for replies.
+top_level_count   | integer?                              | integerof comments at the top level. Not returned for replies.
+total             | integer?                              | Total number of comments. Not retuned for replies.
 user_follow       | boolean                               | is the current user watching the comment thread?
-user_votes        | number[]                              | IDs of the comments in the bundle the current user has upvoted
+user_votes        | integer[]                             | IDs of the comments in the bundle the current user has upvoted
 users             | [User](#user)[]                       | array of users related to the comments

--- a/resources/views/docs/_structures/commentable_meta.md
+++ b/resources/views/docs/_structures/commentable_meta.md
@@ -15,8 +15,8 @@ If object is available:
 Field                   | Type                                                               | Description
 ----------------------- | ------------------------------------------------------------------ | ------------------
 current_user_attributes | [CurrentUserAttributes](#commentable-meta-current-user-attributes) | |
-id                      | number                                                             | the ID of the object
-owner_id                | number?                                                            | User ID which owns the object
+id                      | integer                                                            | the ID of the object
+owner_id                | integer?                                                           | User ID which owns the object
 owner_title             | string?                                                            | Object owner type, used for display (`MAPPER` for beatmapset)
 title                   | string                                                             | display title
 type                    | string                                                             | the type of the object

--- a/resources/views/docs/_structures/current_user_attributes.md
+++ b/resources/views/docs/_structures/current_user_attributes.md
@@ -21,4 +21,4 @@ Name              | Type    | Description
 ----------------- | ------- | --------------
 can_message       | boolean | Can send messages to this channel.
 can_message_error | string? | Reason messages cannot be sent to this channel
-last_read_id      | number  | `message_id` of last message read.
+last_read_id      | integer | `message_id` of last message read.

--- a/resources/views/docs/_structures/event.md
+++ b/resources/views/docs/_structures/event.md
@@ -58,7 +58,7 @@ When a beatmap has been played for certain number of times.
 Field       | Type
 ------------|------------
 beatmap     | [Event.Beatmap](#event-beatmap)
-count       | number
+count       | integer
 
 #### beatmapsetApprove
 

--- a/resources/views/docs/_structures/event.md
+++ b/resources/views/docs/_structures/event.md
@@ -5,7 +5,7 @@ The object has different attributes depending on its `type`. Following are attri
 Field      | Type                      | Description
 -----------|---------------------------|------------
 created_at | [Timestamp](#timestamp)   | |
-id         | number                    | |
+id         | integer                   | |
 type       | [Event.Type](#event-type) | |
 
 ### Additional objects
@@ -112,7 +112,7 @@ When a user achieves a certain rank on a beatmap.
 Field     | Type                            | Description
 ----------|---------------------------------|--------------------------------------------
 scoreRank | string                          | (FIXME)
-rank      | number                          | |
+rank      | integer                         | |
 mode      | [Ruleset](#ruleset)             | |
 beatmap   | [Event.Beatmap](#event-beatmap) | |
 user      | [Event.User](#event-user)       | |

--- a/resources/views/docs/_structures/event.md
+++ b/resources/views/docs/_structures/event.md
@@ -113,7 +113,7 @@ Field     | Type                            | Description
 ----------|---------------------------------|--------------------------------------------
 scoreRank | string                          | (FIXME)
 rank      | number                          | |
-mode      | GameMode                        | |
+mode      | [Ruleset](#ruleset)             | |
 beatmap   | [Event.Beatmap](#event-beatmap) | |
 user      | [Event.User](#event-user)       | |
 
@@ -123,7 +123,7 @@ When a user loses first place to another user.
 
 Field     | Type
 ----------|-------------
-mode      | [GameMode](#gamemode)
+mode      | [Ruleset](#ruleset)
 beatmap   | [Event.Beatmap](#event-beatmap)
 user      | [Event.User](#event-user)
 

--- a/resources/views/docs/_structures/forum_post.md
+++ b/resources/views/docs/_structures/forum_post.md
@@ -5,11 +5,11 @@ Field        | Type                     | Description
 created_at   | [Timestamp](#timestamp)  | |
 deleted_at   | [Timestamp](#timestamp)? | |
 edited_at    | [Timestamp](#timestamp)? | |
-edited_by_id | number?                  | |
-forum_id     | number                   | |
-id           | number                   | |
-topic_id     | number                   | |
-user_id      | number                   | |
+edited_by_id | ingeter?                 | |
+forum_id     | ingeter                  | |
+id           | ingeter                  | |
+topic_id     | ingeter                  | |
+user_id      | ingeter                  | |
 
 Following fields are optional.
 

--- a/resources/views/docs/_structures/forum_post.md
+++ b/resources/views/docs/_structures/forum_post.md
@@ -5,11 +5,11 @@ Field        | Type                     | Description
 created_at   | [Timestamp](#timestamp)  | |
 deleted_at   | [Timestamp](#timestamp)? | |
 edited_at    | [Timestamp](#timestamp)? | |
-edited_by_id | ingeter?                 | |
-forum_id     | ingeter                  | |
-id           | ingeter                  | |
-topic_id     | ingeter                  | |
-user_id      | ingeter                  | |
+edited_by_id | integer?                 | |
+forum_id     | integer                  | |
+id           | integer                  | |
+topic_id     | integer                  | |
+user_id      | integer                  | |
 
 Following fields are optional.
 

--- a/resources/views/docs/_structures/forum_topic.md
+++ b/resources/views/docs/_structures/forum_topic.md
@@ -4,17 +4,17 @@ Field         | Type
 --------------|-----
 created_at    | [Timestamp](#timestamp)
 deleted_at    | [Timestamp](#timestamp)?
-first_post_id | number
-forum_id      | number
-id            | number
+first_post_id | integer
+forum_id      | integer
+id            | integer
 is_locked     | boolean
-last_post_id  | number
+last_post_id  | integer
 poll          | [Poll](#forum-topic-poll)?
-post_count    | number
+post_count    | integer
 title         | string
 type          | `normal` \| `sticky` \| `announcement`
 updated_at    | [Timestamp](#timestamp)
-user_id       | number
+user_id       | integer
 
 <div id="forum-topic-poll" data-unique="forum-topic-poll"></div>
 
@@ -26,12 +26,12 @@ allow_vote_change       | boolean
 ended_at                | [Timestamp](#timestamp)?
 hide_incomplete_results | boolean
 last_vote_at            | [Timestamp](#timestamp)?
-max_votes               | number
+max_votes               | integer
 options                 | [PollOption](#forum-topic-polloption)[]
 started_at              | [Timestamp](#timestamp)
 title.bbcode            | string
 title.html              | string
-total_vote_count        | number
+total_vote_count        | integer
 
 <div id="forum-topic-polloption" data-unique="forum-topic-polloption"></div>
 

--- a/resources/views/docs/_structures/forum_topic.md
+++ b/resources/views/docs/_structures/forum_topic.md
@@ -37,9 +37,9 @@ total_vote_count        | number
 
 ### PollOption
 
-Field       | Type    | Notes
-------------|---------|------
-id          | number  | Unique only per-topic.
-text.bbcode | string  | |
-text.html   | string  | |
-vote_count  | number? | Not present if the poll is incomplete and results are hidden.
+Field       | Type     | Notes
+------------|----------|------
+id          | integer  | Unique only per-topic.
+text.bbcode | string   | |
+text.html   | string   | |
+vote_count  | integer? | Not present if the poll is incomplete and results are hidden.

--- a/resources/views/docs/_structures/github_user.md
+++ b/resources/views/docs/_structures/github_user.md
@@ -17,7 +17,7 @@ Field           | Type
 display_name    | string
 github_url      | string?
 github_username | string?
-id              | number?
+id              | integer?
 osu_username    | string?
-user_id         | number?
+user_id         | integer?
 user_url        | string?

--- a/resources/views/docs/_structures/group.md
+++ b/resources/views/docs/_structures/group.md
@@ -7,7 +7,7 @@ Field           | Type    | Description
 colour          | string? | |
 has_listing     | boolean | Whether this group displays a listing at `/groups/{id}`.
 has_playmodes   | boolean | Whether this group associates [Rulesets](#ruleset) with users' memberships.
-id              | number  | |
+id              | integer | |
 identifier      | string  | Unique string to identify the group.
 is_probationary | boolean | Whether members of this group are considered probationary.
 name            | string  | |

--- a/resources/views/docs/_structures/group.md
+++ b/resources/views/docs/_structures/group.md
@@ -6,7 +6,7 @@ Field           | Type    | Description
 ----------------|---------|------------------------------------------------------------
 colour          | string? | |
 has_listing     | boolean | Whether this group displays a listing at `/groups/{id}`.
-has_playmodes   | boolean | Whether this group associates [GameModes](#gamemode) with users' memberships.
+has_playmodes   | boolean | Whether this group associates [Rulesets](#ruleset) with users' memberships.
 id              | number  | |
 identifier      | string  | Unique string to identify the group.
 is_probationary | boolean | Whether members of this group are considered probationary.

--- a/resources/views/docs/_structures/kudosu_history.md
+++ b/resources/views/docs/_structures/kudosu_history.md
@@ -1,14 +1,14 @@
 ## KudosuHistory
 
-Field      | Type       | Description
------------|------------|-----------------------------
-id         | integer    | |
-action     | string     | One of `give`, `vote.give`, `reset`, `vote.reset`, `revoke`, or `vote.revoke`.
-amount     | integer    | |
-model      | string     | Object type which the exchange happened on (`forum_post`, etc).
-created_at | Timestamp  | |
-giver      | Giver?     | Simple detail of the user who started the exchange.
-post       | Post       | Simple detail of the object for display.
+Field      | Type                    | Description
+-----------|-------------------------|-----------------------------
+id         | integer                 | |
+action     | string                  | One of `give`, `vote.give`, `reset`, `vote.reset`, `revoke`, or `vote.revoke`.
+amount     | integer                 | |
+model      | string                  | Object type which the exchange happened on (`forum_post`, etc).
+created_at | [Timestamp](#timestamp) | |
+giver      | Giver?                  | Simple detail of the user who started the exchange.
+post       | Post                    | Simple detail of the object for display.
 
 ### Giver
 

--- a/resources/views/docs/_structures/kudosu_history.md
+++ b/resources/views/docs/_structures/kudosu_history.md
@@ -2,9 +2,9 @@
 
 Field      | Type       | Description
 -----------|------------|-----------------------------
-id         | number     | |
+id         | integer    | |
 action     | string     | One of `give`, `vote.give`, `reset`, `vote.reset`, `revoke`, or `vote.revoke`.
-amount     | number     | |
+amount     | integer    | |
 model      | string     | Object type which the exchange happened on (`forum_post`, etc).
 created_at | Timestamp  | |
 giver      | Giver?     | Simple detail of the user who started the exchange.

--- a/resources/views/docs/_structures/multiplayer_score.md
+++ b/resources/views/docs/_structures/multiplayer_score.md
@@ -2,20 +2,20 @@
 
 Score data.
 
-Field              | Type                       | Description
--------------------|----------------------------|-------------------
-`id`               | `integer`                  |  |
-`user_id`          | `integer`                  |  |
-`room_id`          | `integer`                  |  |
-`playlist_item_id` | `integer`                  |  |
-`beatmap_id`       | `integer`                  |  |
-`rank`             | `rank`                     |  |
-`total_score`      | `integer`                  |  |
-`accuracy`         | `float`                    |  |
-`max_combo`        | `integer`                  |  |
-`mods`             | `Mod[]`                    |  |
-`statistics`       | `Statistics`               |  |
-`passed`           | `bool`                     |  |
-`position`         | `integer?`                 |  |
-`scores_around`    | `MultiplayerScoresAround?` | Scores around the specified score.
-`user`             | `User`                     |  |
+Field            | Type                     | Description
+-----------------|--------------------------|-------------------
+id               | integer                  |  |
+user_id          | integer                  |  |
+room_id          | integer                  |  |
+playlist_item_id | integer                  |  |
+beatmap_id       | integer                  |  |
+rank             | rank                     |  |
+total_score      | integer                  |  |
+accuracy         | float                    |  |
+max_combo        | integer                  |  |
+mods             | Mod[]                    |  |
+statistics       | Statistics               |  |
+passed           | boolean                  |  |
+position         | integer?                 |  |
+scores_around    | MultiplayerScoresAround? | Scores around the specified score.
+user             | User                     |  |

--- a/resources/views/docs/_structures/multiplayer_score.md
+++ b/resources/views/docs/_structures/multiplayer_score.md
@@ -4,18 +4,18 @@ Score data.
 
 Field              | Type                       | Description
 -------------------|----------------------------|-------------------
-`id`               | `number`                   |  |
-`user_id`          | `number`                   |  |
-`room_id`          | `number`                   |  |
-`playlist_item_id` | `number`                   |  |
-`beatmap_id`       | `number`                   |  |
+`id`               | `integer`                  |  |
+`user_id`          | `integer`                  |  |
+`room_id`          | `integer`                  |  |
+`playlist_item_id` | `integer`                  |  |
+`beatmap_id`       | `integer`                  |  |
 `rank`             | `rank`                     |  |
-`total_score`      | `number`                   |  |
-`accuracy`         | `number`                   |  |
-`max_combo`        | `number`                   |  |
+`total_score`      | `integer`                  |  |
+`accuracy`         | `float`                    |  |
+`max_combo`        | `integer`                  |  |
 `mods`             | `Mod[]`                    |  |
 `statistics`       | `Statistics`               |  |
 `passed`           | `bool`                     |  |
-`position`         | `number?`                  |  |
+`position`         | `integer?`                 |  |
 `scores_around`    | `MultiplayerScoresAround?` | Scores around the specified score.
 `user`             | `User`                     |  |

--- a/resources/views/docs/_structures/multiplayer_score.md
+++ b/resources/views/docs/_structures/multiplayer_score.md
@@ -4,18 +4,18 @@ Score data.
 
 Field            | Type                     | Description
 -----------------|--------------------------|-------------------
-id               | integer                  |  |
-user_id          | integer                  |  |
-room_id          | integer                  |  |
-playlist_item_id | integer                  |  |
-beatmap_id       | integer                  |  |
-rank             | rank                     |  |
-total_score      | integer                  |  |
 accuracy         | float                    |  |
+beatmap_id       | integer                  |  |
+id               | integer                  |  |
 max_combo        | integer                  |  |
 mods             | Mod[]                    |  |
-statistics       | Statistics               |  |
 passed           | boolean                  |  |
+playlist_item_id | integer                  |  |
 position         | integer?                 |  |
+rank             | rank                     |  |
+room_id          | integer                  |  |
+statistics       | Statistics               |  |
 scores_around    | MultiplayerScoresAround? | Scores around the specified score.
+total_score      | integer                  |  |
 user             | User                     |  |
+user_id          | integer                  |  |

--- a/resources/views/docs/_structures/multiplayer_scores.md
+++ b/resources/views/docs/_structures/multiplayer_scores.md
@@ -4,8 +4,8 @@ An object which contains scores and related data for fetching next page of the r
 
 Field           | Type                 | Description
 --------------- | -------------------- | -------------------------------------------------------------
-`cursor_string` | `CursorString`       | To be used to fetch the next page.
-`params`        | `object`             | Parameters used for score listing.
-`scores`        | `MultiplayerScore[]` | |
-`total`         | `integer?`           | Index only. Total scores of the specified playlist item.
-`user_score`    | `MultiplayerScore?`  | Index only. Score of the accessing user if exists.
+cursor_string   | CursorString         | To be used to fetch the next page.
+params          | object               | Parameters used for score listing.
+scores          | MultiplayerScore[]   | |
+total           | integer?             | Index only. Total scores of the specified playlist item.
+user_score      | MultiplayerScore?    | Index only. Score of the accessing user if exists.

--- a/resources/views/docs/_structures/multiplayer_scores.md
+++ b/resources/views/docs/_structures/multiplayer_scores.md
@@ -7,5 +7,5 @@ Field           | Type                 | Description
 `cursor_string` | `CursorString`       | To be used to fetch the next page.
 `params`        | `object`             | Parameters used for score listing.
 `scores`        | `MultiplayerScore[]` | |
-`total`         | `number?`            | Index only. Total scores of the specified playlist item.
+`total`         | `integer?`           | Index only. Total scores of the specified playlist item.
 `user_score`    | `MultiplayerScore?`  | Index only. Score of the accessing user if exists.

--- a/resources/views/docs/_structures/multiplayer_scores_around.md
+++ b/resources/views/docs/_structures/multiplayer_scores_around.md
@@ -1,6 +1,6 @@
 ## MultiplayerScoresAround
 
-Field    | Type                | Description
----------|---------------------|------------
-`higher` | `MultiplayerScores` |  |
-`lower`  | `MultiplayerScores` |  |
+Field  | Type              | Description
+-------|-------------------|------------
+higher | MultiplayerScores |  |
+lower  | MultiplayerScores |  |

--- a/resources/views/docs/_structures/multiplayer_scores_cursor.md
+++ b/resources/views/docs/_structures/multiplayer_scores_cursor.md
@@ -4,5 +4,5 @@ An object which contains pointer for fetching further results of a request. It d
 
 Field         | Type    | Description
 --------------|---------|---------------------------------------------------------------------------
-`score_id`    | integer | Last score id of current result (`score_asc`, `score_desc`).
-`total_score` | integer | Last score's total score of current result (`score_asc`, `score_desc`).
+score_id      | integer | Last score id of current result (`score_asc`, `score_desc`).
+total_score   | integer | Last score's total score of current result (`score_asc`, `score_desc`).

--- a/resources/views/docs/_structures/multiplayer_scores_cursor.md
+++ b/resources/views/docs/_structures/multiplayer_scores_cursor.md
@@ -2,7 +2,7 @@
 
 An object which contains pointer for fetching further results of a request. It depends on the sort option.
 
-Field         | Type     | Description
---------------|----------|---------------------------------------------------------------------------
-`score_id`    | `number` | Last score id of current result (`score_asc`, `score_desc`).
-`total_score` | `number` | Last score's total score of current result (`score_asc`, `score_desc`).
+Field         | Type    | Description
+--------------|---------|---------------------------------------------------------------------------
+`score_id`    | integer | Last score id of current result (`score_asc`, `score_desc`).
+`total_score` | integer | Last score's total score of current result (`score_asc`, `score_desc`).

--- a/resources/views/docs/_structures/multiplayer_scores_sort.md
+++ b/resources/views/docs/_structures/multiplayer_scores_sort.md
@@ -4,5 +4,5 @@ Sort option for multiplayer scores index.
 
 Name         | Description
 ------------ | ----------------------------
-`score_asc`  | Sort by scores, ascending.
-`score_desc` | Sort by scores, descending.
+score_asc    | Sort by scores, ascending.
+score_desc   | Sort by scores, descending.

--- a/resources/views/docs/_structures/news_post.md
+++ b/resources/views/docs/_structures/news_post.md
@@ -5,7 +5,7 @@ Field        | Type                    | Description
 author       | string                  | |
 edit_url     | string                  | Link to the file view on GitHub.
 first_image  | string?                 | Link to the first image in the document.
-id           | number                  | |
+id           | integer                 | |
 published_at | [Timestamp](#timestamp) | |
 slug         | string                  | Filename without the extension, used in URLs.
 title        | string                  | |

--- a/resources/views/docs/_structures/nomination.md
+++ b/resources/views/docs/_structures/nomination.md
@@ -3,6 +3,6 @@
 Field            | Type
 -----------------|-----
 beatmapset_id    | number
-rulesets         | [GameMode](#gamemode)[]
+rulesets         | [Ruleset](#ruleset)[]
 reset            | boolean
 user_id          | number

--- a/resources/views/docs/_structures/nomination.md
+++ b/resources/views/docs/_structures/nomination.md
@@ -2,7 +2,7 @@
 
 Field            | Type
 -----------------|-----
-beatmapset_id    | number
+beatmapset_id    | integer
 rulesets         | [Ruleset](#ruleset)[]
 reset            | boolean
-user_id          | number
+user_id          | integer

--- a/resources/views/docs/_structures/notification.md
+++ b/resources/views/docs/_structures/notification.md
@@ -17,16 +17,16 @@
 
 Represents a notification object.
 
-Field            | Type     | Description
----------------- | -------  | ------------------------------------------------------------------------
-id               | integer  | |
-name             | string   | Name of the event
-created_at       | string   | ISO 8601 date
-object_type      | string   | |
-object_id        | integer  | |
-source_user_id   | integer? | |
-is_read          | boolean  | |
-details          | object   | `message_id` of last known message (only returned in presence responses)
+Field            | Type                    | Description
+---------------- | ----------------------- | ------------------------------------------------------------------------
+id               | integer                 | |
+name             | string                  | Name of the event
+created_at       | [Timestamp](#timestamp) | ISO 8601 date
+object_type      | string                  | |
+object_id        | integer                 | |
+source_user_id   | integer?                | |
+is_read          | boolean                 | |
+details          | object                  | `message_id` of last known message (only returned in presence responses)
 
 ### Event Names
 

--- a/resources/views/docs/_structures/notification.md
+++ b/resources/views/docs/_structures/notification.md
@@ -17,16 +17,16 @@
 
 Represents a notification object.
 
-Field            | Type    | Description
----------------- | ------- | ------------------------------------------------------------------------
-id               | number  | |
-name             | string  | Name of the event
-created_at       | string  | ISO 8601 date
-object_type      | string  | |
-object_id        | number  | |
-source_user_id   | number? | |
-is_read          | boolean | |
-details          | object  | `message_id` of last known message (only returned in presence responses)
+Field            | Type     | Description
+---------------- | -------  | ------------------------------------------------------------------------
+id               | integer  | |
+name             | string   | Name of the event
+created_at       | string   | ISO 8601 date
+object_type      | string   | |
+object_id        | integer  | |
+source_user_id   | integer? | |
+is_read          | boolean  | |
+details          | object   | `message_id` of last known message (only returned in presence responses)
 
 ### Event Names
 
@@ -48,11 +48,11 @@ Name                                                                           |
 
 #### `beatmapset_discussion_lock`
 
-Field          | Type   | Description
--------------- | ------ | --------------------------
-object_id      | number | Beatmapset id
-object_type    | string | `beatmapset`
-source_user_id | number | User who locked discussion
+Field          | Type    | Description
+-------------- | ------- | --------------------------
+object_id      | integer | Beatmapset id
+object_type    | string  | `beatmapset`
+source_user_id | integer | User who locked discussion
 
 Details object:
 
@@ -66,32 +66,32 @@ username  | string | Username of `source_user_id`
 
 #### `beatmapset_discussion_post_new`
 
-Field          | Type   | Description
--------------- | ------ | -----------------------------
-object_id      | number | Beatmapset id
-object_type    | string | `beatmapset`
-source_user_id | number | Poster of the discussion
+Field          | Type    | Description
+-------------- | ------- | -----------------------------
+object_id      | integer | Beatmapset id
+object_type    | string  | `beatmapset`
+source_user_id | integer | Poster of the discussion
 
 Details object:
 
-Field         | Type    | Description
-------------- | ------- | ------------------------------
-title         | string  | Beatmap title
-cover_url     | string  | Beatmap cover
-discussion_id | number  | |
-post_id       | number  | |
-beatmap_id    | number? | `null` if posted to general all
-username      | string  | Username of `source_user_id`
+Field         | Type     | Description
+------------- | -------- | ------------------------------
+title         | string   | Beatmap title
+cover_url     | string   | Beatmap cover
+discussion_id | integer  | |
+post_id       | integer  | |
+beatmap_id    | integer? | `null` if posted to general all
+username      | string   | Username of `source_user_id`
 
 <div id="notification-beatmapset_discussion_unlock" data-unique="notification-beatmapset_discussion_unlock"></div>
 
 #### `beatmapset_discussion_unlock`
 
-Field          | Type   | Description
--------------- | ------ | ----------------------------
-object_id      | number | Beatmapset id
-object_type    | string | `beatmapset`
-source_user_id | number | User who unlocked discussion
+Field          | Type    | Description
+-------------- | ------- | ----------------------------
+object_id      | integer | Beatmapset id
+object_type    | string  | `beatmapset`
+source_user_id | integer | User who unlocked discussion
 
 Details object:
 
@@ -105,11 +105,11 @@ username  | string | Username of `source_user_id`
 
 #### `beatmapset_disqualify`
 
-Field          | Type   | Description
--------------- | ------ | --------------------------------
-object_id      | number | Beatmapset id
-object_type    | string | `beatmapset`
-source_user_id | number | User who disqualified beatmapset
+Field          | Type    | Description
+-------------- | ------- | --------------------------------
+object_id      | integer | Beatmapset id
+object_type    | string  | `beatmapset`
+source_user_id | integer | User who disqualified beatmapset
 
 Details object:
 
@@ -124,11 +124,11 @@ username  | string | Username of `source_user_id`
 
 #### `beatmapset_love`
 
-Field          | Type   | Description
--------------- | ------ | -------------------------------------
-object_id      | number | Beatmapset id
-object_type    | string | `beatmapset`
-source_user_id | number | User who promoted beatmapset to loved
+Field          | Type    | Description
+-------------- | ------- | -------------------------------------
+object_id      | integer | Beatmapset id
+object_type    | string  | `beatmapset`
+source_user_id | integer | User who promoted beatmapset to loved
 
 Details object:
 
@@ -142,11 +142,11 @@ username  | string | Username of `source_user_id`
 
 #### `beatmapset_nominate`
 
-Field          | Type   | Description
--------------- | ------ | -----------------------------
-object_id      | number | Beatmapset id
-object_type    | string | `beatmapset`
-source_user_id | number | User who nominated beatmapset
+Field          | Type    | Description
+-------------- | ------- | -----------------------------
+object_id      | integer | Beatmapset id
+object_type    | string  | `beatmapset`
+source_user_id | integer | User who nominated beatmapset
 
 Details object:
 
@@ -160,11 +160,11 @@ username  | string | Username of `source_user_id`
 
 #### `beatmapset_qualify`
 
-Field          | Type   | Description
--------------- | ------ | -------------------------------------------------------
-object_id      | number | Beatmapset id
-object_type    | string | `beatmapset`
-source_user_id | number | User whom beatmapset nomination triggered qualification
+Field          | Type    | Description
+-------------- | ------- | -------------------------------------------------------
+object_id      | integer | Beatmapset id
+object_type    | string  | `beatmapset`
+source_user_id | integer | User whom beatmapset nomination triggered qualification
 
 Details object:
 
@@ -178,11 +178,11 @@ username  | string | Username of `source_user_id`
 
 #### `beatmapset_remove_from_loved`
 
-Field          | Type   | Description
--------------- | ------ | --------------------------------------
-object_id      | number | Beatmapset id
-object_type    | string | `beatmapset`
-source_user_id | number | User who removed beatmapset from Loved
+Field          | Type    | Description
+-------------- | ------- | --------------------------------------
+object_id      | integer | Beatmapset id
+object_type    | string  | `beatmapset`
+source_user_id | integer | User who removed beatmapset from Loved
 
 Details object:
 
@@ -196,11 +196,11 @@ username  | string | Username of `source_user_id`
 
 #### `beatmapset_reset_nominations`
 
-Field          | Type   | Description
--------------- | ------ | -----------------------------------
-object_id      | number | Beatmapset id
-object_type    | string | `beatmapset`
-source_user_id | number | User who triggered nomination reset
+Field          | Type    | Description
+-------------- | ------- | -----------------------------------
+object_id      | integer | Beatmapset id
+object_type    | string  | `beatmapset`
+source_user_id | integer | User who triggered nomination reset
 
 Details object:
 
@@ -214,11 +214,11 @@ username  | string | Username of `source_user_id`
 
 #### `channel_message`
 
-Field          | Type   | Description
--------------- | ------ | -----------------------
-object_id      | number | Channel id
-object_type    | string | `channel`
-source_user_id | number | User who posted message
+Field          | Type    | Description
+-------------- | ------- | -----------------------
+object_id      | integer | Channel id
+object_type    | string  | `channel`
+source_user_id | integer | User who posted message
 
 Details object:
 
@@ -232,11 +232,11 @@ username  | string | Username of `source_user_id`
 
 #### `forum_topic_reply`
 
-Field          | Type   | Description
--------------- | ------ | -----------------------
-object_id      | number | Topic id
-object_type    | string | `forum_topic`
-source_user_id | number | User who posted message
+Field          | Type    | Description
+-------------- | ------- | -----------------------
+object_id      | integer | Topic id
+object_type    | string  | `forum_topic`
+source_user_id | integer | User who posted message
 
 Details object:
 
@@ -244,5 +244,5 @@ Field     | Type    | Description
 --------- | ------- | ----------------------------
 title     | string  | Title of the replied topic
 cover_url | string  | Topic cover
-post_id   | number  | Post id
+post_id   | integer | Post id
 username  | string? | Username of `source_user_id`

--- a/resources/views/docs/_structures/rankings.md
+++ b/resources/views/docs/_structures/rankings.md
@@ -63,4 +63,4 @@ beatmapsets    | [BeatmapsetExtended](#beatmapsetextended)[]? | The list of beat
 cursor         | [Cursor](#cursor)                            | A cursor
 ranking        | [UserStatistics](#userstatistics)[]          | Score details ordered by rank in descending order.
 spotlight      | [Spotlight](#spotlight)?                     | Spotlight details; only available if `type` is `charts`
-total          | number                                       | An approximate count of ranks available
+total          | integer                                      | An approximate count of ranks available

--- a/resources/views/docs/_structures/ruleset.md
+++ b/resources/views/docs/_structures/ruleset.md
@@ -1,6 +1,6 @@
-## GameMode
+## Ruleset
 
-Available game modes:
+Available rulesets:
 
 Name   | Description
 ------ | ---------------

--- a/resources/views/docs/_structures/spotlight.md
+++ b/resources/views/docs/_structures/spotlight.md
@@ -15,9 +15,9 @@ The details of a spotlight.
 Field             | Type     | Description
 ----------------- | -------- | ----------------------------------------------------------------------------
 end_date          | DateTime | The end date of the spotlight.
-id                | number   | The ID of this spotlight.
+id                | integer  | The ID of this spotlight.
 mode_specific     | boolean  | If the spotlight has different mades specific to each [Ruleset](#ruleset).
-participant_count | number?  | The number of users participating in this spotlight. This is only shown when viewing a single spotlight.
+participant_count | integer? | The number of users participating in this spotlight. This is only shown when viewing a single spotlight.
 name              | string   | The name of the spotlight.
 start_date        | DateTime | The starting date of the spotlight.
 type              | string   | The type of spotlight.

--- a/resources/views/docs/_structures/spotlight.md
+++ b/resources/views/docs/_structures/spotlight.md
@@ -12,12 +12,12 @@
 
 The details of a spotlight.
 
-Field             | Type     | Description
------------------ | -------- | ----------------------------------------------------------------------------
-end_date          | DateTime | The end date of the spotlight.
-id                | integer  | The ID of this spotlight.
-mode_specific     | boolean  | If the spotlight has different mades specific to each [Ruleset](#ruleset).
-participant_count | integer? | The number of users participating in this spotlight. This is only shown when viewing a single spotlight.
-name              | string   | The name of the spotlight.
-start_date        | DateTime | The starting date of the spotlight.
-type              | string   | The type of spotlight.
+Field             | Type      | Description
+----------------- | --------- | ----------------------------------------------------------------------------
+end_date          | Timestamp | The end date of the spotlight.
+id                | integer   | The ID of this spotlight.
+mode_specific     | boolean   | If the spotlight has different mades specific to each [Ruleset](#ruleset).
+participant_count | integer?  | The number of users participating in this spotlight. This is only shown when viewing a single spotlight.
+name              | string    | The name of the spotlight.
+start_date        | Timestamp | The starting date of the spotlight.
+type              | string    | The type of spotlight.

--- a/resources/views/docs/_structures/spotlight.md
+++ b/resources/views/docs/_structures/spotlight.md
@@ -16,7 +16,7 @@ Field             | Type     | Description
 ----------------- | -------- | ----------------------------------------------------------------------------
 end_date          | DateTime | The end date of the spotlight.
 id                | number   | The ID of this spotlight.
-mode_specific     | boolean  | If the spotlight has different mades specific to each [GameMode](#gamemode).
+mode_specific     | boolean  | If the spotlight has different mades specific to each [Ruleset](#ruleset).
 participant_count | number?  | The number of users participating in this spotlight. This is only shown when viewing a single spotlight.
 name              | string   | The name of the spotlight.
 start_date        | DateTime | The starting date of the spotlight.

--- a/resources/views/docs/_structures/update_stream.md
+++ b/resources/views/docs/_structures/update_stream.md
@@ -12,7 +12,7 @@
 Field        | Type
 -------------|-----
 display_name | string?
-id           | number
+id           | integer
 is_featured  | boolean
 name         | string
 
@@ -23,4 +23,4 @@ The following are attributes which may be additionally included in responses. Re
 Field        | Type
 -------------|-----
 latest_build | [Build](#build)?
-user_count   | number
+user_count   | integer

--- a/resources/views/docs/_structures/user.md
+++ b/resources/views/docs/_structures/user.md
@@ -21,7 +21,7 @@ Field           | Type                      | Description
 avatar_url      | string                    | url of user's avatar
 country_code    | string                    | two-letter code representing user's country
 default_group   | string?                   | Identifier of the default [Group](#group) the user belongs to.
-id              | number                    | unique identifier for user
+id              | integer                   | unique identifier for user
 is_active       | boolean                   | has this account been active in the last x months?
 is_bot          | boolean                   | is this a bot account?
 is_deleted      | boolean                   ||
@@ -48,8 +48,8 @@ blocks                     | |
 country                    | |
 cover                      | |
 favourite_beatmapset_count | number
-follow_user_mapping        | number[]
-follower_count             | number
+follow_user_mapping        | integer[]
+follower_count             | integer
 friends                    | |
 graveyard_beatmapset_count | number
 groups                     | [UserGroup](#usergroup)[]
@@ -91,8 +91,8 @@ total     | number
 
 Field         | Type        | Description
 --------------|-------------|------------
-id            | number      | |
-tournament_id | number      | |
+id            | integer     | |
+tournament_id | integer     | |
 image         | string?     | |
 image@2x      | string?     | |
 
@@ -126,8 +126,8 @@ updated_at | [Timestamp](#timestamp)
 Field       | Type      | Description
 ------------|-----------|------------
 description | string?   | |
-id          | number    | |
-length      | number    | In seconds.
+id          | integer   | |
+length      | integer   | In seconds.
 permanent   | boolean   | |
 timestamp   | Timestamp | |
 type        | string    | `note`, `restriction`, or `silence`.

--- a/resources/views/docs/_structures/user.md
+++ b/resources/views/docs/_structures/user.md
@@ -123,23 +123,23 @@ updated_at | [Timestamp](#timestamp)
 
 ### UserAccountHistory
 
-Field       | Type      | Description
-------------|-----------|------------
-description | string?   | |
-id          | integer   | |
-length      | integer   | In seconds.
-permanent   | boolean   | |
-timestamp   | Timestamp | |
-type        | string    | `note`, `restriction`, or `silence`.
+Field       | Type                    | Description
+------------|-------------------------|------------
+description | string?                 | |
+id          | integer                 | |
+length      | integer                 | In seconds.
+permanent   | boolean                 | |
+timestamp   | [Timestamp](#timestamp) | |
+type        | string                  | `note`, `restriction`, or `silence`.
 
 <div id="user-userbadge" data-unique="user-userbadge"></div>
 
 ### UserBadge
 
-Field        | Type      | Description
--------------|-----------|------------
-awarded_at   | Timestamp | |
-description  | string    | |
-image@2x_url | string    | |
-image_url    | string    | |
-url          | string    | |
+Field        | Type                    | Description
+-------------|-------------------------|------------
+awarded_at   | [Timestamp](#timestamp) | |
+description  | string                  | |
+image@2x_url | string                  | |
+image_url    | string                  | |
+url          | string                  | |

--- a/resources/views/docs/_structures/user.md
+++ b/resources/views/docs/_structures/user.md
@@ -43,21 +43,21 @@ Field                      | Type
 account_history            | [User.UserAccountHistory](#user-useraccounthistory)[]
 active_tournament_banner   | [User.ProfileBanner](#user-profilebanner)?
 badges                     | [User.UserBadge](#user-userbadge)[]
-beatmap_playcounts_count   | number
+beatmap_playcounts_count   | integer
 blocks                     | |
 country                    | |
 cover                      | |
-favourite_beatmapset_count | number
+favourite_beatmapset_count | integer
 follow_user_mapping        | integer[]
 follower_count             | integer
 friends                    | |
-graveyard_beatmapset_count | number
+graveyard_beatmapset_count | integer
 groups                     | [UserGroup](#usergroup)[]
-guest_beatmapset_count     | number
+guest_beatmapset_count     | integer
 is_restricted              | boolean?
 kudosu                     | [User.Kudosu](#user-kudosu)
-loved_beatmapset_count     | number
-mapping_follower_count     | number
+loved_beatmapset_count     | integer
+mapping_follower_count     | integer
 monthly_playcounts         | [UserMonthlyPlaycount](#usermonthlyplaycount)[]
 page                       | |
 pending_beatmapset_count   | |
@@ -66,9 +66,9 @@ rank_highest               | [User.RankHighest](#user-rankhighest)?
 rank_history               | |
 ranked_beatmapset_count    | |
 replays_watched_counts     | |
-scores_best_count          | number
-scores_first_count         | number
-scores_recent_count        | number
+scores_best_count          | integer
+scores_first_count         | integer
+scores_recent_count        | integer
 statistics                 | |
 statistics_rulesets        | UserStatisticsRulesets
 support_level              | |
@@ -82,8 +82,8 @@ user_preferences           | |
 
 Field     | Type
 ----------|-----
-available | number
-total     | number
+available | integer
+total     | integer
 
 <div id="user-profilebanner" data-unique="user-profilebanner"></div>
 
@@ -116,7 +116,7 @@ image@2x      | string?     | |
 
 Field      | Type
 -----------|-----
-rank       | number
+rank       | integer
 updated_at | [Timestamp](#timestamp)
 
 <div id="user-useraccounthistory" data-unique="user-useraccounthistory"></div>

--- a/resources/views/docs/_structures/user_extended.md
+++ b/resources/views/docs/_structures/user_extended.md
@@ -177,7 +177,7 @@ max_friends      | integer                            | maximum number of friend
 occupation       | string?                            | |
 playmode         | [Ruleset](#ruleset)                | |
 playstyle        | string[]                           | Device choices of the user.
-post_count       | integer                            | integerof forum posts
+post_count       | integer                            | Number of forum posts
 profile_order    | [ProfilePage](#user-profilepage)[] | ordered array of sections in user profile page
 title            | string?                            | user-specific title
 title_url        | string?                            | |

--- a/resources/views/docs/_structures/user_extended.md
+++ b/resources/views/docs/_structures/user_extended.md
@@ -175,7 +175,7 @@ location         | string?                            | |
 max_blocks       | number                             | maximum number of users allowed to be blocked
 max_friends      | number                             | maximum number of friends allowed to be added
 occupation       | string?                            | |
-playmode         | [GameMode](#gamemode)              | |
+playmode         | [Ruleset](#ruleset)                | |
 playstyle        | string[]                           | Device choices of the user.
 post_count       | number                             | number of forum posts
 profile_order    | [ProfilePage](#user-profilepage)[] | ordered array of sections in user profile page

--- a/resources/views/docs/_structures/user_extended.md
+++ b/resources/views/docs/_structures/user_extended.md
@@ -172,12 +172,12 @@ has_supported    | boolean                            | whether or not ever bein
 interests        | string?                            | |
 join_date        | Timestamp                          | |
 location         | string?                            | |
-max_blocks       | number                             | maximum number of users allowed to be blocked
-max_friends      | number                             | maximum number of friends allowed to be added
+max_blocks       | integer                            | maximum number of users allowed to be blocked
+max_friends      | integer                            | maximum number of friends allowed to be added
 occupation       | string?                            | |
 playmode         | [Ruleset](#ruleset)                | |
 playstyle        | string[]                           | Device choices of the user.
-post_count       | number                             | number of forum posts
+post_count       | integer                            | integerof forum posts
 profile_order    | [ProfilePage](#user-profilepage)[] | ordered array of sections in user profile page
 title            | string?                            | user-specific title
 title_url        | string?                            | |

--- a/resources/views/docs/_structures/user_group.md
+++ b/resources/views/docs/_structures/user_group.md
@@ -4,4 +4,4 @@ Describes a [Group](#group) membership of a [User](#user). It contains all of th
 
 Field     | Type      | Description
 ----------|-----------|------------------------------------------------------------
-playmodes | string[]? | [GameModes](#gamemode) associated with this membership (null if `has_playmodes` is unset).
+playmodes | string[]? | [Rulesets](#ruleset) associated with this membership (null if `has_playmodes` is unset).

--- a/resources/views/docs/_structures/user_silence.md
+++ b/resources/views/docs/_structures/user_silence.md
@@ -8,7 +8,7 @@
 
 A record indicating a [User](#user) was silenced.
 
-Field   | Type   | Description
-------- |------- |------------------------------------------------------------
-id      | number | id of this object.
-user_id | number | id of the [User](#user) that was silenced
+Field   | Type    | Description
+------- |-------- |------------------------------------------------------------
+id      | integer | id of this object.
+user_id | integer | id of the [User](#user) that was silenced

--- a/resources/views/docs/_structures/user_statistics.md
+++ b/resources/views/docs/_structures/user_statistics.md
@@ -53,7 +53,7 @@
 }
 ```
 
-A summary of various gameplay statistics for a [User](#user). Specific to a [GameMode](#gamemode)
+A summary of various gameplay statistics for a [User](#user). Specific to a [Ruleset](#ruleset)
 
 Field                     | Type          | Description
 ------------------------- | ------------- | -----------

--- a/resources/views/docs/_structures/user_statistics.md
+++ b/resources/views/docs/_structures/user_statistics.md
@@ -62,24 +62,24 @@ count_300                 | integer       | |
 count_50                  | integer       | |
 count_miss                | integer       | |
 country_rank              | integer?      | Current country rank according to pp.
-grade_counts.a            | integer       | integerof A ranked scores.
-grade_counts.s            | integer       | integerof S ranked scores.
-grade_counts.sh           | integer       | integerof Silver S ranked scores.
-grade_counts.ss           | integer       | integerof SS ranked scores.
-grade_counts.ssh          | integer       | integerof Silver SS ranked scores.
+grade_counts.a            | integer       | Number of A ranked scores.
+grade_counts.s            | integer       | Number of S ranked scores.
+grade_counts.sh           | integer       | Number of Silver S ranked scores.
+grade_counts.ss           | integer       | Number of SS ranked scores.
+grade_counts.ssh          | integer       | Number of Silver SS ranked scores.
 hit_accuracy              | float         | Hit accuracy percentage
 is_ranked                 | boolean       | Is actively ranked
 level.current             | integer       | Current level.
 level.progress            | float         | Progress to next level.
 maximum_combo             | integer       | Highest maximum combo.
-play_count                | integer       | integerof maps played.
+play_count                | integer       | Number of maps played.
 play_time                 | integer       | Cumulative time played.
 pp                        | float         | Performance points
 pp_exp                    | float         | Experimental (lazer) performance points
 global_rank               | integer?      | Current rank according to pp.
 global_rank_exp           | integer?      | Current rank according to experimental (lazer) pp.
 ranked_score              | integer       | Current ranked score.
-replays_watched_by_others | integer       | integerof replays watched by other users.
+replays_watched_by_others | integer       | Number of replays watched by other users.
 total_hits                | integer       | Total number of hits.
 total_score               | integer       | Total score.
 user                      | [User](#user) | The associated user.

--- a/resources/views/docs/_structures/user_statistics.md
+++ b/resources/views/docs/_structures/user_statistics.md
@@ -57,29 +57,29 @@ A summary of various gameplay statistics for a [User](#user). Specific to a [Rul
 
 Field                     | Type          | Description
 ------------------------- | ------------- | -----------
-count_100                 | number        | |
-count_300                 | number        | |
-count_50                  | number        | |
-count_miss                | number        | |
-country_rank              | number?       | Current country rank according to pp.
-grade_counts.a            | number        | Number of A ranked scores.
-grade_counts.s            | number        | Number of S ranked scores.
-grade_counts.sh           | number        | Number of Silver S ranked scores.
-grade_counts.ss           | number        | Number of SS ranked scores.
-grade_counts.ssh          | number        | Number of Silver SS ranked scores.
-hit_accuracy              | number        | Hit accuracy percentage
+count_100                 | integer       | |
+count_300                 | integer       | |
+count_50                  | integer       | |
+count_miss                | integer       | |
+country_rank              | integer?      | Current country rank according to pp.
+grade_counts.a            | integer       | integerof A ranked scores.
+grade_counts.s            | integer       | integerof S ranked scores.
+grade_counts.sh           | integer       | integerof Silver S ranked scores.
+grade_counts.ss           | integer       | integerof SS ranked scores.
+grade_counts.ssh          | integer       | integerof Silver SS ranked scores.
+hit_accuracy              | float         | Hit accuracy percentage
 is_ranked                 | boolean       | Is actively ranked
-level.current             | number        | Current level.
-level.progress            | number        | Progress to next level.
-maximum_combo             | number        | Highest maximum combo.
-play_count                | number        | Number of maps played.
-play_time                 | number        | Cumulative time played.
-pp                        | number        | Performance points
-pp_exp                    | number        | Experimental (lazer) performance points
-global_rank               | number?       | Current rank according to pp.
-global_rank_exp           | number?       | Current rank according to experimental (lazer) pp.
-ranked_score              | number        | Current ranked score.
-replays_watched_by_others | number        | Number of replays watched by other users.
-total_hits                | number        | Total number of hits.
-total_score               | number        | Total score.
+level.current             | integer       | Current level.
+level.progress            | float         | Progress to next level.
+maximum_combo             | integer       | Highest maximum combo.
+play_count                | integer       | integerof maps played.
+play_time                 | integer       | Cumulative time played.
+pp                        | float         | Performance points
+pp_exp                    | float         | Experimental (lazer) performance points
+global_rank               | integer?      | Current rank according to pp.
+global_rank_exp           | integer?      | Current rank according to experimental (lazer) pp.
+ranked_score              | integer       | Current ranked score.
+replays_watched_by_others | integer       | integerof replays watched by other users.
+total_hits                | integer       | Total number of hits.
+total_score               | integer       | Total score.
 user                      | [User](#user) | The associated user.

--- a/resources/views/docs/_websocket_events.md
+++ b/resources/views/docs/_websocket_events.md
@@ -37,10 +37,10 @@ Sent when a notification has been read.
 
 TODO: `ids` should be moved to `data` to match other events.
 
-Field | Type     | Description
------ | -------- | ----------------------------------
-event | string   | `read`
-ids   | number[] | id of Notifications which are read
+Field | Type      | Description
+----- | --------- | ----------------------------------
+event | string    | `read`
+ids   | integer[] | id of Notifications which are read
 
 ## chat.channel.join
 

--- a/resources/views/docs/auth.blade.php
+++ b/resources/views/docs/auth.blade.php
@@ -120,7 +120,7 @@ Restricted users can grant authorization like anyone else. If your client should
             'client_id' => [
                 'description' => 'The Client ID you received when you [registered]('.route('account.edit').'#new-oauth-application).',
                 'name' => 'client_id',
-                'type' => 'number',
+                'type' => 'integer',
                 'example' => 1,
             ],
             'redirect_uri' => [
@@ -173,12 +173,12 @@ Restricted users can grant authorization like anyone else. If your client should
 
         Successful requests will be issued an access token:
 
-        Name          | Type   | Description
-        --------------|--------|-----------------------------
-        token_type    | string | The type of token, this should always be `Bearer`.
-        expires_in    | number | The number of seconds the token will be valid for.
-        access_token  | string | The access token.
-        refresh_token | string | The refresh token.
+        Name          | Type    | Description
+        --------------|---------|-----------------------------
+        token_type    | string  | The type of token, this should always be `Bearer`.
+        expires_in    | integer | The number of seconds the token will be valid for.
+        access_token  | string  | The access token.
+        refresh_token | string  | The refresh token.
         EOT;
     $uri = route('oauth.passport.token', null, false);
     $endpoint = new OutputEndpointData([
@@ -258,11 +258,11 @@ Restricted users can grant authorization like anyone else. If your client should
         Successful requests will be issued an access token and a new refresh token:
 
         Name          | Type   | Description
-        --------------|--------|-----------------------------
-        token_type    | string | The type of token, this should always be `Bearer`.
-        expires_in    | number | The number of seconds the token will be valid for.
-        access_token  | string | The access token.
-        refresh_token | string | The refresh token.
+        --------------|---------|-----------------------------
+        token_type    | string  | The type of token, this should always be `Bearer`.
+        expires_in    | integer | The number of seconds the token will be valid for.
+        access_token  | string  | The access token.
+        refresh_token | string  | The refresh token.
         EOT;
     $uri = route('oauth.passport.token', null, false);
     $endpoint = new OutputEndpointData([
@@ -271,7 +271,7 @@ Restricted users can grant authorization like anyone else. If your client should
                 'description' => 'The Client ID you received when you [registered]('.route('account.edit').'#new-oauth-application).',
                 'name' => 'client_id',
                 'required' => true,
-                'type' => 'number',
+                'type' => 'integer',
                 'example' => 1,
             ],
             'client_secret' => [
@@ -345,11 +345,11 @@ Restricted users can grant authorization like anyone else. If your client should
 
         Successful requests will be issued an access token:
 
-        Name          | Type   | Description
-        --------------|--------|-----------------------------
-        token_type    | string | The type of token, this should always be `Bearer`.
-        expires_in    | number | The number of seconds the token will be valid for.
-        access_token  | string | The access token.
+        Name          | Type    | Description
+        --------------|---------|-----------------------------
+        token_type    | string  | The type of token, this should always be `Bearer`.
+        expires_in    | integer | The number of seconds the token will be valid for.
+        access_token  | string  | The access token.
         EOT;
     $uri = route('oauth.passport.token', null, false);
     $endpoint = new OutputEndpointData([
@@ -358,7 +358,7 @@ Restricted users can grant authorization like anyone else. If your client should
                 'description' => 'The Client ID you received when you [registered]('.route('account.edit').'#new-oauth-application).',
                 'name' => 'client_id',
                 'required' => true,
-                'type' => 'number',
+                'type' => 'integer',
                 'example' => 1,
             ],
             'client_secret' => [

--- a/resources/views/docs/info.md.blade.php
+++ b/resources/views/docs/info.md.blade.php
@@ -34,6 +34,10 @@ For a full list of changes, see the
 
 ## Breaking Changes
 
+### 2023-10-17
+- GameMode has been renamed to [Ruleset](#ruleset); existing property names remain unchanged.
+- `number` has been removed from documentation and replaced with `integer` or `float` to better reflect the type of number.
+
 ### 2023-09-11
 - object structures with two main variants (Beatmap, Beatmapset, and User) have their naming changed. The base object which previously has `Compact` suffix has their suffix removed and the previously extended object with no suffix now has `Extended` suffix instead. This matches existing TypeScript interface.
 


### PR DESCRIPTION
- `number` is now either `integer` or `float` (a reversal from https://github.com/ppy/osu-web/pull/10618#discussion_r1358134093 which is what made me think about this); while JSON doesn't define either, JSON Schema has at least `integer` and it's more useful for API consumers in other languages to know if a number if an integer or not.
- date strings should now all be `Timestamp`
- `GameMode` is now `Ruleset` to match our naming for it going forward

There's other stuff like more linking to types and the `Multiplayer*` structures being in code blocks for some reason❔ that will be done separately


... it would be nice if we could just stick attributes on the transformers or something and have the correct type and markdown tables generated 👀 