### PR TITLE
Support annotations to handle cursor_string parameter for apidocs

### DIFF
--- a/app/Docs/Strategies/UsesCursor.php
+++ b/app/Docs/Strategies/UsesCursor.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace App\Docs\Strategies;
+
+use Knuckles\Camel\Extraction\ExtractedEndpointData;
+use Knuckles\Scribe\Extracting\RouteDocBlocker;
+use Knuckles\Scribe\Extracting\Strategies\Strategy;
+
+class UsesCursor extends Strategy
+{
+    public function __invoke(ExtractedEndpointData $endpointData, array $routeRules = []): ?array
+    {
+        $docBlock = RouteDocBlocker::getDocBlocksFromRoute($endpointData->route)['method'];
+        $tags = $docBlock->getTagsByName('usesCursor');
+
+        if (empty($tags)) {
+            return [];
+        }
+
+        return [
+            'cursor_string' => [
+                'description' => '[CursorString](#cursorstring) for pagination.',
+                'required' => false,
+                'example' => null,
+            ],
+        ];
+    }
+}

--- a/app/Docs/Strategies/UsesCursor.php
+++ b/app/Docs/Strategies/UsesCursor.php
@@ -1,5 +1,10 @@
 <?php
 
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
+declare(strict_types=1);
+
 namespace App\Docs\Strategies;
 
 use Knuckles\Camel\Extraction\ExtractedEndpointData;
@@ -13,16 +18,14 @@ class UsesCursor extends Strategy
         $docBlock = RouteDocBlocker::getDocBlocksFromRoute($endpointData->route)['method'];
         $tags = $docBlock->getTagsByName('usesCursor');
 
-        if (empty($tags)) {
-            return [];
-        }
-
-        return [
-            'cursor_string' => [
-                'description' => '[CursorString](#cursorstring) for pagination.',
-                'required' => false,
-                'example' => null,
-            ],
-        ];
+        return empty($tags)
+            ? []
+            : [
+                'cursor_string' => [
+                    'description' => '[CursorString](#cursorstring) for pagination.',
+                    'required' => false,
+                    'example' => null,
+                ],
+            ];
     }
 }

--- a/app/Http/Controllers/BeatmapDiscussionsController.php
+++ b/app/Http/Controllers/BeatmapDiscussionsController.php
@@ -90,6 +90,7 @@ class BeatmapDiscussionsController extends Controller
      * reviews_config.max_blocks | number                                          | Maximum number of blocks allowed in a review.
      * users                     | [User](#user)[]                                 | List of users associated with the discussions returned.
      *
+     * @usesCursor
      * @queryParam beatmap_id `id` of the [Beatmap](#beatmap).
      * @queryParam beatmapset_id `id` of the [Beatmapset](#beatmapset).
      * @queryParam beatmapset_status One of `all`, `ranked`, `qualified`, `disqualified`, `never_qualified`. Defaults to `all`. TODO: better descriptions.

--- a/app/Http/Controllers/BeatmapPacksController.php
+++ b/app/Http/Controllers/BeatmapPacksController.php
@@ -37,7 +37,7 @@ class BeatmapPacksController extends Controller
      * ------------- | -----------------------------
      * beatmap_packs | [BeatmapPack](#beatmappack)[]
      *
-     * @queryParam cursor_string Parameter for pagination.
+     * @usesCursor
      * @queryParam type string [BeatmapPackType](#beatmappacktype) of the beatmap packs to be returned. Defaults to `standard`.
      */
     public function index()

--- a/app/Http/Controllers/BeatmapsetsController.php
+++ b/app/Http/Controllers/BeatmapsetsController.php
@@ -25,6 +25,9 @@ use Carbon\Carbon;
 use DB;
 use Request;
 
+/**
+ * @group Beatmapsets
+ */
 class BeatmapsetsController extends Controller
 {
     public function __construct()
@@ -110,6 +113,11 @@ class BeatmapsetsController extends Controller
         }
     }
 
+    /**
+     * TODO: documentation
+     *
+     * @usesCursor
+     */
     public function search()
     {
         $response = $this->getSearchResponse();

--- a/app/Http/Controllers/EventsController.php
+++ b/app/Http/Controllers/EventsController.php
@@ -35,7 +35,7 @@ class EventsController extends Controller
      * cursor_string | [CursorString](#cursorstring)
      * events        | [Event](#event)[]
      *
-     * @queryParam cursor_string Parameter for pagination. No-example
+     * @usesCursor
      * @queryParam sort Sorting option. Valid values are `id_desc` (default) and `id_asc`. No-example
      *
      * @response {

--- a/app/Http/Controllers/Forum/TopicsController.php
+++ b/app/Http/Controllers/Forum/TopicsController.php
@@ -285,7 +285,7 @@ class TopicsController extends Controller
      *
      * @urlParam topic integer required Id of the topic. Example: 1
      *
-     * @queryParam cursor_string Parameter for pagination. No-example
+     * @usesCursor
      * @queryParam sort Post sorting option. Valid values are `id_asc` (default) and `id_desc`. No-example
      * @queryParam limit Maximum number of posts to be returned (20 default, 50 at most). No-example
      * @queryParam start First post id to be returned with `sort` set to `id_asc`. This parameter is ignored if `cursor_string` is specified. No-example

--- a/app/Http/Controllers/Multiplayer/Rooms/Playlist/ScoresController.php
+++ b/app/Http/Controllers/Multiplayer/Rooms/Playlist/ScoresController.php
@@ -39,9 +39,9 @@ class ScoresController extends BaseController
      * @urlParam room integer required Id of the room.
      * @urlParam playlist integer required Id of the playlist item.
      *
+     * @usesCursor
      * @queryParam limit Number of scores to be returned.
      * @queryParam sort [MultiplayerScoresSort](#multiplayerscoressort) parameter.
-     * @queryParam cursor_string [CursorString](#cursorstring) parameter.
      */
     public function index($roomId, $playlistId)
     {

--- a/app/Http/Controllers/NewsController.php
+++ b/app/Http/Controllers/NewsController.php
@@ -36,9 +36,9 @@ class NewsController extends Controller
      *   <a href="#newspost">NewsPost</a> collections queried by year will also include posts published in November and December of the previous year if the current date is the same year and before April.
      * </aside>
      *
+     * @usesCursor
      * @queryParam limit integer Maximum number of posts (12 default, 1 minimum, 21 maximum). No-example
      * @queryParam year integer Year to return posts from. No-example
-     * @queryParam cursor_string [CursorString](#cursorstring) for pagination. No-example
      * @response {
      *   "news_posts": [
      *     {

--- a/config/scribe.php
+++ b/config/scribe.php
@@ -310,6 +310,7 @@ INTRO
             Strategies\QueryParameters\GetFromQueryParamTag::class,
             Strategies\QueryParameters\GetFromFormRequest::class,
             Strategies\QueryParameters\GetFromInlineValidator::class,
+            App\Docs\Strategies\UsesCursor::class,
         ],
         'headers' => [
             Strategies\Headers\GetFromRouteRules::class,


### PR DESCRIPTION
Standardize the `cursor_string` description instead of repeating the description text everywhere; some other params could probably be standardized as well.
The down side is they are all ordered at the bottom at the moment 🤔 