### PR TITLE
Use user_id for profile customisation model primary key

### DIFF
--- a/app/Models/UserProfileCustomization.php
+++ b/app/Models/UserProfileCustomization.php
@@ -41,10 +41,13 @@ class UserProfileCustomization extends Model
         'views' => ['all' => ['card', 'list', 'brick'], 'default' => 'card'],
     ];
 
+    public $incrementing = false;
+
     protected $casts = [
         'cover_json' => 'array',
         'options' => AsArrayObject::class,
     ];
+    protected $primaryKey = 'user_id';
 
     private $cover;
 


### PR DESCRIPTION
I don't remember why it has its own primary key ಠ_ಠ

I'll drop the column in a different PR since this needs to be deployed first.

On unrelated note, considering how frequent this model is needed just for the cover, I'm thinking of moving the cover column over to user model. It doesn't need to be a full json column, a normal varchar is sufficient.