### PR TITLE
update ossapi link

### DIFF
--- a/resources/views/docs/info.md.blade.php
+++ b/resources/views/docs/info.md.blade.php
@@ -22,7 +22,7 @@ Current rate limit is set at an insanely high 1200 requests per minute, with bur
 
 Below is a list of some language-specific wrappers maintained by the community. Your mileage may vary when using them – please report any issues to the wrapper first before reporting back to us.
 
-- [ossapi](https://github.com/circleguard/ossapi) (python)
+- [ossapi](https://github.com/tybug/ossapi) (python)
 - [aiosu](https://github.com/NiceAesth/aiosu) (python)
 - [rosu-v2](https://github.com/MaxOhn/rosu-v2) (rust)
 - [osu.js](https://github.com/L-Mario564/osu.js) (javascript/typescript)


### PR DESCRIPTION
I recently transferred the ossapi repository from the circleguard org to my personal account. Links currently redirect fine, but as I expect this move will be permanent, we might as well link avoid a redirect in the docs.