### PR TITLE
Drop id column from user profile customisations table

### DIFF
--- a/database/migrations/2023_10_24_122345_drop_id_from_user_profile_customizations.php
+++ b/database/migrations/2023_10_24_122345_drop_id_from_user_profile_customizations.php
@@ -1,0 +1,42 @@
+<?php
+
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('user_profile_customizations', function (Blueprint $table) {
+            $table->unsignedInteger('user_id')->nullable(false)->default(null)->change();
+            $table->dropColumn('id');
+            $table->primary('user_id');
+            $table->dropIndex('user_profile_customizations_user_id_unique');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('user_profile_customizations', function (Blueprint $table) {
+            $table->unsignedInteger('user_id')->nullable(false)->default(0)->change();
+            $table->unique('user_id');
+            $table->dropPrimary('user_id');
+        });
+
+        Schema::table('user_profile_customizations', function (Blueprint $table) {
+            $table->increments('id')->first();
+        });
+    }
+};


### PR DESCRIPTION
That's a lot more involved than I expected. I suspect a manual migration is required.

- [x] actual migrate on prod. Migration entry: `2023_10_24_122345_drop_id_from_user_profile_customizations`

```sql
alter table `user_profile_customizations` modify `user_id` int unsigned not null;
alter table `user_profile_customizations` drop `id`;
alter table `user_profile_customizations` add primary key (`user_id`);
alter table `user_profile_customizations` drop index `user_profile_customizations_user_id_unique`;
```