### PR TITLE
Remove unused multiplayer score link related columns

### DIFF
--- a/database/migrations/2023_10_25_093434_drop_unused_score_link_columns.php
+++ b/database/migrations/2023_10_25_093434_drop_unused_score_link_columns.php
@@ -1,0 +1,45 @@
+<?php
+
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('multiplayer_score_links', function (Blueprint $table) {
+            $table->dropColumn('id');
+            $table->dropColumn('room_id');
+            $table->dropColumn('beatmap_id');
+            $table->dropColumn('build_id');
+            $table->dropColumn('created_at');
+            $table->dropColumn('updated_at');
+            $table->primary('score_id');
+            $table->dropIndex(['score_id']);
+            $table->dropIndex('multiplayer_score_links_room_id_user_id_index');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('multiplayer_score_links', function (Blueprint $table) {
+            $table->dropPrimary('score_id');
+        });
+        Schema::table('multiplayer_score_links', function (Blueprint $table) {
+            $table->bigIncrements('id')->first();
+            $table->unsignedBigInteger('room_id')->after('user_id')->nullable(true);
+            $table->unsignedMediumInteger('beatmap_id')->after('playlist_item_id')->nullable(true);
+            $table->unsignedMediumInteger('build_id')->after('beatmap_id')->nullable(false)->default(0);
+            $table->timestamp('created_at');
+            $table->timestamp('updated_at');
+            $table->index(['score_id']);
+            $table->index(['room_id', 'user_id']);
+        });
+    }
+};

--- a/database/migrations/2023_10_25_094633_drop_score_link_id_from_multiplayer_scores_high.php
+++ b/database/migrations/2023_10_25_094633_drop_score_link_id_from_multiplayer_scores_high.php
@@ -1,0 +1,29 @@
+<?php
+
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('multiplayer_scores_high', function (Blueprint $table) {
+            $table->dropColumn('score_link_id');
+            $table->dropIndex('top_scores_linked');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('multiplayer_scores_high', function (Blueprint $table) {
+            $table->unsignedBigInteger('score_link_id')->after('score_id')->nullable(true);
+            $table->index(['playlist_item_id', DB::raw('total_score DESC'), 'score_link_id'], 'top_scores_linked');
+        });
+    }
+};

--- a/database/migrations/2023_10_25_094642_drop_last_score_link_id_from_multiplayer_rooms_high.php
+++ b/database/migrations/2023_10_25_094642_drop_last_score_link_id_from_multiplayer_rooms_high.php
@@ -1,0 +1,27 @@
+<?php
+
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('multiplayer_rooms_high', function (Blueprint $table) {
+            $table->dropColumn('last_score_link_id');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('multiplayer_rooms_high', function (Blueprint $table) {
+            $table->unsignedBigInteger('last_score_link_id')->after('last_score_id')->nullable(true);
+        });
+    }
+};


### PR DESCRIPTION
~~Three migrations, two of which should be pretty trivial (drop columns) but the last one is a bit involved and includes creating a new primary key so maybe another manual migration.~~

- [x] entry: `2023_10_25_093434_drop_unused_score_link_columns`
  ```sql
  alter table `multiplayer_score_links` drop `id`;
  alter table `multiplayer_score_links` drop `room_id`;
  alter table `multiplayer_score_links` drop `beatmap_id`;
  alter table `multiplayer_score_links` drop `build_id`;
  alter table `multiplayer_score_links` drop `created_at`;
  alter table `multiplayer_score_links` drop `updated_at`;
  alter table `multiplayer_score_links` add primary key (`score_id`);
  alter table `multiplayer_score_links` drop index `multiplayer_score_links_score_id_index`;
  alter table `multiplayer_score_links` drop index `multiplayer_score_links_room_id_user_id_index`;
  ```
- [x] entry: `2023_10_25_094633_drop_score_link_id_from_multiplayer_scores_high`
  ```sql
  alter table `multiplayer_scores_high` drop `score_link_id`;
  alter table `multiplayer_scores_high` drop index `top_scores_linked`;
  ```
- [x] entry: `2023_10_25_094642_drop_last_score_link_id_from_multiplayer_rooms_high`
  ```sql
  alter table `multiplayer_rooms_high` drop `last_score_link_id`;
  ```
