### PR TITLE
Fix multiplayer score mods not being validated properly when playlist item has no allowed mods

### DIFF
--- a/app/Models/Multiplayer/ScoreLink.php
+++ b/app/Models/Multiplayer/ScoreLink.php
@@ -81,13 +81,13 @@ class ScoreLink extends Model
                 }
             }
 
-            $missingMods = array_diff(
+            $disallowedMods = array_diff(
                 array_column($mods, 'acronym'),
                 array_column($this->playlistItem->required_mods, 'acronym'),
                 array_column($this->playlistItem->allowed_mods, 'acronym')
             );
 
-            if (!empty($missingMods)) {
+            if (!empty($disallowedMods)) {
                 throw new InvariantException('This play includes mods that are not allowed.');
             }
 

--- a/app/Models/Multiplayer/ScoreLink.php
+++ b/app/Models/Multiplayer/ScoreLink.php
@@ -81,16 +81,14 @@ class ScoreLink extends Model
                 }
             }
 
-            if (!empty($this->playlistItem->allowed_mods)) {
-                $missingMods = array_diff(
-                    array_column($mods, 'acronym'),
-                    array_column($this->playlistItem->required_mods, 'acronym'),
-                    array_column($this->playlistItem->allowed_mods, 'acronym')
-                );
+            $missingMods = array_diff(
+                array_column($mods, 'acronym'),
+                array_column($this->playlistItem->required_mods, 'acronym'),
+                array_column($this->playlistItem->allowed_mods, 'acronym')
+            );
 
-                if (!empty($missingMods)) {
-                    throw new InvariantException('This play includes mods that are not allowed.');
-                }
+            if (!empty($missingMods)) {
+                throw new InvariantException('This play includes mods that are not allowed.');
             }
 
             $this->score()->associate($score);

--- a/tests/Models/Multiplayer/ScoreLinkTest.php
+++ b/tests/Models/Multiplayer/ScoreLinkTest.php
@@ -8,7 +8,6 @@ declare(strict_types=1);
 namespace Tests\Models\Multiplayer;
 
 use App\Exceptions\InvariantException;
-use App\Models\Beatmap;
 use App\Models\Multiplayer\PlaylistItem;
 use App\Models\Multiplayer\ScoreLink;
 use App\Models\User;
@@ -20,7 +19,6 @@ class ScoreLinkTest extends TestCase
     public function testRequiredModsMissing()
     {
         $user = User::factory()->create();
-        $beatmap = Beatmap::factory()->create();
         $playlistItem = PlaylistItem::factory()->create([
             'required_mods' => [[
                 'acronym' => 'HD',
@@ -34,8 +32,8 @@ class ScoreLinkTest extends TestCase
         $this->expectException(InvariantException::class);
         $this->expectExceptionMessage('This play does not include the mods required.');
         $scoreLink->complete([
-            'beatmap_id' => $beatmap->getKey(),
-            'ruleset_id' => 0,
+            'beatmap_id' => $playlistItem->beatmap_id,
+            'ruleset_id' => $playlistItem->ruleset_id,
             'user_id' => $user->getKey(),
             'ended_at' => json_date(Carbon::now()),
             'mods' => [],
@@ -48,7 +46,6 @@ class ScoreLinkTest extends TestCase
     public function testRequiredModsPresent()
     {
         $user = User::factory()->create();
-        $beatmap = Beatmap::factory()->create();
         $playlistItem = PlaylistItem::factory()->create([
             'required_mods' => [[
                 'acronym' => 'HD',
@@ -61,8 +58,8 @@ class ScoreLinkTest extends TestCase
 
         $this->expectNotToPerformAssertions();
         $scoreLink->complete([
-            'beatmap_id' => $beatmap->getKey(),
-            'ruleset_id' => 0,
+            'beatmap_id' => $playlistItem->beatmap_id,
+            'ruleset_id' => $playlistItem->ruleset_id,
             'user_id' => $user->getKey(),
             'ended_at' => json_date(Carbon::now()),
             'mods' => [['acronym' => 'HD']],
@@ -75,7 +72,6 @@ class ScoreLinkTest extends TestCase
     public function testExpectedAllowedMod()
     {
         $user = User::factory()->create();
-        $beatmap = Beatmap::factory()->create();
         $playlistItem = PlaylistItem::factory()->create([
             'required_mods' => [[
                 'acronym' => 'DT',
@@ -91,8 +87,8 @@ class ScoreLinkTest extends TestCase
 
         $this->expectNotToPerformAssertions();
         $scoreLink->complete([
-            'beatmap_id' => $beatmap->getKey(),
-            'ruleset_id' => 0,
+            'beatmap_id' => $playlistItem->beatmap_id,
+            'ruleset_id' => $playlistItem->ruleset_id,
             'user_id' => $user->getKey(),
             'ended_at' => json_date(Carbon::now()),
             'mods' => [
@@ -108,7 +104,6 @@ class ScoreLinkTest extends TestCase
     public function testUnexpectedAllowedMod()
     {
         $user = User::factory()->create();
-        $beatmap = Beatmap::factory()->create();
         $playlistItem = PlaylistItem::factory()->create([
             'required_mods' => [[
                 'acronym' => 'DT',
@@ -125,8 +120,8 @@ class ScoreLinkTest extends TestCase
         $this->expectException(InvariantException::class);
         $this->expectExceptionMessage('This play includes mods that are not allowed.');
         $scoreLink->complete([
-            'beatmap_id' => $beatmap->getKey(),
-            'ruleset_id' => 0,
+            'beatmap_id' => $playlistItem->beatmap_id,
+            'ruleset_id' => $playlistItem->ruleset_id,
             'user_id' => $user->getKey(),
             'ended_at' => json_date(Carbon::now()),
             'mods' => [
@@ -142,7 +137,6 @@ class ScoreLinkTest extends TestCase
     public function testUnexpectedModWhenNoModsAreAllowed()
     {
         $user = User::factory()->create();
-        $beatmap = Beatmap::factory()->create();
         $playlistItem = PlaylistItem::factory()->create(); // no required or allowed mods.
         $scoreLink = ScoreLink::factory()->create([
             'user_id' => $user,
@@ -152,8 +146,8 @@ class ScoreLinkTest extends TestCase
         $this->expectException(InvariantException::class);
         $this->expectExceptionMessage('This play includes mods that are not allowed.');
         $scoreLink->complete([
-            'beatmap_id' => $beatmap->getKey(),
-            'ruleset_id' => 0,
+            'beatmap_id' => $playlistItem->beatmap_id,
+            'ruleset_id' => $playlistItem->ruleset_id,
             'user_id' => $user->getKey(),
             'ended_at' => json_date(Carbon::now()),
             'mods' => [['acronym' => 'HD']],

--- a/tests/Models/Multiplayer/ScoreLinkTest.php
+++ b/tests/Models/Multiplayer/ScoreLinkTest.php
@@ -1,0 +1,141 @@
+<?php
+
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
+declare(strict_types=1);
+
+namespace Tests\Models\Multiplayer;
+
+use App\Exceptions\InvariantException;
+use App\Models\Beatmap;
+use App\Models\Multiplayer\PlaylistItem;
+use App\Models\Multiplayer\ScoreLink;
+use App\Models\User;
+use Carbon\Carbon;
+use Tests\TestCase;
+
+class ScoreLinkTest extends TestCase
+{
+    public function testRequiredModsMissing()
+    {
+        $user = User::factory()->create();
+        $beatmap = Beatmap::factory()->create();
+        $playlistItem = PlaylistItem::factory()->create([
+            'required_mods' => [[
+                'acronym' => 'HD'
+            ]],
+        ]);
+        $scoreLink = ScoreLink::factory()->create([
+            'user_id' => $user,
+            'playlist_item_id' => $playlistItem
+        ]);
+
+        $this->expectException(InvariantException::class);
+        $this->expectExceptionMessage("This play does not include the mods required.");
+        $scoreLink->complete([
+            'beatmap_id' => $beatmap->getKey(),
+            'ruleset_id' => 0,
+            'user_id' => $user->getKey(),
+            'ended_at' => json_date(Carbon::now()),
+            'mods' => [],
+            'statistics' => [
+                'great' => 1
+            ]
+        ]);
+    }
+
+    public function testRequiredModsPresent()
+    {
+        $user = User::factory()->create();
+        $beatmap = Beatmap::factory()->create();
+        $playlistItem = PlaylistItem::factory()->create([
+            'required_mods' => [[
+                'acronym' => 'HD'
+            ]],
+        ]);
+        $scoreLink = ScoreLink::factory()->create([
+            'user_id' => $user,
+            'playlist_item_id' => $playlistItem
+        ]);
+
+        $this->expectNotToPerformAssertions();
+        $scoreLink->complete([
+            'beatmap_id' => $beatmap->getKey(),
+            'ruleset_id' => 0,
+            'user_id' => $user->getKey(),
+            'ended_at' => json_date(Carbon::now()),
+            'mods' => [['acronym' => 'HD']],
+            'statistics' => [
+                'great' => 1
+            ]
+        ]);
+    }
+
+    public function testExpectedAllowedMod()
+    {
+        $user = User::factory()->create();
+        $beatmap = Beatmap::factory()->create();
+        $playlistItem = PlaylistItem::factory()->create([
+            'required_mods' => [[
+                'acronym' => 'DT'
+            ]],
+            'allowed_mods' => [[
+                'acronym' => 'HD'
+            ]],
+        ]);
+        $scoreLink = ScoreLink::factory()->create([
+            'user_id' => $user,
+            'playlist_item_id' => $playlistItem
+        ]);
+
+        $this->expectNotToPerformAssertions();
+        $scoreLink->complete([
+            'beatmap_id' => $beatmap->getKey(),
+            'ruleset_id' => 0,
+            'user_id' => $user->getKey(),
+            'ended_at' => json_date(Carbon::now()),
+            'mods' => [
+                ['acronym' => 'DT'],
+                ['acronym' => 'HD']
+            ],
+            'statistics' => [
+                'great' => 1
+            ]
+        ]);
+    }
+
+    public function testUnexpectedAllowedMod()
+    {
+        $user = User::factory()->create();
+        $beatmap = Beatmap::factory()->create();
+        $playlistItem = PlaylistItem::factory()->create([
+            'required_mods' => [[
+                'acronym' => 'DT'
+            ]],
+            'allowed_mods' => [[
+                'acronym' => 'HR'
+            ]],
+        ]);
+        $scoreLink = ScoreLink::factory()->create([
+            'user_id' => $user,
+            'playlist_item_id' => $playlistItem
+        ]);
+
+        $this->expectException(InvariantException::class);
+        $this->expectExceptionMessage("This play includes mods that are not allowed.");
+        $scoreLink->complete([
+            'beatmap_id' => $beatmap->getKey(),
+            'ruleset_id' => 0,
+            'user_id' => $user->getKey(),
+            'ended_at' => json_date(Carbon::now()),
+            'mods' => [
+                ['acronym' => 'DT'],
+                ['acronym' => 'HD']
+            ],
+            'statistics' => [
+                'great' => 1
+            ]
+        ]);
+    }
+}

--- a/tests/Models/Multiplayer/ScoreLinkTest.php
+++ b/tests/Models/Multiplayer/ScoreLinkTest.php
@@ -23,16 +23,16 @@ class ScoreLinkTest extends TestCase
         $beatmap = Beatmap::factory()->create();
         $playlistItem = PlaylistItem::factory()->create([
             'required_mods' => [[
-                'acronym' => 'HD'
+                'acronym' => 'HD',
             ]],
         ]);
         $scoreLink = ScoreLink::factory()->create([
             'user_id' => $user,
-            'playlist_item_id' => $playlistItem
+            'playlist_item_id' => $playlistItem,
         ]);
 
         $this->expectException(InvariantException::class);
-        $this->expectExceptionMessage("This play does not include the mods required.");
+        $this->expectExceptionMessage('This play does not include the mods required.');
         $scoreLink->complete([
             'beatmap_id' => $beatmap->getKey(),
             'ruleset_id' => 0,
@@ -40,8 +40,8 @@ class ScoreLinkTest extends TestCase
             'ended_at' => json_date(Carbon::now()),
             'mods' => [],
             'statistics' => [
-                'great' => 1
-            ]
+                'great' => 1,
+            ],
         ]);
     }
 
@@ -51,12 +51,12 @@ class ScoreLinkTest extends TestCase
         $beatmap = Beatmap::factory()->create();
         $playlistItem = PlaylistItem::factory()->create([
             'required_mods' => [[
-                'acronym' => 'HD'
+                'acronym' => 'HD',
             ]],
         ]);
         $scoreLink = ScoreLink::factory()->create([
             'user_id' => $user,
-            'playlist_item_id' => $playlistItem
+            'playlist_item_id' => $playlistItem,
         ]);
 
         $this->expectNotToPerformAssertions();
@@ -67,8 +67,8 @@ class ScoreLinkTest extends TestCase
             'ended_at' => json_date(Carbon::now()),
             'mods' => [['acronym' => 'HD']],
             'statistics' => [
-                'great' => 1
-            ]
+                'great' => 1,
+            ],
         ]);
     }
 
@@ -78,15 +78,15 @@ class ScoreLinkTest extends TestCase
         $beatmap = Beatmap::factory()->create();
         $playlistItem = PlaylistItem::factory()->create([
             'required_mods' => [[
-                'acronym' => 'DT'
+                'acronym' => 'DT',
             ]],
             'allowed_mods' => [[
-                'acronym' => 'HD'
+                'acronym' => 'HD',
             ]],
         ]);
         $scoreLink = ScoreLink::factory()->create([
             'user_id' => $user,
-            'playlist_item_id' => $playlistItem
+            'playlist_item_id' => $playlistItem,
         ]);
 
         $this->expectNotToPerformAssertions();
@@ -97,11 +97,11 @@ class ScoreLinkTest extends TestCase
             'ended_at' => json_date(Carbon::now()),
             'mods' => [
                 ['acronym' => 'DT'],
-                ['acronym' => 'HD']
+                ['acronym' => 'HD'],
             ],
             'statistics' => [
-                'great' => 1
-            ]
+                'great' => 1,
+            ],
         ]);
     }
 
@@ -111,19 +111,19 @@ class ScoreLinkTest extends TestCase
         $beatmap = Beatmap::factory()->create();
         $playlistItem = PlaylistItem::factory()->create([
             'required_mods' => [[
-                'acronym' => 'DT'
+                'acronym' => 'DT',
             ]],
             'allowed_mods' => [[
-                'acronym' => 'HR'
+                'acronym' => 'HR',
             ]],
         ]);
         $scoreLink = ScoreLink::factory()->create([
             'user_id' => $user,
-            'playlist_item_id' => $playlistItem
+            'playlist_item_id' => $playlistItem,
         ]);
 
         $this->expectException(InvariantException::class);
-        $this->expectExceptionMessage("This play includes mods that are not allowed.");
+        $this->expectExceptionMessage('This play includes mods that are not allowed.');
         $scoreLink->complete([
             'beatmap_id' => $beatmap->getKey(),
             'ruleset_id' => 0,
@@ -131,11 +131,11 @@ class ScoreLinkTest extends TestCase
             'ended_at' => json_date(Carbon::now()),
             'mods' => [
                 ['acronym' => 'DT'],
-                ['acronym' => 'HD']
+                ['acronym' => 'HD'],
             ],
             'statistics' => [
-                'great' => 1
-            ]
+                'great' => 1,
+            ],
         ]);
     }
 
@@ -146,11 +146,11 @@ class ScoreLinkTest extends TestCase
         $playlistItem = PlaylistItem::factory()->create(); // no required or allowed mods.
         $scoreLink = ScoreLink::factory()->create([
             'user_id' => $user,
-            'playlist_item_id' => $playlistItem
+            'playlist_item_id' => $playlistItem,
         ]);
 
         $this->expectException(InvariantException::class);
-        $this->expectExceptionMessage("This play includes mods that are not allowed.");
+        $this->expectExceptionMessage('This play includes mods that are not allowed.');
         $scoreLink->complete([
             'beatmap_id' => $beatmap->getKey(),
             'ruleset_id' => 0,
@@ -158,8 +158,8 @@ class ScoreLinkTest extends TestCase
             'ended_at' => json_date(Carbon::now()),
             'mods' => [['acronym' => 'HD']],
             'statistics' => [
-                'great' => 1
-            ]
+                'great' => 1,
+            ],
         ]);
     }
 }

--- a/tests/Models/Multiplayer/ScoreLinkTest.php
+++ b/tests/Models/Multiplayer/ScoreLinkTest.php
@@ -138,4 +138,28 @@ class ScoreLinkTest extends TestCase
             ]
         ]);
     }
+
+    public function testUnexpectedModWhenNoModsAreAllowed()
+    {
+        $user = User::factory()->create();
+        $beatmap = Beatmap::factory()->create();
+        $playlistItem = PlaylistItem::factory()->create(); // no required or allowed mods.
+        $scoreLink = ScoreLink::factory()->create([
+            'user_id' => $user,
+            'playlist_item_id' => $playlistItem
+        ]);
+
+        $this->expectException(InvariantException::class);
+        $this->expectExceptionMessage("This play includes mods that are not allowed.");
+        $scoreLink->complete([
+            'beatmap_id' => $beatmap->getKey(),
+            'ruleset_id' => 0,
+            'user_id' => $user->getKey(),
+            'ended_at' => json_date(Carbon::now()),
+            'mods' => [['acronym' => 'HD']],
+            'statistics' => [
+                'great' => 1
+            ]
+        ]);
+    }
 }

--- a/tests/Models/Multiplayer/ScoreLinkTest.php
+++ b/tests/Models/Multiplayer/ScoreLinkTest.php
@@ -24,7 +24,8 @@ class ScoreLinkTest extends TestCase
                 'acronym' => 'HD',
             ]],
         ]);
-        $scoreLink = ScoreLink::factory()->create([
+        $scoreLink = ScoreLink::factory()->make([
+            'score_id' => null,
             'user_id' => $user,
             'playlist_item_id' => $playlistItem,
         ]);
@@ -51,7 +52,8 @@ class ScoreLinkTest extends TestCase
                 'acronym' => 'HD',
             ]],
         ]);
-        $scoreLink = ScoreLink::factory()->create([
+        $scoreLink = ScoreLink::factory()->make([
+            'score_id' => null,
             'user_id' => $user,
             'playlist_item_id' => $playlistItem,
         ]);
@@ -80,7 +82,8 @@ class ScoreLinkTest extends TestCase
                 'acronym' => 'HD',
             ]],
         ]);
-        $scoreLink = ScoreLink::factory()->create([
+        $scoreLink = ScoreLink::factory()->make([
+            'score_id' => null,
             'user_id' => $user,
             'playlist_item_id' => $playlistItem,
         ]);
@@ -112,7 +115,8 @@ class ScoreLinkTest extends TestCase
                 'acronym' => 'HR',
             ]],
         ]);
-        $scoreLink = ScoreLink::factory()->create([
+        $scoreLink = ScoreLink::factory()->make([
+            'score_id' => null,
             'user_id' => $user,
             'playlist_item_id' => $playlistItem,
         ]);
@@ -138,7 +142,8 @@ class ScoreLinkTest extends TestCase
     {
         $user = User::factory()->create();
         $playlistItem = PlaylistItem::factory()->create(); // no required or allowed mods.
-        $scoreLink = ScoreLink::factory()->create([
+        $scoreLink = ScoreLink::factory()->make([
+            'score_id' => null,
             'user_id' => $user,
             'playlist_item_id' => $playlistItem,
         ]);


### PR DESCRIPTION
The `allowed_mods` list being empty is not supposed to mean that any mod is allowed. Any and all allowed / "free" mods must (and will) be explicitly listed in `allowed_mods`; if the list is empty, then it means that the score's mods must be exactly set-equal to `required_mods`.

I discovered this when working on https://github.com/ppy/osu/issues/5378 - I was very surprised when web set me submit a play with the "Touch Device" mod active even when it was (by design) not included in either the required or allowed mods. As it turns out, it would only let me do this if no allowed / "free" mods were set; if at least one allowed mod was specified, the client would correctly report an error when trying to submit the score.

(And yeah that means I'm likely going to be adding a carve-out for the Touch Device mod so that it can be submitted regardless of required or allowed mods. In discussing this with the client team [we came to a conclusion that it'll probably be a hardcoded check for that specific mod for now](https://discord.com/channels/188630481301012481/188630652340404224/1168936077344657452) as we don't foresee this being needed very often in the future.)

Dunno if the included tests are up to scratch. They do seem to be working like I want them to, but they were mostly written using the process of trial and error (mostly error).