### PR TITLE
Move private method

### DIFF
--- a/app/Libraries/Countries.php
+++ b/app/Libraries/Countries.php
@@ -15,13 +15,13 @@ class Countries
 {
     use Memoizes;
 
-    private function allByCode(): Collection
-    {
-        return $this->memoize(__FUNCTION__, fn () => Country::get(['acronym', 'name'])->keyBy('acronym'));
-    }
-
     public function byCode(string $code): ?Country
     {
         return $this->allByCode()->get($code);
+    }
+
+    private function allByCode(): Collection
+    {
+        return $this->memoize(__FUNCTION__, fn () => Country::get(['acronym', 'name'])->keyBy('acronym'));
     }
 }


### PR DESCRIPTION
Accidentally accessed the method when doing review of another PR thinking it's public as it's the first method of the class.