### PR TITLE
Fix beatmap and spotlight selector blackout when navigating via history

### DIFF
--- a/resources/js/components/select-options.tsx
+++ b/resources/js/components/select-options.tsx
@@ -48,8 +48,7 @@ export default class SelectOptions<T extends Option> extends React.Component<Pro
     super(props);
     makeObservable(this);
     disposeOnUnmount(this, autorun(() => {
-      const value = this.props.blackout && this.showingSelector;
-      blackoutToggle(value, 0.5);
+      blackoutToggle(this.props.blackout && this.showingSelector, 0.5);
     }));
   }
 

--- a/resources/js/components/select-options.tsx
+++ b/resources/js/components/select-options.tsx
@@ -29,7 +29,7 @@ interface ComponentOptionRenderProps<T extends Option> {
 }
 
 interface Props<T extends Option> {
-  blackout?: boolean;
+  blackout: boolean;
   modifiers?: Modifiers;
   onChange: (option: T) => void;
   options: T[];
@@ -48,7 +48,7 @@ export default class SelectOptions<T extends Option> extends React.Component<Pro
     super(props);
     makeObservable(this);
     disposeOnUnmount(this, autorun(() => {
-      const value = (this.props.blackout ?? false) && this.showingSelector;
+      const value = this.props.blackout && this.showingSelector;
       blackoutToggle(value, 0.5);
     }));
   }

--- a/resources/js/components/select-options.tsx
+++ b/resources/js/components/select-options.tsx
@@ -52,6 +52,7 @@ export default class SelectOptions<T extends Option> extends React.Component<Pro
       (value) => {
         blackoutToggle(value ?? false, 0.5);
       },
+      { fireImmediately: true },
     ));
   }
 

--- a/resources/js/components/select-options.tsx
+++ b/resources/js/components/select-options.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
-import { action, observable, makeObservable, reaction } from 'mobx';
+import { action, autorun, makeObservable, observable } from 'mobx';
 import { disposeOnUnmount, observer } from 'mobx-react';
 import * as React from 'react';
 import { blackoutToggle } from 'utils/blackout';
@@ -47,13 +47,10 @@ export default class SelectOptions<T extends Option> extends React.Component<Pro
   constructor(props: Props<T>) {
     super(props);
     makeObservable(this);
-    disposeOnUnmount(this, reaction(
-      () => this.props.blackout && this.showingSelector,
-      (value) => {
-        blackoutToggle(value ?? false, 0.5);
-      },
-      { fireImmediately: true },
-    ));
+    disposeOnUnmount(this, autorun(() => {
+      const value = (this.props.blackout ?? false) && this.showingSelector;
+      blackoutToggle(value, 0.5);
+    }));
   }
 
   componentDidMount() {

--- a/resources/js/utils/blackout.ts
+++ b/resources/js/utils/blackout.ts
@@ -12,7 +12,7 @@ export function blackoutShow() {
 }
 
 export function blackoutToggle(state: boolean, opacity?: number) {
-  const el = document.querySelector('.js-blackout');
+  const el = window.newBody?.querySelector('.js-blackout');
 
   if (el instanceof HTMLElement) {
     el.style.opacity = !state || opacity == null ? '' : String(opacity);


### PR DESCRIPTION
Blackout doesn't get cleared/set properly on the discussion beatmap list and spotlights selector when they're open and navigating back/forwards to the page.