### PR TITLE
Use correct int size for multiplayer attempts column

### DIFF
--- a/database/migrations/2023_11_22_055714_change_multiplayer_scores_high_attempts_to_int.php
+++ b/database/migrations/2023_11_22_055714_change_multiplayer_scores_high_attempts_to_int.php
@@ -1,0 +1,27 @@
+<?php
+
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('multiplayer_scores_high', function (Blueprint $table) {
+            $table->unsignedInteger('attempts')->default(0)->change();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('multiplayer_scores_high', function (Blueprint $table) {
+            $table->unsignedTinyInteger('attempts')->default(0)->change();
+        });
+    }
+};


### PR DESCRIPTION
I'm not sure where it came from 🤨 (probably because I saw it on playlist item `max_attempts`)

This one matches the one in `multiplayer_rooms_high`

- [x] migration entry `2023_11_22_055714_change_multiplayer_scores_high_attempts_to_int` @peppy 