### PR TITLE
Fix incorrect check for completed playlist item

### DIFF
--- a/app/Models/Multiplayer/UserScoreAggregate.php
+++ b/app/Models/Multiplayer/UserScoreAggregate.php
@@ -202,7 +202,7 @@ class UserScoreAggregate extends Model
 
     private function updateUserTotal(ScoreLink $currentScoreLink, PlaylistItemUserHighScore $prev)
     {
-        if ($prev->exists) {
+        if ($prev->last_score_id !== null) {
             $this->total_score -= $prev->total_score;
             $this->accuracy -= $prev->accuracy;
             $this->pp -= $prev->pp;


### PR DESCRIPTION
The change to always create playlist item high score entry broke the exist check.

Note: untested.

Resolves #10778 (probably)