### PR TITLE
Don't render spoiler button in button

### DIFF
--- a/app/Libraries/BBCodeFromDB.php
+++ b/app/Libraries/BBCodeFromDB.php
@@ -62,7 +62,16 @@ class BBCodeFromDB
 
     public function parseBox($text)
     {
-        $text = preg_replace("#\[box=((\\\[\[\]]|[^][]|\[(\\\[\[\]]|[^][]|(?R))*\])*?):{$this->uid}\]\n*#s", $this->parseBoxHelperPrefix('\\1'), $text);
+        $text = preg_replace_callback("#\[box=((\\\[\[\]]|[^][]|\[(\\\[\[\]]|[^][]|(?R))*\])*?):{$this->uid}\]\n*#s", function ($m) {
+            // don't render button in button.
+            $escapedMatch = strtr($m[1], [
+                "[spoilerbox:{$this->uid}]" => '',
+                "[/spoilerbox:{$this->uid}]" => '',
+            ]);
+
+            return $this->parseBoxHelperPrefix($escapedMatch);
+        }, $text);
+
         $text = preg_replace("#\n*\[/box:{$this->uid}]\n?#s", $this->parseBoxHelperSuffix(), $text);
 
         $text = preg_replace("#\[spoilerbox:{$this->uid}\]\n*#s", $this->parseBoxHelperPrefix(), $text);

--- a/tests/Libraries/bbcode_examples/box_with_spoilerbox.base.txt
+++ b/tests/Libraries/bbcode_examples/box_with_spoilerbox.base.txt
@@ -1,0 +1,1 @@
+[box=button[spoilerbox]in button[/spoilerbox]]best regex[/box]

--- a/tests/Libraries/bbcode_examples/box_with_spoilerbox.db.txt
+++ b/tests/Libraries/bbcode_examples/box_with_spoilerbox.db.txt
@@ -1,0 +1,1 @@
+[box=button[spoilerbox:1]in button[/spoilerbox:1]:1]best regex[/box:1]

--- a/tests/Libraries/bbcode_examples/box_with_spoilerbox.html
+++ b/tests/Libraries/bbcode_examples/box_with_spoilerbox.html
@@ -1,0 +1,4 @@
+<div class="js-spoilerbox bbcode-spoilerbox">
+  <button class="js-spoilerbox__link bbcode-spoilerbox__link" type="button"><span class="bbcode-spoilerbox__link-icon"></span>buttonin button</button>
+  <div class="bbcode-spoilerbox__body">best regex</div>
+</div>


### PR DESCRIPTION
Nested `buttons` are not valid and will result in stupid rendering.
The best part is dev inspector will helpfully 'fix' the html tree so you don't actually see what's actually being rendered ( ﾟ ヮﾟ)