### PR TITLE
Update scores table structure

### DIFF
--- a/app/Models/Solo/Score.php
+++ b/app/Models/Solo/Score.php
@@ -24,12 +24,14 @@ use Storage;
 /**
  * @property int $beatmap_id
  * @property \Carbon\Carbon|null $created_at
- * @property \stdClass $data
- * @property \Carbon\Carbon|null $deleted_at
+ * @property string|null $created_at_json
+ * @property ScoreData $data
+ * @property bool $has_replay
  * @property int $id
  * @property bool $preserve
+ * @property bool $ranked
  * @property int $ruleset_id
- * @property \Carbon\Carbon|null $updated_at
+ * @property int $unix_updated_at
  * @property User $user
  * @property int $user_id
  */
@@ -38,6 +40,8 @@ class Score extends Model implements Traits\ReportableInterface
     use Traits\Reportable, Traits\WithWeightedPp;
 
     const PROCESSING_QUEUE = 'osu-queue:score-statistics';
+
+    public $timestamps = false;
 
     protected $casts = [
         'data' => ScoreData::class,
@@ -151,13 +155,13 @@ class Score extends Model implements Traits\ReportableInterface
             'data' => $this->getClassCastableAttributeValue($key, $this->getRawAttribute($key)),
 
             'has_replay',
-            'preserve' => (bool) $this->getRawAttribute($key),
+            'preserve',
+            'ranked' => (bool) $this->getRawAttribute($key),
 
-            'created_at',
-            'updated_at' => $this->getTimeFast($key),
+            'unix_updated_at' => $this->getRawAttribute($key),
 
-            'created_at_json',
-            'updated_at_json' => $this->getJsonTimeFast($key),
+            'created_at' => $this->getTimeFast($key),
+            'created_at_json' => $this->getJsonTimeFast($key),
 
             'pp' => $this->performance?->pp,
 

--- a/app/Models/Solo/Score.php
+++ b/app/Models/Solo/Score.php
@@ -150,6 +150,7 @@ class Score extends Model implements Traits\ReportableInterface
             'beatmap_id',
             'id',
             'ruleset_id',
+            'unix_updated_at',
             'user_id' => $this->getRawAttribute($key),
 
             'data' => $this->getClassCastableAttributeValue($key, $this->getRawAttribute($key)),
@@ -157,8 +158,6 @@ class Score extends Model implements Traits\ReportableInterface
             'has_replay',
             'preserve',
             'ranked' => (bool) $this->getRawAttribute($key),
-
-            'unix_updated_at' => $this->getRawAttribute($key),
 
             'created_at' => $this->getTimeFast($key),
             'created_at_json' => $this->getJsonTimeFast($key),

--- a/database/migrations/2023_12_18_085034_update_scores_table.php
+++ b/database/migrations/2023_12_18_085034_update_scores_table.php
@@ -1,0 +1,69 @@
+<?php
+
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    private static function resetView(): void
+    {
+        DB::statement('DROP VIEW scores');
+        DB::statement('CREATE VIEW scores AS SELECT * FROM solo_scores');
+    }
+
+    public function up(): void
+    {
+        Schema::table('solo_scores', function (Blueprint $table) {
+            $table->dropColumn('updated_at');
+
+            $table->dropIndex('solo_scores_beatmap_id_index');
+            $table->dropIndex('solo_scores_preserve_index');
+            $table->dropIndex('user_ruleset_id_index');
+
+            $table->boolean('ranked')->default(true)->after('preserve');
+            $table->unsignedInteger('unix_updated_at')->default(DB::raw('(unix_timestamp())'));
+            $table->timestamp('created_at')->useCurrent()->change();
+
+            $table->index(['user_id', 'ruleset_id'], 'user_ruleset_index');
+            $table->index(['beatmap_id', 'user_id'], 'beatmap_user_index');
+        });
+
+        DB::statement('ALTER TABLE solo_scores MODIFY id bigint unsigned NOT NULL');
+        DB::statement('ALTER TABLE solo_scores DROP PRIMARY KEY');
+        DB::statement('ALTER TABLE solo_scores ADD PRIMARY KEY (id, preserve, unix_updated_at)');
+        DB::statement('ALTER TABLE solo_scores MODIFY id bigint unsigned NOT NULL AUTO_INCREMENT');
+
+        static::resetView();
+    }
+
+    public function down(): void
+    {
+        Schema::table('solo_scores', function (Blueprint $table) {
+            $table->dropColumn('unix_updated_at');
+            $table->dropColumn('ranked');
+
+            $table->dropIndex('user_ruleset_index');
+            $table->dropIndex('beatmap_user_index');
+
+            $table->datetime('created_at')->change();
+            $table->timestamp('updated_at')->nullable(true);
+
+            $table->index('preserve', 'solo_scores_preserve_index');
+            $table->index('beatmap_id', 'solo_scores_beatmap_id_index');
+            $table->index(['user_id', 'ruleset_id', DB::raw('id DESC')], 'user_ruleset_id_index');
+        });
+
+        DB::statement('ALTER TABLE solo_scores MODIFY id bigint unsigned NOT NULL');
+        DB::statement('ALTER TABLE solo_scores DROP PRIMARY KEY');
+        DB::statement('ALTER TABLE solo_scores ADD PRIMARY KEY (id)');
+        DB::statement('ALTER TABLE solo_scores MODIFY id bigint unsigned NOT NULL AUTO_INCREMENT');
+
+        static::resetView();
+    }
+};


### PR DESCRIPTION
Matches current prod except the partitioning. 

- [x] migration entry `2023_12_18_085034_update_scores_table`
- [x] add `default current_timestamp` to `created_at` column in prod `solo_scores`