### PR TITLE
Reuse generated score id array for queue

### DIFF
--- a/app/Libraries/Search/ScoreSearch.php
+++ b/app/Libraries/Search/ScoreSearch.php
@@ -116,11 +116,13 @@ class ScoreSearch extends RecordSearch
 
         $schemas ??= $this->getActiveSchemas();
 
+        $values = array_map(
+            static fn (int $id): string => json_encode(['ScoreId' => $id]),
+            $ids,
+        );
+
         foreach ($schemas as $schema) {
-            LaravelRedis::lpush("osu-queue:score-index-{$schema}", ...array_map(
-                fn (int $id): string => json_encode(['ScoreId' => $id]),
-                $ids,
-            ));
+            LaravelRedis::lpush("osu-queue:score-index-{$schema}", ...$values);
         }
     }
 


### PR DESCRIPTION
Found this when cleaning up branches.