### PR TITLE
Add toggle for legacy score only view

### DIFF
--- a/app/Http/Controllers/AccountController.php
+++ b/app/Http/Controllers/AccountController.php
@@ -257,6 +257,7 @@ class AccountController extends Controller
             'comments_sort:string',
             'extras_order:string[]',
             'forum_posts_show_deleted:bool',
+            'legacy_score_only:bool',
             'profile_cover_expanded:bool',
             'user_list_filter:string',
             'user_list_sort:string',

--- a/app/Libraries/Search/ScoreSearchParams.php
+++ b/app/Libraries/Search/ScoreSearchParams.php
@@ -11,11 +11,26 @@ use App\Libraries\Elasticsearch\SearchParams;
 use App\Libraries\Elasticsearch\Sort;
 use App\Models\Solo\Score;
 use App\Models\User;
+use App\Models\UserProfileCustomization;
 
 class ScoreSearchParams extends SearchParams
 {
     const VALID_TYPES = ['global', 'country', 'friend'];
     const DEFAULT_TYPE = 'global';
+
+    public ?array $beatmapIds = null;
+    public ?Score $beforeScore = null;
+    public ?int $beforeTotalScore = null;
+    public ?array $excludeMods = null;
+    public ?bool $isLegacy = null;
+    public ?array $mods = null;
+    public ?int $rulesetId = null;
+    public $size = 50;
+    public ?User $user = null;
+    public ?int $userId = null;
+
+    private ?string $countryCode = null;
+    private string $type = self::DEFAULT_TYPE;
 
     public static function fromArray(array $rawParams): static
     {
@@ -39,19 +54,10 @@ class ScoreSearchParams extends SearchParams
         return $params;
     }
 
-    public ?array $beatmapIds = null;
-    public ?Score $beforeScore = null;
-    public ?int $beforeTotalScore = null;
-    public ?array $excludeMods = null;
-    public ?bool $isLegacy = null;
-    public ?array $mods = null;
-    public ?int $rulesetId = null;
-    public $size = 50;
-    public ?User $user = null;
-    public ?int $userId = null;
-
-    private ?string $countryCode = null;
-    private string $type = self::DEFAULT_TYPE;
+    public static function showLegacyForUser(?User $user): bool
+    {
+        return $user?->userProfileCustomization?->legacy_score_only ?? UserProfileCustomization::DEFAULT_LEGACY_ONLY_ATTRIBUTE;
+    }
 
     public function getCountryCode(): string
     {

--- a/app/Models/UserProfileCustomization.php
+++ b/app/Models/UserProfileCustomization.php
@@ -37,13 +37,13 @@ class UserProfileCustomization extends Model
 
     const BEATMAPSET_DOWNLOAD = ['all', 'no_video', 'direct'];
 
+    const DEFAULT_LEGACY_ONLY_ATTRIBUTE = true;
+
     const USER_LIST = [
         'filters' => ['all' => ['all', 'online', 'offline'], 'default' => 'all'],
         'sorts' => ['all' => ['last_visit', 'rank', 'username'], 'default' => 'last_visit'],
         'views' => ['all' => ['card', 'list', 'brick'], 'default' => 'card'],
     ];
-
-    private const DEFAULT_LEGACY_ONLY_ATTRIBUTE = true;
 
     public $incrementing = false;
 

--- a/app/Models/UserProfileCustomization.php
+++ b/app/Models/UserProfileCustomization.php
@@ -43,6 +43,8 @@ class UserProfileCustomization extends Model
         'views' => ['all' => ['card', 'list', 'brick'], 'default' => 'card'],
     ];
 
+    private const DEFAULT_LEGACY_ONLY_ATTRIBUTE = true;
+
     public $incrementing = false;
 
     protected $casts = [
@@ -192,6 +194,16 @@ class UserProfileCustomization extends Model
     public function setForumPostsShowDeletedAttribute($value)
     {
         $this->setOption('forum_posts_show_deleted', get_bool($value));
+    }
+
+    public function getLegacyScoreOnlyAttribute(): bool
+    {
+        return $this->options['legacy_score_only'] ?? static::DEFAULT_LEGACY_ONLY_ATTRIBUTE;
+    }
+
+    public function setLegacyScoreOnlyAttribute($value): void
+    {
+        $this->setOption('legacy_score_only', get_bool($value));
     }
 
     public function getUserListFilterAttribute()

--- a/app/Transformers/UserCompactTransformer.php
+++ b/app/Transformers/UserCompactTransformer.php
@@ -450,6 +450,7 @@ class UserCompactTransformer extends TransformerAbstract
             'beatmapset_title_show_original',
             'comments_show_deleted',
             'forum_posts_show_deleted',
+            'legacy_score_only',
             'profile_cover_expanded',
             'user_list_filter',
             'user_list_sort',


### PR DESCRIPTION
This doesn't do anything by itself but should theoretically allow me to update the other new score PRs without going back to interleaving the commits with each other.

I hope.

Added helper because it's needed in quite a few places.