### PR TITLE
👷 Also build images from private-staging-v2

### DIFF
--- a/.github/workflows/pack.yml
+++ b/.github/workflows/pack.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - master
       - private-staging
+      - private-staging-v2
     tags:
       - '*'
 


### PR DESCRIPTION
Going with branch builds, unless we go with tags instead? Would have to for automated deploys.