### PR TITLE
React typing fixes

### DIFF
--- a/resources/js/components/beatmapset-event.tsx
+++ b/resources/js/components/beatmapset-event.tsx
@@ -114,11 +114,11 @@ export default class BeatmapsetEvent extends React.PureComponent<Props> {
   }
 
   private content() {
-    let discussionLink: React.ReactElement | string = '';
-    let discussionUserLink: React.ReactElement | string = '[unknown user]';
-    let text: React.ReactElement | string = '';
+    let discussionLink: NonNullable<React.ReactNode> = '';
+    let discussionUserLink: NonNullable<React.ReactNode> = '[unknown user]';
+    let text: NonNullable<React.ReactNode> = '';
     let url = '';
-    let user: React.ReactElement | string | undefined;
+    let user: React.ReactNode;
 
     if (this.discussionId != null) {
       if (this.discussion == null) {

--- a/resources/js/components/beatmapset-event.tsx
+++ b/resources/js/components/beatmapset-event.tsx
@@ -114,11 +114,11 @@ export default class BeatmapsetEvent extends React.PureComponent<Props> {
   }
 
   private content() {
-    let discussionLink: React.ReactChild = '';
-    let discussionUserLink: React.ReactChild = '[unknown user]';
-    let text: React.ReactChild = '';
+    let discussionLink: React.ReactElement | number | string = '';
+    let discussionUserLink: React.ReactElement | number | string = '[unknown user]';
+    let text: React.ReactElement | number | string = '';
     let url = '';
-    let user: React.ReactChild | undefined;
+    let user: React.ReactElement | number | string | undefined;
 
     if (this.discussionId != null) {
       if (this.discussion == null) {

--- a/resources/js/components/beatmapset-event.tsx
+++ b/resources/js/components/beatmapset-event.tsx
@@ -114,11 +114,11 @@ export default class BeatmapsetEvent extends React.PureComponent<Props> {
   }
 
   private content() {
-    let discussionLink: React.ReactElement | number | string = '';
-    let discussionUserLink: React.ReactElement | number | string = '[unknown user]';
-    let text: React.ReactElement | number | string = '';
+    let discussionLink: React.ReactElement | string = '';
+    let discussionUserLink: React.ReactElement | string = '[unknown user]';
+    let text: React.ReactElement | string = '';
     let url = '';
-    let user: React.ReactElement | number | string | undefined;
+    let user: React.ReactElement | string | undefined;
 
     if (this.discussionId != null) {
       if (this.discussion == null) {

--- a/resources/js/components/modal.tsx
+++ b/resources/js/components/modal.tsx
@@ -8,13 +8,12 @@ import Portal from './portal';
 export const isModalOpen = () => modals.size !==  0;
 
 interface Props {
-  children: React.ReactNode;
   onClose?: () => void;
 }
 
 const modals = new Set<Modal>();
 
-export default class Modal extends React.PureComponent<Props> {
+export default class Modal extends React.PureComponent<React.PropsWithChildren<Props>> {
   private clickEndTarget: undefined | EventTarget;
   private clickStartTarget: undefined | EventTarget;
   private readonly ref = React.createRef<HTMLDivElement>();

--- a/resources/js/components/portal.ts
+++ b/resources/js/components/portal.ts
@@ -1,11 +1,10 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
-import { PureComponent, ReactNode } from 'react';
+import { PropsWithChildren, PureComponent } from 'react';
 import { createPortal } from 'react-dom';
 
 interface Props {
-  children: ReactNode;
   root?: Element;
 }
 
@@ -17,7 +16,7 @@ export function removeLeftoverPortalContainers() {
   }
 }
 
-export default class Portal extends PureComponent<Props> {
+export default class Portal extends PureComponent<PropsWithChildren<Props>> {
   private readonly container: HTMLDivElement;
 
   constructor(props: Props) {

--- a/resources/js/utils/lang.tsx
+++ b/resources/js/utils/lang.tsx
@@ -10,7 +10,7 @@ type Replacement = string | number;
 export type Replacements = Partial<Record<string, Replacement>>;
 
 export function joinComponents(array: React.ReactElement[], key = 'common.array_and') {
-  const nodes: React.ReactFragment[] = [];
+  const nodes: React.ReactNode[] = [];
 
   if (array.length > 0) {
     nodes.push(array[0]);


### PR DESCRIPTION
Some updates of the react types to prepare for updating to React 18.

`ReactChild` and `ReactFragment` are deprecated, `ReactFragment` not even actually a `Fragment`