### PR TITLE
Always push beatmaps to BSS queue after they become eligible for score submission

### DIFF
--- a/app/Models/Beatmapset.php
+++ b/app/Models/Beatmapset.php
@@ -688,6 +688,7 @@ class Beatmapset extends Model implements AfterCommit, Commentable, Indexable, T
             $this->events()->create(['type' => BeatmapsetEvent::QUALIFY]);
 
             $this->setApproved('qualified', $user);
+            $this->bssProcessQueues()->create();
 
             // global event
             Event::generate('beatmapsetApprove', ['beatmapset' => $this]);
@@ -829,7 +830,9 @@ class Beatmapset extends Model implements AfterCommit, Commentable, Indexable, T
 
         $this->getConnection()->transaction(function () use ($user, $beatmapIds) {
             $this->events()->create(['type' => BeatmapsetEvent::LOVE, 'user_id' => $user->user_id]);
+
             $this->setApproved('loved', $user, $beatmapIds);
+            $this->bssProcessQueues()->create();
 
             Event::generate('beatmapsetApprove', ['beatmapset' => $this]);
 

--- a/tests/Models/BeatmapsetTest.php
+++ b/tests/Models/BeatmapsetTest.php
@@ -39,6 +39,8 @@ class BeatmapsetTest extends TestCase
         $otherUser = User::factory()->create();
         $beatmapset->watches()->create(['user_id' => $otherUser->getKey()]);
 
+        $this->expectCountChange(fn () => $beatmapset->bssProcessQueues()->count(), 1);
+
         $beatmapset->love($user);
 
         $this->assertSame($notifications + 1, Notification::count());
@@ -116,6 +118,8 @@ class BeatmapsetTest extends TestCase
 
         $otherUser = User::factory()->create();
         $beatmapset->watches()->create(['user_id' => $otherUser->getKey()]);
+
+        $this->expectCountChange(fn () => $beatmapset->bssProcessQueues()->count(), 1);
 
         $beatmapset->qualify($user);
 


### PR DESCRIPTION
**Please exercise caution when reviewing. I'm PRing this in the hope that this can be helpful and at least partially offload other team members, but I only _sort of_ know what I'm doing here and operating mostly off intuition. Please take any steps that you feel expedient in validating the assumptions behind these changes, which I will attempt to explain below, first.**

---

The reasoning for this change is related to the introduction of legacy scoring attributes (https://github.com/ppy/osu-difficulty-calculator/pull/224) which are intended to be used by `osu-difficulty-calculator` to recalculate scores imported from stable to the new standardised scoring scheme.

Today it was revealed that some stable scores could not be imported to the new scoring tables due to missing legacy scoring attributes. In particular, said failing scores were set on [the following beatmap](https://osu.ppy.sh/beatmapsets/2004898).

The current working theory which intends to support this change is that the scoring attributes are missing for this beatmap due to the following coincidence of circumstances:

- During back-population of scoring attributes, the beatmap in question was excluded due to being in pending state
- The beatmap has not been updated by the creator since the back-population, meaning that it wouldn't have been pushed to `osu-difficulty-calculator` for reprocessing via the standard beatmap update flow
- At 20231228T130004Z the beatmap was qualified, which up until this change was a process involving `osu-web` only and as such would not queue the beatmap for BSS reprocessing.

Notably a similar sequence of events can also plausibly happen when loving a beatmap, as it is another case wherein a beatmap enters a state wherein scores set on it will be submitted and preserved in the database.

The suggested fix here is to queue the beatmap for a BSS reprocess after both of the aforementioned ranked status changes, which will - via the submission flow - ensure that the beatmap reaches `osu-difficulty-calculator` for reprocessing, and receive legacy scoring attributes as a result. This was already happening for newly-ranked beatmaps, so this is intended to simply be an extension of that.