### PR TITLE
Update `BanchoStats` to include `users_lazer` for online user count(s)

### DIFF
--- a/app/Libraries/CurrentStats.php
+++ b/app/Libraries/CurrentStats.php
@@ -6,7 +6,6 @@
 namespace App\Libraries;
 
 use App\Models\BanchoStats;
-use App\Models\Build;
 use App\Models\Count;
 use Auth;
 use Cache;

--- a/app/Libraries/CurrentStats.php
+++ b/app/Libraries/CurrentStats.php
@@ -25,10 +25,8 @@ class CurrentStats
             $stats = BanchoStats::stats();
             $latest = array_last($stats);
 
-            $online_users = Build::onlineUsers();
-
             return [
-                'currentOnline' => $online_users ?? 0,
+                'currentOnline' => Build::onlineUsers(),
                 'currentGames' => $latest['multiplayer_games'] ?? 0,
                 'graphData' => array_to_graph_json($stats, 'users_osu'),
                 'totalUsers' => Count::totalUsers()->count,

--- a/app/Libraries/CurrentStats.php
+++ b/app/Libraries/CurrentStats.php
@@ -6,6 +6,7 @@
 namespace App\Libraries;
 
 use App\Models\BanchoStats;
+use App\Models\Build;
 use App\Models\Count;
 use Auth;
 use Cache;
@@ -24,8 +25,10 @@ class CurrentStats
             $stats = BanchoStats::stats();
             $latest = array_last($stats);
 
+            $online_users = Build::onlineUsers();
+
             return [
-                'currentOnline' => $latest['users_osu'] ?? 0,
+                'currentOnline' => $online_users ?? 0,
                 'currentGames' => $latest['multiplayer_games'] ?? 0,
                 'graphData' => array_to_graph_json($stats, 'users_osu'),
                 'totalUsers' => Count::totalUsers()->count,

--- a/app/Libraries/CurrentStats.php
+++ b/app/Libraries/CurrentStats.php
@@ -26,9 +26,9 @@ class CurrentStats
             $latest = array_last($stats);
 
             return [
-                'currentOnline' => Build::onlineUsers(),
+                'currentOnline' => $latest['users'] ?? 0,
                 'currentGames' => $latest['multiplayer_games'] ?? 0,
-                'graphData' => array_to_graph_json($stats, 'users_osu'),
+                'graphData' => array_to_graph_json($stats, 'users'),
                 'totalUsers' => Count::totalUsers()->count,
             ];
         });

--- a/app/Models/BanchoStats.php
+++ b/app/Models/BanchoStats.php
@@ -5,12 +5,15 @@
 
 namespace App\Models;
 
+use Illuminate\Support\Facades\DB;
+
 /**
  * @property int $banchostats_id
  * @property \Carbon\Carbon $date
  * @property int $multiplayer_games
  * @property int $users_irc
  * @property int $users_osu
+ * @property int $users_lazer
  */
 class BanchoStats extends Model
 {
@@ -23,7 +26,7 @@ class BanchoStats extends Model
     {
         return array_reverse(
             static::whereRaw('banchostats_id mod 10 = 0')
-                ->select(['users_irc', 'users_osu', 'multiplayer_games', 'date'])
+                ->select(['users_irc', DB::raw('(users_osu + users_lazer) AS users'), 'multiplayer_games', 'date'])
                 ->orderBy('banchostats_id', 'DESC')
                 ->limit(24 * 60 / 10)
                 ->get()

--- a/app/Models/Build.php
+++ b/app/Models/Build.php
@@ -252,7 +252,7 @@ class Build extends Model implements Commentable
         // In order to not double-count users, we must use the "main" releases which will never have a stream_id.
         return static
             ::where('allow_bancho', 1)
-            ->whereNull('stream_id')
+            ->whereNotNull('stream_id')
             ->sum('users');
     }
 }

--- a/app/Models/Build.php
+++ b/app/Models/Build.php
@@ -248,6 +248,11 @@ class Build extends Model implements Commentable
 
     public static function onlineUsers()
     {
-        return static::where('allow_bancho', 1)->sum('users');
+        // Lazer builds uses "fake" release rows to track platform-specific builds
+        // In order to not double-count users, we must use the "main" releases which will never have a hash.
+        return static
+            ::where('allow_bancho', 1)
+            ->whereNull('hash')
+            ->sum('users');
     }
 }

--- a/app/Models/Build.php
+++ b/app/Models/Build.php
@@ -245,14 +245,4 @@ class Build extends Model implements Commentable
     {
         return preg_replace('#[^0-9.]#', '', $this->version);
     }
-
-    public static function onlineUsers()
-    {
-        // Lazer builds uses "fake" release rows to track platform-specific builds
-        // In order to not double-count users, we must use the "main" releases which will always have a stream_id.
-        return static
-            ::where('allow_bancho', 1)
-            ->whereNotNull('stream_id')
-            ->sum('users');
-    }
 }

--- a/app/Models/Build.php
+++ b/app/Models/Build.php
@@ -249,10 +249,10 @@ class Build extends Model implements Commentable
     public static function onlineUsers()
     {
         // Lazer builds uses "fake" release rows to track platform-specific builds
-        // In order to not double-count users, we must use the "main" releases which will never have a hash.
+        // In order to not double-count users, we must use the "main" releases which will never have a stream_id.
         return static
             ::where('allow_bancho', 1)
-            ->whereNull('hash')
+            ->whereNull('stream_id')
             ->sum('users');
     }
 }

--- a/app/Models/Build.php
+++ b/app/Models/Build.php
@@ -249,7 +249,6 @@ class Build extends Model implements Commentable
 
     public static function onlineUsers()
     {
-        return static::where('allow_bancho', 1)
-            ->sum('users');
+        return static::where('allow_bancho', 1)->sum('users');
     }
 }

--- a/app/Models/Build.php
+++ b/app/Models/Build.php
@@ -7,7 +7,6 @@ namespace App\Models;
 
 use App\Libraries\Commentable;
 use Carbon\Carbon;
-use Cache;
 
 /**
  * @property bool $allow_bancho

--- a/app/Models/Build.php
+++ b/app/Models/Build.php
@@ -7,6 +7,7 @@ namespace App\Models;
 
 use App\Libraries\Commentable;
 use Carbon\Carbon;
+use Cache;
 
 /**
  * @property bool $allow_bancho
@@ -244,5 +245,11 @@ class Build extends Model implements Commentable
     public function displayVersion()
     {
         return preg_replace('#[^0-9.]#', '', $this->version);
+    }
+
+    public static function onlineUsers()
+    {
+        return static::where('allow_bancho', 1)
+            ->sum('users');
     }
 }

--- a/app/Models/Build.php
+++ b/app/Models/Build.php
@@ -249,7 +249,7 @@ class Build extends Model implements Commentable
     public static function onlineUsers()
     {
         // Lazer builds uses "fake" release rows to track platform-specific builds
-        // In order to not double-count users, we must use the "main" releases which will never have a stream_id.
+        // In order to not double-count users, we must use the "main" releases which will always have a stream_id.
         return static
             ::where('allow_bancho', 1)
             ->whereNotNull('stream_id')

--- a/database/migrations/2024_02_12_000001_add_users_lazer_to_bancho_stats.php
+++ b/database/migrations/2024_02_12_000001_add_users_lazer_to_bancho_stats.php
@@ -1,0 +1,33 @@
+<?php
+
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('osu_banchostats', function (Blueprint $table) {
+            $table->unsignedMediumInteger('users_lazer')->after('users_osu');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('osu_banchostats', function (Blueprint $table) {
+            $table->dropColumn('users_lazer');
+        });
+    }
+};


### PR DESCRIPTION
Resolves #10991.

Something to note is that this doesn't change the user counts used for the user graph, since this works by Bancho inserting user counts on an interval and that doesn't seem possible with the `osu_builds` table.

The issue mentions caching the user count for around a minute, however the homepage is already doing a 5 minute cache on all of the stats so I don't think it's necessary.