### PR TITLE
Update ziggy

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -44,7 +44,7 @@
     "paypal/paypal-checkout-sdk": "*",
     "sentry/sentry-laravel": "*",
     "symfony/yaml": "*",
-    "tightenco/ziggy": ">=0.8.1",
+    "tightenco/ziggy": "^1.8",
     "xsolla/xsolla-sdk-php": "dev-php81"
   },
   "require-dev": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "c748b63fdc90f32f3850b615cb80eb80",
+    "content-hash": "0f9e7b546f1c77a54bd518d7918c1e4d",
     "packages": [
         {
             "name": "anhskohbo/no-captcha",
@@ -10698,16 +10698,16 @@
         },
         {
             "name": "tightenco/ziggy",
-            "version": "v1.6.0",
+            "version": "v1.8.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/tighten/ziggy.git",
-                "reference": "3beb080be60b1eadad043f3773a160df13fa215f"
+                "reference": "22dafc51f3f5ae5ed51f7cb6b566e6b9537f6937"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/tighten/ziggy/zipball/3beb080be60b1eadad043f3773a160df13fa215f",
-                "reference": "3beb080be60b1eadad043f3773a160df13fa215f",
+                "url": "https://api.github.com/repos/tighten/ziggy/zipball/22dafc51f3f5ae5ed51f7cb6b566e6b9537f6937",
+                "reference": "22dafc51f3f5ae5ed51f7cb6b566e6b9537f6937",
                 "shasum": ""
             },
             "require": {
@@ -10759,9 +10759,9 @@
             ],
             "support": {
                 "issues": "https://github.com/tighten/ziggy/issues",
-                "source": "https://github.com/tighten/ziggy/tree/v1.6.0"
+                "source": "https://github.com/tighten/ziggy/tree/v1.8.1"
             },
-            "time": "2023-05-12T20:08:56+00:00"
+            "time": "2023-10-12T18:31:26+00:00"
         },
         {
             "name": "tijsverkoyen/css-to-inline-styles",

--- a/package.json
+++ b/package.json
@@ -98,7 +98,8 @@
     "webpack-cli": "^5.1.4",
     "webpack-manifest-plugin": "^5.0.0",
     "webpack-sentry-plugin": "^2.0.2",
-    "yargs": "^12.0.5"
+    "yargs": "^12.0.5",
+    "ziggy-js": "^1.8.1"
   },
   "devDependencies": {
     "@typescript-eslint/eslint-plugin": "^6.6.0",

--- a/resources/js/beatmap-discussions/post.tsx
+++ b/resources/js/beatmap-discussions/post.tsx
@@ -173,8 +173,8 @@ export default class Post extends React.Component<Props> {
 
   private deleteHref(op: 'destroy' | 'restore') {
     const [controller, key] = this.props.type === 'reply'
-      ? ['beatmapsets.discussions.posts', 'post']
-      : ['beatmapsets.discussions', 'discussion'];
+      ? ['beatmapsets.discussions.posts', 'post'] as const
+      : ['beatmapsets.discussions', 'discussion'] as const;
 
     return route(`${controller}.${op}`, { [key]: this.deleteModel.id });
   }

--- a/resources/js/components/quick-search-button.tsx
+++ b/resources/js/components/quick-search-button.tsx
@@ -20,7 +20,7 @@ interface State {
 
 @observer export default class QuickSearchButton extends React.Component<Props, State> {
   formRef = React.createRef<QuickSearch>();
-  searchPath = route('search', null, false);
+  searchPath = route('search', undefined, false);
   state: State = { open: false };
 
   private get isSearchPage() {
@@ -36,7 +36,7 @@ interface State {
   render() {
     let className = 'nav2__menu-link-main nav2__menu-link-main--search';
 
-    if (this.state.open || currentUrl().pathname === route('search', null, false)) {
+    if (this.state.open || currentUrl().pathname === route('search', undefined, false)) {
       className += ' u-section--bg-normal';
     }
 

--- a/resources/js/laroute.ts
+++ b/resources/js/laroute.ts
@@ -3,11 +3,13 @@
 
 import { currentUrl } from 'utils/turbolinks';
 import { Ziggy } from 'ziggy';
-import route from 'ziggy-js';
+import ziggyRoute, { RouteList } from 'ziggy-js';
 
 // ensure correct url
 const siteUrl = currentUrl();
 Ziggy.port = +siteUrl.port || null; // either port number or null if empty (converted to 0)
 Ziggy.url = siteUrl.origin;
 
-export { route };
+export function route<T extends keyof RouteList>(name: T, params?: Partial<Record<string, string | number | null>>, absolute?: boolean) {
+  return ziggyRoute<T>(name, params, absolute, Ziggy);
+}

--- a/resources/js/laroute.ts
+++ b/resources/js/laroute.ts
@@ -3,13 +3,11 @@
 
 import { currentUrl } from 'utils/turbolinks';
 import { Ziggy } from 'ziggy';
-import ziggyRoute from 'ziggy-route';
+import route from 'ziggy-js';
 
 // ensure correct url
 const siteUrl = currentUrl();
 Ziggy.port = +siteUrl.port || null; // either port number or null if empty (converted to 0)
 Ziggy.url = siteUrl.origin;
 
-export function route(name: string, params?: Partial<Record<string, string | number | null>> | null, absolute?: boolean) {
-  return ziggyRoute(name, params ?? {}, absolute, Ziggy).toString();
-}
+export { route };

--- a/resources/js/laroute.ts
+++ b/resources/js/laroute.ts
@@ -10,6 +10,9 @@ const siteUrl = currentUrl();
 Ziggy.port = +siteUrl.port || null; // either port number or null if empty (converted to 0)
 Ziggy.url = siteUrl.origin;
 
-export function route<T extends keyof RouteList>(name: T, params?: Partial<Record<string, string | number | null>>, absolute?: boolean) {
+type RouteName = keyof RouteList;
+type Params<T extends RouteName> = Parameters<typeof ziggyRoute<T>>[1];
+
+export function route<T extends RouteName>(name: T, params?: Params<T>, absolute?: boolean) {
   return ziggyRoute<T>(name, params, absolute, Ziggy);
 }

--- a/resources/js/profile-page/cover.tsx
+++ b/resources/js/profile-page/cover.tsx
@@ -18,7 +18,7 @@ import { trans } from 'utils/lang';
 
 interface Props {
   coverUrl: string | null;
-  currentMode: GameMode | null;
+  currentMode: GameMode;
   editor?: JSX.Element;
   isUpdatingCover?: boolean;
   modifiers?: Modifiers;

--- a/resources/js/utils/offset-paginator.ts
+++ b/resources/js/utils/offset-paginator.ts
@@ -4,6 +4,7 @@
 import KudosuHistoryJson from 'interfaces/kudosu-history-json';
 import { route } from 'laroute';
 import { action } from 'mobx';
+import { RouteList } from 'ziggy-js';
 
 type RouteParams = Partial<Record<string, string | number>>;
 
@@ -17,7 +18,7 @@ export interface OffsetPaginatorJson<T> {
   pagination: OffsetPaginationJson;
 }
 
-export const apiShowMore = action(<T>(json: OffsetPaginatorJson<T>, routeName: string, baseRouteParams: RouteParams): JQuery.jqXHR<T[]> => {
+export const apiShowMore = action(<T>(json: OffsetPaginatorJson<T>, routeName: keyof RouteList, baseRouteParams: RouteParams): JQuery.jqXHR<T[]> => {
   json.pagination.loading = true;
 
   let limit = baseRouteParams.limit;

--- a/resources/js/ziggy.d.ts
+++ b/resources/js/ziggy.d.ts
@@ -2,14 +2,12 @@
 // See the LICENCE file in the repository root for full licence text.
 
 declare module 'ziggy' {
-  interface ZiggyClass {
+  // Reduced version of unexported ziggy Config for typing when setting the port and url.
+  // Using Parameters<typeof route>[3] doesn't quite work since route has overloaded parameters.
+  interface ZiggyGlobal {
     port: number | null;
     url: string;
   }
 
-  export const Ziggy: ZiggyClass;
-}
-
-declare module 'ziggy-route' {
-  export default function route(name: string, params: any, absolute?: boolean, ziggy?: import('ziggy').ZiggyClass): string;
+  export const Ziggy: ZiggyGlobal;
 }

--- a/resources/js/ziggy.d.ts
+++ b/resources/js/ziggy.d.ts
@@ -11,3 +11,13 @@ declare module 'ziggy' {
 
   export const Ziggy: ZiggyGlobal;
 }
+
+declare module 'ziggy-js' {
+  export default function route<T extends keyof RouteList>(
+    name: T,
+    // retyping because RouteParams (or RouteName...or all the other useful types)
+    params?: Partial<Record<string, string | number | null>>,
+    absolute?: boolean,
+    config?: import('ziggy').ZiggyGlobal,
+  ): string;
+}

--- a/resources/js/ziggy.d.ts
+++ b/resources/js/ziggy.d.ts
@@ -2,23 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 declare module 'ziggy' {
-  // Reduced version of unexported ziggy Config for typing when setting the port and url.
-  // Using Parameters<typeof route>[3] doesn't quite work since route has overloaded parameters.
-  interface ZiggyGlobal {
-    port: number | null;
-    url: string;
-  }
+  import route, { RouteList } from 'ziggy-js';
 
-  export const Ziggy: ZiggyGlobal;
-}
-
-declare module 'ziggy-js' {
-  export default function route<T extends keyof RouteList>(
-    name: T,
-    // Retyping because RouteParams (or RouteName...or all the other useful types) aren't exported.
-    // We can't use Parameters<T> either because it uses the last declared overload.
-    params?: Partial<Record<string, string | number | null>>,
-    absolute?: boolean,
-    config?: import('ziggy').ZiggyGlobal,
-  ): string;
+  export const Ziggy: NonNullable<Parameters<typeof route<keyof RouteList>>[3]>;
 }

--- a/resources/js/ziggy.d.ts
+++ b/resources/js/ziggy.d.ts
@@ -15,7 +15,8 @@ declare module 'ziggy' {
 declare module 'ziggy-js' {
   export default function route<T extends keyof RouteList>(
     name: T,
-    // retyping because RouteParams (or RouteName...or all the other useful types)
+    // Retyping because RouteParams (or RouteName...or all the other useful types) aren't exported.
+    // We can't use Parameters<T> either because it uses the last declared overload.
     params?: Partial<Record<string, string | number | null>>,
     absolute?: boolean,
     config?: import('ziggy').ZiggyGlobal,

--- a/tests/karma/tsconfig.json
+++ b/tests/karma/tsconfig.json
@@ -15,6 +15,7 @@
   },
   "include": [
     "../../resources/js",
+    "../../resources/builds/ziggy.d.ts",
     ".",
   ]
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -17,6 +17,7 @@
     "useDefineForClassFields": true
   },
   "include": [
-    "resources/js"
+    "resources/js",
+    "resources/builds/ziggy.d.ts"
   ]
 }

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -293,7 +293,7 @@ const watches = [
   {
     callback: () => spawnSync(
       'php',
-      ['artisan', 'ziggy:generate', 'resources/builds/ziggy.js'],
+      ['artisan', 'ziggy:generate', 'resources/builds/ziggy.js', '--types'],
       { stdio: 'inherit' },
     ),
     path: resolvePath('routes/web.php'),

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -218,7 +218,6 @@ const resolve = {
   alias: {
     '@fonts': path.resolve(__dirname, 'resources/fonts'),
     '@images': path.resolve(__dirname, 'public/images'),
-    'ziggy-route': resolvePath('vendor/tightenco/ziggy/dist/index.es.js'),
   },
   extensions: ['*', '.js', '.coffee', '.ts', '.tsx'],
   modules: [

--- a/yarn.lock
+++ b/yarn.lock
@@ -6483,6 +6483,11 @@ qs@~6.5.2:
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.5.3.tgz#3aeeffc91967ef6e35c0e488ef46fb296ab76aad"
   integrity sha512-qxXIEh4pCGfHICj1mAJQ2/2XVZkjCDTcEgfoSQxc/fYivUZxTkk7L3bDBJSoNrEzXI17oUO5Dp07ktqE5KzczA==
 
+qs@~6.9.7:
+  version "6.9.7"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.9.7.tgz#4610846871485e1e048f44ae3b94033f0e675afe"
+  integrity sha512-IhMFgUmuNpyRfxA90umL7ByLlgRXu6tIfKPpF5TmcfRLlLCckfP/g3IQmju6jjpu+Hh8rA+2p6A27ZSPOOHdKw==
+
 "qtip2@https://github.com/notbakaneko/qTip2.git#cd5f038667d2b23a44f4274c46de01834d704ce6":
   version "3.0.3-jquery3"
   resolved "https://github.com/notbakaneko/qTip2.git#cd5f038667d2b23a44f4274c46de01834d704ce6"
@@ -8244,6 +8249,13 @@ yargs@^16.1.1:
     string-width "^4.2.0"
     y18n "^5.0.5"
     yargs-parser "^20.2.2"
+
+ziggy-js@^1.8.1:
+  version "1.8.1"
+  resolved "https://registry.yarnpkg.com/ziggy-js/-/ziggy-js-1.8.1.tgz#582f4c19424cec0f8b80de2d033d70f953314a94"
+  integrity sha512-fnf30uG0yvUQBPL4T8YPgmkBHUdjYaOFgUb1K1gj0+rclnLTNr9/K/cxC3xkCZyYCZz8oTnXkdf3oJXRPSzavw==
+  dependencies:
+    qs "~6.9.7"
 
 zwitch@^1.0.0:
   version "1.0.5"


### PR DESCRIPTION
Originally looked at updating this to get the route typings and then discovering ziggy doesn't export the parameter typings so there's still the workaround typings for the wrapper (because we're using `Ziggy` as an export, not global). 
~~We can't use the `Parameters<T>` utility type to infer `route` argument types either because it's declared as an overload and it only uses the last one...so I'm not sure what to do with it that doesn't involve just copying their whole `d.ts` and adding `export` ಠ_ಠ~~
Turns out the generic type was important 👀 