### PR TITLE
Fix field initialization order

### DIFF
--- a/resources/js/core/timeago.ts
+++ b/resources/js/core/timeago.ts
@@ -16,7 +16,7 @@ export default class Timeago {
     });
   }
 
-  private static readonly handleMutation = (mutation: MutationRecord) => {
+  private static handleMutation(this: void, mutation: MutationRecord) {
     switch (mutation.type) {
       case 'childList':
         $(mutation.addedNodes)
@@ -34,12 +34,12 @@ export default class Timeago {
         }
         break;
     }
-  };
+  }
 
-  private static readonly handleMutations = (mutations: MutationRecord[]) => {
+  private static handleMutations(this: void, mutations: MutationRecord[]) {
     // Third-party scripts may init conflicting versions of jquery
     if ($.fn.timeago == null) return;
 
     mutations.forEach(Timeago.handleMutation);
-  };
+  }
 }

--- a/resources/js/notifications/notification-controller.ts
+++ b/resources/js/notifications/notification-controller.ts
@@ -13,7 +13,7 @@ export default class NotificationController {
   @observable currentFilter: NotificationTypeName;
 
   private readonly store: NotificationStackStore;
-  private readonly typeNamesWithoutNull = typeNames.filter((name) => !(name == null || this.isExcluded(name)));
+  private readonly typeNamesWithoutNull;
 
   @computed
   get isMarkingCurrentTypeAsRead() {
@@ -39,6 +39,8 @@ export default class NotificationController {
     protected readonly contextType: NotificationContextData,
     filter?: NotificationTypeName,
   ) {
+    this.typeNamesWithoutNull = typeNames.filter((name) => !(name == null || this.isExcluded(name)));
+
     // TODO: should probably not infer from url here.
     this.currentFilter = filter !== undefined ? filter : this.typeNameFromUrl;
 


### PR DESCRIPTION
targeting `ES2022` and later changes fields to be initialized earlier (but still after parent class, so `this.props` is generally fine)