### PR TITLE
Mark user active on password reset

### DIFF
--- a/app/Http/Controllers/PasswordResetController.php
+++ b/app/Http/Controllers/PasswordResetController.php
@@ -11,6 +11,7 @@ use App\Exceptions\User\PasswordResetFailException;
 use App\Libraries\User\PasswordResetData;
 use App\Models\User;
 use App\Models\UserAccountHistory;
+use Carbon\CarbonImmutable;
 
 class PasswordResetController extends Controller
 {
@@ -124,6 +125,7 @@ class PasswordResetController extends Controller
         }
 
         $user->validatePasswordConfirmation();
+        $params['user']['user_lastvisit'] = CarbonImmutable::now();
         if ($user->update($params['user'])) {
             $user->resetSessions();
             $this->login($user);


### PR DESCRIPTION
Seems to make more sense. Also avoids reset re-triggering forced reactivation when the redirect never happens and the user logs in again from a different session.