### PR TITLE
Deprecate active_tournament_banner property in User API response

### DIFF
--- a/app/Transformers/UserCompactTransformer.php
+++ b/app/Transformers/UserCompactTransformer.php
@@ -47,7 +47,7 @@ class UserCompactTransformer extends TransformerAbstract
 
     protected array $availableIncludes = [
         'account_history',
-        'active_tournament_banner',
+        'active_tournament_banner', // deprecated
         'active_tournament_banners',
         'badges',
         'beatmap_playcounts_count',

--- a/resources/css/entrypoints/docs.less
+++ b/resources/css/entrypoints/docs.less
@@ -40,9 +40,6 @@ html {
 .content code {
     word-break: break-all;
     word-break: break-word;
-    -webkit-hyphens: auto;
-    -ms-hyphens: auto;
-    hyphens: auto
 }
 
 .content aside.notice:before,

--- a/resources/views/docs/_structures/user.md
+++ b/resources/views/docs/_structures/user.md
@@ -24,7 +24,7 @@ default_group   | string?                   | Identifier of the default [Group](
 id              | integer                   | unique identifier for user
 is_active       | boolean                   | has this account been active in the last x months?
 is_bot          | boolean                   | is this a bot account?
-is_deleted      | boolean                   ||
+is_deleted      | boolean                   | |
 is_online       | boolean                   | is the user currently online? (either on lazer or the new website)
 is_supporter    | boolean                   | does this user have supporter?
 last_visit      | [Timestamp](#timestamp)?  | last access time. `null` if the user hides online presence

--- a/resources/views/docs/_structures/user.md
+++ b/resources/views/docs/_structures/user.md
@@ -38,44 +38,44 @@ username        | string                    | user's display name
 
 Following are attributes which may be additionally included in the response. Relevant endpoints should list them if applicable.
 
-Field                      | Type
----------------------------|-----
-account_history            | [User.UserAccountHistory](#user-useraccounthistory)[]
-active_tournament_banner   | Deprecated, use `active_tournament_banners` instead. [User.ProfileBanner](#user-profilebanner)?
-active_tournament_banners  | [User.ProfileBanner](#user-profilebanner)[]
-badges                     | [User.UserBadge](#user-userbadge)[]
-beatmap_playcounts_count   | integer
-blocks                     | |
-country                    | |
-cover                      | |
-favourite_beatmapset_count | integer
-follow_user_mapping        | integer[]
-follower_count             | integer
-friends                    | |
-graveyard_beatmapset_count | integer
-groups                     | [UserGroup](#usergroup)[]
-guest_beatmapset_count     | integer
-is_restricted              | boolean?
-kudosu                     | [User.Kudosu](#user-kudosu)
-loved_beatmapset_count     | integer
-mapping_follower_count     | integer
-monthly_playcounts         | [UserMonthlyPlaycount](#usermonthlyplaycount)[]
-page                       | |
-pending_beatmapset_count   | |
-previous_usernames         | |
-rank_highest               | [User.RankHighest](#user-rankhighest)?
-rank_history               | |
-ranked_beatmapset_count    | |
-replays_watched_counts     | |
-scores_best_count          | integer
-scores_first_count         | integer
-scores_recent_count        | integer
-statistics                 | |
-statistics_rulesets        | UserStatisticsRulesets
-support_level              | |
-unread_pm_count            | |
-user_achievements          | |
-user_preferences           | |
+Field                      | Type | Notes
+---------------------------|----- | -----
+account_history            | [User.UserAccountHistory](#user-useraccounthistory)[] | |
+active_tournament_banner   | [User.ProfileBanner](#user-profilebanner)? | Deprecated, use `active_tournament_banners` instead.
+active_tournament_banners  | [User.ProfileBanner](#user-profilebanner)[] | |
+badges                     | [User.UserBadge](#user-userbadge)[] | |
+beatmap_playcounts_count   | integer | |
+blocks                     | | | |
+country                    | | | |
+cover                      | | | |
+favourite_beatmapset_count | integer | |
+follow_user_mapping        | integer[] | |
+follower_count             | integer | |
+friends                    | | | |
+graveyard_beatmapset_count | integer | |
+groups                     | [UserGroup](#usergroup)[] | |
+guest_beatmapset_count     | integer | |
+is_restricted              | boolean? | |
+kudosu                     | [User.Kudosu](#user-kudosu) | |
+loved_beatmapset_count     | integer | |
+mapping_follower_count     | integer | |
+monthly_playcounts         | [UserMonthlyPlaycount](#usermonthlyplaycount)[] | |
+page                       | | | |
+pending_beatmapset_count   | | | |
+previous_usernames         | | | |
+rank_highest               | [User.RankHighest](#user-rankhighest)? | |
+rank_history               | | | |
+ranked_beatmapset_count    | | | |
+replays_watched_counts     | | | |
+scores_best_count          | integer | |
+scores_first_count         | integer | |
+scores_recent_count        | integer | |
+statistics                 | | | |
+statistics_rulesets        | UserStatisticsRulesets | |
+support_level              | | | |
+unread_pm_count            | | | |
+user_achievements          | | | |
+user_preferences           | | | |
 
 <div id="user-kudosu" data-unique="user-kudosu"></div>
 

--- a/resources/views/docs/_structures/user.md
+++ b/resources/views/docs/_structures/user.md
@@ -45,13 +45,13 @@ active_tournament_banner   | [User.ProfileBanner](#user-profilebanner)? | Deprec
 active_tournament_banners  | [User.ProfileBanner](#user-profilebanner)[] | |
 badges                     | [User.UserBadge](#user-userbadge)[] | |
 beatmap_playcounts_count   | integer | |
-blocks                     | | | |
-country                    | | | |
-cover                      | | | |
+blocks                     | | |
+country                    | | |
+cover                      | | |
 favourite_beatmapset_count | integer | |
 follow_user_mapping        | integer[] | |
 follower_count             | integer | |
-friends                    | | | |
+friends                    | | |
 graveyard_beatmapset_count | integer | |
 groups                     | [UserGroup](#usergroup)[] | |
 guest_beatmapset_count     | integer | |
@@ -60,22 +60,22 @@ kudosu                     | [User.Kudosu](#user-kudosu) | |
 loved_beatmapset_count     | integer | |
 mapping_follower_count     | integer | |
 monthly_playcounts         | [UserMonthlyPlaycount](#usermonthlyplaycount)[] | |
-page                       | | | |
-pending_beatmapset_count   | | | |
-previous_usernames         | | | |
+page                       | | |
+pending_beatmapset_count   | | |
+previous_usernames         | | |
 rank_highest               | [User.RankHighest](#user-rankhighest)? | |
-rank_history               | | | |
-ranked_beatmapset_count    | | | |
-replays_watched_counts     | | | |
+rank_history               | | |
+ranked_beatmapset_count    | | |
+replays_watched_counts     | | |
 scores_best_count          | integer | |
 scores_first_count         | integer | |
 scores_recent_count        | integer | |
-statistics                 | | | |
+statistics                 | | |
 statistics_rulesets        | UserStatisticsRulesets | |
-support_level              | | | |
-unread_pm_count            | | | |
-user_achievements          | | | |
-user_preferences           | | | |
+support_level              | | |
+unread_pm_count            | | |
+user_achievements          | | |
+user_preferences           | | |
 
 <div id="user-kudosu" data-unique="user-kudosu"></div>
 

--- a/resources/views/docs/_structures/user.md
+++ b/resources/views/docs/_structures/user.md
@@ -41,7 +41,8 @@ Following are attributes which may be additionally included in the response. Rel
 Field                      | Type
 ---------------------------|-----
 account_history            | [User.UserAccountHistory](#user-useraccounthistory)[]
-active_tournament_banner   | [User.ProfileBanner](#user-profilebanner)?
+active_tournament_banner   | Deprecated, use `active_tournament_banners` instead. [User.ProfileBanner](#user-profilebanner)?
+active_tournament_banners  | [User.ProfileBanner](#user-profilebanner)[]
 badges                     | [User.UserBadge](#user-userbadge)[]
 beatmap_playcounts_count   | integer
 blocks                     | |

--- a/resources/views/docs/info.md.blade.php
+++ b/resources/views/docs/info.md.blade.php
@@ -34,6 +34,9 @@ For a full list of changes, see the
 
 ## Breaking Changes
 
+### 2024-01-23
+- `active_tournament_banner` in [User](#user) has been deprecated, use `active_tournament_banners` instead.
+
 ### 2023-10-17
 - GameMode has been renamed to [Ruleset](#ruleset); existing property names remain unchanged.
 - `number` has been removed from documentation and replaced with `integer` or `float` to better reflect the type of number.


### PR DESCRIPTION
Should use `active_tournament_banners` for the list of banners instead