### PR TITLE
Limit recent scores to 48h

### DIFF
--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -847,7 +847,9 @@ class UsersController extends Controller
                     ->default()
                     ->forRuleset($this->mode)
                     ->includeFails($options['includeFails'] ?? false)
-                    ->reorderBy('id', 'desc')
+                    // 2 days (2 * 24 * 3600)
+                    ->where('unix_updated_at', '>', time() - 172_800)
+                    ->reorderBy('unix_updated_at', 'desc')
                     ->with(ScoreTransformer::USER_PROFILE_INCLUDES_PRELOAD);
                 $userRelationColumn = 'user';
                 break;

--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -188,7 +188,7 @@ class UsersController extends Controller
                     'monthly_playcounts' => json_collection($this->user->monthlyPlaycounts, new UserMonthlyPlaycountTransformer()),
                     'recent' => $this->getExtraSection(
                         'scoresRecent',
-                        $this->user->recentScoreCount($this->mode)
+                        $this->user->soloScores()->recent($this->mode, false)->count(),
                     ),
                     'replays_watched_counts' => json_collection($this->user->replaysWatchedCounts, new UserReplaysWatchedCountTransformer()),
                 ];
@@ -844,11 +844,7 @@ class UsersController extends Controller
                 $transformer = new ScoreTransformer();
                 $includes = ScoreTransformer::USER_PROFILE_INCLUDES;
                 $query = $this->user->soloScores()
-                    ->default()
-                    ->forRuleset($this->mode)
-                    ->includeFails($options['includeFails'] ?? false)
-                    // 2 days (2 * 24 * 3600)
-                    ->where('unix_updated_at', '>', time() - 172_800)
+                    ->recent($this->mode, $options['includeFails'] ?? false)
                     ->reorderBy('unix_updated_at', 'desc')
                     ->with(ScoreTransformer::USER_PROFILE_INCLUDES_PRELOAD);
                 $userRelationColumn = 'user';

--- a/app/Models/Solo/Score.php
+++ b/app/Models/Solo/Score.php
@@ -164,6 +164,16 @@ class Score extends Model implements Traits\ReportableInterface
             ->whereHas('user', fn (Builder $q): Builder => $q->default());
     }
 
+    public function scopeRecent(Builder $query, string $ruleset, bool $includeFails): Builder
+    {
+        return $query
+            ->default()
+            ->forRuleset($ruleset)
+            ->includeFails($includeFails)
+            // 2 days (2 * 24 * 3600)
+            ->where('unix_updated_at', '>', time() - 172_800);
+    }
+
     public function getAttribute($key)
     {
         return match ($key) {

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -1802,18 +1802,6 @@ class User extends Model implements AfterCommit, AuthenticatableContract, HasLoc
         return hash('sha256', $this->user_email).':'.hash('sha256', $this->user_password);
     }
 
-    public function recentScoreCount(string $ruleset): int
-    {
-        return $this->soloScores()
-            ->default()
-            ->forRuleset($ruleset)
-            ->includeFails(false)
-            ->select('id')
-            ->limit(100)
-            ->get()
-            ->count();
-    }
-
     public function resetSessions(?string $excludedSessionId = null): void
     {
         $userId = $this->getKey();

--- a/app/Transformers/UserCompactTransformer.php
+++ b/app/Transformers/UserCompactTransformer.php
@@ -407,7 +407,7 @@ class UserCompactTransformer extends TransformerAbstract
 
     public function includeScoresRecentCount(User $user)
     {
-        return $this->primitive($user->recentScoreCount($this->mode));
+        return $this->primitive($user->soloScores()->recent($this->mode, false)->count());
     }
 
     public function includeSessionVerified(User $user)


### PR DESCRIPTION
This will roll through all the user's scores but apparently it's already doing something like it anyway due to the user index in prod has a lot more columns in it (instead of just user_id and ruleset_id). So maybe it'll be fine? 🤷‍♀️

One of the worst cases is going through something like 200k rows.

Resolves #10912.