### PR TITLE
Remove lazer score conversion to legacy score

### DIFF
--- a/app/Http/Controllers/Solo/ScoresController.php
+++ b/app/Http/Controllers/Solo/ScoresController.php
@@ -34,7 +34,6 @@ class ScoresController extends BaseController
             if ($scoreToken->score_id === null) {
                 $params = Score::extractParams($request->all(), $scoreToken);
                 $score = Score::createFromJsonOrExplode($params);
-                $score->createLegacyEntryOrExplode();
                 $scoreToken->fill(['score_id' => $score->getKey()])->saveOrExplode();
             } else {
                 // assume score exists and is valid

--- a/app/Models/Solo/Score.php
+++ b/app/Models/Solo/Score.php
@@ -223,15 +223,6 @@ class Score extends Model implements Traits\ReportableInterface
         }
     }
 
-    public function createLegacyEntryOrExplode()
-    {
-        $score = $this->makeLegacyEntry();
-
-        $score->saveOrExplode();
-
-        return $score;
-    }
-
     public function getMode(): string
     {
         return Beatmap::modeStr($this->ruleset_id);

--- a/tests/Controllers/Solo/ScoresControllerTest.php
+++ b/tests/Controllers/Solo/ScoresControllerTest.php
@@ -6,7 +6,6 @@
 namespace Tests\Controllers\Solo;
 
 use App\Models\Build;
-use App\Models\Score as LegacyScore;
 use App\Models\ScoreToken;
 use App\Models\Solo\Score;
 use App\Models\User;
@@ -19,10 +18,8 @@ class ScoresControllerTest extends TestCase
     {
         $build = Build::factory()->create(['allow_ranking' => true]);
         $scoreToken = ScoreToken::factory()->create(['build_id' => $build]);
-        $legacyScoreClass = LegacyScore\Model::getClassByRulesetId($scoreToken->beatmap->playmode);
 
         $this->expectCountChange(fn () => Score::count(), 1);
-        $this->expectCountChange(fn () => $legacyScoreClass::count(), 1);
         $this->expectCountChange(fn () => $this->processingQueueCount(), 1);
         $this->expectCountChange(
             fn () => \LaravelRedis::llen($GLOBALS['cfg']['osu']['client']['token_queue']),

--- a/tests/Models/Solo/ScoreTest.php
+++ b/tests/Models/Solo/ScoreTest.php
@@ -53,7 +53,7 @@ class ScoreTest extends TestCase
         $this->assertTrue($score->passed);
         $this->assertSame($score->rank, 'S');
 
-        $legacy = $score->createLegacyEntryOrExplode();
+        $legacy = $score->makeLegacyEntry();
 
         $this->assertTrue($legacy->perfect);
         $this->assertSame($legacy->rank, 'S');
@@ -78,7 +78,7 @@ class ScoreTest extends TestCase
         $this->assertFalse($score->passed);
         $this->assertSame($score->rank, 'F');
 
-        $legacy = $score->createLegacyEntryOrExplode();
+        $legacy = $score->makeLegacyEntry();
 
         $this->assertFalse($legacy->perfect);
         $this->assertSame($legacy->rank, 'F');
@@ -98,7 +98,7 @@ class ScoreTest extends TestCase
             'statistics' => ['great' => 10, 'ok' => 20, 'meh' => 30, 'miss' => 40],
             'total_score' => 1000,
             'user_id' => 1,
-        ])->createLegacyEntryOrExplode();
+        ])->makeLegacyEntry();
 
         $this->assertFalse($legacy->perfect);
         $this->assertSame($legacy->count300, 10);
@@ -121,7 +121,7 @@ class ScoreTest extends TestCase
             'statistics' => ['Great' => 10, 'Ok' => 20, 'Meh' => 30, 'Miss' => 40],
             'total_score' => 1000,
             'user_id' => 1,
-        ])->createLegacyEntryOrExplode();
+        ])->makeLegacyEntry();
 
         $this->assertFalse($legacy->perfect);
         $this->assertSame($legacy->count300, 10);


### PR DESCRIPTION
Not needed anymore after migration to new score table.

The converter function stays because it's still used by transformer.

Removal of the old transformer will be done later. Maybe.

~~(this PR is untested)~~ the test passed so it should be fine™