### PR TITLE
Remove alias for for scores table

### DIFF
--- a/database/migrations/2024_01_31_181425_unview_scores.php
+++ b/database/migrations/2024_01_31_181425_unview_scores.php
@@ -1,0 +1,23 @@
+<?php
+
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        DB::statement('DROP VIEW scores');
+        DB::statement('ALTER TABLE solo_scores RENAME TO scores');
+    }
+
+    public function down(): void
+    {
+        DB::statement('ALTER TABLE scores RENAME TO solo_scores');
+        DB::statement('CREATE VIEW scores AS SELECT * from solo_scores');
+    }
+};


### PR DESCRIPTION
Force index doesn't work on view...

(actual force index was pushed directly to master)

Removal of other aliases will come later™

- [x] `2024_01_31_181425_unview_scores` migration entry