### PR TITLE
Better initial score preserve value

### DIFF
--- a/app/Models/Solo/Score.php
+++ b/app/Models/Solo/Score.php
@@ -125,7 +125,7 @@ class Score extends Model implements Traits\ReportableInterface
             Beatmapset::STATES['ranked'],
         ], true);
 
-        $params['preserve'] = $params['passed'];
+        $params['preserve'] = $params['passed'] ?? false;
 
         return $params;
     }

--- a/app/Models/Solo/Score.php
+++ b/app/Models/Solo/Score.php
@@ -125,6 +125,8 @@ class Score extends Model implements Traits\ReportableInterface
             Beatmapset::STATES['ranked'],
         ], true);
 
+        $params['preserve'] = $params['passed'];
+
         return $params;
     }
 


### PR DESCRIPTION
This prevents scores that's waiting to be processed from being deleted by different clean up process.

Failing scores stay marked as not preserved initially as there's less processing involved.

Resolves #10942.