### PR TITLE
Fix rank calculator for catch

### DIFF
--- a/app/Models/Traits/Scoreable.php
+++ b/app/Models/Traits/Scoreable.php
@@ -129,7 +129,7 @@ trait Scoreable
 
                 break;
 
-            case 'catch':
+            case 'fruits':
                 $this->rank = match (true) {
                     $accuracy === 1 =>
                         $this->shouldHaveHiddenRank() ? 'XH' : 'X',


### PR DESCRIPTION
It originally used enum but then converted to string and catch stayed as is 👀