### PR TITLE
Fix recent votes section of modding profile

### DIFF
--- a/resources/js/modding-profile/main.tsx
+++ b/resources/js/modding-profile/main.tsx
@@ -190,7 +190,7 @@ export default class Main extends React.Component<BeatmapsetDiscussionsBundleJso
       case 'posts':
         return <Posts posts={this.props.posts} store={this.store} user={this.user} />;
       case 'votes':
-        return <Votes users={this.props.users} votes={this.props.votes} />;
+        return <Votes users={this.store.users} votes={this.props.votes} />;
       default:
         switchNever(name);
         throw new Error('unsupported extra page');

--- a/resources/js/modding-profile/votes.tsx
+++ b/resources/js/modding-profile/votes.tsx
@@ -15,7 +15,7 @@ const directions = ['received', 'given'] as const;
 export type Direction = (typeof directions)[number];
 
 interface Props {
-  users: Partial<Record<number, UserJson>>;
+  users: Map<number | null | undefined, UserJson>;
   votes: Record<Direction, VoteSummary[]>;
 }
 
@@ -38,7 +38,7 @@ export default class Votes extends React.Component<Props> {
             />
             {this.props.votes[direction].length > 0 && (
               <div className='modding-profile-list modding-profile-list--votes'>
-                {this.props.votes[direction].map((vote) => this.renderUser(vote.score, vote.count, this.props.users[vote.user_id]))}
+                {this.props.votes[direction].map((vote) => this.renderUser(vote.score, vote.count, this.props.users.get(vote.user_id)))}
               </div>
             )}
           </React.Fragment>


### PR DESCRIPTION
resolves #10956. the section was empty because the user store was not being read from correctly, and fallback behavior is to not show anything in that component

seems to have regressed in #10409 and I think it went unnoticed because `UserJson[]` can assign to `Partial<Record<number, UserJson>>`...