### PR TITLE
Add `speed_note_count` to docs

### DIFF
--- a/resources/views/docs/_structures/beatmap_difficulty_attributes.md
+++ b/resources/views/docs/_structures/beatmap_difficulty_attributes.md
@@ -17,6 +17,7 @@ flashlight_difficulty | float
 overall_difficulty    | float
 slider_factor         | float
 speed_difficulty      | float
+speed_note_count      | float
 
 ### taiko
 


### PR DESCRIPTION
# Resolves #10345

API call for `BeatmapDifficultyAttributes` looks like this (in osu):

<img width="317" alt="image" src="https://github.com/ppy/osu-web/assets/62069795/b7ffb2f5-b4c3-495f-9c06-69c02b2392cf">

So I added the missing `speed_note_count` to docs and it looks like this now:

<img width="216" alt="image" src="https://github.com/ppy/osu-web/assets/62069795/3f5293ec-1698-4123-8766-983fb0f20672">

### I also checked the other gamemodes and found some things off:

# Taiko

API

<img width="295" alt="image" src="https://github.com/ppy/osu-web/assets/62069795/6cd0d114-4033-497e-bbc0-5feaa564e863">

Docs

<img width="229" alt="image" src="https://github.com/ppy/osu-web/assets/62069795/2d4eff70-d305-49b4-9714-4ab9bdc9a178">

(peak_difficulty vs approach_rate)

# Mania

API 

<img width="263" alt="image" src="https://github.com/ppy/osu-web/assets/62069795/784ae87c-49c0-4ef3-a21f-45aad7622f34">

Docs

<img width="227" alt="image" src="https://github.com/ppy/osu-web/assets/62069795/fbbc4fd4-c120-4870-86b9-eab84951c758">

(score_multiplier just missing in general?)

---

Is this intended? Otherwise I can offer to fix it in the docs.