### PR TITLE
An attempt to get legacy perfect for mania closer to what it should be

### DIFF
--- a/app/Models/Solo/Score.php
+++ b/app/Models/Solo/Score.php
@@ -274,24 +274,31 @@ class Score extends Model implements Traits\ReportableInterface
      */
     public function isPerfectLegacyCombo(): ?bool
     {
+        // This is best effort as there's no way to re-generate the correct
+        // value short of checking the source legacy score.
         if ($this->ruleset_id === Ruleset::mania->value) {
             if (!$this->passed) {
                 return false;
             }
 
-            // Reference: https://github.com/ppy/osu/blob/012039ff90a2bf234418caef81792af0ffb4d123/osu.Game/Rulesets/Scoring/HitResult.cs#L279-L299
-            // (in combination with AffectsCombo)
-            static $breaksCombo = [
+            static $noPerfect = [
                 'combo_break',
                 'large_tick_miss',
+                'meh',
                 'miss',
+                'ok',
             ];
 
             $statistics = $this->data->statistics;
-            foreach ($breaksCombo as $field) {
+            foreach ($noPerfect as $field) {
                 if ($statistics->$field !== 0) {
                     return false;
                 }
+            }
+
+            $hits = $statistics->good + $statistics->great + $statistics->perfect;
+            if ($hits !== $this->data->maximumStatistics->perfect) {
+                return false;
             }
 
             return true;

--- a/app/Models/Solo/Score.php
+++ b/app/Models/Solo/Score.php
@@ -297,12 +297,12 @@ class Score extends Model implements Traits\ReportableInterface
             }
 
             $hits = $statistics->good + $statistics->great + $statistics->perfect;
-            if ($hits !== $this->data->maximumStatistics->perfect) {
+            $maxHits = $this->data->maximumStatistics->perfect;
+            if ($hits !== $maxHits) {
                 return false;
             }
 
-            $totalHits = $hits + $statistics->meh + $statistics->ok + $statistics->miss;
-            if ($statistics->good / $totalHits >= 0.1) {
+            if ($statistics->good / $maxHits >= 0.1) {
                 return false;
             }
 

--- a/app/Models/Solo/Score.php
+++ b/app/Models/Solo/Score.php
@@ -301,6 +301,11 @@ class Score extends Model implements Traits\ReportableInterface
                 return false;
             }
 
+            $totalHits = $hits + $statistics->meh + $statistics->ok + $statistics->miss;
+            if ($statistics->good / $totalHits >= 0.1) {
+                return false;
+            }
+
             return true;
         }
 


### PR DESCRIPTION
Calling this a mess is a bit of understatement. Also it's still kind of wrong.

```csharp
            if ((CurrentScore.CountMiss + CurrentScore.Count50 + CurrentScore.Count100) == 0 && ((float)CurrentScore.CountKatu / CurrentScore.TotalHits) < 0.1)
                CurrentScore.Perfect = true;
            else
                CurrentScore.Perfect = false;
```

Related: #10679