### PR TITLE
Use 2x variant for default avatar image

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -85,7 +85,7 @@ SLACK_ENDPOINT=https://myconan.net/null/
 # AVATAR_CACHE_PURGE_PREFIX=
 # AVATAR_CACHE_PURGE_METHOD=
 # AVATAR_CACHE_PURGE_AUTHORIZATION_KEY=
-# DEFAULT_AVATAR=http://localhost/images/layout/avatar-guest.png
+# DEFAULT_AVATAR=http://localhost/images/layout/avatar-guest@2x.png
 
 # Either "s3" or "local".
 # SCORE_REPLAYS_STORAGE=local

--- a/config/osu.php
+++ b/config/osu.php
@@ -32,7 +32,7 @@ return [
         'cache_purge_prefix' => env('AVATAR_CACHE_PURGE_PREFIX'),
         'cache_purge_method' => env('AVATAR_CACHE_PURGE_METHOD'),
         'cache_purge_authorization_key' => env('AVATAR_CACHE_PURGE_AUTHORIZATION_KEY'),
-        'default' => env('DEFAULT_AVATAR', env('APP_URL', 'http://localhost').'/images/layout/avatar-guest.png'),
+        'default' => env('DEFAULT_AVATAR', env('APP_URL', 'http://localhost').'/images/layout/avatar-guest@2x.png'),
         'storage' => env('AVATAR_STORAGE', 'local-avatar'),
     ],
 

--- a/resources/js/models/user.ts
+++ b/resources/js/models/user.ts
@@ -15,7 +15,7 @@ export function usernameSortAscending(x: UserJson | User , y: UserJson | User) {
 }
 
 export default class User {
-  @observable avatarUrl = '/images/layout/avatar-guest.png'; // TODO: move to a global config store?
+  @observable avatarUrl = '/images/layout/avatar-guest@2x.png'; // TODO: move to a global config store?
   @observable countryCode = 'XX';
   @observable defaultGroup = '';
   @observable groups?: UserGroupJson[];


### PR DESCRIPTION
the guest user correctly shows a 1x or 2x variant, but a real user with default avatar only shows 1x at the moment

feels weird to write in a `@2x` like this but I think it's fine? alternatively `avatar_url` could be null for default but I don't think that's what API consumers would want.