### PR TITLE
Fix disqualify button not focusing on new discussion text box

### DIFF
--- a/resources/js/beatmap-discussions/nominations.tsx
+++ b/resources/js/beatmap-discussions/nominations.tsx
@@ -243,8 +243,11 @@ export class Nominations extends React.Component<Props> {
     // and thus new discussion box isn't visible.
     if (this.props.discussionsState.currentPage === 'events') {
       this.props.discussionsState.changeDiscussionPage('generalAll');
-      this.focusNewDiscussion();
     }
+
+    window.setTimeout(() => {
+      this.focusNewDiscussion();
+    }, 0);
   };
 
   private readonly handlePendingProblemsClick = (event: React.SyntheticEvent<HTMLElement>) => {

--- a/resources/js/beatmap-discussions/nominations.tsx
+++ b/resources/js/beatmap-discussions/nominations.tsx
@@ -241,7 +241,7 @@ export class Nominations extends React.Component<Props> {
   private readonly focusNewDiscussionWithModeSwitch = () => {
     // Switch to generalAll tab just in case currently in event tab
     // and thus new discussion box isn't visible.
-    if (this.props.discussionsState.currentPage === 'events') {
+    if (this.props.discussionsState.currentPage === 'events' || this.props.discussionsState.currentPage === 'reviews') {
       this.props.discussionsState.changeDiscussionPage('generalAll');
     }
 


### PR DESCRIPTION
`window.setTimeout` is for if the page has to switch from the History tab, otherwise the focus won't trigger.