### PR TITLE
Fix error on passing unexpected parameter type

### DIFF
--- a/app/Libraries/Search/WikiSuggestionsRequestParams.php
+++ b/app/Libraries/Search/WikiSuggestionsRequestParams.php
@@ -11,6 +11,6 @@ class WikiSuggestionsRequestParams extends WikiSuggestionsParams
     {
         parent::__construct();
 
-        $this->queryString = trim($request['query'] ?? null);
+        $this->queryString = trim(get_string($request['query'] ?? null) ?? '');
     }
 }


### PR DESCRIPTION
Passing an array `query` would cause error. Also ensured to not pass null to trim.