### PR TITLE
Fix search highlight cutoff position

### DIFF
--- a/app/Libraries/Elasticsearch/Hit.php
+++ b/app/Libraries/Elasticsearch/Hit.php
@@ -47,7 +47,7 @@ class Hit implements \ArrayAccess
                 $cap = mb_strrpos($text, '</em>');
                 $cap = $cap === false ? false : $cap + 5;
 
-                return truncate($text, $cap === false ? $limit : max($cap, $limit));
+                return truncate_inclusive($text, $cap === false ? $limit : max($cap, $limit));
             }, $highlights);
         }
 

--- a/app/Libraries/Elasticsearch/Hit.php
+++ b/app/Libraries/Elasticsearch/Hit.php
@@ -44,10 +44,7 @@ class Hit implements \ArrayAccess
             return array_map(function ($text) use ($limit) {
                 // ensure cutoff is after the end of the highlight, if any.
                 // TODO: look at storing offsets in index and using those to build highlights instead?
-                $lastEmStart = mb_strrpos($text, '<em>');
-                $cap = $lastEmStart === false
-                    ? false
-                    : mb_strpos($text, '</em>', $lastEmStart);
+                $cap = mb_strrpos($text, '</em>');
                 $cap = $cap === false ? false : $cap + 5;
 
                 return truncate($text, $cap === false ? $limit : max($cap, $limit));

--- a/app/Libraries/Elasticsearch/Hit.php
+++ b/app/Libraries/Elasticsearch/Hit.php
@@ -44,9 +44,13 @@ class Hit implements \ArrayAccess
             return array_map(function ($text) use ($limit) {
                 // ensure cutoff is after the end of the highlight, if any.
                 // TODO: look at storing offsets in index and using those to build highlights instead?
-                $cap = strpos($text, '</em>') + 5;
+                $lastEmStart = mb_strrpos($text, '<em>');
+                $cap = $lastEmStart === false
+                    ? false
+                    : mb_strpos($text, '</em>', $lastEmStart);
+                $cap = $cap === false ? false : $cap + 5;
 
-                return str_limit($text, $cap === false ? $limit : max($cap, $limit));
+                return truncate($text, $cap === false ? $limit : max($cap, $limit));
             }, $highlights);
         }
 

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -449,6 +449,15 @@ function truncate(string $text, $limit = 100, $ellipsis = '...')
     return $text;
 }
 
+function truncate_inclusive(string $text, int $limit): string
+{
+    if (mb_strlen($text) > $limit) {
+        return mb_substr($text, 0, $limit).'...';
+    }
+
+    return $text;
+}
+
 function json_date(?DateTime $date): ?string
 {
     return $date === null ? null : $date->format('Y-m-d');

--- a/resources/views/home/_search_result_forum_post.blade.php
+++ b/resources/views/home/_search_result_forum_post.blade.php
@@ -28,7 +28,7 @@
             'user' => $user,
             'title' => $title,
             'link' => $postUrl,
-            'excerpt' => $search->getHighlights($entry, 'search_content') ?? str_limit($entry->source('search_content'), 100),
+            'excerpt' => $search->getHighlights($entry, 'search_content') ?? truncate($entry->source('search_content'), 100),
             'postId' => $postId,
             'time' => $entry->source('post_time'),
             'topic' => $topic,


### PR DESCRIPTION
There may be another `<em>` after $cap that's still below $limit. When that happens, the $limit cutoff may include the extra tag without its corresponding closing tag.

Additionally, use `mb_` for position calculation and `truncate` for truncating text because str_limit uses "width" nonsense.