### PR TITLE
Use docker builtin init

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,6 +18,7 @@ x-web: &x-web
   build:
     context: ./docker/development
     dockerfile: ../../Dockerfile.development
+  init: true
   volumes:
     - .:/app
   environment:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,3 @@
-version: '3.4'
-
 x-env: &x-env
   APP_KEY: "${APP_KEY}"
   BEATMAPS_DIFFICULTY_CACHE_SERVER_URL: http://beatmap-difficulty-lookup-cache


### PR DESCRIPTION
This speeds up shutdown time since artisan queue doesn't quite handle signal correctly. Similarly with schedule loop.