### PR TITLE
Fix default deployment docker command

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,7 @@
 .docker/
 .env*
 .git/
+.webpack-build-notifier-config.js
 Dockerfile
 bootstrap/cache/
 bootstrap/compiler.php

--- a/Dockerfile.deployment
+++ b/Dockerfile.deployment
@@ -109,4 +109,3 @@ EXPOSE 8000
 EXPOSE 8080
 
 ENTRYPOINT ["/app/docker/deployment/entrypoint.sh"]
-CMD ["octane"]

--- a/docker/deployment/entrypoint.sh
+++ b/docker/deployment/entrypoint.sh
@@ -5,7 +5,7 @@ set -e
 # exit on unassigned variable
 set -u
 
-command=php
+command=octane
 if [ "$#" -gt 0 ]; then
     command="$1"
     shift


### PR DESCRIPTION
The previous default action was removed, making it invalid. And then the new default is defined in a different place. The end result is two defaults defined separately.