### PR TITLE
Display changelog entries count on user profile link section

### DIFF
--- a/app/Transformers/UserTransformer.php
+++ b/app/Transformers/UserTransformer.php
@@ -48,6 +48,8 @@ class UserTransformer extends UserCompactTransformer
             'title_url' => $user->titleUrl(),
             'twitter' => $user->user_twitter,
             'website' => $user->user_website,
+            'changelog_entries_count' => $user->githubUser?->changelogEntries->count(),
+            'github_url' => $user->githubUser?->githubUrl(),
         ]);
     }
 }

--- a/resources/js/interfaces/user-extended-json.ts
+++ b/resources/js/interfaces/user-extended-json.ts
@@ -51,6 +51,8 @@ interface UserExtendedAdditionalAttributes {
   title_url: string | null;
   twitter: string | null;
   website: string | null;
+  changelog_entries_count: number | null;
+  github_url: string | null;
 }
 
 type UserExtendedJson = UserJson & Required<Pick<UserJson, UserExtendedDefaultIncludes>> & UserExtendedAdditionalAttributes;

--- a/resources/js/profile-page/links.tsx
+++ b/resources/js/profile-page/links.tsx
@@ -14,7 +14,7 @@ import { classWithModifiers } from 'utils/css';
 import { trans, transChoice } from 'utils/lang';
 
 // these are ordered in the order they appear in.
-const textKeys = ['join_date', 'last_visit', 'playstyle', 'post_count', 'comments_count'] as const;
+const textKeys = ['join_date', 'last_visit', 'playstyle', 'post_count', 'comments_count', 'changelog_entries_count'] as const;
 type TextKey = (typeof textKeys)[number];
 
 const bioKeys = ['location', 'interests', 'occupation'] as const;
@@ -133,6 +133,14 @@ const textMapping: Record<TextKey, (user: UserExtendedJson) => StringWithCompone
     return {
       mappings: { link: <a className={classWithModifiers('profile-links__value', 'link')} href={url}>{count}</a> },
       pattern: trans('users.show.post_count._'),
+    };
+  },
+  changelog_entries_count: (user: UserExtendedJson) => {
+    const count = transChoice('users.show.changelog_entries_count.count', user.changelog_entries_count ?? 0);
+
+    return {
+      mappings: { link: <a className={classWithModifiers('profile-links__value', 'link')} href={user.github_url!}>{count}</a> },
+      pattern: trans('users.show.changelog_entries_count._'),
     };
   },
 };

--- a/resources/lang/en/users.php
+++ b/resources/lang/en/users.php
@@ -441,6 +441,10 @@ return [
             '_' => 'Contributed :link',
             'count' => ':count_delimited forum post|:count_delimited forum posts',
         ],
+        'changelog_entries_count' => [
+            '_' => 'Contributed :link',
+            'count' => ':count_delimited changelog entry|:count_delimited changelog entries',
+        ],
         'rank' => [
             'country' => 'Country rank for :mode',
             'country_simple' => 'Country Ranking',


### PR DESCRIPTION
Resolves #10962.

## GitHub user linked
![image](https://github.com/ppy/osu-web/assets/51536154/124f2176-e08c-48d1-9981-e0acbb7c72fa)

## GitHub user not linked
![image](https://github.com/ppy/osu-web/assets/51536154/a8fc9dc2-141e-48a5-98c9-8972c73b8347)