### PR TITLE
Update relative link to absolute link on click

### DIFF
--- a/resources/js/core/fix-relative-link.ts
+++ b/resources/js/core/fix-relative-link.ts
@@ -1,0 +1,22 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
+function fixLink(e: MouseEvent) {
+  if (!(e.target instanceof Element)) {
+    return;
+  }
+  const link = e.target.closest('a');
+  if (!(link instanceof HTMLAnchorElement)) {
+    return;
+  }
+
+  if (link.getAttribute('href')?.startsWith('./')) {
+    link.setAttribute('href', link.href);
+  }
+}
+
+export default class FixRelativeLink {
+  constructor() {
+    document.addEventListener('click', fixLink);
+  }
+}

--- a/resources/js/osu-core.ts
+++ b/resources/js/osu-core.ts
@@ -129,7 +129,6 @@ export default class OsuCore {
     if (!isLoading) {
       this.updateCurrentUser();
     }
-
   }
 
   readonly updateCurrentUser = () => {

--- a/resources/js/osu-core.ts
+++ b/resources/js/osu-core.ts
@@ -7,6 +7,7 @@ import BrowserTitleWithNotificationCount from 'core/browser-title-with-notificat
 import Captcha from 'core/captcha';
 import ClickMenu from 'core/click-menu';
 import Enchant from 'core/enchant';
+import FixRelativeLink from 'core/fix-relative-link';
 import ForumPoll from 'core/forum/forum-poll';
 import ForumPostEdit from 'core/forum/forum-post-edit';
 import ForumPostInput from 'core/forum/forum-post-input';
@@ -45,6 +46,7 @@ export default class OsuCore {
   readonly currentUserModel;
   readonly dataStore;
   readonly enchant;
+  readonly fixRelativeLink;
   readonly forumPoll;
   readonly forumPostEdit;
   readonly forumPostInput;
@@ -90,6 +92,7 @@ export default class OsuCore {
     this.chatWorker = new ChatWorker();
     this.clickMenu = new ClickMenu();
     this.currentUserModel = new UserModel(this);
+    this.fixRelativeLink = new FixRelativeLink();
     this.forumPoll = new ForumPoll();
     this.forumPostEdit = new ForumPostEdit();
     this.forumPostInput = new ForumPostInput();
@@ -126,6 +129,7 @@ export default class OsuCore {
     if (!isLoading) {
       this.updateCurrentUser();
     }
+
   }
 
   readonly updateCurrentUser = () => {


### PR DESCRIPTION
Turbolinks appends the url right away and clicking the link again will append it again which is definitely not the intended effect.

Resolves #10662.