### PR TITLE
Fix beatmap discussion filter resetting when switching difficulties or page tabs

### DIFF
--- a/resources/js/beatmap-discussions/beatmap-list.tsx
+++ b/resources/js/beatmap-discussions/beatmap-list.tsx
@@ -83,7 +83,7 @@ export default class BeatmapList extends React.Component<Props> {
       >
         <BeatmapListItem
           beatmap={beatmap}
-          beatmapUrl={makeUrl({ beatmap })}
+          beatmapUrl={makeUrl({ beatmap, filter: this.props.discussionsState.currentFilter })}
           beatmapset={this.props.discussionsState.beatmapset}
           mapper={this.props.users.get(beatmap.user_id) ?? deletedUserJson}
           showNonGuestMapper={false}

--- a/resources/js/beatmap-discussions/discussions-state.ts
+++ b/resources/js/beatmap-discussions/discussions-state.ts
@@ -351,7 +351,7 @@ export default class DiscussionsState {
       // record page and filter when switching to events
       this.previousPage = this.currentPage;
       this.previousFilter = this.currentFilter;
-    } else if (this.currentFilter !== this.previousFilter) {
+    } else if (this.currentPage === 'events' && this.currentFilter !== this.previousFilter) {
       // restore previous filter when switching away from events
       this.currentFilter = this.previousFilter;
     }


### PR DESCRIPTION
closes #10987

also added the filter to the url for middle clicks