### PR TITLE
Add description to user achievement unlock event payload

### DIFF
--- a/app/Jobs/Notifications/UserAchievementUnlock.php
+++ b/app/Jobs/Notifications/UserAchievementUnlock.php
@@ -45,6 +45,7 @@ class UserAchievementUnlock extends BroadcastNotificationBase
             'cover_url' => $this->achievement->iconUrl(),
             'slug' => $this->achievement->slug,
             'title' => $this->achievement->name,
+            'description' => $this->achievement->description,
             'user_id' => $this->source->getKey(),
         ];
     }


### PR DESCRIPTION
To be used for lazer-side display of awarded medals (https://github.com/ppy/osu/issues/18880, client-side PR to come shortly). Previously discussed [on discord](https://discord.com/channels/188630481301012481/188630616286167041/1209458059638874142).

Opening as draft to start with since I'm not completely sure yet we're going to be using the notifications websocket for this client-side. But I did test full-stack and it appears to work.