### PR TITLE
Improve supporter icon alignment

### DIFF
--- a/resources/css/bem/supporter-icon.less
+++ b/resources/css/bem/supporter-icon.less
@@ -28,7 +28,7 @@
     width: @user-card-icon-size;
     font-size: @user-card-icon-size / 2;
     border-radius: 50%;
-    padding: unset;
+    padding: 1px 0 0;
   }
 
   &--user-list {

--- a/resources/js/components/supporter-icon.tsx
+++ b/resources/js/components/supporter-icon.tsx
@@ -3,22 +3,23 @@
 
 import { times } from 'lodash';
 import * as React from 'react';
-import { classWithModifiers } from 'utils/css';
+import { classWithModifiers, Modifiers } from 'utils/css';
 import { trans } from 'utils/lang';
 
 interface Props {
   level?: number;
-  modifiers?: string[];
+  modifiers?: Modifiers;
 }
 
-export const SupporterIcon = (props: Props) => {
-  const className = classWithModifiers('supporter-icon', props.modifiers);
-
+export default function SupporterIcon(props: Props) {
   return (
-    <span className={className} title={trans('users.show.is_supporter')}>
+    <span
+      className={classWithModifiers('supporter-icon', props.modifiers)}
+      title={trans('users.show.is_supporter')}
+    >
       {
         times(props.level ?? 1, (n) => <span key={n} className='fas fa-heart' />)
       }
     </span>
   );
-};
+}

--- a/resources/js/components/user-card.tsx
+++ b/resources/js/components/user-card.tsx
@@ -18,7 +18,7 @@ import { PopupMenuPersistent } from './popup-menu-persistent';
 import { ReportReportable } from './report-reportable';
 import { Spinner } from './spinner';
 import StringWithComponent from './string-with-component';
-import { SupporterIcon } from './supporter-icon';
+import SupporterIcon from './supporter-icon';
 import TimeWithTooltip from './time-with-tooltip';
 import UserCardBrick from './user-card-brick';
 import UserGroupBadges from './user-group-badges';
@@ -228,7 +228,7 @@ export class UserCard extends React.PureComponent<Props, State> {
           <>
             {this.user.is_supporter && (
               <a className='user-card__icon' href={route('support-the-game')}>
-                <SupporterIcon modifiers={['user-card']} />
+                <SupporterIcon modifiers='user-card' />
               </a>
             )}
             <div className='user-card__icon'>
@@ -254,7 +254,7 @@ export class UserCard extends React.PureComponent<Props, State> {
       <div className='user-card__icons'>
         {this.user.is_supporter && (
           <a className='user-card__icon' href={route('support-the-game')}>
-            <SupporterIcon level={this.user.support_level} modifiers={['user-list']} />
+            <SupporterIcon level={this.user.support_level} modifiers='user-list' />
           </a>
         )}
 

--- a/resources/js/quick-search/user.tsx
+++ b/resources/js/quick-search/user.tsx
@@ -3,7 +3,7 @@
 
 import FlagCountry from 'components/flag-country';
 import FriendButton from 'components/friend-button';
-import { SupporterIcon } from 'components/supporter-icon';
+import SupporterIcon from 'components/supporter-icon';
 import UserGroupBadges from 'components/user-group-badges';
 import UserJson from 'interfaces/user-json';
 import { route } from 'laroute';
@@ -33,7 +33,7 @@ export default function User({ user, modifiers = [] }: { modifiers?: string[]; u
           {user.is_supporter
             ? (
               <div className='user-search-card__col user-search-card__col--icon u-hidden-narrow'>
-                <SupporterIcon level={user.support_level} modifiers={['quick-search']} />
+                <SupporterIcon level={user.support_level} modifiers='quick-search' />
               </div>
             ) : null}
 


### PR DESCRIPTION
Looks better on 100ppi display with 100%, 150%, and 200% scaling. Also on phone with 445ppi display with unknown scaling.

Cleaned up SupporterIcon component while at it.

Resolves #1574.