### PR TITLE
Specify defaults for medal unlock notification options

### DIFF
--- a/app/Jobs/Notifications/UserAchievementUnlock.php
+++ b/app/Jobs/Notifications/UserAchievementUnlock.php
@@ -11,6 +11,11 @@ use App\Models\User;
 
 class UserAchievementUnlock extends BroadcastNotificationBase
 {
+    // Mainly to ensure client always getting the event.
+    // Also it probably doesn't really make sense to mail the event
+    // in the first place.
+    const DELIVERY_MODE_DEFAULTS = ['mail' => false, 'push' => true];
+
     protected $achievement;
 
     public static function getMailGroupingKey(Notification $notification): string


### PR DESCRIPTION
Explicitly set so it doesn't depend on the base class providing the expected defaults.