### PR TITLE
Update ranked flag to remove scores from index

### DIFF
--- a/app/Models/Solo/Score.php
+++ b/app/Models/Solo/Score.php
@@ -164,6 +164,7 @@ class Score extends Model implements Traits\ReportableInterface
     {
         return $query
             ->where('preserve', true)
+            ->where('ranked', true)
             ->whereHas('user', fn (Builder $q): Builder => $q->default());
     }
 

--- a/tests/Jobs/RemoveBeatmapsetSoloScoresTest.php
+++ b/tests/Jobs/RemoveBeatmapsetSoloScoresTest.php
@@ -47,7 +47,7 @@ class RemoveBeatmapsetSoloScoresTest extends TestCase
             $this->createScore($beatmapset);
         }
 
-        $this->expectCountChange(fn () => Score::count(), count($scores) * -2, 'removes scores');
+        $this->expectCountChange(fn () => Score::indexable()->count(), count($scores) * -2, 'removes scores');
 
         static::reindexScores();
 


### PR DESCRIPTION
Prevents scores from being actually deleted, for things like multiplayer scores which scores should stay.