### PR TITLE
Skip fetching rank for certain score types

### DIFF
--- a/app/Models/Solo/Score.php
+++ b/app/Models/Solo/Score.php
@@ -427,6 +427,10 @@ class Score extends Model implements Traits\ReportableInterface
 
     public function userRank(?array $params = null): int
     {
+        if (!$this->ranked || !$this->preserve) {
+            return 0;
+        }
+
         // Non-legacy score always has its rank checked against all score types.
         if (!$this->isLegacy()) {
             $params['is_legacy'] = null;

--- a/resources/js/scores-show/player.tsx
+++ b/resources/js/scores-show/player.tsx
@@ -17,7 +17,7 @@ export default function Player(props: Props) {
   let title: string;
   let content: React.ReactNode;
 
-  if (props.score.rank_global == null || props.score.ranked === false || props.score.preserve === false) {
+  if (props.score.rank_global == null || props.score.rank_global === 0 || props.score.ranked === false || props.score.preserve === false) {
     title = trans('scores.status.no_rank');
     content = '-';
   } else {


### PR DESCRIPTION
No point fetching the rank from es if it's not supposed to have one? Using 0 as placeholder.