### PR TITLE
Fix inconsistency in displayed miss count between stable & lazer catch scores

### DIFF
--- a/resources/css/bem/beatmap-scoreboard-table.less
+++ b/resources/css/bem/beatmap-scoreboard-table.less
@@ -75,7 +75,7 @@
       white-space: nowrap;
     }
 
-    &--hitstat-count_miss {
+    &--hitstat-miss {
       width: 50px;
     }
 

--- a/resources/js/beatmapsets-show/scoreboard/table-row.tsx
+++ b/resources/js/beatmapsets-show/scoreboard/table-row.tsx
@@ -16,7 +16,7 @@ import PpValue from 'scores/pp-value';
 import { classWithModifiers, Modifiers } from 'utils/css';
 import { formatNumber } from 'utils/html';
 import { trans } from 'utils/lang';
-import { accuracy, filterMods, hasMenu, isPerfectCombo, modeAttributesMap, rank, scoreUrl, totalScore } from 'utils/score-helper';
+import { accuracy, filterMods, hasMenu, isPerfectCombo, attributeDisplayTotals, rank, scoreUrl, totalScore } from 'utils/score-helper';
 
 const bn = 'beatmap-scoreboard-table';
 
@@ -128,13 +128,13 @@ export default class ScoreboardTableRow extends React.Component<Props> {
           {`${formatNumber(score.max_combo)}x`}
         </TdLink>
 
-        {modeAttributesMap[this.props.beatmap.mode].map((stat) => (
+        {attributeDisplayTotals(this.props.beatmap.mode, score).map((stat) => (
           <TdLink
-            key={stat.attribute}
+            key={stat.key}
             href={this.scoreUrl}
-            modifiers={{ zero: (score.statistics[stat.attribute] ?? 0) === 0 }}
+            modifiers={{ zero: stat.total === 0 }}
           >
-            {formatNumber(score.statistics[stat.attribute] ?? 0)}
+            {formatNumber(stat.total)}
           </TdLink>
         ))}
 

--- a/resources/js/beatmapsets-show/scoreboard/table.tsx
+++ b/resources/js/beatmapsets-show/scoreboard/table.tsx
@@ -8,7 +8,7 @@ import { ContainerContext, KeyContext } from 'stateful-activation-context';
 import { shouldShowPp } from 'utils/beatmap-helper';
 import { classWithModifiers } from 'utils/css';
 import { trans } from 'utils/lang';
-import { attributeDisplayLabels } from 'utils/score-helper';
+import { modeAttributesMap } from 'utils/score-helper';
 import Controller from './controller';
 import TableRow from './table-row';
 
@@ -62,7 +62,7 @@ export default class Table extends React.Component<Props> {
                 <th className={`${bn}__header ${bn}__header--maxcombo`}>
                   {trans('beatmapsets.show.scoreboard.headers.combo')}
                 </th>
-                {attributeDisplayLabels(this.props.controller.beatmap.mode).map((stat) => (
+                {modeAttributesMap[this.props.controller.beatmap.mode].map((stat) => (
                   <th
                     key={stat.key}
                     className={classWithModifiers(`${bn}__header`, ['hitstat', `hitstat-${stat.key}`])}

--- a/resources/js/beatmapsets-show/scoreboard/table.tsx
+++ b/resources/js/beatmapsets-show/scoreboard/table.tsx
@@ -8,7 +8,7 @@ import { ContainerContext, KeyContext } from 'stateful-activation-context';
 import { shouldShowPp } from 'utils/beatmap-helper';
 import { classWithModifiers } from 'utils/css';
 import { trans } from 'utils/lang';
-import { modeAttributesMap } from 'utils/score-helper';
+import { attributeDisplayLabels } from 'utils/score-helper';
 import Controller from './controller';
 import TableRow from './table-row';
 
@@ -62,10 +62,10 @@ export default class Table extends React.Component<Props> {
                 <th className={`${bn}__header ${bn}__header--maxcombo`}>
                   {trans('beatmapsets.show.scoreboard.headers.combo')}
                 </th>
-                {modeAttributesMap[this.props.controller.beatmap.mode].map((stat) => (
+                {attributeDisplayLabels(this.props.controller.beatmap.mode).map((stat) => (
                   <th
-                    key={stat.attribute}
-                    className={classWithModifiers(`${bn}__header`, ['hitstat', `hitstat-${stat.attribute}`])}
+                    key={stat.key}
+                    className={classWithModifiers(`${bn}__header`, ['hitstat', `hitstat-${stat.key}`])}
                   >
                     {stat.label}
                   </th>

--- a/resources/js/beatmapsets-show/scoreboard/top-card.tsx
+++ b/resources/js/beatmapsets-show/scoreboard/top-card.tsx
@@ -19,7 +19,7 @@ import { rulesetName, shouldShowPp } from 'utils/beatmap-helper';
 import { classWithModifiers, Modifiers } from 'utils/css';
 import { formatNumber } from 'utils/html';
 import { trans } from 'utils/lang';
-import { accuracy, filterMods, isPerfectCombo, modeAttributesMap, rank, scoreUrl, totalScore } from 'utils/score-helper';
+import { accuracy, filterMods, isPerfectCombo, attributeDisplayTotals, rank, scoreUrl, totalScore } from 'utils/score-helper';
 
 interface Props {
   beatmap: BeatmapJson;
@@ -147,13 +147,13 @@ export default class TopCard extends React.PureComponent<Props> {
             </div>
 
             <div className='beatmap-score-top__stats beatmap-score-top__stats--wrappable'>
-              {modeAttributesMap[ruleset].map((attr) => (
-                <div key={attr.attribute} className='beatmap-score-top__stat'>
+              {attributeDisplayTotals(ruleset, this.props.score).map((attr) => (
+                <div key={attr.key} className='beatmap-score-top__stat'>
                   <div className='beatmap-score-top__stat-header'>
                     {attr.label}
                   </div>
                   <div className='beatmap-score-top__stat-value beatmap-score-top__stat-value--smaller'>
-                    {formatNumber(this.props.score.statistics[attr.attribute] ?? 0)}
+                    {formatNumber(attr.total)}
                   </div>
                 </div>
               ))}

--- a/resources/js/scores-show/stats.tsx
+++ b/resources/js/scores-show/stats.tsx
@@ -10,7 +10,7 @@ import { rulesetName, shouldShowPp } from 'utils/beatmap-helper';
 import { classWithModifiers } from 'utils/css';
 import { formatNumber } from 'utils/html';
 import { trans } from 'utils/lang';
-import { accuracy, isPerfectCombo, modeAttributesMap } from 'utils/score-helper';
+import { accuracy, isPerfectCombo, attributeDisplayTotals } from 'utils/score-helper';
 
 interface Props {
   beatmap: BeatmapJson;
@@ -58,13 +58,13 @@ export default function Stats(props: Props) {
           )}
         </div>
         <div className='score-stats__group-row'>
-          {modeAttributesMap[rulesetName(props.score.ruleset_id)].map((attr) => (
-            <div key={attr.attribute} className='score-stats__stat'>
+          {attributeDisplayTotals(rulesetName(props.score.ruleset_id), props.score).map((attr) => (
+            <div key={attr.key} className='score-stats__stat'>
               <div className='score-stats__stat-row score-stats__stat-row--label'>
                 {attr.label}
               </div>
               <div className='score-stats__stat-row'>
-                {formatNumber(props.score.statistics[attr.attribute] ?? 0)}
+                {formatNumber(attr.total)}
               </div>
             </div>
           ))}

--- a/resources/js/utils/score-helper.ts
+++ b/resources/js/utils/score-helper.ts
@@ -48,40 +48,67 @@ export function isPerfectCombo(score: SoloScoreJson) {
     : score.is_perfect_combo;
 }
 
-interface AttributeData {
-  attribute: SoloScoreStatisticsAttribute;
+interface AttributeDisplayMapping {
+  key: string,
+  attributes: SoloScoreStatisticsAttribute[];
   label: string;
+}
+
+interface AttributeDisplay {
+  key: string,
+  label: string;
+}
+
+interface AttributeDisplayTotal extends AttributeDisplay {
+  total: number;
 }
 
 const labelMiss = trans('beatmapsets.show.scoreboard.headers.miss');
 
-export const modeAttributesMap: Record<GameMode, AttributeData[]> = {
+const modeAttributesMap: Record<GameMode, AttributeDisplayMapping[]> = {
   fruits: [
-    { attribute: 'great', label: 'fruits' },
-    { attribute: 'large_tick_hit', label: 'ticks' },
-    { attribute: 'small_tick_miss', label: 'drp miss' },
-    { attribute: 'miss', label: labelMiss },
+    { key: 'great', attributes: ['great'], label: 'fruits' },
+    { key: 'ticks', attributes: ['large_tick_hit'], label: 'ticks' },
+    { key: 'drp_miss', attributes: ['small_tick_miss'], label: 'drp miss' },
+    // legacy/stable scores merge miss and large_tick_miss into one number
+    { key: 'miss', attributes: ['miss', 'large_tick_miss'], label: labelMiss },
   ],
   mania: [
-    { attribute: 'perfect', label: 'max' },
-    { attribute: 'great', label: '300' },
-    { attribute: 'good', label: '200' },
-    { attribute: 'ok', label: '100' },
-    { attribute: 'meh', label: '50' },
-    { attribute: 'miss', label: labelMiss },
+    { key: 'perfect', attributes: ['perfect'], label: 'max' },
+    { key: 'great', attributes: ['great'], label: '300' },
+    { key: 'good', attributes: ['good'], label: '200' },
+    { key: 'ok', attributes: ['ok'], label: '100' },
+    { key: 'meh', attributes: ['meh'], label: '50' },
+    { key: 'miss', attributes: ['miss'], label: labelMiss },
   ],
   osu: [
-    { attribute: 'great', label: '300' },
-    { attribute: 'ok', label: '100' },
-    { attribute: 'meh', label: '50' },
-    { attribute: 'miss', label: labelMiss },
+    { key: 'great', attributes: ['great'], label: '300' },
+    { key: 'ok', attributes: ['ok'], label: '100' },
+    { key: 'meh', attributes: ['meh'], label: '50' },
+    { key: 'miss', attributes: ['miss'], label: labelMiss },
   ],
   taiko: [
-    { attribute: 'great', label: 'great' },
-    { attribute: 'ok', label: 'good' },
-    { attribute: 'miss', label: labelMiss },
+    { key: 'great', attributes: ['great'], label: 'great' },
+    { key: 'ok', attributes: ['ok'], label: 'good' },
+    { key: 'miss', attributes: ['miss'], label: labelMiss },
   ],
 };
+
+export function attributeDisplayLabels(ruleset: GameMode): AttributeDisplay[] {
+  return modeAttributesMap[ruleset].map((mapping) => ({
+    key: mapping.key,
+    label: mapping.label
+  }));
+}
+
+export function attributeDisplayTotals(ruleset: GameMode, score: SoloScoreJson): AttributeDisplayTotal[] {
+  const modeMapping = modeAttributesMap[ruleset];
+  return modeMapping.map((mapping) => ({
+    key: mapping.key,
+    label: mapping.label,
+    total: mapping.attributes.map((attribute) => score.statistics[attribute] ?? 0).reduce((sum, elem) => sum + elem, 0)
+  }));
+}
 
 export function rank(score: SoloScoreJson) {
   return shouldReturnLegacyValue(score)

--- a/resources/js/utils/score-helper.ts
+++ b/resources/js/utils/score-helper.ts
@@ -49,13 +49,13 @@ export function isPerfectCombo(score: SoloScoreJson) {
 }
 
 interface AttributeDisplayMapping {
-  key: string,
   attributes: SoloScoreStatisticsAttribute[];
+  key: string;
   label: string;
 }
 
 interface AttributeDisplay {
-  key: string,
+  key: string;
   label: string;
 }
 
@@ -67,37 +67,37 @@ const labelMiss = trans('beatmapsets.show.scoreboard.headers.miss');
 
 const modeAttributesMap: Record<GameMode, AttributeDisplayMapping[]> = {
   fruits: [
-    { key: 'great', attributes: ['great'], label: 'fruits' },
-    { key: 'ticks', attributes: ['large_tick_hit'], label: 'ticks' },
-    { key: 'drp_miss', attributes: ['small_tick_miss'], label: 'drp miss' },
+    { attributes: ['great'], key: 'great', label: 'fruits' },
+    { attributes: ['large_tick_hit'], key: 'ticks', label: 'ticks' },
+    { attributes: ['small_tick_miss'], key: 'drp_miss', label: 'drp miss' },
     // legacy/stable scores merge miss and large_tick_miss into one number
-    { key: 'miss', attributes: ['miss', 'large_tick_miss'], label: labelMiss },
+    { attributes: ['miss', 'large_tick_miss'], key: 'miss', label: labelMiss },
   ],
   mania: [
-    { key: 'perfect', attributes: ['perfect'], label: 'max' },
-    { key: 'great', attributes: ['great'], label: '300' },
-    { key: 'good', attributes: ['good'], label: '200' },
-    { key: 'ok', attributes: ['ok'], label: '100' },
-    { key: 'meh', attributes: ['meh'], label: '50' },
-    { key: 'miss', attributes: ['miss'], label: labelMiss },
+    { attributes: ['perfect'], key: 'perfect', label: 'max' },
+    { attributes: ['great'], key: 'great', label: '300' },
+    { attributes: ['good'], key: 'good', label: '200' },
+    { attributes: ['ok'], key: 'ok', label: '100' },
+    { attributes: ['meh'], key: 'meh', label: '50' },
+    { attributes: ['miss'], key: 'miss', label: labelMiss },
   ],
   osu: [
-    { key: 'great', attributes: ['great'], label: '300' },
-    { key: 'ok', attributes: ['ok'], label: '100' },
-    { key: 'meh', attributes: ['meh'], label: '50' },
-    { key: 'miss', attributes: ['miss'], label: labelMiss },
+    { attributes: ['great'], key: 'great', label: '300' },
+    { attributes: ['ok'], key: 'ok', label: '100' },
+    { attributes: ['meh'], key: 'meh', label: '50' },
+    { attributes: ['miss'], key: 'miss', label: labelMiss },
   ],
   taiko: [
-    { key: 'great', attributes: ['great'], label: 'great' },
-    { key: 'ok', attributes: ['ok'], label: 'good' },
-    { key: 'miss', attributes: ['miss'], label: labelMiss },
+    { attributes: ['great'], key: 'great', label: 'great' },
+    { attributes: ['ok'], key: 'ok', label: 'good' },
+    { attributes: ['miss'], key: 'miss', label: labelMiss },
   ],
 };
 
 export function attributeDisplayLabels(ruleset: GameMode): AttributeDisplay[] {
   return modeAttributesMap[ruleset].map((mapping) => ({
     key: mapping.key,
-    label: mapping.label
+    label: mapping.label,
   }));
 }
 
@@ -106,7 +106,7 @@ export function attributeDisplayTotals(ruleset: GameMode, score: SoloScoreJson):
   return modeMapping.map((mapping) => ({
     key: mapping.key,
     label: mapping.label,
-    total: mapping.attributes.map((attribute) => score.statistics[attribute] ?? 0).reduce((sum, elem) => sum + elem, 0)
+    total: mapping.attributes.map((attribute) => score.statistics[attribute] ?? 0).reduce((sum, elem) => sum + elem, 0),
   }));
 }
 

--- a/resources/js/utils/score-helper.ts
+++ b/resources/js/utils/score-helper.ts
@@ -54,18 +54,15 @@ interface AttributeDisplayMapping {
   label: string;
 }
 
-interface AttributeDisplay {
+interface AttributeDisplayTotal {
   key: string;
   label: string;
-}
-
-interface AttributeDisplayTotal extends AttributeDisplay {
   total: number;
 }
 
 const labelMiss = trans('beatmapsets.show.scoreboard.headers.miss');
 
-const modeAttributesMap: Record<GameMode, AttributeDisplayMapping[]> = {
+export const modeAttributesMap: Record<GameMode, AttributeDisplayMapping[]> = {
   fruits: [
     { attributes: ['great'], key: 'great', label: 'fruits' },
     { attributes: ['large_tick_hit'], key: 'ticks', label: 'ticks' },
@@ -94,19 +91,11 @@ const modeAttributesMap: Record<GameMode, AttributeDisplayMapping[]> = {
   ],
 };
 
-export function attributeDisplayLabels(ruleset: GameMode): AttributeDisplay[] {
+export function attributeDisplayTotals(ruleset: GameMode, score: SoloScoreJson): AttributeDisplayTotal[] {
   return modeAttributesMap[ruleset].map((mapping) => ({
     key: mapping.key,
     label: mapping.label,
-  }));
-}
-
-export function attributeDisplayTotals(ruleset: GameMode, score: SoloScoreJson): AttributeDisplayTotal[] {
-  const modeMapping = modeAttributesMap[ruleset];
-  return modeMapping.map((mapping) => ({
-    key: mapping.key,
-    label: mapping.label,
-    total: mapping.attributes.map((attribute) => score.statistics[attribute] ?? 0).reduce((sum, elem) => sum + elem, 0),
+    total: mapping.attributes.reduce((sum, attribute) => sum + (score.statistics[attribute] ?? 0), 0),
   }));
 }
 


### PR DESCRIPTION
Related: https://github.com/ppy/osu/issues/27473

In stable, both fruit misses and large droplet misses were counted as full misses and shown in the miss column. In lazer they are two disparate statistics (misses and large tick misses).

Because we cannot retroactively get this data out for all scores on stable, this PR changes the display instead so that lazer scores have misses and large tick misses summed up in the "miss" column, which restores parity (stable scores will be full misses which actually include large tick misses, plus zero "actual" large tick misses, and lazer scores will just sum actual full misses and actual large tick misses).

In the process this fixes silent CSS breakage due to implicit dependency of the CSS rule changed on the textual value of `attribute` key of each label.

Naming suggestions appreciated, I kinda didn't know what to do there.