### PR TITLE
 Better image size error logging

### DIFF
--- a/app/Exceptions/FastImagesizeFetchException.php
+++ b/app/Exceptions/FastImagesizeFetchException.php
@@ -1,0 +1,12 @@
+<?php
+
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
+declare(strict_types=1);
+
+namespace App\Exceptions;
+
+class FastImagesizeFetchException extends \Exception
+{
+}

--- a/resources/views/store/products/show.blade.php
+++ b/resources/views/store/products/show.blade.php
@@ -29,7 +29,7 @@
                         <div class="gallery-previews">
                             @foreach($product->images() as $i => $image)
                                 @php
-                                    $imageSize = fast_imagesize($image[1]);
+                                    $imageSize = fast_imagesize($image[1], "store_product:{$product->getKey()}");
                                 @endphp
                                 <a
                                     class="gallery-previews__item js-gallery"


### PR DESCRIPTION
Trying to figure out wtf is happening with contest image. 

Also added similar logging for store product image so it doesn't silently fail.

- [x] depends on #11069