### PR TITLE
Include more detail when GitHub returns unexpected response

### DIFF
--- a/app/Exceptions/GitHubInvalidDataException.php
+++ b/app/Exceptions/GitHubInvalidDataException.php
@@ -1,0 +1,12 @@
+<?php
+
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
+declare(strict_types=1);
+
+namespace App\Exceptions;
+
+class GitHubInvalidDataException extends \Exception
+{
+}

--- a/app/Libraries/OsuWiki.php
+++ b/app/Libraries/OsuWiki.php
@@ -16,8 +16,12 @@ class OsuWiki
 {
     const CACHE_DURATION = 60;
 
-    public $path;
-    public $data;
+    public array $data;
+
+    public function __construct(public string $path)
+    {
+        $this->data = static::fetch($this->path);
+    }
 
     public static function cleanPath($path)
     {
@@ -139,12 +143,6 @@ class OsuWiki
     public static function user()
     {
         return $GLOBALS['cfg']['osu']['wiki']['user'];
-    }
-
-    public function __construct($path)
-    {
-        $this->path = $path;
-        $this->data = static::fetch($this->path);
     }
 
     public function content()


### PR DESCRIPTION
Somehow github returned an object without content (twice) but it's not supposed to happen so having an idea what it actually returns may help.