### PR TITLE
Fix password reset error on null email

### DIFF
--- a/app/Libraries/User/PasswordResetData.php
+++ b/app/Libraries/User/PasswordResetData.php
@@ -74,7 +74,7 @@ class PasswordResetData
 
     private static function authHash(User $user): string
     {
-        return hash('sha256', $user->user_email).':'.hash('sha256', $user->user_password);
+        return hash('sha256', $user->user_email ?? '').':'.hash('sha256', $user->user_password);
     }
 
     private function __construct(

--- a/app/Libraries/User/PasswordResetData.php
+++ b/app/Libraries/User/PasswordResetData.php
@@ -16,6 +16,14 @@ class PasswordResetData
 
     private string $cacheKey;
 
+    private function __construct(
+        public array $attrs,
+        private readonly User $user,
+        string $username
+    ) {
+        $this->cacheKey = static::cacheKey($this->user, $username);
+    }
+
     public static function create(?User $user, string $username): ?string
     {
         if ($user === null) {
@@ -75,14 +83,6 @@ class PasswordResetData
     private static function authHash(User $user): string
     {
         return hash('sha256', $user->user_email ?? '').':'.hash('sha256', $user->user_password);
-    }
-
-    private function __construct(
-        public array $attrs,
-        private readonly User $user,
-        string $username
-    ) {
-        $this->cacheKey = static::cacheKey($this->user, $username);
     }
 
     public function delete(): void


### PR DESCRIPTION
While the initial step does check for valid email, the current user status check that happens later doesn't.