### PR TITLE
Don't increment replay counts if replay download is coming from an API request

### DIFF
--- a/app/Http/Controllers/ScoresController.php
+++ b/app/Http/Controllers/ScoresController.php
@@ -52,7 +52,7 @@ class ScoresController extends Controller
             abort(404);
         }
 
-        if (\Auth::user()->getKey() !== $score->user_id) {
+        if (\Auth::user()->getKey() !== $score->user_id && !is_api_request()) {
             $score->user->statistics($score->getMode(), true)->increment('replay_popularity');
 
             $month = CarbonImmutable::now();


### PR DESCRIPTION
Resolves #11019.

Took the direction peppy suggested as it makes sense to me, but I can change direction if something else is wanted.