### PR TITLE
Remove usage of profile customization model for user cover

### DIFF
--- a/app/Http/Controllers/BeatmapsController.php
+++ b/app/Http/Controllers/BeatmapsController.php
@@ -75,7 +75,7 @@ class BeatmapsController extends Controller
             'type' => $type,
             'user' => $currentUser,
         ]);
-        $scores = $esFetch->all()->loadMissing(['beatmap', 'user.country', 'user.userProfileCustomization']);
+        $scores = $esFetch->all()->loadMissing(['beatmap', 'user.country']);
         $userScore = $esFetch->userBest();
         $scoreTransformer = new ScoreTransformer($scoreTransformerType);
 

--- a/app/Http/Controllers/RankingController.php
+++ b/app/Http/Controllers/RankingController.php
@@ -197,10 +197,6 @@ class RankingController extends Controller
             if (isset($forceIndex)) {
                 $stats->from(DB::raw("{$table} FORCE INDEX ($forceIndex)"));
             }
-
-            if (is_api_request()) {
-                $stats->with(['user.userProfileCustomization']);
-            }
         }
 
         $maxResults = $this->maxResults($modeInt, $stats);
@@ -304,13 +300,11 @@ class RankingController extends Controller
             }
 
             if (is_api_request()) {
-                $scores = $scores->with(['user.userProfileCustomization'])->get();
-
                 return [
                     // transformer can't do nested includes with params properly.
                     // https://github.com/thephpleague/fractal/issues/239
                     'beatmapsets' => json_collection($beatmapsets, 'Beatmapset', ['beatmaps']),
-                    'ranking' => json_collection($scores, 'UserStatistics', ['user', 'user.cover', 'user.country']),
+                    'ranking' => json_collection($scores->get(), 'UserStatistics', ['user', 'user.cover', 'user.country']),
                     'spotlight' => json_item($spotlight, 'Spotlight', ["participant_count:mode({$mode})"]),
                 ];
             } else {

--- a/app/Libraries/Search/UserSearch.php
+++ b/app/Libraries/Search/UserSearch.php
@@ -8,6 +8,7 @@ namespace App\Libraries\Search;
 use App\Libraries\Elasticsearch\BoolQuery;
 use App\Libraries\Elasticsearch\RecordSearch;
 use App\Models\User;
+use App\Transformers\UserCompactTransformer;
 
 class UserSearch extends RecordSearch
 {
@@ -22,7 +23,7 @@ class UserSearch extends RecordSearch
 
     public function records()
     {
-        return $this->response()->records()->with(['country', 'userProfileCustomization', 'userGroups'])->get();
+        return $this->response()->records()->with(UserCompactTransformer::CARD_INCLUDES_PRELOAD)->get();
     }
 
     /**

--- a/app/Transformers/ScoreTransformer.php
+++ b/app/Transformers/ScoreTransformer.php
@@ -25,7 +25,6 @@ class ScoreTransformer extends TransformerAbstract
     const MULTIPLAYER_BASE_PRELOAD = [
         'scoreLink.score',
         'scoreLink.user.country',
-        'scoreLink.user.userProfileCustomization',
     ];
 
     const TYPE_LEGACY = 'legacy';

--- a/app/Transformers/UserCompactTransformer.php
+++ b/app/Transformers/UserCompactTransformer.php
@@ -23,7 +23,6 @@ class UserCompactTransformer extends TransformerAbstract
     const CARD_INCLUDES_PRELOAD = [
         'country',
         'userGroups',
-        'userProfileCustomization',
     ];
 
     const LIST_INCLUDES = [
@@ -111,8 +110,6 @@ class UserCompactTransformer extends TransformerAbstract
         'is_restricted' => 'UserShowRestrictedStatus',
         'is_silenced' => 'IsNotOAuth',
     ];
-
-    protected $userProfileCustomization = [];
 
     public function transform(User $user)
     {
@@ -448,7 +445,7 @@ class UserCompactTransformer extends TransformerAbstract
 
     public function includeUserPreferences(User $user)
     {
-        $customization = $this->userProfileCustomization($user);
+        $customization = $user->userProfileCustomization ?? new UserProfileCustomization();
 
         return $this->primitive($customization->only([
             'audio_autoplay',
@@ -473,14 +470,5 @@ class UserCompactTransformer extends TransformerAbstract
         $this->mode = $mode;
 
         return $this;
-    }
-
-    protected function userProfileCustomization(User $user): UserProfileCustomization
-    {
-        if (!isset($this->userProfileCustomization[$user->getKey()])) {
-            $this->userProfileCustomization[$user->getKey()] = $user->userProfileCustomization ?? $user->userProfileCustomization()->make();
-        }
-
-        return $this->userProfileCustomization[$user->getKey()];
     }
 }

--- a/app/Transformers/UserTransformer.php
+++ b/app/Transformers/UserTransformer.php
@@ -6,6 +6,7 @@
 namespace App\Transformers;
 
 use App\Models\User;
+use App\Models\UserProfileCustomization;
 
 class UserTransformer extends UserCompactTransformer
 {
@@ -28,7 +29,8 @@ class UserTransformer extends UserCompactTransformer
     {
         $result = parent::transform($user);
 
-        $profileCustomization = $this->userProfileCustomization($user);
+        $profileOrder = $user->userProfileCustomization->extras_order
+            ?? UserProfileCustomization::SECTIONS;
 
         return array_merge($result, [
             'cover_url' => $user->cover()->url(), // TODO: deprecated.
@@ -43,7 +45,7 @@ class UserTransformer extends UserCompactTransformer
             'playmode' => $user->playmode,
             'playstyle' => $user->osu_playstyle,
             'post_count' => $user->user_posts,
-            'profile_order' => $profileCustomization->extras_order,
+            'profile_order' => $profileOrder,
             'title' => $user->title(),
             'title_url' => $user->titleUrl(),
             'twitter' => $user->user_twitter,


### PR DESCRIPTION
🧹 

<del>drafting since I forgot to add migration to remove the column</del> Will do that after this one is deployed instead.