### PR TITLE
Skip beatmap cover regenerate on missing archive

### DIFF
--- a/app/Models/Beatmapset.php
+++ b/app/Models/Beatmapset.php
@@ -501,6 +501,10 @@ class Beatmapset extends Model implements AfterCommit, Commentable, Indexable, T
         }
 
         $statusCode = curl_getinfo($curl, CURLINFO_HTTP_CODE);
+        // archive file is gone, nothing to do for now
+        if ($statusCode === 302) {
+            return false;
+        }
         if ($statusCode !== 200) {
             throw new BeatmapProcessorException('Failed downloading osz: HTTP Error '.$statusCode);
         }


### PR DESCRIPTION
It should be regenerated when it comes back and update is re-triggered 🤷 