### PR TITLE
Always set default cover id

### DIFF
--- a/app/Libraries/User/Cover.php
+++ b/app/Libraries/User/Cover.php
@@ -32,23 +32,18 @@ class Cover
         return $this->user->customCover()->url();
     }
 
+    public function defaultPresetId(): string
+    {
+        $id = $this->user->getKey() ?? 0;
+
+        return static::AVAILABLE_PRESET_IDS[$id % count(static::AVAILABLE_PRESET_IDS)];
+    }
+
     public function presetId(): ?string
     {
-        if ($this->hasCustomCover()) {
-            return null;
-        }
-
-        $id = $this->user->getKey();
-
-        if ($id === null || $id < 1) {
-            return null;
-        }
-
-        $presetId = (string) $this->user->cover_preset_id;
-
-        return static::isValidPresetId($presetId)
-            ? $presetId
-            : static::AVAILABLE_PRESET_IDS[$id % count(static::AVAILABLE_PRESET_IDS)];
+        return $this->hasCustomCover()
+            ? null
+            : (string) ($this->user->cover_preset_id ?? $this->defaultPresetId());
     }
 
     public function set(?string $presetId, ?string $filePath): void

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -2398,6 +2398,10 @@ class User extends Model implements AfterCommit, AuthenticatableContract, HasLoc
 
     public function save(array $options = [])
     {
+        if (!$this->exists) {
+            $this->cover_preset_id ??= $this->cover()->defaultPresetId();
+        }
+
         if ($options['skipValidations'] ?? false) {
             return parent::save($options);
         }

--- a/tests/Libraries/UserRegistrationTest.php
+++ b/tests/Libraries/UserRegistrationTest.php
@@ -17,17 +17,17 @@ class UserRegistrationTest extends TestCase
     {
         $attrs = $this->basicAttributes();
 
-        $origCount = User::count();
-        $origCountCache = Count::totalUsers()->count;
+        $this->expectCountChange(fn () => User::count(), 1);
+        $this->expectCountChange(fn () => Count::totalUsers()->count, 1);
         $reg = new UserRegistration($attrs);
         $thrown = $this->runSubject($reg);
 
         $this->assertFalse($thrown);
-        $this->assertSame($origCount + 1, User::count());
-        $this->assertTrue($reg->user()->userGroups->every(function ($userGroup) {
-            return $userGroup->user_pending === false;
-        }));
-        $this->assertSame($origCountCache + 1, Count::totalUsers()->count);
+
+        $user = $reg->user()->fresh();
+        $this->assertNotNull($user->cover_preset_id);
+        $this->assertTrue($user->userGroups->every(fn ($userGroup) =>
+            $userGroup->user_pending === false));
     }
 
     public function testRequiresUsername()


### PR DESCRIPTION
Consistent profile cover if we're to add more or change presets. The existing ones also need to be filled in but it can be done with one liner tinker.