### PR TITLE
Add API endpoints for creating/editing beatmap discussion posts

### DIFF
--- a/app/Http/Controllers/BeatmapDiscussionPostsController.php
+++ b/app/Http/Controllers/BeatmapDiscussionPostsController.php
@@ -27,8 +27,7 @@ class BeatmapDiscussionPostsController extends Controller
         $this->middleware('require-scopes:public', ['only' => ['index']]);
         $this->middleware('require-scopes:beatmapset_discussion.write', ['only' => [
             'store',
-            'update',
-            'destroy'
+            'update'
         ]]);
 
         parent::__construct();

--- a/app/Http/Controllers/BeatmapDiscussionPostsController.php
+++ b/app/Http/Controllers/BeatmapDiscussionPostsController.php
@@ -27,7 +27,8 @@ class BeatmapDiscussionPostsController extends Controller
         $this->middleware('require-scopes:public', ['only' => ['index']]);
         $this->middleware('require-scopes:beatmapset_discussion.write', ['only' => [
             'store',
-            'update'
+            'update',
+            'destroy'
         ]]);
 
         parent::__construct();

--- a/app/Http/Controllers/BeatmapDiscussionPostsController.php
+++ b/app/Http/Controllers/BeatmapDiscussionPostsController.php
@@ -112,6 +112,29 @@ class BeatmapDiscussionPostsController extends Controller
         return ujs_redirect(route('beatmapsets.discussion', $beatmapset).'#/'.$discussion->getKey().'/'.$post->getKey());
     }
 
+    /**
+     * Create a new Beatmapset Discussion Post. 
+     * 
+     * Replies to a Beatmapset Discussion or creates a new one.
+     * 
+     * ---
+     *
+     * ### Response Format
+     *
+     * Field                             | Type                                                    | Description
+     * --------------------------------- | ------------------------------------------------------- | -----------
+     * beatmapset                        | [Beatmapset](#beatmapset)                               |                                                    |
+     * beatmap_discussion_post_ids       | integer[]                                               | id of Beatmapset Discussion Posts that are created |
+     * beatmap_discussion_id             | integer                                                 | id of the Beatmapset Discussion                    |
+     *
+     * @bodyParam beatmap_discussion_id integer `id` of the [BeatmapsetDiscussion](#beatmapsetdiscussion) to reply to. Example: 1
+     * @bodyParam beatmapset_id integer `id` of the [Beatmapset](#beatmapset) to create a new discussion for. Required if no `beatmap_discussion_id` is provided. No-example
+     * @bodyParam beatmap_discussion_post[message] string required Message content as plain text. Example: hello 
+     * @bodyParam beatmap_discussion[message_type] [MessageType](#messagetype), required when creating a new discussion No-example
+     * @bodyParam beatmap_discussion[timestamp] integer Will place the post in the timeline tab at the given timestamp when creating a new discussion. No-example
+     * @bodyParam beatmap_discussion[beatmap_id] integer `id` of the [Beatmap](#beatmap) the discussion addresses. Required when `timestamp` is being used. No-example
+     * @bodyParam beatmap_discussion[resolved] boolean Changes resolved status of a discussion. Example: true 
+     */
     public function store()
     {
         /** @var User $user */
@@ -151,6 +174,21 @@ class BeatmapDiscussionPostsController extends Controller
         ];
     }
 
+    /**
+     * Edit Beatmapset Discussion Post
+     * 
+     * Edit specified beatmapset discussion post.
+     * 
+     * ---
+     * 
+     * ### Response Format
+     *
+     * [Beatmapset](#beatmapset)
+     *
+     * @urlParam post integer required Id of the post. Example: 1
+     *
+     * @bodyParam beatmap_discussion_post[message] string required New post content in plaintext. Example: hello
+     */
     public function update($id)
     {
         $post = BeatmapDiscussionPost::findOrFail($id);

--- a/app/Http/Controllers/BeatmapDiscussionPostsController.php
+++ b/app/Http/Controllers/BeatmapDiscussionPostsController.php
@@ -25,6 +25,10 @@ class BeatmapDiscussionPostsController extends Controller
     {
         $this->middleware('auth', ['except' => ['index', 'show']]);
         $this->middleware('require-scopes:public', ['only' => ['index']]);
+        $this->middleware('require-scopes:beatmapset_discussion.write', ['only' => [
+            'store',
+            'update'
+        ]]);
 
         parent::__construct();
     }

--- a/app/Http/Controllers/BeatmapDiscussionPostsController.php
+++ b/app/Http/Controllers/BeatmapDiscussionPostsController.php
@@ -25,7 +25,7 @@ class BeatmapDiscussionPostsController extends Controller
     {
         $this->middleware('auth', ['except' => ['index', 'show']]);
         $this->middleware('require-scopes:public', ['only' => ['index']]);
-        $this->middleware('require-scopes:beatmapset_discussion.write', ['only' => [
+        $this->middleware('require-scopes:beatmap_discussion.write', ['only' => [
             'store',
             'update'
         ]]);

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -74,7 +74,7 @@ class AuthServiceProvider extends ServiceProvider
             'friends.read' => osu_trans('api.scopes.friends.read'),
             'identify' => osu_trans('api.scopes.identify'),
             'public' => osu_trans('api.scopes.public'),
-            'beatmapset_discussion.write' => osu_trans('api.scopes.beatmapset_discussion.write'),
+            'beatmap_discussion.write' => osu_trans('api.scopes.beatmap_discussion.write'),
         ]);
     }
 }

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -74,6 +74,7 @@ class AuthServiceProvider extends ServiceProvider
             'friends.read' => osu_trans('api.scopes.friends.read'),
             'identify' => osu_trans('api.scopes.identify'),
             'public' => osu_trans('api.scopes.public'),
+            'beatmapset_discussion.write' => osu_trans('api.scopes.beatmapset_discussion.write'),
         ]);
     }
 }

--- a/resources/lang/de/api.php
+++ b/resources/lang/de/api.php
@@ -30,7 +30,7 @@ return [
             'read' => 'Sehen, wem du folgst.',
         ],
 
-        'beatmapset_discussion' => [
+        'beatmap_discussion' => [
             'write' => 'Beatmap-Diskussionen in deinem Namen erstellen und bearbeiten.',
         ],
 

--- a/resources/lang/de/api.php
+++ b/resources/lang/de/api.php
@@ -30,6 +30,10 @@ return [
             'read' => 'Sehen, wem du folgst.',
         ],
 
+        'beatmapset_discussion' => [
+            'write' => 'Beatmap-Diskussionen in deinem Namen erstellen und bearbeiten.',
+        ],
+
         'public' => 'In deinem Namen öffentliche Daten auslesen.',
     ],
 ];

--- a/resources/lang/en/api.php
+++ b/resources/lang/en/api.php
@@ -31,7 +31,7 @@ return [
         ],
 
         'beatmapset_discussion' => [
-            'write' => 'Create, edit and delete beatmap discussions on your behalf',
+            'write' => 'Create and edit beatmap discussion posts on your behalf',
         ],
 
         'public' => 'Read public data on your behalf.',

--- a/resources/lang/en/api.php
+++ b/resources/lang/en/api.php
@@ -30,6 +30,10 @@ return [
             'read' => 'See who you are following.',
         ],
 
+        'beatmapset_discussion' => [
+            'write' => 'Create, edit and delete beatmap discussions on your behalf',
+        ],
+
         'public' => 'Read public data on your behalf.',
     ],
 ];

--- a/resources/lang/en/api.php
+++ b/resources/lang/en/api.php
@@ -30,7 +30,7 @@ return [
             'read' => 'See who you are following.',
         ],
 
-        'beatmapset_discussion' => [
+        'beatmap_discussion' => [
             'write' => 'Create and edit beatmap discussion posts on your behalf',
         ],
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -440,7 +440,7 @@ Route::group(['as' => 'api.', 'prefix' => 'api', 'middleware' => ['api', Throttl
             Route::apiResource('events', 'BeatmapsetEventsController', ['only' => ['index']]);
 
             Route::group(['as' => 'discussions.', 'prefix' => 'discussions'], function () {
-                Route::apiResource('posts', 'BeatmapDiscussionPostsController', ['only' => ['index', 'store', 'update']]);
+                Route::apiResource('posts', 'BeatmapDiscussionPostsController', ['only' => ['index', 'store', 'update', 'destroy']]);
                 Route::apiResource('votes', 'BeatmapsetDiscussionVotesController', ['only' => ['index']]);
             });
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -440,7 +440,7 @@ Route::group(['as' => 'api.', 'prefix' => 'api', 'middleware' => ['api', Throttl
             Route::apiResource('events', 'BeatmapsetEventsController', ['only' => ['index']]);
 
             Route::group(['as' => 'discussions.', 'prefix' => 'discussions'], function () {
-                Route::apiResource('posts', 'BeatmapDiscussionPostsController', ['only' => ['index', 'store', 'update', 'destroy']]);
+                Route::apiResource('posts', 'BeatmapDiscussionPostsController', ['only' => ['index', 'store', 'update']]);
                 Route::apiResource('votes', 'BeatmapsetDiscussionVotesController', ['only' => ['index']]);
             });
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -440,7 +440,7 @@ Route::group(['as' => 'api.', 'prefix' => 'api', 'middleware' => ['api', Throttl
             Route::apiResource('events', 'BeatmapsetEventsController', ['only' => ['index']]);
 
             Route::group(['as' => 'discussions.', 'prefix' => 'discussions'], function () {
-                Route::apiResource('posts', 'BeatmapDiscussionPostsController', ['only' => ['index']]);
+                Route::apiResource('posts', 'BeatmapDiscussionPostsController', ['only' => ['index', 'store', 'update']]);
                 Route::apiResource('votes', 'BeatmapsetDiscussionVotesController', ['only' => ['index']]);
             });
 

--- a/tests/api_routes.json
+++ b/tests/api_routes.json
@@ -253,6 +253,55 @@
         ]
     },
     {
+        "uri": "api/v2/beatmapsets/discussions/posts",
+        "methods": [
+            "POST"
+        ],
+        "controller": "App\\Http\\Controllers\\BeatmapDiscussionPostsController@store",
+        "middlewares": [
+            "App\\Http\\Middleware\\ThrottleRequests:1200,1,api:",
+            "App\\Http\\Middleware\\RequireScopes",
+            "Illuminate\\Auth\\Middleware\\Authenticate",
+            "App\\Http\\Middleware\\RequireScopes:beatmapset_discussion.write"
+        ],
+        "scopes": [
+            "beatmapset_discussion.write"
+        ]
+    },
+    {
+        "uri": "api/v2/beatmapsets/discussions/posts/{post}",
+        "methods": [
+            "PATCH",
+            "PUT"
+        ],
+        "controller": "App\\Http\\Controllers\\BeatmapDiscussionPostsController@update",
+        "middlewares": [
+            "App\\Http\\Middleware\\ThrottleRequests:1200,1,api:",
+            "App\\Http\\Middleware\\RequireScopes",
+            "Illuminate\\Auth\\Middleware\\Authenticate",
+            "App\\Http\\Middleware\\RequireScopes:beatmapset_discussion.write"
+        ],
+        "scopes": [
+            "beatmapset_discussion.write"
+        ]
+    },
+    {
+        "uri": "api/v2/beatmapsets/discussions/posts/{post}",
+        "methods": [
+            "DELETE"
+        ],
+        "controller": "App\\Http\\Controllers\\BeatmapDiscussionPostsController@destroy",
+        "middlewares": [
+            "App\\Http\\Middleware\\ThrottleRequests:1200,1,api:",
+            "App\\Http\\Middleware\\RequireScopes",
+            "Illuminate\\Auth\\Middleware\\Authenticate",
+            "App\\Http\\Middleware\\RequireScopes:beatmapset_discussion.write"
+        ],
+        "scopes": [
+            "beatmapset_discussion.write"
+        ]
+    },
+    {
         "uri": "api/v2/beatmapsets/discussions/votes",
         "methods": [
             "GET",

--- a/tests/api_routes.json
+++ b/tests/api_routes.json
@@ -262,10 +262,10 @@
             "App\\Http\\Middleware\\ThrottleRequests:1200,1,api:",
             "App\\Http\\Middleware\\RequireScopes",
             "Illuminate\\Auth\\Middleware\\Authenticate",
-            "App\\Http\\Middleware\\RequireScopes:beatmapset_discussion.write"
+            "App\\Http\\Middleware\\RequireScopes:beatmap_discussion.write"
         ],
         "scopes": [
-            "beatmapset_discussion.write"
+            "beatmap_discussion.write"
         ]
     },
     {
@@ -279,10 +279,10 @@
             "App\\Http\\Middleware\\ThrottleRequests:1200,1,api:",
             "App\\Http\\Middleware\\RequireScopes",
             "Illuminate\\Auth\\Middleware\\Authenticate",
-            "App\\Http\\Middleware\\RequireScopes:beatmapset_discussion.write"
+            "App\\Http\\Middleware\\RequireScopes:beatmap_discussion.write"
         ],
         "scopes": [
-            "beatmapset_discussion.write"
+            "beatmap_discussion.write"
         ]
     },
     {

--- a/tests/api_routes.json
+++ b/tests/api_routes.json
@@ -286,22 +286,6 @@
         ]
     },
     {
-        "uri": "api/v2/beatmapsets/discussions/posts/{post}",
-        "methods": [
-            "DELETE"
-        ],
-        "controller": "App\\Http\\Controllers\\BeatmapDiscussionPostsController@destroy",
-        "middlewares": [
-            "App\\Http\\Middleware\\ThrottleRequests:1200,1,api:",
-            "App\\Http\\Middleware\\RequireScopes",
-            "Illuminate\\Auth\\Middleware\\Authenticate",
-            "App\\Http\\Middleware\\RequireScopes:beatmapset_discussion.write"
-        ],
-        "scopes": [
-            "beatmapset_discussion.write"
-        ]
-    },
-    {
         "uri": "api/v2/beatmapsets/discussions/votes",
         "methods": [
             "GET",


### PR DESCRIPTION
Closes #10199 

Adds the ability to create new beatmap discussions, reply to existing discussions, and updating discussion posts, via the API. The whole thing is based on the forum API for how OAuth scopes are set up (`forum.write` scope).

## Use cases
- Bots that automatically detect unrankables and create posts about it
- Ability to write mods in third party mapping tools & editors
- Would help pave the way for modding in the lazer editor

## List of all changes:
- Added API endpoints for `BeatmapDiscussionPostsController.store` and `BeatmapDiscussionPostsController.update`
- Added a `beatmap_discussion.write` OAuth scope
- Added API Documentation for `BeatmapDiscussionPostsController.store` and `BeatmapDiscussionPostsController`
- Made adjustments to expected endpoints in `RouteScopesTest`
- Added English & German translations for `beatmap_discussion.write` OAuth scope