### PR TITLE
Always preserve multiplayer scores regardless of pass/fail

### DIFF
--- a/app/Models/Multiplayer/ScoreLink.php
+++ b/app/Models/Multiplayer/ScoreLink.php
@@ -29,6 +29,10 @@ class ScoreLink extends Model
     {
         return \DB::transaction(function () use ($params, $token) {
             $score = Score::createFromJsonOrExplode($params);
+            
+            // multiplayer scores are always preserved.
+            $score->preserve = true;
+            $score->saveOrExplode();
 
             $playlistItem = $token->playlistItem;
             $requiredMods = array_column($playlistItem->required_mods, 'acronym');

--- a/app/Models/Multiplayer/ScoreLink.php
+++ b/app/Models/Multiplayer/ScoreLink.php
@@ -28,11 +28,8 @@ class ScoreLink extends Model
     public static function complete(ScoreToken $token, array $params): static
     {
         return \DB::transaction(function () use ($params, $token) {
-            $score = Score::createFromJsonOrExplode($params);
-            
             // multiplayer scores are always preserved.
-            $score->preserve = true;
-            $score->saveOrExplode();
+            $score = Score::createFromJsonOrExplode([...$params, 'preserve' => true]);
 
             $playlistItem = $token->playlistItem;
             $requiredMods = array_column($playlistItem->required_mods, 'acronym');

--- a/tests/Models/Multiplayer/ScoreLinkTest.php
+++ b/tests/Models/Multiplayer/ScoreLinkTest.php
@@ -176,4 +176,22 @@ class ScoreLinkTest extends TestCase
             'user_id' => $scoreToken->user_id,
         ]);
     }
+
+    public function testFailedMultiplayerScoresArePreserved()
+    {
+        $playlistItem = PlaylistItem::factory()->create();
+        $scoreToken = ScoreToken::factory()->create([
+            'beatmap_id' => $playlistItem->beatmap_id,
+            'playlist_item_id' => $playlistItem,
+        ]);
+
+        $scoreLink = ScoreLink::complete($scoreToken, [
+            ...static::$commonScoreParams,
+            'beatmap_id' => $playlistItem->beatmap_id,
+            'ruleset_id' => $playlistItem->ruleset_id,
+            'user_id' => $scoreToken->user_id,
+            'passed' => false,
+        ]);
+        $this->assertTrue($scoreLink->score->preserve);
+    }
 }


### PR DESCRIPTION
Related: https://github.com/ppy/osu-queue-score-statistics/issues/141, https://github.com/ppy/osu-web/pull/10946

We want to preserve failed scores if they come from multiplayer so that the results of the multiplayer room can be accessed in the indeterminate future. Currently this would not happen if a multiplayer score was a fail.