### PR TITLE
Remove yellow border from wiki search text box when unfocused and added styling when focused.

### DIFF
--- a/resources/css/bem/wiki-search.less
+++ b/resources/css/bem/wiki-search.less
@@ -20,7 +20,12 @@
     font-size: @font-size--wiki-search;
     background-color: @osu-colour-b6;
 
-    border: @_border-size solid @osu-colour-orange-1;
+    border: @_border-size solid @osu-colour-b6;
+    
+    &:focus-within {
+      box-shadow: 0 0 10px @osu-colour-orange-1;
+      border: @_border-size solid @osu-colour-orange-1
+    }
   }
 
   &__input {


### PR DESCRIPTION
This pull request addresses issue #10238

Changes Made:
- Removed the yellow border color from the wiki search text box when unfocused to align with user expectations.
- Added focus styling to enhance user interaction, including a yellow/orange border and a subtle box shadow.  The styling matches the behavior of the search box in the beatmap listing.

![osu-css-border-style](https://github.com/ppy/osu-web/assets/77649505/e4448c40-6034-4c59-8615-68f731cdab7b)
