### PR TITLE
Change docker compose service healthcheck interval

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -107,10 +107,10 @@ services:
       # important to use 127.0.0.1 instead of localhost as mysql starts twice.
       # the first time it listens on sockets but isn't actually ready
       # see https://github.com/docker-library/mysql/issues/663
-      test: ["CMD", "mysqladmin", "ping", "-h", "127.0.0.1"]
-      interval: 1s
-      timeout: 60s
+      start_interval: 1s
       start_period: 60s
+      test: ["CMD", "mysqladmin", "ping", "-h", "127.0.0.1"]
+      timeout: 60s
 
   redis:
     command: ['redis-server', '--save', '60', '1', '--loglevel', 'warning']
@@ -118,10 +118,10 @@ services:
     ports:
       - "${REDIS_EXTERNAL_PORT:-127.0.0.1:6379}:6379"
     healthcheck:
-      test: ["CMD", "redis-cli", "--raw", "incr", "ping"]
-      interval: 1s
-      timeout: 60s
+      start_interval: 1s
       start_period: 60s
+      test: ["CMD", "redis-cli", "--raw", "incr", "ping"]
+      timeout: 60s
     volumes:
       - redis:/data
 
@@ -138,10 +138,10 @@ services:
       ES_JAVA_OPTS: "-Xms512m -Xmx512m" # less OOM on default settings.
       ingest.geoip.downloader.enabled: false
     healthcheck:
-      test: curl -s http://localhost:9200/_cluster/health?wait_for_status=yellow >/dev/null || exit 1
-      interval: 1s
-      timeout: 60s
+      start_interval: 1s
       start_period: 60s
+      test: curl -s http://localhost:9200/_cluster/health?wait_for_status=yellow >/dev/null || exit 1
+      timeout: 60s
 
   nginx:
     image: nginx:latest


### PR DESCRIPTION
Set start_interval to 1s and use default (30s) for after the service is started.