### PR TITLE
Fix null user id error when reporting old (imported) comments

### DIFF
--- a/app/Models/Comment.php
+++ b/app/Models/Comment.php
@@ -302,7 +302,7 @@ class Comment extends Model implements Traits\ReportableInterface
     {
         return [
             'reason' => 'Spam',
-            'user_id' => $this->user_id,
+            'user_id' => $this->user_id ?? 0,
         ];
     }
 


### PR DESCRIPTION
💤 