### PR TITLE
Hotfix adding empty username to cart

### DIFF
--- a/app/Models/Store/Order.php
+++ b/app/Models/Store/Order.php
@@ -694,7 +694,7 @@ class Order extends Model
                 $params['extra_data'] = ExtraDataSupporterTag::fromOrderItemParams($params, $this->user);
                 break;
             // TODO: look at migrating to extra_data
-            case 'username-change':
+            case Product::USERNAME_CHANGE:
                 // ignore received cost
                 $params['cost'] = $this->user->usernameChangeCost();
                 break;

--- a/app/Models/Store/OrderItem.php
+++ b/app/Models/Store/OrderItem.php
@@ -115,7 +115,7 @@ class OrderItem extends Model
     {
         // only one for now
         if ($this->product->custom_class === 'username-change') {
-            return new ChangeUsername($this->order->user, $this->extra_info);
+            return new ChangeUsername($this->order->user, $this->extra_info ?? '');
         }
     }
 

--- a/app/Models/Store/Product.php
+++ b/app/Models/Store/Product.php
@@ -40,8 +40,10 @@ use Carbon\Carbon;
  */
 class Product extends Model
 {
+    const BUTTON_DISABLED = [self::SUPPORTER_TAG_NAME, self::USERNAME_CHANGE];
     const REDIRECT_PLACEHOLDER = 'redirect';
     const SUPPORTER_TAG_NAME = 'supporter-tag';
+    const USERNAME_CHANGE = 'username-change';
 
     protected $primaryKey = 'product_id';
 

--- a/resources/views/store/products/show.blade.php
+++ b/resources/views/store/products/show.blade.php
@@ -128,7 +128,7 @@
                 <button
                     class="btn-osu-big btn-osu-big--store-action js-login-required--click js-store-add-to-cart"
                     type="submit"
-                    {{ $product->custom_class === App\Models\Store\Product::SUPPORTER_TAG_NAME ? 'disabled' : '' }}
+                    {{ in_array($product->custom_class, App\Models\Store\Product::BUTTON_DISABLED, true) ? 'disabled' : '' }}
                 >
                     {{ osu_trans('store.product.add_to_cart') }}
                 </button>


### PR DESCRIPTION
Initialize the add to cart button as disabled instead of relying on javascript to run first; on production the script that doesn't disable the button doesn't seem to trigger at the right time allowing an empty username to be added to the cart, which isn't valid. 
I can't seem to replicate the issue on dev on any browser 🤷 

The null coalesce for the username change check is a quick hotfix until better validation for the cart input is added for `extra_data` and `extra_info`