### PR TITLE
Include more information in queue worker output

### DIFF
--- a/app/Jobs/EsDocument.php
+++ b/app/Jobs/EsDocument.php
@@ -33,6 +33,11 @@ class EsDocument implements ShouldQueue
         ];
     }
 
+    public function displayName()
+    {
+        return static::class." ({$this->modelMeta['class']} {$this->modelMeta['id']})";
+    }
+
     /**
      * Execute the job.
      *

--- a/app/Jobs/Notifications/BeatmapsetNotification.php
+++ b/app/Jobs/Notifications/BeatmapsetNotification.php
@@ -28,6 +28,11 @@ abstract class BeatmapsetNotification extends BroadcastNotificationBase
         $this->beatmapset = $beatmapset;
     }
 
+    public function displayName()
+    {
+        return static::class." (Beatmapset {$this->beatmapset->getKey()})";
+    }
+
     public function getDetails(): array
     {
         return [

--- a/app/Jobs/RegenerateBeatmapsetCover.php
+++ b/app/Jobs/RegenerateBeatmapsetCover.php
@@ -42,6 +42,11 @@ class RegenerateBeatmapsetCover implements ShouldQueue
         $this->sizesToRegenerate = $sizesToRegenerate;
     }
 
+    public function displayName()
+    {
+        return static::class." (Beatmapset {$this->beatmapset->getKey()})";
+    }
+
     /**
      * Execute the job.
      *

--- a/app/Jobs/RemoveBeatmapsetBestScores.php
+++ b/app/Jobs/RemoveBeatmapsetBestScores.php
@@ -36,6 +36,11 @@ class RemoveBeatmapsetBestScores implements ShouldQueue
         }
     }
 
+    public function displayName()
+    {
+        return static::class." (Beatmapset {$this->beatmapset->getKey()})";
+    }
+
     /**
      * Execute the job.
      *

--- a/app/Jobs/RemoveBeatmapsetSoloScores.php
+++ b/app/Jobs/RemoveBeatmapsetSoloScores.php
@@ -37,6 +37,11 @@ class RemoveBeatmapsetSoloScores implements ShouldQueue
         $this->maxScoreId = Score::max('id') ?? 0;
     }
 
+    public function displayName()
+    {
+        return static::class." (Beatmapset {$this->beatmapsetId})";
+    }
+
     /**
      * Execute the job.
      *


### PR DESCRIPTION
Include the model id to help tell what the job is actually running on, especially for `EsDocument` (also, displayName is added when job is queued, not when it runs)

```
  2024-04-15 10:23:20 App\Jobs\EsDocument (App\Models\User 475001) .......................... RUNNING
  2024-04-15 10:23:20 App\Jobs\EsDocument (App\Models\User 475001) ..................... 92.40ms DONE
  2024-04-15 10:24:56 App\Jobs\EsDocument (App\Models\Beatmapset 600016) .................... RUNNING
  2024-04-15 10:24:56 App\Jobs\EsDocument (App\Models\Beatmapset 600016) ............... 80.64ms DONE
  2024-04-15 10:26:05 App\Jobs\RemoveBeatmapsetBestScores (Beatmapset 600040) ............... RUNNING
  2024-04-15 10:26:05 App\Jobs\RemoveBeatmapsetBestScores (Beatmapset 600040) .......... 93.41ms DONE
  2024-04-15 10:26:05 App\Jobs\RemoveBeatmapsetSoloScores (Beatmapset 600040) ............... RUNNING
  2024-04-15 10:26:05 App\Jobs\RemoveBeatmapsetSoloScores (Beatmapset 600040) .......... 11.22ms DONE
  2024-04-15 10:26:05 App\Jobs\EsDocument (App\Models\Beatmapset 600040) .................... RUNNING
  2024-04-15 10:26:05 App\Jobs\EsDocument (App\Models\Beatmapset 600040) ............... 37.28ms DONE
  2024-04-15 10:26:05 App\Jobs\Notifications\BeatmapsetLove (Beatmapset 600040) ............. RUNNING
  2024-04-15 10:26:05 App\Jobs\Notifications\BeatmapsetLove (Beatmapset 600040) ........ 13.16ms DONE
```