### PR TITLE
Add osu.py to list of API wrappers on the docs

### DIFF
--- a/resources/views/docs/info.md.blade.php
+++ b/resources/views/docs/info.md.blade.php
@@ -24,6 +24,7 @@ Below is a list of some language-specific wrappers maintained by the community. 
 
 - [ossapi](https://github.com/tybug/ossapi) (python)
 - [aiosu](https://github.com/NiceAesth/aiosu) (python)
+- [osu.py](https://github.com/sheppsu/osu.py) (python)
 - [rosu-v2](https://github.com/MaxOhn/rosu-v2) (rust)
 - [osu.js](https://github.com/L-Mario564/osu.js) (javascript/typescript)
 


### PR DESCRIPTION
There was a problem last time I made this PR (sorry about that!) since the wrapper supported lazer-only methods; however, they've been removed as of [this commit](https://github.com/Sheppsu/osu.py/commit/0db165316b67cf3d95cd13bfea46ccad4bc31845) and [this commit](https://github.com/Sheppsu/osu.py/commit/05d7cdec071d63598a2dc4bf72461765329ab318). I hope it's fine to be on the docs now :D 