### PR TITLE
Apply chat filters to name when creating multiplayer rooms

### DIFF
--- a/app/Models/Multiplayer/Room.php
+++ b/app/Models/Multiplayer/Room.php
@@ -520,7 +520,6 @@ class Room extends Model
 
         $this->fill([
             'max_attempts' => $params['max_attempts'],
-            'name' => $params['name'],
             'starts_at' => now(),
             'type' => $params['type'],
             'queue_mode' => $params['queue_mode'],
@@ -528,6 +527,15 @@ class Room extends Model
             'auto_skip' => $params['auto_skip'] ?? false,
             'user_id' => $host->getKey(),
         ]);
+
+        $name = $params['name'];
+        $filters = app('chat-filters')->all();
+
+        foreach ($filters as $filter) {
+            $name = str_replace($filter->match, $filter->replacement, $name);
+        }
+
+        $this->name = $name;
 
         $this->setRelation('host', $host);
 

--- a/tests/Models/Multiplayer/RoomTest.php
+++ b/tests/Models/Multiplayer/RoomTest.php
@@ -7,6 +7,7 @@ namespace Tests\Models\Multiplayer;
 
 use App\Exceptions\InvariantException;
 use App\Models\Beatmap;
+use App\Models\ChatFilter;
 use App\Models\Multiplayer\PlaylistItem;
 use App\Models\Multiplayer\Room;
 use App\Models\User;
@@ -184,6 +185,32 @@ class RoomTest extends TestCase
 
         $this->expectException(InvariantException::class);
         (new Room())->startGame($user, $params);
+    }
+
+    public function testNameFiltering()
+    {
+        ChatFilter::factory()->create([
+            'match' => 'bad',
+            'replacement' => 'good',
+        ]);
+        $beatmap = Beatmap::factory()->create();
+        $user = User::factory()->create();
+
+        $params = [
+            'name' => 'bad word',
+            'playlist' => [
+                [
+                    'beatmap_id' => $beatmap->getKey(),
+                    'ruleset_id' => $beatmap->playmode,
+                    'played_at' => time(),
+                ],
+            ],
+            'type' => 'head_to_head',
+        ];
+
+        $room = new Room();
+        $room->startGame($user, $params);
+        $this->assertSame('good word', $room->name);
     }
 
     public static function startGameDurationDataProvider()


### PR DESCRIPTION
Because some people just _cannot_ be trusted with a text box. There's no issue for this but I do believe this sort of thing has necessitated some manual intervention in the past and this PR wasn't very much work soooo... maybe worth?

Reuses chat filters because it feels like a no-brainer kinda? Also considered both applying the replace or just not allowing creation. Stuck with replace in the end, but switching to disallowing entirely is trivial if that's considered better.

Tested full-stack with lazer for whatever that's worth. The rename takes effect on the room creator's side as well.