### PR TITLE
Add extended capabilities for chat filters

### DIFF
--- a/app/Exceptions/ContentModerationException.php
+++ b/app/Exceptions/ContentModerationException.php
@@ -1,0 +1,14 @@
+<?php
+
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
+namespace App\Exceptions;
+
+/**
+ * Exception thrown on user-supplied input that fails to clear automated moderation checks.
+ * It is generally fine to not provide any user-facing message to indicate that this is the case.
+ */
+class ContentModerationException extends SilencedException
+{
+}

--- a/app/Http/Controllers/Multiplayer/RoomsController.php
+++ b/app/Http/Controllers/Multiplayer/RoomsController.php
@@ -5,6 +5,7 @@
 
 namespace App\Http\Controllers\Multiplayer;
 
+use App\Exceptions\ContentModerationException;
 use App\Exceptions\InvariantException;
 use App\Http\Controllers\Controller as BaseController;
 use App\Models\Multiplayer\Room;
@@ -207,6 +208,8 @@ class RoomsController extends BaseController
             );
         } catch (InvariantException $e) {
             return error_popup($e->getMessage(), $e->getStatusCode());
+        } catch (ContentModerationException) {
+            abort(422);
         }
     }
 }

--- a/app/Libraries/Chat.php
+++ b/app/Libraries/Chat.php
@@ -6,7 +6,9 @@
 namespace App\Libraries;
 
 use App\Exceptions\API;
+use App\Exceptions\ContentModerationException;
 use App\Exceptions\InvariantException;
+use App\Exceptions\SilencedException;
 use App\Models\Chat\Channel;
 use App\Models\User;
 use LaravelRedis as Redis;
@@ -96,6 +98,8 @@ class Chat
             abort(422, $e->getMessage());
         } catch (API\ChatMessageTooLongException $e) {
             abort(422, $e->getMessage());
+        } catch (ContentModerationException) {
+            abort(422);
         } catch (API\ExcessiveChatMessagesException $e) {
             abort(429, $e->getMessage());
         }

--- a/app/Models/Chat/Channel.php
+++ b/app/Models/Chat/Channel.php
@@ -7,7 +7,10 @@ namespace App\Models\Chat;
 
 use App\Events\ChatChannelEvent;
 use App\Exceptions\API;
+use App\Exceptions\ContentModerationException;
 use App\Exceptions\InvariantException;
+use App\Exceptions\SilencedException;
+use App\Exceptions\ValidationException;
 use App\Jobs\Notifications\ChannelAnnouncement;
 use App\Jobs\Notifications\ChannelMessage;
 use App\Libraries\AuthorizationResult;
@@ -414,6 +417,13 @@ class Channel extends Model
         });
     }
 
+    /**
+     * @throws API\ChatMessageEmptyException
+     * @throws API\ChatMessageTooLongException
+     * @throws API\ExcessiveChatMessagesException
+     * @throws ContentModerationException
+     * @throws \Throwable
+     */
     public function receiveMessage(User $sender, ?string $content, bool $isAction = false, ?string $uuid = null)
     {
         if (!$this->isAnnouncement()) {

--- a/app/Models/ChatFilter.php
+++ b/app/Models/ChatFilter.php
@@ -8,6 +8,8 @@ namespace App\Models;
 /**
  * @property string $match
  * @property string $replacement
+ * @property bool $block
+ * @property bool $whitespace_delimited
  */
 class ChatFilter extends Model
 {

--- a/app/Models/Multiplayer/Room.php
+++ b/app/Models/Multiplayer/Room.php
@@ -6,7 +6,11 @@
 namespace App\Models\Multiplayer;
 
 use App\Casts\PresentString;
+use App\Exceptions\ContentModerationException;
 use App\Exceptions\InvariantException;
+use App\Exceptions\ModelNotSavedException;
+use App\Exceptions\SilencedException;
+use App\Exceptions\ValidationException;
 use App\Models\Beatmap;
 use App\Models\Chat\Channel;
 use App\Models\Model;
@@ -500,6 +504,11 @@ class Room extends Model
             ->all();
     }
 
+    /**
+     * @throws InvariantException
+     * @throws ContentModerationException
+     * @throws \Throwable
+     */
     public function startGame(User $host, array $rawParams)
     {
         priv_check_user($host, 'MultiplayerRoomCreate')->ensureCan();

--- a/app/Singletons/ChatFilters.php
+++ b/app/Singletons/ChatFilters.php
@@ -32,9 +32,9 @@ class ChatFilters
         });
 
 
-        $blockingFilters = array_where($filters, fn ($filter) => $filter->block);
         // blocking filters (finding any of these phrases throws moderation exceptions)
-        if (preg_match(self::combinedFilterRegex($blockingFilters), $text)) {
+        $blockingFilters = array_where($filters, fn ($filter) => $filter->block);
+        if (!empty($blockingFilters) && preg_match(self::combinedFilterRegex($blockingFilters), $text)) {
             throw new ContentModerationException();
         }
 

--- a/database/migrations/2024_04_25_153450_add_block_and_whitespace_delimited_to_chat_filters.php
+++ b/database/migrations/2024_04_25_153450_add_block_and_whitespace_delimited_to_chat_filters.php
@@ -1,0 +1,29 @@
+<?php
+
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('chat_filters', function (Blueprint $table) {
+            $table->boolean('block')->default(false);
+            $table->boolean('whitespace_delimited')->default(false);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('chat_filters', function (Blueprint $table) {
+            $table->dropColumn('block');
+            $table->dropColumn('whitespace_delimited');
+        });
+    }
+};

--- a/tests/Singletons/ChatFiltersTest.php
+++ b/tests/Singletons/ChatFiltersTest.php
@@ -11,22 +11,17 @@ use Tests\TestCase;
 
 class ChatFiltersTest extends TestCase
 {
-    protected function setUp(): void
-    {
-        parent::setUp();
-
-        ChatFilter::factory()->createMany([
-            ['match' => 'bad', 'replacement' => 'good'],
-            ['match' => 'fullword', 'replacement' => 'okay', 'whitespace_delimited' => true],
-            ['match' => 'absolutely forbidden', 'replacement' => '', 'block' => true],
-        ]);
-    }
-
     /**
      * @dataProvider plainFilterTests
      */
     public function testPlainFilterReplacement($input, $expected_output)
     {
+        ChatFilter::factory()->createMany([
+            ['match' => 'bad', 'replacement' => 'good'],
+            ['match' => 'fullword', 'replacement' => 'okay', 'whitespace_delimited' => true],
+            ['match' => 'absolutely forbidden', 'replacement' => '', 'block' => true],
+        ]);
+
         $result = app('chat-filters')->filter($input);
         $this->assertSame($expected_output, $result);
     }
@@ -36,6 +31,12 @@ class ChatFiltersTest extends TestCase
      */
     public function testWhitespaceDelimitedFilterReplacement($input, $expected_output)
     {
+        ChatFilter::factory()->createMany([
+            ['match' => 'bad', 'replacement' => 'good'],
+            ['match' => 'fullword', 'replacement' => 'okay', 'whitespace_delimited' => true],
+            ['match' => 'absolutely forbidden', 'replacement' => '', 'block' => true],
+        ]);
+
         $result = app('chat-filters')->filter($input);
         $this->assertSame($expected_output, $result);
     }
@@ -45,8 +46,25 @@ class ChatFiltersTest extends TestCase
      */
     public function testBlockingFilter($input)
     {
+        ChatFilter::factory()->createMany([
+            ['match' => 'bad', 'replacement' => 'good'],
+            ['match' => 'fullword', 'replacement' => 'okay', 'whitespace_delimited' => true],
+            ['match' => 'absolutely forbidden', 'replacement' => '', 'block' => true],
+        ]);
+
         $this->expectException(ContentModerationException::class);
         app('chat-filters')->filter($input);
+    }
+
+    public function testLackOfBlockingFilters()
+    {
+        ChatFilter::factory()->createMany([
+            ['match' => 'bad', 'replacement' => 'good'],
+            ['match' => 'fullword', 'replacement' => 'okay', 'whitespace_delimited' => true],
+        ]);
+
+        $this->expectNotToPerformAssertions();
+        app('chat-filters')->filter('this should be completely fine');
     }
 
     public static function plainFilterTests()

--- a/tests/Singletons/ChatFiltersTest.php
+++ b/tests/Singletons/ChatFiltersTest.php
@@ -1,0 +1,78 @@
+<?php
+
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
+namespace Tests\Singletons;
+
+use App\Exceptions\ValidationException;
+use App\Models\ChatFilter;
+use Tests\TestCase;
+
+class ChatFiltersTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+
+        ChatFilter::factory()->createMany([
+            ['match' => 'bad', 'replacement' => 'good'],
+            ['match' => 'fullword', 'replacement' => 'okay', 'whitespace_delimited' => true],
+            ['match' => 'absolutely forbidden', 'replacement' => '', 'block' => true],
+        ]);
+    }
+
+    /**
+     * @dataProvider plainFilterTests
+     */
+    public function testPlainFilterReplacement($input, $expected_output)
+    {
+        $result = app('chat-filters')->filter($input);
+        $this->assertSame($expected_output, $result);
+    }
+
+    /**
+     * @dataProvider fullWordFilterTests
+     */
+    public function testWhitespaceDelimitedFilterReplacement($input, $expected_output)
+    {
+        $result = app('chat-filters')->filter($input);
+        $this->assertSame($expected_output, $result);
+    }
+
+    /**
+     * @dataProvider blockingFilterTests
+     */
+    public function testBlockingFilter($input)
+    {
+        $this->expectException(ValidationException::class);
+        app('chat-filters')->filter($input);
+    }
+
+    public static function plainFilterTests()
+    {
+        return [
+            ['bad phrase', 'good phrase'],
+            ['thing is bad', 'thing is good'],
+            ['look at this badness', 'look at this goodness'],
+        ];
+    }
+
+    public static function fullWordFilterTests()
+    {
+        return [
+            ['fullword at the start', 'okay at the start'],
+            ['at the end is fullword', 'at the end is okay'],
+            ['middle is where the fullword is', 'middle is where the okay is'],
+            ['anotherfullword is not replaced', 'anotherfullword is not replaced'],
+        ];
+    }
+
+    public static function blockingFilterTests()
+    {
+        return [
+            ['absolutely forbidden'],
+            ['this is absolutely forbidden full stop!!!'],
+        ];
+    }
+}

--- a/tests/Singletons/ChatFiltersTest.php
+++ b/tests/Singletons/ChatFiltersTest.php
@@ -34,6 +34,7 @@ class ChatFiltersTest extends TestCase
         ChatFilter::factory()->createMany([
             ['match' => 'bad', 'replacement' => 'good'],
             ['match' => 'fullword', 'replacement' => 'okay', 'whitespace_delimited' => true],
+            ['match' => 'fullword2', 'replacement' => 'great', 'whitespace_delimited' => true],
             ['match' => 'absolutely forbidden', 'replacement' => '', 'block' => true],
         ]);
 
@@ -83,6 +84,8 @@ class ChatFiltersTest extends TestCase
             ['at the end is fullword', 'at the end is okay'],
             ['middle is where the fullword is', 'middle is where the okay is'],
             ['anotherfullword is not replaced', 'anotherfullword is not replaced'],
+            ['fullword fullword2', 'okay great'],
+            ['fullwordfullword2', 'fullwordfullword2'],
         ];
     }
 

--- a/tests/Singletons/ChatFiltersTest.php
+++ b/tests/Singletons/ChatFiltersTest.php
@@ -5,7 +5,7 @@
 
 namespace Tests\Singletons;
 
-use App\Exceptions\ValidationException;
+use App\Exceptions\ContentModerationException;
 use App\Models\ChatFilter;
 use Tests\TestCase;
 
@@ -45,7 +45,7 @@ class ChatFiltersTest extends TestCase
      */
     public function testBlockingFilter($input)
     {
-        $this->expectException(ValidationException::class);
+        $this->expectException(ContentModerationException::class);
         app('chat-filters')->filter($input);
     }
 


### PR DESCRIPTION
These are to match things that bancho can do.

- `block` means that the input should be outright rejected (any higher-level operation should fail). This is achieved by throwing an exception and handling locally (as to avoid returning 500s). I made a new exception type because it made sense to me at the time, but maybe it doesn't. Both usage sites will return a 422 with no error message when they spot it.
- `whitespace_delimited` means that the filter is supposed to be matching a full word and not a substring. Implemented using regex because of course.

This is probably awkward in multiple places, but I'm feeling pretty okay with this as is. Dunno if I need to be doing something special with migration if the tables already exist on production (not sure if they do).

I'll add spectator server handling of these after this is reviewed/accepted wrt behaviour.