### PR TITLE
Fix chat messages not updating to replacement words

### DIFF
--- a/resources/js/models/chat/message.ts
+++ b/resources/js/models/chat/message.ts
@@ -47,6 +47,7 @@ export default class Message {
   @action
   persist(json: MessageJson) {
     if (this.persisted) return;
+    this.content = json.content;
     this.messageId = json.message_id;
     this.timestamp = json.timestamp;
     this.persisted = true;


### PR DESCRIPTION
Happens if the endpoint returns before the websocket message arrives.