### PR TITLE
Skip beatmapset_id for converting to legacy score

### DIFF
--- a/app/Models/Score/Model.php
+++ b/app/Models/Score/Model.php
@@ -28,7 +28,7 @@ abstract class Model extends BaseModel
         'date' => 'datetime',
         'pass' => 'bool',
         'perfect' => 'bool',
-        'replay' => 'bool',
+        'replay' => 'bool', // for best model
     ];
     protected $primaryKey = 'score_id';
 

--- a/app/Models/Solo/Score.php
+++ b/app/Models/Solo/Score.php
@@ -352,7 +352,7 @@ class Score extends Model implements Traits\ReportableInterface
             ? LegacyScore\Best\Model::getClass($this->getMode())
             : LegacyScore\Model::getClass($this->getMode());
 
-        // Only attributes available to best model.
+        // Only attributes available to best model (and `pass`).
         $score = new $scoreClass([
             'beatmap_id' => $this->beatmap_id,
             'countmiss' => $statistics->miss,

--- a/app/Models/Solo/Score.php
+++ b/app/Models/Solo/Score.php
@@ -352,6 +352,7 @@ class Score extends Model implements Traits\ReportableInterface
             ? LegacyScore\Best\Model::getClass($this->getMode())
             : LegacyScore\Model::getClass($this->getMode());
 
+        // Only attributes available to both base and best models.
         $score = new $scoreClass([
             'beatmap_id' => $this->beatmap_id,
             'countmiss' => $statistics->miss,
@@ -363,7 +364,6 @@ class Score extends Model implements Traits\ReportableInterface
             'pp' => $this->pp,
             'replay' => $this->has_replay,
             'score' => $this->legacy_total_score,
-            'scorechecksum' => "\0",
             'user_id' => $this->user_id,
         ]);
 

--- a/app/Models/Solo/Score.php
+++ b/app/Models/Solo/Score.php
@@ -354,7 +354,6 @@ class Score extends Model implements Traits\ReportableInterface
 
         $score = new $scoreClass([
             'beatmap_id' => $this->beatmap_id,
-            'beatmapset_id' => $this->beatmap?->beatmapset_id ?? 0,
             'countmiss' => $statistics->miss,
             'date' => $this->ended_at_json,
             'enabled_mods' => app('mods')->idsToBitset(array_column($data->mods, 'acronym')),

--- a/app/Models/Solo/Score.php
+++ b/app/Models/Solo/Score.php
@@ -352,7 +352,7 @@ class Score extends Model implements Traits\ReportableInterface
             ? LegacyScore\Best\Model::getClass($this->getMode())
             : LegacyScore\Model::getClass($this->getMode());
 
-        // Only attributes available to both base and best models.
+        // Only attributes available to best model.
         $score = new $scoreClass([
             'beatmap_id' => $this->beatmap_id,
             'countmiss' => $statistics->miss,


### PR DESCRIPTION
It's not actually used in the json.

It's also causing additional queries during conversion for searching played beatmapset because of missing preload.