### PR TITLE
Fix default entry icon for submitted beatmaps contests

### DIFF
--- a/resources/js/contest-voting/entry.coffee
+++ b/resources/js/contest-voting/entry.coffee
@@ -49,7 +49,7 @@ export class Entry extends React.Component
         if @props.contest.submitted_beatmaps
           a href: route('beatmapsets.show', beatmapset: @props.entry.preview), className: 'contest-voting-list__icon contest-voting-list__icon--submitted-beatmaps', style: { background: "url(https://b.ppy.sh/thumb/#{@props.entry.preview}.jpg)" },
             span className: 'contest-voting-list__link contest-voting-list__link--shadowed',
-              i className: "fal fa-fw fa-lg fa-#{@props.contest.link_icon}"
+              i className: "fas fa-fw fa-lg fa-#{@props.contest.link_icon}"
         else
           div className: 'contest-voting-list__icon contest-voting-list__icon--bg',
             a


### PR DESCRIPTION
noticed this while testing contests... the default icon, `download`, doesn't have a free version with the `fal` style. on the live site I think this never makes a difference because the icons are always gamemodes, overriding `fal`/`fas` either way