### PR TITLE
Fix ellipsis overflow mixin

### DIFF
--- a/resources/css/bem/beatmap-owner-editor.less
+++ b/resources/css/bem/beatmap-owner-editor.less
@@ -59,7 +59,7 @@
 
     &--static {
       // defined here so it doesn't trigger tooltip in addition to usercard
-      .u-ellipsis-overflow();
+      .ellipsis-overflow();
       background-color: transparent;
       padding-left: 0;
       padding-right: 0;

--- a/resources/css/bem/play-detail.less
+++ b/resources/css/bem/play-detail.less
@@ -65,7 +65,7 @@
   }
 
   &__beatmap {
-    .u-ellipsis-overflow();
+    .ellipsis-overflow();
     color: @yellow-dark;
   }
 

--- a/resources/css/functions.less
+++ b/resources/css/functions.less
@@ -10,6 +10,12 @@
   height: @diameter;
 }
 
+.ellipsis-overflow() {
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  overflow: hidden;
+}
+
 .fade-element(@duration, @type: ease-in-out, @target: all) {
   transition: @target @duration @type;
 }

--- a/resources/css/utilities.less
+++ b/resources/css/utilities.less
@@ -23,14 +23,12 @@
 }
 
 .u-ellipsis-overflow {
-  white-space: nowrap !important;
-  text-overflow: ellipsis !important;
-  overflow: hidden !important;
+  .ellipsis-overflow() !important;
 }
 
 .u-ellipsis-overflow-desktop {
   @media @desktop {
-    .u-ellipsis-overflow();
+    .ellipsis-overflow() !important;
   }
 }
 


### PR DESCRIPTION
Create a general mixin and then apply accordingly instead of using the one from utility class which has `!important` applied to all the styles.

Conveniently lesscss has the directive to mark mixin styles as `!important`.