### PR TITLE
Include variant statistics in user index API

### DIFF
--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -354,7 +354,7 @@ class UsersController extends Controller
      *
      * Field | Type            | Description
      * ----- | --------------- | -----------
-     * users | [User](#user)[] | Includes: country, cover, groups, statistics_rulesets.
+     * users | [User](#user)[] | Includes `country`, `cover`, `groups`, `statistics_rulesets`, and `statistics_rulesets.variants`.
      *
      * @queryParam ids[] User id to be returned. Specify once for each user id requested. Up to 50 users can be requested at once. Example: 1
      *

--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -382,7 +382,7 @@ class UsersController extends Controller
             $preload = UserCompactTransformer::CARD_INCLUDES_PRELOAD;
 
             foreach (Beatmap::MODES as $modeStr => $modeInt) {
-                $includes[] = "statistics_rulesets.{$modeStr}";
+                $includes[] = "statistics_rulesets.{$modeStr}.variants";
                 $preload[] = camel_case("statistics_{$modeStr}");
             }
 

--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -382,9 +382,10 @@ class UsersController extends Controller
         $includes = UserCompactTransformer::CARD_INCLUDES;
 
         if (isset($params['ids'])) {
-            RequestCost::setCost(count($params['ids']));
             $includeVariantStatistics = $params['include_variant_statistics'] ?? false;
             $preload = UserCompactTransformer::CARD_INCLUDES_PRELOAD;
+
+            RequestCost::setCost(count($params['ids']) * ($includeVariantStatistics ? 3 : 1));
 
             foreach (Beatmap::MODES as $ruleset => $_rulesetId) {
                 $includes[] = "statistics_rulesets.{$ruleset}";

--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -381,12 +381,12 @@ class UsersController extends Controller
             RequestCost::setCost(count($params['ids']));
             $preload = UserCompactTransformer::CARD_INCLUDES_PRELOAD;
 
-            foreach (Beatmap::MODES as $modeStr => $modeInt) {
-                $includes[] = "statistics_rulesets.{$modeStr}.variants";
-                $preload[] = User::statisticsRelationName($modeStr);
+            foreach (Beatmap::MODES as $ruleset => $_rulesetId) {
+                $includes[] = "statistics_rulesets.{$ruleset}.variants";
+                $preload[] = User::statisticsRelationName($ruleset);
 
-                foreach (Beatmap::VARIANTS[$modeStr] ?? [] as $variant) {
-                    $preload[] = User::statisticsRelationName($modeStr, $variant);
+                foreach (Beatmap::VARIANTS[$ruleset] ?? [] as $variant) {
+                    $preload[] = User::statisticsRelationName($ruleset, $variant);
                 }
             }
 

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -281,6 +281,17 @@ class User extends Model implements AfterCommit, AuthenticatableContract, HasLoc
 
     private $isSessionVerified;
 
+    public static function statisticsRelationName(string $ruleset, ?string $variant = null): ?string
+    {
+        if (!Beatmap::isModeValid($ruleset) || !Beatmap::isVariantValid($ruleset, $variant)) {
+            return null;
+        }
+
+        $variantSuffix = $variant === null ? '' : "_{$variant}";
+
+        return 'statistics'.studly_case("{$ruleset}{$variantSuffix}");
+    }
+
     public function userCountryHistory(): HasMany
     {
         return $this->hasMany(UserCountryHistory::class);
@@ -1337,17 +1348,6 @@ class User extends Model implements AfterCommit, AuthenticatableContract, HasLoc
     public function statisticsTaiko()
     {
         return $this->hasOne(UserStatistics\Taiko::class);
-    }
-
-    public static function statisticsRelationName(string $ruleset, ?string $variant = null): ?string
-    {
-        if (!Beatmap::isModeValid($ruleset) || !Beatmap::isVariantValid($ruleset, $variant)) {
-            return null;
-        }
-
-        $variantSuffix = $variant === null ? '' : "_{$variant}";
-
-        return 'statistics'.studly_case("{$ruleset}{$variantSuffix}");
     }
 
     public function statistics(string $ruleset, bool $returnQuery = false, ?string $variant = null)

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -1339,21 +1339,24 @@ class User extends Model implements AfterCommit, AuthenticatableContract, HasLoc
         return $this->hasOne(UserStatistics\Taiko::class);
     }
 
-    public function statistics(string $ruleset, bool $returnQuery = false, ?string $variant = null)
+    public static function statisticsRelationName(string $ruleset, ?string $variant = null): ?string
     {
-        if (!Beatmap::isModeValid($ruleset)) {
-            return;
-        }
-
-        if (!Beatmap::isVariantValid($ruleset, $variant)) {
-            return;
+        if (!Beatmap::isModeValid($ruleset) || !Beatmap::isVariantValid($ruleset, $variant)) {
+            return null;
         }
 
         $variantSuffix = $variant === null ? '' : "_{$variant}";
 
-        $relation = 'statistics'.studly_case("{$ruleset}{$variantSuffix}");
+        return 'statistics'.studly_case("{$ruleset}{$variantSuffix}");
+    }
 
-        return $returnQuery ? $this->$relation() : $this->$relation;
+    public function statistics(string $ruleset, bool $returnQuery = false, ?string $variant = null)
+    {
+        $relationName = static::statisticsRelationName($ruleset, $variant);
+
+        if ($relationName !== null) {
+            return $returnQuery ? $this->$relationName() : $this->$relationName;
+        }
     }
 
     public function scoresOsu()


### PR DESCRIPTION
(probably) resolves #10556

I hope the request cost thing compensates for doing 2 country rank lookups on every user :thinking: 

the mentioned include in API docs isn't actually documented, but that's not really a new issue to this PR so I didn't fix it here.