### PR TITLE
Fix error on setting playstyle to null

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -699,9 +699,11 @@ class User extends Model implements AfterCommit, AuthenticatableContract, HasLoc
     {
         $styles = 0;
 
-        foreach (self::PLAYSTYLES as $type => $bit) {
-            if (in_array($type, $value, true)) {
-                $styles += $bit;
+        if ($value !== null) {
+            foreach (self::PLAYSTYLES as $type => $bit) {
+                if (in_array($type, $value, true)) {
+                    $styles += $bit;
+                }
             }
         }
 


### PR DESCRIPTION
Includes but not limited to sending non-array `osu_playstyles` to account option update.