### PR TITLE
Fix chat filter word matching

### DIFF
--- a/app/Singletons/ChatFilters.php
+++ b/app/Singletons/ChatFilters.php
@@ -25,7 +25,8 @@ class ChatFilters
     private static function combinedFilterRegex($filters): string
     {
         $regex = $filters->map(fn ($filter) => self::singleFilterRegex($filter, '/'))->join('|');
-        return '/'.$regex.'/i';
+
+        return "/{$regex}/iu";
     }
 
     /**
@@ -53,7 +54,7 @@ class ChatFilters
 
             $ret['whitespace_delimited_replaces'] = $replaceFilters
                 ->where('whitespace_delimited', true)
-                ->mapWithKeys(fn ($filter) => ['/'.self::singleFilterRegex($filter, '/').'/i' => $filter->replacement])
+                ->mapWithKeys(fn ($filter) => ['/'.self::singleFilterRegex($filter, '/').'/iu' => $filter->replacement])
                 ->all();
             $ret['non_whitespace_delimited_replaces'] = $replaceFilters
                 ->where('whitespace_delimited', false)

--- a/tests/Singletons/ChatFiltersTest.php
+++ b/tests/Singletons/ChatFiltersTest.php
@@ -32,6 +32,7 @@ class ChatFiltersTest extends TestCase
             ['fullword fullword2', 'okay great'],
             ['fullwordfullword2', 'fullwordfullword2'],
             ['i do a delimiter/inside', 'i do a nice try'],
+            ['español', 'español'],
         ];
     }
 
@@ -70,6 +71,7 @@ class ChatFiltersTest extends TestCase
             ['match' => 'fullword2', 'replacement' => 'great', 'whitespace_delimited' => true],
             ['match' => 'delimiter/inside', 'replacement' => 'nice try', 'whitespace_delimited' => true],
             ['match' => 'absolutely forbidden', 'replacement' => '', 'block' => true],
+            ['match' => 'ñ', 'replacement' => 'nnnn', 'whitespace_delimited' => true],
         ]);
 
         $result = app('chat-filters')->filter($input);


### PR DESCRIPTION
The flag is needed to correctly match multibyte letters.

Resolves #11233 (although I have no idea why that rule exists in the first place)