### PR TITLE
Automatically schedule daily challenge room creation

### DIFF
--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -140,6 +140,11 @@ class Kernel extends ConsoleKernel
             ->everyFiveMinutes()
             ->withoutOverlapping()
             ->onOneServer();
+
+        $schedule->command('daily-challenge:create-next')
+            ->cron('5 0 * * *')
+            ->withoutOverlapping()
+            ->onOneServer();
     }
 
     protected function commands()


### PR DESCRIPTION
Cron is intended to run every day at 00:05 UTC. Looking at daily metrics, this should coincide with the tail end of the daily user peak. The five minutes is just supposed to be a bit of a safety gap to ensure subsequent rooms don't run into each other.

If required, the time can be probably shifted around (userbase nadir appears to be roughly somewhere between ~06:00 and 08:00 UTC), but if that is to happen, then the end date of the room will also need to be shifted forward 8 hours (currently set to 00:00 UTC of the next day).

Maybe this will be obvious to anyone but me, but notably, when I wanted to test this locally to check that this works, it didn't really fire for me until I did something along the lines of

```diff
diff --git a/app/Console/Kernel.php b/app/Console/Kernel.php
index 1a9317a197..e7ee55f2fd 100644
--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -142,7 +142,7 @@ class Kernel extends ConsoleKernel
             ->onOneServer();
 
         $schedule->command('daily-challenge:create-next')
-            ->cron('5 0 * * *')
+            ->cron('23 8 * * *')
             ->withoutOverlapping()
             ->onOneServer();
     }
diff --git a/docker/development/entrypoint.sh b/docker/development/entrypoint.sh
index 31759d75c8..a384b030b3 100755
--- a/docker/development/entrypoint.sh
+++ b/docker/development/entrypoint.sh
@@ -48,9 +48,9 @@ _octane() {
 }
 
 _schedule() {
-    while sleep 300; do
+    while sleep 60; do
         _run php /app/artisan schedule:run &
-        echo 'Sleeping for 5 minutes'
+        echo 'Sleeping for 1 minute'
     done
 }
 

```

I don't know how scheduling is done in production, but at least in the dev setup it _appears_ that what `artisan schedule:run` does is run cronjobs whose expressions match the current time instant, meaning that if it's not run often enough, it could drop crons entirely.