### PR TITLE
Do not return daily challenge rooms in `GET /rooms` endpoint if API version too low

### DIFF
--- a/app/Http/Controllers/Multiplayer/RoomsController.php
+++ b/app/Http/Controllers/Multiplayer/RoomsController.php
@@ -46,7 +46,15 @@ class RoomsController extends BaseController
         }
 
         $search = Room::search($params);
-        $rooms = $search['query']
+        $query = $search['query'];
+
+        // temporary workaround for lazer client failing to deserialise `daily_challenge` room category
+        // can be removed 20241129
+        if ($apiVersion < 20240529) {
+            $query->whereNot('category', 'daily_challenge');
+        }
+
+        $rooms = $query
             ->with($includes)
             ->withRecentParticipantIds()
             ->get();

--- a/resources/views/docs/info.md.blade.php
+++ b/resources/views/docs/info.md.blade.php
@@ -134,7 +134,7 @@ Version 0 is assumed when the header is omitted.
 Version  | Change
 -------- | ------
 20220705 | [Score](#score) object with different set of fields.
-20240529 | [`GET /rooms`](#get-multiplayer-rooms) will not return rooms with category `daily_challenge` prior to this version.
+20240529 | [`GET /rooms`](#get-multiplayer-rooms) will not return rooms with category `daily_challenge` prior to this version. Temporary, will not be supported after 2024-11-29.
 
 ## Language
 

--- a/resources/views/docs/info.md.blade.php
+++ b/resources/views/docs/info.md.blade.php
@@ -134,6 +134,7 @@ Version 0 is assumed when the header is omitted.
 Version  | Change
 -------- | ------
 20220705 | [Score](#score) object with different set of fields.
+20240529 | [`GET /rooms`](#get-multiplayer-rooms) will not return rooms with category `daily_challenge` prior to this version.
 
 ## Language
 


### PR DESCRIPTION
RFC.

Currently old lazer clients die on these due to deserialisation woes (it can't figure out what enum value to deserialise `daily_challenge` to as it doesn't exist yet), which makes deployment of the feature a bit tricky logistically.

Since we can't fix old clients (because they're already released, and we would have to push an update either way), hide daily challenge rooms behind an `x-api-version` header check. Note that challenge rooms can still be accessed directly by ID regardless of API version, but that's fine for this case, since the client won't be doing it.