### PR TITLE
Report chat message for user card on chat page

### DIFF
--- a/resources/js/chat/message-group.tsx
+++ b/resources/js/chat/message-group.tsx
@@ -3,6 +3,8 @@
 
 import UserAvatar from 'components/user-avatar';
 import UserLink from 'components/user-link';
+import Reportable from 'interfaces/reportable';
+import { last } from 'lodash';
 import { observer } from 'mobx-react';
 import Message from 'models/chat/message';
 import * as moment from 'moment';
@@ -17,6 +19,23 @@ interface Props {
 
 @observer
 export default class MessageGroup extends React.Component<Props> {
+  private get reportable() {
+    const lastMessage = last(this.props.messages);
+
+    if (lastMessage == null) {
+      throw new Error('invalid reportable access on empty message group');
+    }
+
+    if (typeof lastMessage.messageId !== 'number') {
+      return undefined;
+    }
+
+    return {
+      id: lastMessage.messageId.toString(),
+      type: 'message',
+    } satisfies Reportable;
+  }
+
   render(): React.ReactNode {
     const messages = this.props.messages;
 
@@ -29,7 +48,11 @@ export default class MessageGroup extends React.Component<Props> {
     return (
       <div className={classWithModifiers('chat-message-group', { own: sender.id === core.currentUser?.id })}>
         <div className='chat-message-group__sender'>
-          <UserLink tooltipPosition='top center' user={sender}>
+          <UserLink
+            reportable={this.reportable}
+            tooltipPosition='top center'
+            user={sender}
+          >
             <div className='chat-message-group__avatar'>
               <UserAvatar modifiers='full-circle' user={{ avatar_url: sender.avatarUrl }} />
             </div>

--- a/resources/js/components/report-reportable.tsx
+++ b/resources/js/components/report-reportable.tsx
@@ -1,9 +1,10 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+import { ReportableType } from 'interfaces/reportable';
 import * as React from 'react';
 import { trans } from 'utils/lang';
-import { ReportableType, reportableTypeToGroupKey, showReportForm } from './report-form';
+import { reportableTypeToGroupKey, showReportForm } from './report-form';
 
 type ReactButton = React.DetailedHTMLProps<React.ButtonHTMLAttributes<HTMLButtonElement>, HTMLButtonElement>;
 type ReactButtonWithoutRef = Pick<ReactButton, Exclude<keyof ReactButton, 'ref'>>;

--- a/resources/js/components/user-card-tooltip.tsx
+++ b/resources/js/components/user-card-tooltip.tsx
@@ -1,6 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+import Reportable from 'interfaces/reportable';
 import UserJson from 'interfaces/user-json';
 import { route } from 'laroute';
 import * as _ from 'lodash';
@@ -86,8 +87,8 @@ function createTooltip(element: HTMLElement) {
   card.classList.remove('js-react--user-card');
   card.classList.add('js-react--user-card-tooltip');
   card.dataset.lookup = userId;
-  if (element.dataset.tooltipPosition != null) {
-    card.dataset.tooltipPosition = element.dataset.tooltipPosition;
+  for (const [key, value] of Object.entries(element.dataset)) {
+    card.dataset[key] = value;
   }
 
   $(element).qtip(createTooltipOptions(card));
@@ -214,6 +215,14 @@ export class UserCardTooltip extends React.PureComponent<Props, State> {
   state: Readonly<State> = {};
   private readonly contextActiveKeyDidChange = contextActiveKeyDidChange.bind(this);
 
+  private get reportable() {
+    const dataString = this.props.container.dataset.reportable;
+
+    return dataString == null
+      ? undefined
+      : JSON.parse(dataString) as Reportable;
+  }
+
   componentDidMount() {
     this.getUser().then((user) => {
       this.setState({ user });
@@ -237,7 +246,11 @@ export class UserCardTooltip extends React.PureComponent<Props, State> {
       <TooltipContext.Provider value={this.props.container}>
         <ContainerContext.Provider value={{ activeKeyDidChange: this.activeKeyDidChange }}>
           <KeyContext.Provider value={this.props.lookup}>
-            <UserCard activated={activated} user={this.state.user} />
+            <UserCard
+              activated={activated}
+              reportable={this.reportable}
+              user={this.state.user}
+            />
           </KeyContext.Provider>
         </ContainerContext.Provider>
       </TooltipContext.Provider>

--- a/resources/js/components/user-card.tsx
+++ b/resources/js/components/user-card.tsx
@@ -3,6 +3,7 @@
 
 import BlockButton from 'components/block-button';
 import FriendButton from 'components/friend-button';
+import Reportable from 'interfaces/reportable';
 import UserJson from 'interfaces/user-json';
 import { route } from 'laroute';
 import * as _ from 'lodash';
@@ -30,6 +31,7 @@ interface Props {
   activated: boolean;
   mode: ViewMode;
   modifiers?: Modifiers;
+  reportable?: Reportable;
   user?: UserJson | null;
 }
 
@@ -304,8 +306,8 @@ export class UserCard extends React.PureComponent<Props, State> {
           className='simple-menu__item'
           icon
           onFormOpen={dismiss}
-          reportableId={this.user.id.toString()}
-          reportableType='user'
+          reportableId={this.props.reportable?.id ?? this.user.id.toString()}
+          reportableType={this.props.reportable?.type ?? 'user'}
           user={this.user}
         />
       </div>

--- a/resources/js/components/user-link.tsx
+++ b/resources/js/components/user-link.tsx
@@ -1,6 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+import Reportable from 'interfaces/reportable';
 import Ruleset from 'interfaces/ruleset';
 import UserJson from 'interfaces/user-json';
 import { route } from 'laroute';
@@ -10,6 +11,7 @@ interface Props {
   children?: React.ReactNode;
   className?: string;
   mode?: Ruleset;
+  reportable?: Reportable;
   tooltipPosition?: string;
   user: Partial<Pick<UserJson, 'id' | 'username'>>;
 }
@@ -28,6 +30,7 @@ export default class UserLink extends React.PureComponent<Props> {
     return (
       <a
         className={className}
+        data-reportable={JSON.stringify(this.props.reportable)}
         data-tooltip-position={this.props.tooltipPosition}
         data-user-id={this.props.user.id}
         href={href}

--- a/resources/js/interfaces/reportable.ts
+++ b/resources/js/interfaces/reportable.ts
@@ -1,0 +1,20 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
+export type ReportableType =
+  | 'beatmapset'
+  | 'beatmapset_discussion_post'
+  | 'comment'
+  | 'forum_post'
+  | 'message'
+  | 'score_best_fruits'
+  | 'score_best_mania'
+  | 'score_best_osu'
+  | 'score_best_taiko'
+  | 'solo_score'
+  | 'user';
+
+export default interface Reportable {
+  id: string;
+  type: ReportableType;
+}

--- a/resources/lang/en/report.php
+++ b/resources/lang/en/report.php
@@ -24,6 +24,11 @@ return [
         'title' => 'Report :username\'s post?',
     ],
 
+    'message' => [
+        'button' => 'Report Message',
+        'title' => 'Report :username\'s message?',
+    ],
+
     'scores' => [
         'button' => 'Report Score',
         'title' => 'Report :username\'s score?',


### PR DESCRIPTION
With the message grouping, only the last message can be actually reported. The report itself includes some number of previous messages as well so maybe it's fine?

Alternatively a different report button would need to be added instead.