### PR TITLE
Faster multiplayer room participation listing

### DIFF
--- a/app/Http/Controllers/Users/MultiplayerController.php
+++ b/app/Http/Controllers/Users/MultiplayerController.php
@@ -25,7 +25,6 @@ class MultiplayerController extends Controller
             'cursor' => cursor_from_params($rawParams),
             'limit' => get_int($rawParams['limit'] ?? null),
             'mode' => 'participated',
-            'sort' => 'ended',
             'type_group' => $typeGroup,
             'user' => $user,
         ];

--- a/app/Libraries/DbCursorHelper.php
+++ b/app/Libraries/DbCursorHelper.php
@@ -13,7 +13,8 @@ class DbCursorHelper
     private $sort;
     private $sortName;
 
-    public function __construct($sorts, $defaultSort, $requestedSort = null)
+    // $prefix is only because itemToCursor will use the non-prefixed column while everything else uses the prefixed one for join queries.
+    public function __construct($sorts, $defaultSort, $requestedSort = null, private string $prefix = '')
     {
         $this->sortName = $requestedSort;
         $this->sort = $sorts[$requestedSort] ?? null;
@@ -39,6 +40,11 @@ class DbCursorHelper
         }
 
         return $ret;
+    }
+
+    public function getPrefix()
+    {
+        return $this->prefix;
     }
 
     public function getSort()

--- a/app/Models/Multiplayer/Room.php
+++ b/app/Models/Multiplayer/Room.php
@@ -60,7 +60,7 @@ class Room extends Model
         ],
         'participated' => [
             ['column' => 'multiplayer_rooms_high.ends_at', 'order' => 'DESC', 'type' => 'time'],
-            ['column' => 'multiplayer_rooms_high.room_id', 'order' => 'DESC', 'type' => 'int']
+            ['column' => 'multiplayer_rooms_high.room_id', 'order' => 'DESC', 'type' => 'int'],
         ],
     ];
 
@@ -513,6 +513,15 @@ class Room extends Model
             ->get()
             ->pluck('user')
             ->all();
+    }
+
+    public function save(array $options = [])
+    {
+        if ($this->exists && $this->isDirty('ends_at')) {
+            $this->userHighScores()->update(['ends_at' => $this->ends_at]);
+        }
+
+        return parent::save($options);
     }
 
     public function startGame(User $host, array $rawParams)

--- a/app/Models/Multiplayer/Room.php
+++ b/app/Models/Multiplayer/Room.php
@@ -194,7 +194,7 @@ class Room extends Model
                 $sort ??= 'ended';
                 break;
             case 'participated':
-                $query->hasParticipated($user);
+                $query->hasParticipatedForListing($user);
                 $sort = 'participated';
                 break;
             case 'owned':
@@ -275,6 +275,14 @@ class Room extends Model
     }
 
     public function scopeHasParticipated(Builder $query, User $user)
+    {
+        return $query->whereHas(
+            'userHighScores',
+            fn ($q) => $q->where('user_id', $user->getKey()),
+        );
+    }
+
+    public function scopeHasParticipatedForListing(Builder $query, User $user)
     {
         $tempModel = new UserScoreAggregate();
 

--- a/app/Models/Multiplayer/UserScoreAggregate.php
+++ b/app/Models/Multiplayer/UserScoreAggregate.php
@@ -17,6 +17,7 @@ use App\Models\User;
  * @property int $attempts
  * @property int $completed
  * @property \Carbon\Carbon $created_at
+ * @property \Carbon\Carbon|null $ends_at
  * @property int $id
  * @property int|null $last_score_id
  * @property bool $in_room
@@ -61,6 +62,7 @@ class UserScoreAggregate extends Model
         $obj = static::lookupOrDefault($user, $room);
 
         if (!$obj->exists) {
+            $obj->ends_at = $room->ends_at;
             $obj->save(); // force a save now to avoid being trolled later.
             $obj->recalculate();
         }

--- a/app/Singletons/OsuAuthorize.php
+++ b/app/Singletons/OsuAuthorize.php
@@ -1085,7 +1085,7 @@ class OsuAuthorize
         // This check is only for when joining the channel directly; joining via the Room
         // will always add the user to the channel.
         if ($channel->isMultiplayer()) {
-            $room = Room::hasParticipated($user)->find($channel->room_id);
+            $room = Room::where('id', $channel->room_id)->hasParticipated($user)->first();
             if ($room !== null) {
                 return 'ok';
             }

--- a/database/factories/Chat/ChannelFactory.php
+++ b/database/factories/Chat/ChannelFactory.php
@@ -10,6 +10,7 @@ namespace Database\Factories\Chat;
 use App\Exceptions\InvariantException;
 use App\Models\Chat\Channel;
 use App\Models\LegacyMatch\LegacyMatch;
+use App\Models\Multiplayer\Room;
 use App\Models\User;
 use Database\Factories\Factory;
 
@@ -28,6 +29,16 @@ class ChannelFactory extends Factory
     public function moderated(): static
     {
         return $this->state(['moderated' => true]);
+    }
+
+    public function multiplayer(): static
+    {
+        $room = Room::factory()->create();
+
+        return $this->state([
+            'name' => "#lazermp_{$room->getKey()}",
+            'type' => Channel::TYPES['multiplayer'],
+        ]);
     }
 
     public function pm(User ...$users): static

--- a/database/migrations/2024_06_11_000001_add_ends_at_to_multiplayer_rooms_high.php
+++ b/database/migrations/2024_06_11_000001_add_ends_at_to_multiplayer_rooms_high.php
@@ -1,0 +1,35 @@
+<?php
+
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('multiplayer_rooms_high', function (Blueprint $table) {
+            $table->timestampTz('ends_at')->nullable();
+            $table->index([DB::raw('ends_at DESC'), DB::raw('room_id DESC'), 'user_id'], 'participated_rooms');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('multiplayer_rooms_high', function (Blueprint $table) {
+            $table->dropColumn('ends_at');
+            $table->dropIndex('participated_rooms');
+        });
+    }
+};


### PR DESCRIPTION
Duplicates `ends_at` to `multiplayer_rooms_high` and uses it for sort order.
The existing issue is ordering on `multiplayer_rooms` while the existence check uses `multiplayer_rooms_high` can result in  too many records being scanned to get enough matching rows. The issue doesn't exist if there's no sort order, or the required rows are all early in the sorting order.

I made the listing a separate scope so other queries that don't have the issue can skip the join mess.

- [ ] add migration `2024_06_11_000001_add_ends_at_to_multiplayer_rooms_high`
- [ ] `CREATE INDEX participated_rooms ON multiplayer_rooms_high (ends_at DESC, room_id DESC, user_id)`
- [ ] fill column `UPDATE multiplayer_rooms_high h INNER JOIN multiplayer_rooms r ON h.room_id = r.id SET h.ends_at = r.ends_at`