### PR TITLE
Log payment validation errors to Sentry

### DIFF
--- a/app/Exceptions/HasExtraExceptionData.php
+++ b/app/Exceptions/HasExtraExceptionData.php
@@ -3,12 +3,10 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
-declare(strict_types=1);
+namespace App\Exceptions;
 
-namespace App\Libraries\Fulfillments;
-
-use App\Exceptions\Store\OrderException;
-
-class FulfillmentException extends OrderException
+interface HasExtraExceptionData
 {
+    public function getContexts(): array;
+    public function getExtras(): array;
 }

--- a/app/Exceptions/InvalidSignatureException.php
+++ b/app/Exceptions/InvalidSignatureException.php
@@ -9,9 +9,9 @@ use Exception;
 
 class InvalidSignatureException extends Exception implements HasExtraExceptionData
 {
-    public function __construct(private array $extras = [])
+    public function __construct(string $message = '', private array $extras = [])
     {
-        parent::__construct();
+        parent::__construct($message);
     }
 
     // doesn't really contain anything

--- a/app/Exceptions/InvalidSignatureException.php
+++ b/app/Exceptions/InvalidSignatureException.php
@@ -14,7 +14,6 @@ class InvalidSignatureException extends Exception implements HasExtraExceptionDa
         parent::__construct($message);
     }
 
-    // doesn't really contain anything
     public function getContexts(): array
     {
         return [];

--- a/app/Exceptions/InvalidSignatureException.php
+++ b/app/Exceptions/InvalidSignatureException.php
@@ -7,7 +7,21 @@ namespace App\Exceptions;
 
 use Exception;
 
-class InvalidSignatureException extends Exception
+class InvalidSignatureException extends Exception implements HasExtraExceptionData
 {
+    public function __construct(private array $extras = [])
+    {
+        parent::__construct();
+    }
+
     // doesn't really contain anything
+    public function getContexts(): array
+    {
+        return [];
+    }
+
+    public function getExtras(): array
+    {
+        return $this->extras;
+    }
 }

--- a/app/Exceptions/Store/FulfillmentException.php
+++ b/app/Exceptions/Store/FulfillmentException.php
@@ -5,10 +5,8 @@
 
 declare(strict_types=1);
 
-namespace App\Libraries\Payments;
+namespace App\Exceptions\Store;
 
-use App\Exceptions\Store\OrderException;
-
-class PaymentProcessorException extends OrderException
+class FulfillmentException extends OrderException
 {
 }

--- a/app/Exceptions/Store/OrderException.php
+++ b/app/Exceptions/Store/OrderException.php
@@ -15,7 +15,7 @@ class OrderException extends \Exception implements HasExtraExceptionData
 {
     public function __construct(private ?Order $order, private ?ValidationErrors $errors = null, ?\Throwable $previous = null)
     {
-        parent::__construct('', 0, $previous);
+        parent::__construct(previous: $previous);
     }
 
     public function getContexts(): array

--- a/app/Exceptions/Store/OrderException.php
+++ b/app/Exceptions/Store/OrderException.php
@@ -20,7 +20,7 @@ class OrderException extends \Exception implements HasExtraExceptionData
 
     public function getContexts(): array
     {
-        return ['order' => $this->order->only('id', 'provider', 'reference', 'status', 'transaction_id', 'user_id')];
+        return ['order' => $this->order?->only('id', 'provider', 'reference', 'status', 'transaction_id', 'user_id')];
     }
 
     public function getExtras(): array

--- a/app/Exceptions/Store/OrderException.php
+++ b/app/Exceptions/Store/OrderException.php
@@ -1,0 +1,32 @@
+<?php
+
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
+declare(strict_types=1);
+
+namespace App\Exceptions\Store;
+
+use App\Exceptions\HasExtraExceptionData;
+use App\Libraries\ValidationErrors;
+use App\Models\Store\Order;
+
+class OrderException extends \Exception implements HasExtraExceptionData
+{
+    public function __construct(private ?Order $order, private ?ValidationErrors $errors = null, ?\Throwable $previous = null)
+    {
+        parent::__construct('', 0, $previous);
+    }
+
+    public function getContexts(): array
+    {
+        return ['order' => $this->order->only('id', 'provider', 'reference', 'status', 'transaction_id', 'user_id')];
+    }
+
+    public function getExtras(): array
+    {
+        return [
+            'errors' => $this->errors?->all(),
+        ];
+    }
+}

--- a/app/Exceptions/Store/PaymentProcessorException.php
+++ b/app/Exceptions/Store/PaymentProcessorException.php
@@ -5,10 +5,8 @@
 
 declare(strict_types=1);
 
-namespace App\Libraries\Fulfillments;
+namespace App\Exceptions\Store;
 
-use App\Exceptions\Store\OrderException;
-
-class FulfillmentException extends OrderException
+class PaymentProcessorException extends OrderException
 {
 }

--- a/app/Http/Controllers/Payments/PaypalController.php
+++ b/app/Http/Controllers/Payments/PaypalController.php
@@ -6,9 +6,9 @@
 namespace App\Http\Controllers\Payments;
 
 use App\Exceptions\InvalidSignatureException;
+use App\Exceptions\Store\PaymentProcessorException;
 use App\Libraries\OrderCheckout;
 use App\Libraries\Payments\NotificationType;
-use App\Libraries\Payments\PaymentProcessorException;
 use App\Libraries\Payments\PaypalCreatePayment;
 use App\Libraries\Payments\PaypalExecutePayment;
 use App\Libraries\Payments\PaypalPaymentProcessor;

--- a/app/Http/Controllers/Payments/PaypalController.php
+++ b/app/Http/Controllers/Payments/PaypalController.php
@@ -6,7 +6,7 @@
 namespace App\Http\Controllers\Payments;
 
 use App\Exceptions\InvalidSignatureException;
-use App\Exceptions\Store\PaymentProcessorException;
+use App\Exceptions\Store\OrderException;
 use App\Libraries\OrderCheckout;
 use App\Libraries\Payments\NotificationType;
 use App\Libraries\Payments\PaypalCreatePayment;
@@ -101,7 +101,7 @@ class PaypalController extends Controller
 
         try {
             $processor->run();
-        } catch (PaymentProcessorException $exception) {
+        } catch (OrderException $exception) {
             log_error($exception);
 
             return response(['message' => 'A validation error occured while running the transaction'], 406);

--- a/app/Http/Controllers/Payments/PaypalController.php
+++ b/app/Http/Controllers/Payments/PaypalController.php
@@ -6,9 +6,9 @@
 namespace App\Http\Controllers\Payments;
 
 use App\Exceptions\InvalidSignatureException;
-use App\Exceptions\ValidationException;
 use App\Libraries\OrderCheckout;
 use App\Libraries\Payments\NotificationType;
+use App\Libraries\Payments\PaymentProcessorException;
 use App\Libraries\Payments\PaypalCreatePayment;
 use App\Libraries\Payments\PaypalExecutePayment;
 use App\Libraries\Payments\PaypalPaymentProcessor;
@@ -18,7 +18,6 @@ use App\Traits\CheckoutErrorSettable;
 use Illuminate\Database\QueryException;
 use Illuminate\Http\Request as HttpRequest;
 use Lang;
-use Log;
 use PayPalHttp\HttpException;
 
 class PaypalController extends Controller
@@ -102,11 +101,13 @@ class PaypalController extends Controller
 
         try {
             $processor->run();
-        } catch (ValidationException $exception) {
-            Log::error($exception->getMessage());
+        } catch (PaymentProcessorException $exception) {
+            log_error($exception);
 
             return response(['message' => 'A validation error occured while running the transaction'], 406);
         } catch (InvalidSignatureException $exception) {
+            log_error($exception);
+
             return response(['message' => $exception->getMessage()], 406);
         } catch (QueryException $exception) {
             // can get multiple cancellations for the same order from paypal.

--- a/app/Http/Controllers/Payments/ShopifyController.php
+++ b/app/Http/Controllers/Payments/ShopifyController.php
@@ -22,9 +22,7 @@ class ShopifyController extends Controller
     public function callback()
     {
         $signature = new ShopifySignature(request());
-        if (!$signature->isValid()) {
-            throw new InvalidSignatureException();
-        }
+        $signature->assertValid();
 
         // X-Shopify-Hmac-Sha256
         // X-Shopify-Order-Id

--- a/app/Http/Controllers/Payments/ShopifyController.php
+++ b/app/Http/Controllers/Payments/ShopifyController.php
@@ -5,7 +5,6 @@
 
 namespace App\Http\Controllers\Payments;
 
-use App\Exceptions\InvalidSignatureException;
 use App\Exceptions\ModelNotSavedException;
 use App\Libraries\OrderCheckout;
 use App\Libraries\Payments\ShopifySignature;

--- a/app/Http/Controllers/Payments/XsollaController.php
+++ b/app/Http/Controllers/Payments/XsollaController.php
@@ -6,8 +6,8 @@
 namespace App\Http\Controllers\Payments;
 
 use App\Exceptions\InvalidSignatureException;
-use App\Exceptions\ValidationException;
 use App\Libraries\OrderCheckout;
+use App\Libraries\Payments\PaymentProcessorException;
 use App\Libraries\Payments\XsollaPaymentProcessor;
 use App\Libraries\Payments\XsollaSignature;
 use App\Libraries\Payments\XsollaUserNotFoundException;
@@ -15,7 +15,6 @@ use App\Models\Store\Order;
 use Auth;
 use Exception;
 use Illuminate\Http\Request as HttpRequest;
-use Log;
 use Request;
 use Xsolla\SDK\API\PaymentUI\TokenRequest;
 use Xsolla\SDK\API\XsollaClient;
@@ -81,8 +80,8 @@ class XsollaController extends Controller
             }
 
             $processor->run();
-        } catch (ValidationException $exception) {
-            Log::error($exception->getMessage());
+        } catch (PaymentProcessorException $exception) {
+            log_error($exception);
 
             return $this->errorResponse(
                 'A validation error occured while running the transaction',
@@ -90,6 +89,7 @@ class XsollaController extends Controller
                 422
             );
         } catch (InvalidSignatureException $exception) {
+            log_error($exception);
             // xsolla expects INVALID_SIGNATURE
             return $this->errorResponse('The signature is invalid.', 'INVALID_SIGNATURE', 422);
         } catch (XsollaUserNotFoundException $exception) {

--- a/app/Http/Controllers/Payments/XsollaController.php
+++ b/app/Http/Controllers/Payments/XsollaController.php
@@ -6,7 +6,7 @@
 namespace App\Http\Controllers\Payments;
 
 use App\Exceptions\InvalidSignatureException;
-use App\Exceptions\Store\PaymentProcessorException;
+use App\Exceptions\Store\OrderException;
 use App\Libraries\OrderCheckout;
 use App\Libraries\Payments\XsollaPaymentProcessor;
 use App\Libraries\Payments\XsollaSignature;
@@ -80,7 +80,7 @@ class XsollaController extends Controller
             }
 
             $processor->run();
-        } catch (PaymentProcessorException $exception) {
+        } catch (OrderException $exception) {
             log_error($exception);
 
             return $this->errorResponse(

--- a/app/Http/Controllers/Payments/XsollaController.php
+++ b/app/Http/Controllers/Payments/XsollaController.php
@@ -6,8 +6,8 @@
 namespace App\Http\Controllers\Payments;
 
 use App\Exceptions\InvalidSignatureException;
+use App\Exceptions\Store\PaymentProcessorException;
 use App\Libraries\OrderCheckout;
-use App\Libraries\Payments\PaymentProcessorException;
 use App\Libraries\Payments\XsollaPaymentProcessor;
 use App\Libraries\Payments\XsollaSignature;
 use App\Libraries\Payments\XsollaUserNotFoundException;

--- a/app/Libraries/Fulfillments/OrderFulfiller.php
+++ b/app/Libraries/Fulfillments/OrderFulfiller.php
@@ -45,7 +45,7 @@ abstract class OrderFulfiller implements Fulfillable
     protected function throwOnFail(bool $valid = false)
     {
         if (!$valid) {
-            $this->throwValidationFailed(new FulfillmentException($this->validationErrors()));
+            $this->throwValidationFailed(new FulfillmentException($this->order, $this->validationErrors()));
         }
     }
 
@@ -61,11 +61,8 @@ abstract class OrderFulfiller implements Fulfillable
 
     /**
      * Convenience method that calls dispatchValidationFailed() and then throws the supplied exception.
-     *
-     * @param Exception $exception
-     * @return void
      */
-    protected function throwValidationFailed(\Exception $exception)
+    protected function throwValidationFailed(\Exception $exception): void
     {
         $this->dispatchValidationFailed();
         throw $exception;

--- a/app/Libraries/Fulfillments/OrderFulfiller.php
+++ b/app/Libraries/Fulfillments/OrderFulfiller.php
@@ -6,6 +6,7 @@
 namespace App\Libraries\Fulfillments;
 
 use App\Events\Fulfillments\FulfillmentValidationFailed;
+use App\Exceptions\Store\FulfillmentException;
 use App\Models\Store\Order;
 use App\Traits\Validatable;
 

--- a/app/Libraries/Payments/PaymentProcessor.php
+++ b/app/Libraries/Payments/PaymentProcessor.php
@@ -22,15 +22,9 @@ abstract class PaymentProcessor implements \ArrayAccess
 {
     use Memoizes, Validatable;
 
-    protected $params;
-    protected $signature;
-
-    public function __construct(array $params, PaymentSignature $signature)
+    public function __construct(protected array $params, protected PaymentSignature $signature)
     {
         \Log::debug($params);
-
-        $this->params = $params;
-        $this->signature = $signature;
     }
 
     /**
@@ -298,16 +292,11 @@ abstract class PaymentProcessor implements \ArrayAccess
     {
         // just validate the signature until we make sure validating
         //  the whole transaction doesn't make it explode.
-        $this->ensureValidSignature();
+        $this->signature->assertValid();
 
         $order = $this->getOrder();
         $eventName = "store.payments.rejected.{$this->getPaymentProvider()}";
         event($eventName, new PaymentEvent($order));
-    }
-
-    public function ensureValidSignature()
-    {
-        $this->signature->assertValid();
     }
 
     /**

--- a/app/Libraries/Payments/PaymentProcessor.php
+++ b/app/Libraries/Payments/PaymentProcessor.php
@@ -9,6 +9,7 @@ use App\Events\Fulfillments\PaymentEvent;
 use App\Events\Fulfillments\ProcessorValidationFailed;
 use App\Exceptions\InvalidSignatureException;
 use App\Exceptions\ModelNotSavedException;
+use App\Exceptions\Store\PaymentProcessorException;
 use App\Models\Store\Order;
 use App\Models\Store\Payment;
 use App\Traits\Memoizes;

--- a/app/Libraries/Payments/PaymentProcessor.php
+++ b/app/Libraries/Payments/PaymentProcessor.php
@@ -307,11 +307,7 @@ abstract class PaymentProcessor implements \ArrayAccess
 
     public function ensureValidSignature()
     {
-        // TODO: post many warnings
-        if (!$this->signature->isValid()) {
-            $this->validationErrors()->add('header.signature', '.signature.not_match');
-            $this->throwValidationFailed(new InvalidSignatureException());
-        }
+        $this->signature->assertValid();
     }
 
     /**

--- a/app/Libraries/Payments/PaymentProcessor.php
+++ b/app/Libraries/Payments/PaymentProcessor.php
@@ -125,6 +125,8 @@ abstract class PaymentProcessor implements \ArrayAccess
      * Auto run apply() or cancel() depending on the notification type.
      *
      * @return void
+     * @throws InvalidSignatureException thrown if the request signature is invalid.
+     * @throws PaymentProcessorException thrown if the validating the order fails.
      * @throws UnsupportedNotificationTypeException thrown if the notification type is unsupported.
      */
     public function run()

--- a/app/Libraries/Payments/PaymentProcessor.php
+++ b/app/Libraries/Payments/PaymentProcessor.php
@@ -172,7 +172,7 @@ abstract class PaymentProcessor implements \ArrayAccess
         optional($order)->update(['transaction_id' => $this->getTransactionId()]);
 
         if (!$this->validateTransaction()) {
-            $this->throwValidationFailed(new PaymentProcessorException($this->validationErrors()));
+            $this->throwValidationFailed(new PaymentProcessorException($order, $this->validationErrors()));
         }
 
         DB::connection('mysql-store')->transaction(function () use ($order) {
@@ -216,7 +216,7 @@ abstract class PaymentProcessor implements \ArrayAccess
         $this->sandboxAssertion();
 
         if (!$this->validateTransaction()) {
-            $this->throwValidationFailed(new PaymentProcessorException($this->validationErrors()));
+            $this->throwValidationFailed(new PaymentProcessorException($this->getOrder(), $this->validationErrors()));
         }
 
         DB::connection('mysql-store')->transaction(function () {
@@ -263,7 +263,7 @@ abstract class PaymentProcessor implements \ArrayAccess
         $this->sandboxAssertion();
 
         if (!$this->validateTransaction()) {
-            $this->throwValidationFailed(new PaymentProcessorException($this->validationErrors()));
+            $this->throwValidationFailed(new PaymentProcessorException($this->getOrder(), $this->validationErrors()));
         }
 
         DB::connection('mysql-store')->transaction(function () {
@@ -341,11 +341,8 @@ abstract class PaymentProcessor implements \ArrayAccess
 
     /**
      * Convenience method that calls dispatchValidationFailed() and then throws the supplied exception.
-     *
-     * @param Exception $exception
-     * @return void
      */
-    protected function throwValidationFailed(Exception $exception)
+    protected function throwValidationFailed(Exception $exception): void
     {
         $this->dispatchValidationFailed();
         throw $exception;

--- a/app/Libraries/Payments/PaymentProcessorException.php
+++ b/app/Libraries/Payments/PaymentProcessorException.php
@@ -3,10 +3,12 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 namespace App\Libraries\Payments;
 
-use App\Exceptions\ValidationException;
+use App\Exceptions\Store\OrderException;
 
-class PaymentProcessorException extends ValidationException
+class PaymentProcessorException extends OrderException
 {
 }

--- a/app/Libraries/Payments/PaymentSignature.php
+++ b/app/Libraries/Payments/PaymentSignature.php
@@ -7,5 +7,6 @@ namespace App\Libraries\Payments;
 
 interface PaymentSignature
 {
+    public function assertValid();
     public function isValid();
 }

--- a/app/Libraries/Payments/PaymentSignature.php
+++ b/app/Libraries/Payments/PaymentSignature.php
@@ -7,6 +7,5 @@ namespace App\Libraries\Payments;
 
 interface PaymentSignature
 {
-    public function assertValid();
-    public function isValid();
+    public function assertValid(): void;
 }

--- a/app/Libraries/Payments/PaypalPaymentProcessor.php
+++ b/app/Libraries/Payments/PaypalPaymentProcessor.php
@@ -92,7 +92,7 @@ class PaypalPaymentProcessor extends PaymentProcessor
 
     public function validateTransaction()
     {
-        $this->ensureValidSignature();
+        $this->signature->assertValid();
 
         $order = $this->getOrder();
         // order should exist

--- a/app/Libraries/Payments/PaypalSignature.php
+++ b/app/Libraries/Payments/PaypalSignature.php
@@ -5,7 +5,6 @@
 
 namespace App\Libraries\Payments;
 
-use App\Exceptions\HasExtraExceptionData;
 use App\Exceptions\InvalidSignatureException;
 use GuzzleHttp\Client;
 use Illuminate\Http\Request;

--- a/app/Libraries/Payments/PaypalSignature.php
+++ b/app/Libraries/Payments/PaypalSignature.php
@@ -6,6 +6,7 @@
 namespace App\Libraries\Payments;
 
 use App\Exceptions\HasExtraExceptionData;
+use App\Exceptions\InvalidSignatureException;
 use GuzzleHttp\Client;
 use Illuminate\Http\Request;
 
@@ -17,6 +18,13 @@ class PaypalSignature implements HasExtraExceptionData, PaymentSignature
 
     public function __construct(private Request $request)
     {
+    }
+
+    public function assertValid()
+    {
+        if (!$this->isValid()) {
+            throw new InvalidSignatureException($this->extras);
+        }
     }
 
     public function getContexts(): array

--- a/app/Libraries/Payments/ShopifySignature.php
+++ b/app/Libraries/Payments/ShopifySignature.php
@@ -5,6 +5,7 @@
 
 namespace App\Libraries\Payments;
 
+use App\Exceptions\InvalidSignatureException;
 use Illuminate\Http\Request;
 
 class ShopifySignature implements PaymentSignature
@@ -15,6 +16,13 @@ class ShopifySignature implements PaymentSignature
     public function __construct(Request $request)
     {
         $this->request = $request;
+    }
+
+    public function assertValid(): void
+    {
+        if (!$this->isValid()) {
+            throw new InvalidSignatureException();
+        }
     }
 
     public function isValid()

--- a/app/Libraries/Payments/ShopifySignature.php
+++ b/app/Libraries/Payments/ShopifySignature.php
@@ -20,19 +20,17 @@ class ShopifySignature implements PaymentSignature
 
     public function assertValid(): void
     {
-        if (!$this->isValid()) {
-            throw new InvalidSignatureException();
-        }
-    }
-
-    public function isValid()
-    {
         $received = $this->receivedSignature();
-        \Log::debug("ShopifySignature::isValidSignature calc: {$this->calculatedSignature()}, signed: {$received}");
 
-        return $received === null
-            ? false
-            : hash_equals($this->calculatedSignature(), $received);
+        if ($received === null) {
+            throw new InvalidSignatureException('missing signature');
+        }
+
+        $calculated = $this->calculatedSignature();
+
+        if (!hash_equals($calculated, $received)) {
+            throw new InvalidSignatureException('hash mismatch', compact('calculated', 'received'));
+        }
     }
 
     public static function calculateSignature(string $content)

--- a/app/Libraries/Payments/XsollaPaymentProcessor.php
+++ b/app/Libraries/Payments/XsollaPaymentProcessor.php
@@ -73,7 +73,7 @@ class XsollaPaymentProcessor extends PaymentProcessor
     public function isSkipped()
     {
         // just double validate for now
-        $this->ensureValidSignature();
+        $this->signature->assertValid();
 
         $order = $this->getOrder();
         if ($order === null) {
@@ -87,7 +87,7 @@ class XsollaPaymentProcessor extends PaymentProcessor
 
     public function validateTransaction()
     {
-        $this->ensureValidSignature();
+        $this->signature->assertValid();
 
         // received notification_type should be in allowed ranges
         if (!in_array($this['notification_type'], static::PAYMENT_NOTIFICATION_TYPES, true)) {

--- a/app/Libraries/Payments/XsollaSignature.php
+++ b/app/Libraries/Payments/XsollaSignature.php
@@ -14,21 +14,19 @@ class XsollaSignature implements PaymentSignature
     {
     }
 
-    public function assertValid()
-    {
-        if (!$this->isValid()) {
-            throw new InvalidSignatureException();
-        }
-    }
-
-    public function isValid()
+    public function assertValid(): void
     {
         $received = $this->receivedSignature();
-        \Log::debug("XsollaSignature::isValidSignature calc: {$this->calculatedSignature()}, signed: {$received}");
 
-        return $received === null
-            ? false
-            : hash_equals($this->calculatedSignature(), $received);
+        if ($received === null) {
+            throw new InvalidSignatureException('missing signature');
+        }
+
+        $calculated = $this->calculatedSignature();
+
+        if (!hash_equals($calculated, $received)) {
+            throw new InvalidSignatureException('hash mismatch', compact('calculated', 'received'));
+        }
     }
 
     public static function calculateSignature(string $content)

--- a/app/Libraries/Payments/XsollaSignature.php
+++ b/app/Libraries/Payments/XsollaSignature.php
@@ -5,12 +5,20 @@
 
 namespace App\Libraries\Payments;
 
+use App\Exceptions\InvalidSignatureException;
 use Illuminate\Http\Request;
 
 class XsollaSignature implements PaymentSignature
 {
     public function __construct(private Request $request)
     {
+    }
+
+    public function assertValid()
+    {
+        if (!$this->isValid()) {
+            throw new InvalidSignatureException();
+        }
     }
 
     public function isValid()

--- a/tests/Libraries/Fulfillments/SupporterTagFulfillmentTest.php
+++ b/tests/Libraries/Fulfillments/SupporterTagFulfillmentTest.php
@@ -7,8 +7,8 @@ declare(strict_types=1);
 
 namespace Tests\Libraries\Fulfillments;
 
+use App\Exceptions\Store\FulfillmentException;
 use App\Libraries\Fulfillments\ApplySupporterTag;
-use App\Libraries\Fulfillments\FulfillmentException;
 use App\Libraries\Fulfillments\SupporterTagFulfillment;
 use App\Mail\DonationThanks;
 use App\Mail\SupporterGift;

--- a/tests/Libraries/Fulfillments/UsernameChangeFulfillmentTest.php
+++ b/tests/Libraries/Fulfillments/UsernameChangeFulfillmentTest.php
@@ -6,7 +6,7 @@
 namespace Tests\Libraries\Fulfillments;
 
 use App\Exceptions\ChangeUsernameException;
-use App\Libraries\Fulfillments\FulfillmentException;
+use App\Exceptions\Store\FulfillmentException;
 use App\Libraries\Fulfillments\UsernameChangeFulfillment;
 use App\Models\Store\Order;
 use App\Models\Store\OrderItem;

--- a/tests/Libraries/Payments/PaymentProcessorTest.php
+++ b/tests/Libraries/Payments/PaymentProcessorTest.php
@@ -102,9 +102,8 @@ class PaymentProcessorTest extends TestCase
     private function validSignature()
     {
         return new class implements PaymentSignature {
-            public function isValid()
+            public function assertValid(): void
             {
-                return true;
             }
         };
     }

--- a/tests/Libraries/Payments/XsollaPaymentProcessorTest.php
+++ b/tests/Libraries/Payments/XsollaPaymentProcessorTest.php
@@ -164,9 +164,8 @@ class XsollaPaymentProcessorTest extends TestCase
     private function validSignature()
     {
         return new class implements PaymentSignature {
-            public function isValid()
+            public function assertValid(): void
             {
-                return true;
             }
         };
     }
@@ -174,9 +173,9 @@ class XsollaPaymentProcessorTest extends TestCase
     private function invalidSignature()
     {
         return new class implements PaymentSignature {
-            public function isValid()
+            public function assertValid(): void
             {
-                return false;
+                throw new InvalidSignatureException();
             }
         };
     }

--- a/tests/Libraries/Payments/XsollaPaymentProcessorTest.php
+++ b/tests/Libraries/Payments/XsollaPaymentProcessorTest.php
@@ -6,7 +6,7 @@
 namespace Tests\Libraries\Payments;
 
 use App\Exceptions\InvalidSignatureException;
-use App\Libraries\Payments\PaymentProcessorException;
+use App\Exceptions\Store\PaymentProcessorException;
 use App\Libraries\Payments\PaymentSignature;
 use App\Libraries\Payments\XsollaPaymentProcessor;
 use App\Models\Store\Order;


### PR DESCRIPTION
These used to be reported to a now non-existent channel, so this is about getting visibility on payment processing validation errors back (because standard `ValidationException`s don't get reported to sentry).