### PR TITLE
Small translation fixes

### DIFF
--- a/resources/lang/es-419/contest.php
+++ b/resources/lang/es-419/contest.php
@@ -55,7 +55,7 @@ return [
 
         'requirement' => [
             'playlist_beatmapsets' => [
-                'incomplete_play' => 'Debes jugar todos los mapas en las listas de juego especificadas antes de votar',
+                'incomplete_play' => 'Debes jugar todos los mapas en las listas de reproducción especificadas antes de votar',
             ],
         ],
     ],

--- a/resources/lang/es-419/layout.php
+++ b/resources/lang/es-419/layout.php
@@ -51,7 +51,7 @@ return [
 
         'users' => [
             'modding' => 'modding',
-            'playlists' => 'listas de juego',
+            'playlists' => 'listas de reproducción',
             'realtime' => 'multijugador',
             'show' => 'información',
         ],

--- a/resources/lang/es-419/multiplayer.php
+++ b/resources/lang/es-419/multiplayer.php
@@ -6,7 +6,7 @@
 return [
     'empty' => [
         '_' => '¡Aún no se ha jugado ninguna partida :type_group en osu!(lazer)!',
-        'playlists' => 'en las listas de juego',
+        'playlists' => 'en las listas de reproducción',
         'realtime' => 'multijugador',
     ],
 

--- a/resources/lang/es-419/rankings.php
+++ b/resources/lang/es-419/rankings.php
@@ -39,8 +39,8 @@ return [
 
     'seasons' => [
         'empty' => 'Todavía no hay salas en esta temporada.',
-        'ongoing' => 'Esta temporada aún está en curso (se añadirán más listas de juego).',
-        'room_count' => 'Número de listas de juego',
+        'ongoing' => 'Esta temporada aún está en curso (se añadirán más listas de reproducción).',
+        'room_count' => 'Número de listas de reproducción',
         'url' => 'Mostrar más información sobre esa temporada.',
     ],
 

--- a/resources/lang/es-419/users.php
+++ b/resources/lang/es-419/users.php
@@ -347,7 +347,7 @@ return [
                 'title' => 'Medallas',
             ],
             'playlists' => [
-                'title' => 'Partidas de listas de juego',
+                'title' => 'Partidas de listas de reproducción',
             ],
             'posts' => [
                 'title' => 'Publicaciones',

--- a/resources/lang/es/beatmappacks.php
+++ b/resources/lang/es/beatmappacks.php
@@ -43,7 +43,7 @@ return [
     ],
 
     'require_login' => [
-        '_' => 'Necesitas tener la :link para descargar',
+        '_' => 'Necesitas tener el :link para descargar',
         'link_text' => 'sesión iniciada',
     ],
 ];

--- a/resources/lang/es/contest.php
+++ b/resources/lang/es/contest.php
@@ -55,7 +55,7 @@ return [
 
         'requirement' => [
             'playlist_beatmapsets' => [
-                'incomplete_play' => 'Debes jugar todos los mapas en las listas de juego especificadas antes de votar',
+                'incomplete_play' => 'Debes jugar todos los mapas en las listas de reproducción especificadas antes de votar',
             ],
         ],
     ],

--- a/resources/lang/es/layout.php
+++ b/resources/lang/es/layout.php
@@ -35,7 +35,7 @@ return [
         ],
 
         'help' => [
-            'index' => 'índice',
+            'index' => 'listado',
             'sitemap' => 'Mapa del sitio',
         ],
 
@@ -51,7 +51,7 @@ return [
 
         'users' => [
             'modding' => 'modding',
-            'playlists' => 'listas de juego',
+            'playlists' => 'listas de reproducción',
             'realtime' => 'multijugador',
             'show' => 'información',
         ],

--- a/resources/lang/es/multiplayer.php
+++ b/resources/lang/es/multiplayer.php
@@ -6,7 +6,7 @@
 return [
     'empty' => [
         '_' => '¡Aún no se ha jugado ninguna partida de :type_group en osu!(lazer)!',
-        'playlists' => 'lista de juego',
+        'playlists' => 'listas de reproducción',
         'realtime' => 'multijugador',
     ],
 

--- a/resources/lang/es/rankings.php
+++ b/resources/lang/es/rankings.php
@@ -39,8 +39,8 @@ return [
 
     'seasons' => [
         'empty' => 'Todavía no hay salas en esta temporada.',
-        'ongoing' => 'Esta temporada aún está en curso (se agregarán más listas de juego).',
-        'room_count' => 'Número de listas de juego',
+        'ongoing' => 'Esta temporada aún está en curso (se agregarán más listas de reproducción).',
+        'room_count' => 'Número de listas de reproducción',
         'url' => 'Mostrar más información sobre esa temporada.',
     ],
 

--- a/resources/lang/es/users.php
+++ b/resources/lang/es/users.php
@@ -347,7 +347,7 @@ return [
                 'title' => 'Medallas',
             ],
             'playlists' => [
-                'title' => 'Partidas de listas de juego',
+                'title' => 'Partidas de listas de reproducción',
             ],
             'posts' => [
                 'title' => 'Publicaciones',


### PR DESCRIPTION
Just one: 'la link' -> 'el link' (link==enlace, 'el enlace' is correct)
Several: 'listas de juego' -> 'listas de reproducción' (for playlists in English)