### PR TITLE
Remove warning to download beatmap packs from latest to earliest

### DIFF
--- a/resources/css/bem/beatmap-packs-header.less
+++ b/resources/css/bem/beatmap-packs-header.less
@@ -15,9 +15,4 @@
     font-weight: 600;
     letter-spacing: 0.1em;
   }
-
-  &__scary {
-    color: @osu-colour-c2;
-    font-weight: 600;
-  }
 }

--- a/resources/lang/en/beatmappacks.php
+++ b/resources/lang/en/beatmappacks.php
@@ -13,10 +13,6 @@ return [
         'blurb' => [
             'important' => 'READ THIS BEFORE DOWNLOADING',
             'install_instruction' => 'Installation: Once a pack has been downloaded, extract the contents of the pack into your osu! Songs directory and osu! will do the rest.',
-            'note' => [
-                '_' => 'Also note that it is highly recommended to :scary, since older maps are generally of much lower quality than more recent maps.',
-                'scary' => 'download the packs from latest to earliest',
-            ],
         ],
     ],
 

--- a/resources/views/packs/_header.blade.php
+++ b/resources/views/packs/_header.blade.php
@@ -28,10 +28,5 @@
     <div class="beatmap-packs-header">
         <p class="beatmap-packs-header__important">{{ osu_trans('beatmappacks.index.blurb.important') }}</p>
         <p>{{ osu_trans('beatmappacks.index.blurb.install_instruction') }}</p>
-        <p>{!! osu_trans('beatmappacks.index.blurb.note._', ['scary' => tag(
-            'span',
-            ['class' => 'beatmap-packs-header__scary'],
-            osu_trans('beatmappacks.index.blurb.note.scary')
-        )]) !!}</p>
     </div>
 </div>


### PR DESCRIPTION
resolves #9218

in addition to what the issue says, the sorting already heavily steers you toward downloading later packs, so the warning is just unnecessary.