### PR TITLE
Change default filter for unranked Beatmaps to all

### DIFF
--- a/resources/js/beatmap-discussions/discussions-state.ts
+++ b/resources/js/beatmap-discussions/discussions-state.ts
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 import BeatmapsetDiscussionJson from 'interfaces/beatmapset-discussion-json';
+import { BeatmapsetStatus } from 'interfaces/beatmapset-json';
 import BeatmapsetWithDiscussionsJson from 'interfaces/beatmapset-with-discussions-json';
 import Ruleset from 'interfaces/ruleset';
 import { intersectionWith, maxBy, sum } from 'lodash';
@@ -16,6 +17,7 @@ import { Filter, filters } from './current-discussions';
 import DiscussionMode, { discussionModes } from './discussion-mode';
 import DiscussionPage, { isDiscussionPage } from './discussion-page';
 
+const defaultFilterPraise = new Set<BeatmapsetStatus>(['approved', 'ranked']);
 const jsonId = 'json-discussions-state';
 
 export interface UpdateOptions {
@@ -363,7 +365,7 @@ export default class DiscussionsState {
     const query = parseUrl(
       null,
       store.beatmapset.discussions,
-      store.beatmapset.ranked > 0 ? 'praises' : 'total',
+      defaultFilterPraise.has(store.beatmapset.status) ? 'praises' : 'total',
     );
 
     if (query != null) {

--- a/resources/js/beatmap-discussions/discussions-state.ts
+++ b/resources/js/beatmap-discussions/discussions-state.ts
@@ -363,7 +363,7 @@ export default class DiscussionsState {
     const query = parseUrl(
       null,
       store.beatmapset.discussions,
-      store.beatmapset.ranked > 0 ? 'praises' : 'pending',
+      store.beatmapset.ranked > 0 ? 'praises' : 'total',
     );
 
     if (query != null) {


### PR DESCRIPTION
Reverts the default `pending` setting in #11294
Also, `praise` default was supposed to be for ranked maps only and I forgot qualified is `> 0` 👀 

Some feedback regarding it change:
- useful to see hypes and mapper notes by default (also doesn't show up after posting because filtered)
- seeing other already resolved issues