### PR TITLE
Ignore more Paypal IPN transaction types

### DIFF
--- a/app/Libraries/Payments/PaypalPaymentProcessor.php
+++ b/app/Libraries/Payments/PaypalPaymentProcessor.php
@@ -70,6 +70,8 @@ class PaypalPaymentProcessor extends PaymentProcessor
         static $rejectedStatuses = ['Declined', 'Denied', 'Expired', 'Failed', 'Voided'];
 
         $status = $this->getNotificationTypeRaw();
+        // shouldIgnore needs to be first because txn_type needs to be checked in priority over payment_status for ignored notifications,
+        // while payment_status has priority for other notifications.
         if ($this->shouldIgnore($status)) {
             return NotificationType::IGNORED;
         } elseif (in_array($status, $paymentStatuses, true)) {

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -509,7 +509,7 @@ function log_error_sentry(Throwable $exception, ?array $tags = null): ?string
             $contexts = $exception->getContexts();
 
             foreach ($contexts as $name => $value) {
-                $scope->setContext($name, $value);
+                $scope->setContext($name, $value ?? []);
             }
         }
 


### PR DESCRIPTION
Or maybe should ignore everything without `invoice` field set 🤔 (which I recall wasn't done to make sure that callbacks for outgoing transactions that had them missing would explode)