### PR TITLE
Show oauth client owner on authorisation page

### DIFF
--- a/resources/lang/en/oauth.php
+++ b/resources/lang/en/oauth.php
@@ -7,6 +7,7 @@ return [
     'cancel' => 'Cancel',
 
     'authorise' => [
+        'app_owner' => 'an app by :owner',
         'request' => 'is requesting permission to access your account.',
         'scopes_title' => 'This application will be able to:',
         'title' => 'Authorisation Request',

--- a/resources/views/vendor/passport/authorize.blade.php
+++ b/resources/views/vendor/passport/authorize.blade.php
@@ -43,6 +43,11 @@
                 <h2 class="dialog-form__client-name">
                     {{ $client->name }}
                 </h2>
+                <p><small>
+                    {!! osu_trans('oauth.authorise.app_owner', [
+                        'owner' => link_to_user($client->user_id, $client->user->username),
+                    ]) !!}
+                </small></p>
                 <p class="dialog-form__client-request">
                     {{ osu_trans('oauth.authorise.request') }}
                 </p>


### PR DESCRIPTION
The info is already shown on the settings page anyway.

Not sure about the design/wordings 🤷 

Related to #10588.