### PR TITLE
Don't fail if refresh token is missing corresponding access token

### DIFF
--- a/app/Libraries/OAuth/RefreshTokenGrant.php
+++ b/app/Libraries/OAuth/RefreshTokenGrant.php
@@ -26,7 +26,7 @@ class RefreshTokenGrant extends BaseRefreshTokenGrant
         // Copy previous verification state
         $accessToken = (new \ReflectionProperty($refreshTokenData, 'accessToken'))->getValue($refreshTokenData);
         Token::where('id', $accessToken->getIdentifier())->update([
-            'verified' => Token::select('verified')->find($this->oldRefreshToken['access_token_id'])->verified,
+            'verified' => Token::select('verified')->find($this->oldRefreshToken['access_token_id'])?->verified ?? false,
         ]);
         $this->oldRefreshToken = null;
 


### PR DESCRIPTION
This shouldn't happen but it did ಠ_ಠ

These should be eventually cleaned up.