### PR TITLE
Unify empty css content

### DIFF
--- a/resources/css/bem/account-edit.less
+++ b/resources/css/bem/account-edit.less
@@ -26,7 +26,7 @@
     &::after {
       .inner-shadow-top();
       .full-size();
-      content: ' ';
+      content: '';
       pointer-events: none;
     }
   }

--- a/resources/css/bem/beatmap-discussion.less
+++ b/resources/css/bem/beatmap-discussion.less
@@ -38,7 +38,7 @@
 
       &::before {
         .full-size();
-        content: ' ';
+        content: '';
         width: 1px;
         right: 100%;
         background-image: linear-gradient(to bottom, hsla(var(--hsl-b1), 0), @osu-colour-b1 50%, hsla(var(--hsl-b1), 0));
@@ -76,7 +76,7 @@
       .thicker-box-shadow();
       &::after {
         .full-size();
-        content: ' ';
+        content: '';
         background: fade(white, 15%);
         pointer-events: none;
         opacity: 0.5;
@@ -170,7 +170,7 @@
     .@{_top}--unread & {
       &::before {
         .full-size();
-        content: ' ';
+        content: '';
         background-color: @blue-darker;
         width: 5px;
       }

--- a/resources/css/bem/forum-topic-nav.less
+++ b/resources/css/bem/forum-topic-nav.less
@@ -172,7 +172,7 @@
 
     // easier targeting
     &::after {
-      content: ' ';
+      content: '';
       position: absolute;
       left: 0;
       bottom: 100%;
@@ -234,7 +234,7 @@
     flex: none;
 
     &::before {
-      content: ' ';
+      content: '';
       position: absolute;
       top: 100%;
       left: 50%;

--- a/resources/css/bem/landing-nav.less
+++ b/resources/css/bem/landing-nav.less
@@ -83,7 +83,7 @@
     flex-direction: column;
 
     &::before {
-      content: ' ';
+      content: '';
       width: 100%;
       height: 10px;
       bottom: 100%;

--- a/resources/css/bem/loading-overlay.less
+++ b/resources/css/bem/loading-overlay.less
@@ -27,7 +27,7 @@
 
   &::before {
     .full-size();
-    content: ' ';
+    content: '';
     background-color: #000;
     will-change: opacity;
   }

--- a/resources/css/bem/notification-action-button.less
+++ b/resources/css/bem/notification-action-button.less
@@ -27,7 +27,7 @@
 
     &::before {
       .full-size();
-      content: ' ';
+      content: '';
       width: @border-radius-large;
       border-radius: 0 @border-radius-large @border-radius-large 0;
       background-color: transparent;

--- a/resources/css/bem/osu-layout.less
+++ b/resources/css/bem/osu-layout.less
@@ -33,7 +33,7 @@
       height: 100%;
       top: 0;
       left: 0;
-      content: " ";
+      content: '';
       z-index: @z-index--body-background;
     }
   }

--- a/resources/css/bem/profile-extra-entries.less
+++ b/resources/css/bem/profile-extra-entries.less
@@ -28,7 +28,7 @@
 
       &::before {
         .full-size();
-        content: ' ';
+        content: '';
         margin: 0 -10px;
         width: calc(100% + 20px);
         pointer-events: none;

--- a/resources/css/bem/profile-extra-recent-infringements.less
+++ b/resources/css/bem/profile-extra-recent-infringements.less
@@ -78,7 +78,7 @@
     color: @osu-colour-l1;
 
     &::before {
-      content: ' ';
+      content: '';
     }
   }
 }

--- a/resources/css/bem/search-result.less
+++ b/resources/css/bem/search-result.less
@@ -13,7 +13,7 @@
 
   &::before {
     .full-size();
-    content: ' ';
+    content: '';
     width: 5px;
     border-top-left-radius: @border-radius-base;
     border-bottom-left-radius: @border-radius-base;

--- a/resources/css/bem/store-slider.less
+++ b/resources/css/bem/store-slider.less
@@ -49,7 +49,7 @@
       top: 100%;
       left: 50%;
       border: solid transparent;
-      content: " ";
+      content: '';
       height: 0;
       width: 0;
       position: absolute;

--- a/resources/css/bem/supporter-eyecatch.less
+++ b/resources/css/bem/supporter-eyecatch.less
@@ -11,13 +11,13 @@
   position: relative;
 
   &::before {
-    content: ' ';
+    content: '';
     .full-size();
     background: linear-gradient(to bottom, hsla(var(--hsl-b5), 1) 4%, hsla(var(--hsl-b5), 0) 100%);
   }
 
   &::after {
-    content: ' ';
+    content: '';
     .full-size();
     .at2x-simple('~@images/layout/supporter/banner-fg.png');
     background-size: cover;

--- a/resources/css/spinner.less
+++ b/resources/css/spinner.less
@@ -25,7 +25,7 @@
   position: relative;
 
   &::before {
-    content: ' ';
+    content: '';
     position: absolute;
     top: 0;
     left: 0;


### PR DESCRIPTION
🧹  (it'll be converted again to `""` if using prettier)