### PR TITLE
Include user score position when indexing playlist item scores

### DIFF
--- a/app/Http/Controllers/Multiplayer/Rooms/Playlist/ScoresController.php
+++ b/app/Http/Controllers/Multiplayer/Rooms/Playlist/ScoresController.php
@@ -82,7 +82,14 @@ class ScoresController extends BaseController
             )->first();
 
             if ($userHighScoreLink !== null) {
-                $userScoreJson = json_item($userHighScoreLink, $transformer, ScoreTransformer::MULTIPLAYER_BASE_INCLUDES);
+                $userScoreJson = json_item(
+                    $userHighScoreLink,
+                    $transformer,
+                    [
+                        ...ScoreTransformer::MULTIPLAYER_BASE_INCLUDES,
+                        'position',
+                    ]
+                );
             }
         }
 


### PR DESCRIPTION
Needed for daily challenge (without this client can't show position numbers for the user score on the leaderboard).

A second review for performance implications is probably best-advised, this monkey just fix no number showing with hammer. [I tried to ask once](https://discord.com/channels/188630481301012481/188630616286167041/1258386604754604083) but got no reply.