### PR TITLE
Fix considering playlist score as user high if total is equal to previous high

### DIFF
--- a/app/Models/Multiplayer/PlaylistItemUserHighScore.php
+++ b/app/Models/Multiplayer/PlaylistItemUserHighScore.php
@@ -114,7 +114,7 @@ class PlaylistItemUserHighScore extends Model
     {
         $score = $scoreLink->score;
 
-        if ($score === null || !$score->passed || $score->total_score < $this->total_score) {
+        if ($score === null || !$score->passed || $score->total_score <= $this->total_score) {
             return false;
         }
 


### PR DESCRIPTION
Closes https://github.com/ppy/osu/issues/29073.

With the previous check, setting two scores with identical `total_score` would result in the relevant `multiplayer_scores_high` row for the user and playlist item having the ID of the *second* score in the `score_id` column.

This matters, because later, `UserScoreAggregate::refreshStatistics()` sets `last_score_id` as the maximum across all `PlaylistItemUserHighScore`s for a given user:

https://github.com/ppy/osu-web/blob/7400ab9a1c4d158cdca5e26f7d83d21cb6715250/app/Models/Multiplayer/UserScoreAggregate.php#L211

The other relevant piece of information is that `last_score_id` is used as a tie-breaker if the `total_score`s of two users'  aggregates in a room are equal:

https://github.com/ppy/osu-web/blob/7400ab9a1c4d158cdca5e26f7d83d21cb6715250/app/Models/Multiplayer/UserScoreAggregate.php#L176-L177

What this means, in essence, is that a player can inadvertently *lower* their ranking in a room by repeating their highest-score play on *any* of the playlist items in a room, if there is another user that is tie-broken with them on score.

This bug has been here for *ages*, and probably was only unearthed with daily challenge because of its nature (lots of users, expectation that there will be lots of perfect SSes, and only one item in a playlist).