### PR TITLE
Deprecate key option for Get User endpoint

### DIFF
--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -657,10 +657,10 @@ class UsersController extends Controller
      * - support_level
      * - user_achievements
      *
-     * @urlParam user integer required Id or username of the user. Id lookup is prioritised unless `key` parameter is specified. Previous usernames are also checked in some cases. Example: 1
+     * @urlParam user integer required Id or `@`-prefixed username of the user. Previous usernames are also checked in some cases. Example: 1
      * @urlParam mode string [Ruleset](#ruleset). User default mode will be used if not specified. Example: osu
      *
-     * @queryParam key Type of `user` passed in url parameter. Can be either `id` or `username` to limit lookup by their respective type. Passing empty or invalid value will result in id lookup followed by username lookup if not found.
+     * @queryParam key Type of `user` passed in url parameter. Can be either `id` or `username` to limit lookup by their respective type. Passing empty or invalid value will result in id lookup followed by username lookup if not found. This parameter has been deprecated. Prefix `user` parameter with `@` instead to lookup by username.
      *
      * @response "See User object section"
      */

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -550,6 +550,7 @@ class User extends Model implements AfterCommit, AuthenticatableContract, HasLoc
         }
 
         // don't perform username change history lookup if we're searching by ID
+        // TODO: remove this parameter and always rely on `@` prefix or digit check.
         if ($type === 'id') {
             return null;
         }

--- a/resources/views/docs/info.md.blade.php
+++ b/resources/views/docs/info.md.blade.php
@@ -35,6 +35,9 @@ For a full list of changes, see the
 
 ## Breaking Changes
 
+### 2024-07-30
+- `key` parameter for Get User endpoint has been deprecated. Prefix username with `@` to lookup by username instead.
+
 ### 2024-01-23
 - `active_tournament_banner` in [User](#user) has been deprecated, use `active_tournament_banners` instead.
 


### PR DESCRIPTION
It's always been a weird workaround.