### PR TITLE
Set daily challenge room start time to be at the start of the day

### DIFF
--- a/app/Console/Commands/DailyChallengeCreateNext.php
+++ b/app/Console/Commands/DailyChallengeCreateNext.php
@@ -53,7 +53,10 @@ class DailyChallengeCreateNext extends Command
                         'allowed_mods' => $nextQueueItem->allowed_mods,
                         'required_mods' => $nextQueueItem->required_mods,
                     ]],
-                ]
+                ],
+                [
+                    'starts_at' => $startTime,
+                ],
             );
             $room->update(['category' => 'daily_challenge']);
 

--- a/app/Console/Commands/DailyChallengeCreateNext.php
+++ b/app/Console/Commands/DailyChallengeCreateNext.php
@@ -38,7 +38,8 @@ class DailyChallengeCreateNext extends Command
         }
 
         DB::transaction(function () use ($nextQueueItem) {
-            $startTime = today();
+            // matches cron schedule
+            $startTime = today()->addMinutes(5);
             $hostId = $GLOBALS['cfg']['osu']['legacy']['bancho_bot_user_id'];
 
             $room = (new Room())->startGame(

--- a/app/Models/Multiplayer/Room.php
+++ b/app/Models/Multiplayer/Room.php
@@ -519,7 +519,7 @@ class Room extends Model
             ->all();
     }
 
-    public function startGame(User $host, array $rawParams)
+    public function startGame(User $host, array $rawParams, array $extraParams = [])
     {
         priv_check_user($host, 'MultiplayerRoomCreate')->ensureCan();
 
@@ -546,6 +546,7 @@ class Room extends Model
             'auto_start_duration' => $params['auto_start_duration'],
             'auto_skip' => $params['auto_skip'] ?? false,
             'user_id' => $host->getKey(),
+            ...$extraParams,
         ]);
 
         $this->setRelation('host', $host);


### PR DESCRIPTION
This fixes test when it runs exactly within 30 minutes before midnight (23:30 - 00:00).

I don't know if the behaviour is acceptable for live so it'll need maybe @bdach's confirmation (or anyone from client).

Alternatively I can just mock the time used during testing.