### PR TITLE
Add command to fix daily challenge stats

### DIFF
--- a/app/Console/Commands/DailyChallengeUserStatsRecalculate.php
+++ b/app/Console/Commands/DailyChallengeUserStatsRecalculate.php
@@ -28,7 +28,7 @@ class DailyChallengeUserStatsRecalculate extends Command
         }
 
         if (count($userIds) === 0 && !$isAll) {
-            $this->error("either user ids or all option is required");
+            $this->error('either user ids or all option is required');
 
             return 1;
         }

--- a/app/Console/Commands/DailyChallengeUserStatsRecalculate.php
+++ b/app/Console/Commands/DailyChallengeUserStatsRecalculate.php
@@ -27,6 +27,12 @@ class DailyChallengeUserStatsRecalculate extends Command
             return 1;
         }
 
+        if (count($userIds) === 0 && !$isAll) {
+            $this->error("either user ids or all option is required");
+
+            return 1;
+        }
+
         if ($isAll) {
             DailyChallengeUserStats::chunkById(100, function ($statsArray) {
                 $this->process($statsArray->keyBy('user_id')->all(), true);

--- a/app/Console/Commands/DailyChallengeUserStatsRecalculate.php
+++ b/app/Console/Commands/DailyChallengeUserStatsRecalculate.php
@@ -1,0 +1,71 @@
+<?php
+
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use App\Models\DailyChallengeUserStats;
+use Illuminate\Console\Command;
+
+class DailyChallengeUserStatsRecalculate extends Command
+{
+    protected $signature = 'daily-challenge:user-stats-recalculate {--all} {id?*}';
+
+    protected $description = 'Recalculate user daily challenge stats';
+
+    public function handle(): int
+    {
+        $isAll = $this->option('all');
+        $userIds = $this->argument('id');
+
+        if (count($userIds) > 0 && $isAll) {
+            $this->error("can't specify both user ids and all option");
+
+            return 1;
+        }
+
+        if ($isAll) {
+            DailyChallengeUserStats::chunkById(100, function ($statsArray) {
+                $this->process($statsArray->keyBy('user_id')->all(), true);
+            });
+        } else {
+            $statsByUserId = DailyChallengeUserStats::find($userIds)->keyBy('user_id');
+            $statsArray = [];
+            foreach ($userIds as $userId) {
+                $statsArray[$userId] = $statsByUserId[$userId] ?? null;
+            }
+
+            $this->process($statsArray, false);
+        }
+
+        return 0;
+    }
+
+    private function process(array $statsArray, bool $isAll): void
+    {
+        $verbose = $this->option('verbose') || !$isAll;
+
+        foreach ($statsArray as $userId => $stats) {
+            if ($stats === null) {
+                if ($verbose) {
+                    $this->info("User {$userId}: no stats");
+                }
+                continue;
+            }
+
+            $origAttributes = $stats->getAttributes();
+            $stats->fix();
+
+            if ($origAttributes === $stats->getAttributes()) {
+                if ($verbose) {
+                    $this->info("User {$userId}: no change");
+                }
+            } else {
+                $this->info("User {$userId}: updated");
+            }
+        }
+    }
+}

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -81,6 +81,7 @@ class Kernel extends ConsoleKernel
 
         Commands\DailyChallengeCreateNext::class,
         Commands\DailyChallengeUserStatsCalculate::class,
+        Commands\DailyChallengeUserStatsRecalculate::class,
     ];
 
     /**

--- a/tests/Models/DailyChallengeUserStatsTest.php
+++ b/tests/Models/DailyChallengeUserStatsTest.php
@@ -18,19 +18,32 @@ use Tests\TestCase;
 
 class DailyChallengeUserStatsTest extends TestCase
 {
+    protected static function roomAddPlay(User $user, PlaylistItem $playlistItem, array $scoreParams = []): ScoreLink
+    {
+        $room = $playlistItem->room;
+        $origEndsAt = $room->ends_at;
+        $room->update(['ends_at' => CarbonImmutable::now()->addDays(1)]);
+        try {
+            return parent::roomAddPlay($user, $playlistItem, ['passed' => true, ...$scoreParams]);
+        } finally {
+            $room->update(['ends_at' => $origEndsAt]);
+        }
+    }
+
     private static function preparePlaylistItem(CarbonImmutable $playTime): PlaylistItem
     {
         return PlaylistItem::factory()->create([
             'room_id' => Room::factory()->create([
                 'category' => 'daily_challenge',
-                'starts_at' => $playTime,
+                'starts_at' => $playTime->startOfDay(),
+                'ends_at' => $playTime->endOfDay(),
             ]),
         ]);
     }
 
     private static function startOfWeek(): CarbonImmutable
     {
-        return DailyChallengeUserStats::startOfWeek(CarbonImmutable::now());
+        return DailyChallengeUserStats::startOfWeek(CarbonImmutable::now()->subWeeks(1));
     }
 
     public function testCalculateFromStart(): void
@@ -64,7 +77,7 @@ class DailyChallengeUserStatsTest extends TestCase
     public function testCalculateNoPlaysBreaksDailyStreak(): void
     {
         $playTime = static::startOfWeek();
-        $playlistItem = static::preparePlaylistItem($playTime);
+        static::preparePlaylistItem($playTime);
 
         $user = User::factory()->create();
 
@@ -91,7 +104,7 @@ class DailyChallengeUserStatsTest extends TestCase
     public function testCalculateNoPlaysOverAWeekBreaksWeeklyStreak(): void
     {
         $playTime = static::startOfWeek();
-        static::preparePlaylistItem($playTime);
+        $playlistItem = static::preparePlaylistItem($playTime);
 
         $user = User::factory()->create();
 
@@ -146,6 +159,32 @@ class DailyChallengeUserStatsTest extends TestCase
         }
     }
 
+    public function testFix(): void
+    {
+        $user = User::factory()->create();
+
+        foreach ([14, 13, 12, 11, 10, 9, 7, 6, 5] as $subDay) {
+            $playTime = static::startOfWeek()->subDays($subDay);
+            $playlistItem = static::preparePlaylistItem($playTime);
+            $this->roomAddPlay($user, $playlistItem);
+            DailyChallengeUserStats::calculate($playTime);
+        }
+
+        $stats = DailyChallengeUserStats::find($user->getKey());
+        $expectedAttributes = $stats->getAttributes();
+        $stats->fill([...DailyChallengeUserStats::INITIAL_VALUES])->saveOrExplode();
+        $stats->fresh()->fix();
+
+        $stats->refresh();
+        $this->assertSame(9, $stats->playcount);
+        $this->assertSame(3, $stats->daily_streak_current);
+        $this->assertSame(6, $stats->daily_streak_best);
+        $this->assertSame(2, $stats->weekly_streak_current);
+        $this->assertSame(2, $stats->weekly_streak_best);
+        $this->assertSame(9, $stats->top_10p_placements);
+        $this->assertSame(9, $stats->top_50p_placements);
+    }
+
     public function testFlowFromStart(): void
     {
         $playTime = static::startOfWeek();
@@ -154,7 +193,7 @@ class DailyChallengeUserStatsTest extends TestCase
 
         $this->expectCountChange(fn () => DailyChallengeUserStats::count(), 1);
 
-        $this->roomAddPlay($user, $playlistItem, ['passed' => true]);
+        $this->roomAddPlay($user, $playlistItem);
 
         $stats = DailyChallengeUserStats::find($user->getKey());
         $this->assertSame(1, $stats->playcount);
@@ -188,8 +227,8 @@ class DailyChallengeUserStatsTest extends TestCase
         $playlistItem = static::preparePlaylistItem($playTime);
         $user = User::factory()->create();
 
-        $this->roomAddPlay($user, $playlistItem, ['passed' => true]);
-        $this->roomAddPlay($user, $playlistItem, ['passed' => true]);
+        $this->roomAddPlay($user, $playlistItem);
+        $this->roomAddPlay($user, $playlistItem);
 
         DailyChallengeUserStats::calculate($playTime);
         DailyChallengeUserStats::calculate($playTime);
@@ -219,7 +258,7 @@ class DailyChallengeUserStatsTest extends TestCase
 
         $this->expectCountChange(fn () => DailyChallengeUserStats::count(), 0);
 
-        $this->roomAddPlay($user, $playlistItem, ['passed' => true]);
+        $this->roomAddPlay($user, $playlistItem);
         $stats = DailyChallengeUserStats::find($user->getKey());
         $this->assertSame(2, $stats->daily_streak_current);
         $this->assertSame(2, $stats->daily_streak_best);
@@ -257,7 +296,7 @@ class DailyChallengeUserStatsTest extends TestCase
             'last_update' => $playTime->subDays(1),
         ]);
 
-        $this->roomAddPlay($user, $playlistItem, ['passed' => true]);
+        $this->roomAddPlay($user, $playlistItem);
 
         $stats = DailyChallengeUserStats::find($user->getKey());
         $this->assertSame(2, $stats->weekly_streak_current);
@@ -315,5 +354,12 @@ class DailyChallengeUserStatsTest extends TestCase
 
         DailyChallengeUserStats::calculate($playTime);
         $assertValues();
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        // prevent storing percentile cache
+        config_set('cache.default', 'array');
     }
 }


### PR DESCRIPTION
```
artisan daily-challenge:user-stats-recalculate --all

# or individual user(s)
artisan daily-challenge:user-stats-recalculate 0 2 4 6 9
```

The query isn't exactly optimal but I think it should be fine for an adhoc operation...? 🤔 