### PR TITLE
Fix missing closing bracket in daily challenge tier colour

### DIFF
--- a/resources/js/profile-page/daily-challenge.tsx
+++ b/resources/js/profile-page/daily-challenge.tsx
@@ -33,7 +33,7 @@ function tier(days: number) {
 
 function tierStyle(days: number) {
   return {
-    '--colour': `var(--level-tier-${tier(days)}`,
+    '--colour': `var(--level-tier-${tier(days)})`,
   } as React.CSSProperties;
 }
 


### PR DESCRIPTION
As reported in discord. Somehow still works anyway and firefox magically fixes it in dev tools so I didn't notice it.