### PR TITLE
Add download mirror fallback

### DIFF
--- a/app/Http/Controllers/BeatmapsetsController.php
+++ b/app/Http/Controllers/BeatmapsetsController.php
@@ -208,7 +208,9 @@ class BeatmapsetsController extends Controller
         }
 
         $noVideo = get_bool(Request::input('noVideo', false));
-        $mirror = BeatmapMirror::getRandomForRegion(request_country());
+        $mirror = BeatmapMirror::getRandomForRegion(request_country())
+            ?? BeatmapMirror::getDefault()
+            ?? abort(503, osu_trans('beatmapsets.download.no_mirrors'));
 
         BeatmapDownload::create([
             'user_id' => $userId,

--- a/app/Http/Controllers/BeatmapsetsController.php
+++ b/app/Http/Controllers/BeatmapsetsController.php
@@ -197,20 +197,22 @@ class BeatmapsetsController extends Controller
 
         priv_check('BeatmapsetDownload', $beatmapset)->ensureCan();
 
-        $recentlyDownloaded = BeatmapDownload::where('user_id', Auth::user()->user_id)
+        $user = Auth::user();
+        $userId = $user->getKey();
+        $recentlyDownloaded = BeatmapDownload::where('user_id', $userId)
             ->where('timestamp', '>', Carbon::now()->subHours()->getTimestamp())
             ->count();
 
-        if ($recentlyDownloaded > Auth::user()->beatmapsetDownloadAllowance()) {
+        if ($recentlyDownloaded > $user->beatmapsetDownloadAllowance()) {
             abort(429, osu_trans('beatmapsets.download.limit_exceeded'));
         }
 
         $noVideo = get_bool(Request::input('noVideo', false));
-        $mirror = BeatmapMirror::getRandomForRegion(request_country(request()));
+        $mirror = BeatmapMirror::getRandomForRegion(request_country());
 
         BeatmapDownload::create([
-            'user_id' => Auth::user()->user_id,
-            'timestamp' => Carbon::now()->getTimestamp(),
+            'user_id' => $userId,
+            'timestamp' => time(),
             'beatmapset_id' => $beatmapset->beatmapset_id,
             'fulfilled' => 1,
             'mirror_id' => $mirror->mirror_id,

--- a/app/Models/BeatmapMirror.php
+++ b/app/Models/BeatmapMirror.php
@@ -5,7 +5,6 @@
 
 namespace App\Models;
 
-use Auth;
 use Illuminate\Database\Eloquent\Builder;
 
 /**
@@ -91,7 +90,6 @@ class BeatmapMirror extends Model
         $serveFilename = str_replace(['"', '?'], ['', ''], $serveFilename);
 
         $time = time();
-        $userId = Auth::check() ? Auth::user()->user_id : 0;
         $checksum = md5("{$beatmapset->beatmapset_id}{$diskFilename}{$serveFilename}{$time}{$noVideo}{$this->secret_key}");
 
         $url = "{$this->base_url}d/{$beatmapset->beatmapset_id}?fs=".rawurlencode($serveFilename).'&fd='.rawurlencode($diskFilename)."&ts=$time&cs=$checksum&nv=$noVideo";

--- a/app/Models/BeatmapMirror.php
+++ b/app/Models/BeatmapMirror.php
@@ -6,6 +6,7 @@
 namespace App\Models;
 
 use Auth;
+use Illuminate\Database\Eloquent\Builder;
 
 /**
  * @property string $base_url
@@ -29,6 +30,7 @@ class BeatmapMirror extends Model
     public $timestamps = false;
 
     protected $hidden = ['secret_key'];
+    protected array $macros = ['getDefault'];
 
     const MIN_VERSION_TO_USE = 2;
 
@@ -63,6 +65,14 @@ class BeatmapMirror extends Model
         }
 
         return $regionalMirror ?? self::getRandom();
+    }
+
+    public function macroGetDefault(): callable
+    {
+        return fn (Builder $query): ?static => $query
+            ->where('version', '>=', static::MIN_VERSION_TO_USE)
+            ->where('is_master', true)
+            ->first();
     }
 
     public function generateURL(Beatmapset $beatmapset, $skipVideo = false)

--- a/resources/lang/en/beatmapsets.php
+++ b/resources/lang/en/beatmapsets.php
@@ -17,6 +17,7 @@ return [
 
     'download' => [
         'limit_exceeded' => 'Slow down, play more.',
+        'no_mirrors' => 'No download servers available.',
     ],
 
     'featured_artist_badge' => [


### PR DESCRIPTION
This prevents error when all of the mirrors are disabled. It itself is usually caused by temporary routing error from monitoring process so returning main server is usually fine.

Also cleaned up stuff along the way.