### PR TITLE
Move beatmap list on ranking page below the table's pager links

### DIFF
--- a/resources/views/rankings/index.blade.php
+++ b/resources/views/rankings/index.blade.php
@@ -56,8 +56,6 @@
                 @yield('scores')
             </div>
 
-            @yield('ranking-footer')
-
             @if ($hasPager)
                 @include('objects._pagination_v2', [
                     'object' => $scores
@@ -65,6 +63,8 @@
                         ->fragment('scores')
                 ])
             @endif
+
+            @yield('ranking-footer')
         </div>
     @endif
 @endsection


### PR DESCRIPTION
It's got nothing to do with the pager.