### PR TITLE
Fix error running phpcs in docker

### DIFF
--- a/phpcs.xml
+++ b/phpcs.xml
@@ -16,6 +16,7 @@
     <exclude-pattern>resources/docs/source/_tmp/*</exclude-pattern>
     <exclude-pattern>resources/lang/(?!en)[^/]*/.*</exclude-pattern>
 
+    <arg name="basepath" value="."/>
     <arg name="extensions" value="php"/>
     <arg name="report" value="code"/>
     <arg value="npsv"/>


### PR DESCRIPTION
The directory being called `app` broke the namespace matching.