### PR TITLE
Adjust daily challenge stats visibility

### DIFF
--- a/resources/js/profile-page/daily-challenge.tsx
+++ b/resources/js/profile-page/daily-challenge.tsx
@@ -118,6 +118,10 @@ export default class DailyChallenge extends React.Component<Props> {
   }
 
   render() {
+    if (this.props.stats.playcount === 0) {
+      return null;
+    }
+
     return (
       <div
         ref={this.valueRef}

--- a/resources/js/profile-page/detail.tsx
+++ b/resources/js/profile-page/detail.tsx
@@ -68,11 +68,9 @@ export default class Detail extends React.Component<Props> {
                 <Rank highest={this.user.rank_highest} stats={this.user.statistics} type='global' />
                 <Rank stats={this.user.statistics} type='country' />
               </div>
-              {this.props.controller.currentMode === 'osu' && (
-                <div className='profile-detail__values'>
-                  <DailyChallenge stats={this.user.daily_challenge_user_stats} />
-                </div>
-              )}
+              <div className='profile-detail__values'>
+                <DailyChallenge stats={this.user.daily_challenge_user_stats} />
+              </div>
             </div>
 
             <div className='profile-detail__chart'>


### PR DESCRIPTION
Currently the challenge adds other rulesets at random so make the stats visible on all rulesets. Instead hide it if there's no plays recorded.