### PR TITLE
Fix container size of beatmap title and artist

### DIFF
--- a/resources/css/bem/beatmapset-header.less
+++ b/resources/css/bem/beatmapset-header.less
@@ -60,7 +60,6 @@
   }
 
   &__details-text {
-    align-self: flex-start;
     max-width: 100%;
     word-break: break-word;
 


### PR DESCRIPTION
The class was originally directly applied to the search link and thus need to be limited in width so the empty space isn't clickable.

It has since become a container and the actual link has been moved.

Filling the whole width makes selecting text actually selects the respective line instead of whatever below/above it.

Resolves #11472.