### PR TITLE
Fix chat update response when empty

### DIFF
--- a/app/Http/Controllers/Chat/ChatController.php
+++ b/app/Http/Controllers/Chat/ChatController.php
@@ -272,9 +272,7 @@ class ChatController extends Controller
             $response['messages'] = [];
         }
 
-        $hasAny = array_first($response, fn ($val) => count($val) > 0) !== null;
-
-        return $hasAny ? $response : response()->noContent();
+        return $response;
     }
 
     private function getSilences(?int $lastHistoryId, ?int $since)

--- a/resources/js/chat/chat-api.ts
+++ b/resources/js/chat/chat-api.ts
@@ -78,7 +78,7 @@ export function getUpdates(since: number, lastHistoryId?: number | null) {
       includes: ['presence', 'silences'],
       since,
     },
-  ) as JQuery.jqXHR<ChatUpdatesJson | null>;
+  ) as JQuery.jqXHR<ChatUpdatesJson>;
 }
 
 export function joinChannel(channelId: number, userId: number) {

--- a/resources/js/chat/chat-state-store.ts
+++ b/resources/js/chat/chat-state-store.ts
@@ -295,7 +295,6 @@ export default class ChatStateStore implements DispatchListener {
   @action
   private async updateChannelList() {
     const json = await getUpdates(this.channelStore.lastReceivedMessageId, this.lastHistoryId);
-    if (!json) return; // FIXME: fix response
 
     runInAction(() => {
       const newHistoryId = maxBy(json.silences, 'id')?.id;


### PR DESCRIPTION
It was originally added in #3597 to skip sending anything when there's no message but the endpoint has since been changed to always return presence if message isn't requested in #8110, and then further changed to not return messages at all in #9644.

And then the empty response has never been documented in the first place.