### PR TITLE
Sync user preferences when updated from a different tab

### DIFF
--- a/resources/js/core/user/user-preferences.ts
+++ b/resources/js/core/user/user-preferences.ts
@@ -7,6 +7,8 @@ import { route } from 'laroute';
 import { action, makeObservable, observable } from 'mobx';
 import { onErrorWithCallback } from 'utils/ajax';
 
+const localStorageKey = 'userPreferences';
+
 export default class UserPreferences {
   @observable private current: UserPreferencesJson;
   private updatingOptions = false;
@@ -17,9 +19,7 @@ export default class UserPreferences {
 
     makeObservable(this);
 
-    window.addEventListener('storage', action(() => {
-      this.current = this.fromStorageWithDefaults();
-    }));
+    window.addEventListener('storage', this.updateFromStorage);
   }
 
   get<T extends keyof UserPreferencesJson>(key: T) {
@@ -81,7 +81,14 @@ export default class UserPreferences {
     return Object.assign(defaultUserPreferencesJson(), this.fromStorage());
   }
 
+  @action
+  private readonly updateFromStorage = (event: StorageEvent) => {
+    if (event.key == null || event.key === localStorageKey) {
+      this.current = this.fromStorageWithDefaults();
+    }
+  };
+
   private updateStorage() {
-    localStorage.userPreferences = JSON.stringify(this.current);
+    localStorage[localStorageKey] = JSON.stringify(this.current);
   }
 }

--- a/resources/js/core/user/user-preferences.ts
+++ b/resources/js/core/user/user-preferences.ts
@@ -13,9 +13,13 @@ export default class UserPreferences {
   private user?: CurrentUserJson;
 
   constructor() {
-    this.current = Object.assign({}, defaultUserPreferencesJson, this.fromStorage());
+    this.current = this.fromStorageWithDefaults();
 
     makeObservable(this);
+
+    window.addEventListener('storage', action(() => {
+      this.current = this.fromStorageWithDefaults();
+    }));
   }
 
   get<T extends keyof UserPreferencesJson>(key: T) {
@@ -27,7 +31,7 @@ export default class UserPreferences {
     if (this.current[key] === value) return;
 
     this.current[key] = value;
-    localStorage.userPreferences = JSON.stringify(this.current);
+    this.updateStorage();
 
     if (this.user == null) return;
 
@@ -51,7 +55,8 @@ export default class UserPreferences {
     this.user = user;
 
     if (!this.updatingOptions) {
-      this.current = user?.user_preferences ?? structuredClone(defaultUserPreferencesJson);
+      this.current = user?.user_preferences ?? defaultUserPreferencesJson();
+      this.updateStorage();
     }
   }
 
@@ -70,5 +75,13 @@ export default class UserPreferences {
     }
 
     return {};
+  }
+
+  private fromStorageWithDefaults() {
+    return Object.assign(defaultUserPreferencesJson(), this.fromStorage());
+  }
+
+  private updateStorage() {
+    localStorage.userPreferences = JSON.stringify(this.current);
   }
 }

--- a/resources/js/core/user/user-preferences.ts
+++ b/resources/js/core/user/user-preferences.ts
@@ -62,7 +62,7 @@ export default class UserPreferences {
 
   private fromStorage(): Partial<UserPreferencesJson> {
     try {
-      const data = localStorage.getItem('userPreferences');
+      const data = localStorage.getItem(localStorageKey);
       if (data != null) {
         const preferences = JSON.parse(data) as unknown;
 

--- a/resources/js/interfaces/user-preferences-json.ts
+++ b/resources/js/interfaces/user-preferences-json.ts
@@ -5,24 +5,26 @@ import { BeatmapsetCardSize } from 'beatmapset-panel';
 import { ViewMode } from 'components/user-card';
 import { Filter, SortMode } from 'components/user-list';
 
-export const defaultUserPreferencesJson: UserPreferencesJson = {
-  audio_autoplay: false,
-  audio_muted: false,
-  audio_volume: 0.45,
-  beatmapset_card_size: 'normal',
-  beatmapset_download: 'all',
-  beatmapset_show_nsfw: false,
-  beatmapset_title_show_original: false,
-  comments_show_deleted: false,
-  comments_sort: 'new',
-  forum_posts_show_deleted: true,
-  legacy_score_only: false,
-  profile_cover_expanded: true,
-  scoring_mode: 'standardised',
-  user_list_filter: 'all',
-  user_list_sort: 'last_visit',
-  user_list_view: 'card',
-};
+export function defaultUserPreferencesJson(): UserPreferencesJson {
+  return {
+    audio_autoplay: false,
+    audio_muted: false,
+    audio_volume: 0.45,
+    beatmapset_card_size: 'normal',
+    beatmapset_download: 'all',
+    beatmapset_show_nsfw: false,
+    beatmapset_title_show_original: false,
+    comments_show_deleted: false,
+    comments_sort: 'new',
+    forum_posts_show_deleted: true,
+    legacy_score_only: false,
+    profile_cover_expanded: true,
+    scoring_mode: 'standardised',
+    user_list_filter: 'all',
+    user_list_sort: 'last_visit',
+    user_list_view: 'card',
+  };
+}
 
 export default interface UserPreferencesJson {
   audio_autoplay: boolean;

--- a/tests/karma/test-current-user-json.ts
+++ b/tests/karma/test-current-user-json.ts
@@ -56,7 +56,7 @@ const testCurrentUserJson: CurrentUserJson = {
   title_url: null,
   twitter: null,
   unread_pm_count: 0,
-  user_preferences: defaultUserPreferencesJson,
+  user_preferences: defaultUserPreferencesJson(),
   username: 'foo',
   website: null,
 };


### PR DESCRIPTION
Resolves #11295... kind of.

1. (tab A) open a beatmap page
2. (tab B) open some page
3. (tab B) toggle lazer mode
4. (tab A) switch to different difficulty

The result is the scores are fetched using the new option but sorted using the old one.

This PR doesn't change the header correctly but there's currently no framework in place to do it so maybe if someone complains about it.