### PR TITLE
Fix ruleset selector not shown on mobile

### DIFF
--- a/resources/views/rankings/index.blade.php
+++ b/resources/views/rankings/index.blade.php
@@ -39,6 +39,11 @@
 
         @slot('linksAppend')
             @yield('additionalHeaderLinks')
+            @if($hasMode)
+                <div class="visible-xs">
+                    @include('rankings._mode_selector')
+                </div>
+            @endif
         @endslot
     @endcomponent
 


### PR DESCRIPTION
The title/content section of page header is not visible on mobile.

Resolves #11485.