### PR TITLE
Fix BeatmapsetRequalifyTest failing due to timing variance.

### DIFF
--- a/tests/Models/BeatmapsetRequalifyTest.php
+++ b/tests/Models/BeatmapsetRequalifyTest.php
@@ -264,7 +264,7 @@ class BeatmapsetRequalifyTest extends TestCase
 
     private function assertDiffWithinRange(int $expected, int $actual, int $range = 1)
     {
-        return $this->assertTrue(abs($actual - $expected) <= $range);
+        $this->assertTrue(abs($actual - $expected) <= $range);
     }
 
     private function beatmapsetFactory(): BeatmapsetFactory

--- a/tests/Models/BeatmapsetRequalifyTest.php
+++ b/tests/Models/BeatmapsetRequalifyTest.php
@@ -45,7 +45,7 @@ class BeatmapsetRequalifyTest extends TestCase
 
         $discussion = $this->disqualifyOrResetNominations($beatmapset);
         $beatmapset = $beatmapset->fresh();
-        $this->assertDiffWithinRange(static::DISQUALIFIED_INTERVAL, $beatmapset->previous_queue_duration);
+        $this->assertDiffWithinOneSecond(static::DISQUALIFIED_INTERVAL, $beatmapset->previous_queue_duration);
         $this->assertNull($beatmapset->queued_at);
 
         $this->travelBack();
@@ -195,7 +195,7 @@ class BeatmapsetRequalifyTest extends TestCase
 
         // queue should not reset.
         $this->assertTrue($beatmapset->isQualified());
-        $this->assertDiffWithinRange($previousQueueDuration, CarbonImmutable::now()->getTimestamp() - $beatmapset->queued_at->getTimestamp());
+        $this->assertDiffWithinOneSecond($previousQueueDuration, CarbonImmutable::now()->getTimestamp() - $beatmapset->queued_at->getTimestamp());
     }
 
     public function testNewDifficultyAddedResetsQueue()
@@ -262,9 +262,9 @@ class BeatmapsetRequalifyTest extends TestCase
         Bus::fake([CheckBeatmapsetCovers::class]);
     }
 
-    private function assertDiffWithinRange(int $expected, int $actual, int $range = 1)
+    private function assertDiffWithinOneSecond(int $expected, int $actual)
     {
-        $this->assertTrue(abs($actual - $expected) <= $range);
+        $this->assertTrue(abs($actual - $expected) < 2);
     }
 
     private function beatmapsetFactory(): BeatmapsetFactory

--- a/tests/Models/BeatmapsetRequalifyTest.php
+++ b/tests/Models/BeatmapsetRequalifyTest.php
@@ -45,7 +45,7 @@ class BeatmapsetRequalifyTest extends TestCase
 
         $discussion = $this->disqualifyOrResetNominations($beatmapset);
         $beatmapset = $beatmapset->fresh();
-        $this->assertDiffWithinOneSecond(static::DISQUALIFIED_INTERVAL, $beatmapset->previous_queue_duration);
+        $this->assertDiffUpToOneSecond(static::DISQUALIFIED_INTERVAL, $beatmapset->previous_queue_duration);
         $this->assertNull($beatmapset->queued_at);
 
         $this->travelBack();
@@ -195,7 +195,7 @@ class BeatmapsetRequalifyTest extends TestCase
 
         // queue should not reset.
         $this->assertTrue($beatmapset->isQualified());
-        $this->assertDiffWithinOneSecond($previousQueueDuration, CarbonImmutable::now()->getTimestamp() - $beatmapset->queued_at->getTimestamp());
+        $this->assertDiffUpToOneSecond($previousQueueDuration, CarbonImmutable::now()->getTimestamp() - $beatmapset->queued_at->getTimestamp());
     }
 
     public function testNewDifficultyAddedResetsQueue()
@@ -262,7 +262,7 @@ class BeatmapsetRequalifyTest extends TestCase
         Bus::fake([CheckBeatmapsetCovers::class]);
     }
 
-    private function assertDiffWithinOneSecond(int $expected, int $actual)
+    private function assertDiffUpToOneSecond(int $expected, int $actual)
     {
         $this->assertTrue(abs($actual - $expected) < 2);
     }

--- a/tests/Models/BeatmapsetRequalifyTest.php
+++ b/tests/Models/BeatmapsetRequalifyTest.php
@@ -45,7 +45,7 @@ class BeatmapsetRequalifyTest extends TestCase
 
         $discussion = $this->disqualifyOrResetNominations($beatmapset);
         $beatmapset = $beatmapset->fresh();
-        $this->assertTrue(abs(static::DISQUALIFIED_INTERVAL - $beatmapset->previous_queue_duration) < 2);
+        $this->assertDiffWithinRange(static::DISQUALIFIED_INTERVAL, $beatmapset->previous_queue_duration);
         $this->assertNull($beatmapset->queued_at);
 
         $this->travelBack();
@@ -195,7 +195,7 @@ class BeatmapsetRequalifyTest extends TestCase
 
         // queue should not reset.
         $this->assertTrue($beatmapset->isQualified());
-        $this->assertEquals($previousQueueDuration, CarbonImmutable::now()->getTimestamp() - $beatmapset->queued_at->getTimestamp());
+        $this->assertDiffWithinRange($previousQueueDuration, CarbonImmutable::now()->getTimestamp() - $beatmapset->queued_at->getTimestamp());
     }
 
     public function testNewDifficultyAddedResetsQueue()
@@ -260,6 +260,11 @@ class BeatmapsetRequalifyTest extends TestCase
         Language::factory()->create(['language_id' => Language::UNSPECIFIED]);
 
         Bus::fake([CheckBeatmapsetCovers::class]);
+    }
+
+    private function assertDiffWithinRange(int $expected, int $actual, int $range = 1)
+    {
+        return $this->assertTrue(abs($actual - $expected) <= $range);
     }
 
     private function beatmapsetFactory(): BeatmapsetFactory


### PR DESCRIPTION
At least until we explicitly pass the timestamp into the qualify function