### PR TITLE
Allow more users for chat announcement

### DIFF
--- a/app/Libraries/Chat.php
+++ b/app/Libraries/Chat.php
@@ -46,7 +46,7 @@ class Chat
             throw new InvariantException('missing channel parameter');
         }
 
-        $users = User::whereIn('user_id', $params['target_ids'])->get();
+        $users = User::find($params['target_ids']);
         if ($users->isEmpty()) {
             throw new InvariantException('Nobody to broadcast to!');
         }


### PR DESCRIPTION
This is a bad idea to do over web interface.

(working around sql bind parameter limit when dealing with some hundreds of thousands of user ids)