### PR TITLE
Don't send user ids for announcement channels

### DIFF
--- a/app/Http/Controllers/Chat/ChannelsController.php
+++ b/app/Http/Controllers/Chat/ChannelsController.php
@@ -205,7 +205,7 @@ class ChannelsController extends Controller
             'channel' => json_item($channel, ChannelTransformer::forUser($user), ChannelTransformer::LISTING_INCLUDES),
             // TODO: probably going to need a better way to list/fetch/update users on larger channels without sending user on every message.
             'users' => json_collection(
-                $channel->visibleUsers($user)->loadMissing(UserCompactTransformer::CARD_INCLUDES_PRELOAD),
+                $channel->visibleUsers()->loadMissing(UserCompactTransformer::CARD_INCLUDES_PRELOAD),
                 new UserCompactTransformer(),
                 UserCompactTransformer::CARD_INCLUDES
             ),

--- a/app/Models/Chat/Channel.php
+++ b/app/Models/Chat/Channel.php
@@ -291,13 +291,9 @@ class Channel extends Model
         });
     }
 
-    public function visibleUsers(?User $user)
+    public function visibleUsers(): Collection
     {
-        if ($this->isPM() || $this->isAnnouncement() && priv_check_user($user, 'ChatAnnounce', $this)->can()) {
-            return $this->users();
-        }
-
-        return new Collection();
+        return $this->isPM() ? $this->users() : new Collection();
     }
 
     public function scopePublic($query)

--- a/app/Transformers/Chat/ChannelTransformer.php
+++ b/app/Transformers/Chat/ChannelTransformer.php
@@ -99,14 +99,7 @@ class ChannelTransformer extends TransformerAbstract
 
     public function includeUsers(Channel $channel)
     {
-        if (
-            $channel->isPM()
-            || $channel->isAnnouncement() && priv_check_user($this->user, 'ChatAnnounce', $channel)->can()
-        ) {
-            return $this->primitive($channel->userIds());
-        }
-
-        return $this->primitive([]);
+        return $this->primitive($channel->isPM() ? $channel->userIds() : []);
     }
 
     public function includeUuid(Channel $channel)

--- a/tests/Models/Chat/ChannelTest.php
+++ b/tests/Models/Chat/ChannelTest.php
@@ -279,7 +279,7 @@ class ChannelTest extends TestCase
         $channel = Channel::factory()->type('public', [$user])->create();
 
         $this->assertSame(1, $channel->users()->count());
-        $this->assertEmpty($channel->visibleUsers($user));
+        $this->assertEmpty($channel->visibleUsers());
     }
 
     // test add/removeUser resets any memoized values


### PR DESCRIPTION
In the meantime until a separate function for fetching users is added.