### PR TITLE
Improve chat announcement permission message

### DIFF
--- a/app/Singletons/OsuAuthorize.php
+++ b/app/Singletons/OsuAuthorize.php
@@ -863,7 +863,7 @@ class OsuAuthorize
             return 'ok';
         }
 
-        return $prefix.'annnonce_only';
+        return $prefix.'no_announce';
     }
 
     /**

--- a/resources/lang/en/authorization.php
+++ b/resources/lang/en/authorization.php
@@ -61,11 +61,11 @@ return [
     ],
 
     'chat' => [
-        'annnonce_only' => 'This channel is for announcements only.',
         'blocked' => 'Cannot message a user that is blocking you or that you have blocked.',
         'friends_only' => 'User is blocking messages from people not on their friends list.',
         'moderated' => 'This channel is currently moderated.',
         'no_access' => 'You do not have access to that channel.',
+        'no_announce' => 'You do not have permission to post announcement.',
         'receive_friends_only' => 'The user may not be able to reply because you are only accepting messages from people on your friends list.',
         'restricted' => 'You cannot send messages while silenced, restricted or banned.',
         'silenced' => 'You cannot send messages while silenced, restricted or banned.',


### PR DESCRIPTION
The one place the message may make sense doesn't actually show it as the relevant part isn't even rendered. Otherwise it's just confusing when trying to use the api.