### PR TITLE
Reduce session verification key lifetime

### DIFF
--- a/app/Libraries/SessionVerification/State.php
+++ b/app/Libraries/SessionVerification/State.php
@@ -14,7 +14,7 @@ use Carbon\CarbonImmutable;
 
 class State
 {
-    private const KEY_VALID_DURATION = 5 * 3600;
+    private const KEY_VALID_DURATION = 600;
 
     public readonly CarbonImmutable $expiresAt;
     public readonly string $key;


### PR DESCRIPTION
I don't know where the current one came from but it seems a bit too long.