### PR TITLE
Adjust user current location length limit

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -239,7 +239,7 @@ class User extends Model implements AfterCommit, AuthenticatableContract, HasLoc
 
     const MAX_FIELD_LENGTHS = [
         'user_discord' => 37, // max 32char username + # + 4-digit discriminator
-        'user_from' => 30,
+        'user_from' => 25,
         'user_interests' => 30,
         'user_occ' => 30,
         'user_sig' => 3000,

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -76,7 +76,7 @@ class UserFactory extends Factory
             'user_interests' => fn () => mb_substr($this->faker->bs(), 0, 30),
             'user_occ' => fn () => mb_substr($this->faker->catchPhrase(), 0, 30),
             'user_sig' => fn () => $this->faker->realText(155),
-            'user_from' => fn () => mb_substr($this->faker->country(), 0, 30),
+            'user_from' => fn () => mb_substr($this->faker->country(), 0, 25),
             'user_regdate' => fn () => $this->faker->dateTimeBetween('-6 years'),
         ];
     }


### PR DESCRIPTION
Some characters are encoded (like `>`) and thus may end up exceeding table column limit if repeated (30 &times; 4 is 120, the limit is 100).

The alternative would be to just skip html entity encoding altogether... That'd need to migrate current data and make sure nothing outside osu-web is using it directly from the db.