### PR TITLE
Add new score replay count data

### DIFF
--- a/app/Http/Controllers/ScoresController.php
+++ b/app/Http/Controllers/ScoresController.php
@@ -7,6 +7,7 @@ namespace App\Http\Controllers;
 
 use App\Enums\Ruleset;
 use App\Models\Score\Best\Model as ScoreBest;
+use App\Models\ScoreReplayStats;
 use App\Models\Solo\Score as SoloScore;
 use App\Transformers\ScoreTransformer;
 use App\Transformers\UserCompactTransformer;
@@ -58,6 +59,8 @@ class ScoresController extends Controller
                 ::where('score_id', $id)
                 ->where('replay', true)
                 ->firstOrFail();
+
+            $soloScore = SoloScore::firstWhere('legacy_score_id', $score->getKey());
         }
 
         $file = $score->getReplayFile();
@@ -88,6 +91,12 @@ class ScoresController extends Controller
                     $score->replayViewCount()
                         ->firstOrCreate([], ['play_count' => 0])
                         ->incrementInstance('play_count');
+                }
+
+                if ($soloScore !== null) {
+                    ScoreReplayStats
+                        ::createOrFirst(['score_id' => $soloScore->getKey()], ['user_id' => $soloScore->user_id])
+                        ->incrementInstance('watch_count');
                 }
             }
         }

--- a/app/Models/ScoreReplayStats.php
+++ b/app/Models/ScoreReplayStats.php
@@ -1,0 +1,14 @@
+<?php
+
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+class ScoreReplayStats extends Model
+{
+    public $incrementing = false;
+    protected $primaryKey = 'score_id';
+}

--- a/database/migrations/2024_10_04_082317_create_score_replay_stats.php
+++ b/database/migrations/2024_10_04_082317_create_score_replay_stats.php
@@ -1,0 +1,30 @@
+<?php
+
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('score_replay_stats', function (Blueprint $table) {
+            $table->bigInteger('score_id')->unsigned()->primary();
+            $table->bigInteger('user_id')->unsigned();
+            $table->integer('watch_count')->unsigned()->default(0);
+            $table->index(['user_id', 'watch_count']);
+            $table->index('watch_count');
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('score_replay_stats');
+    }
+};

--- a/tests/Controllers/ScoresControllerTest.php
+++ b/tests/Controllers/ScoresControllerTest.php
@@ -7,6 +7,7 @@ namespace Tests\Controllers;
 
 use App\Models\OAuth\Client;
 use App\Models\Score\Best\Osu;
+use App\Models\ScoreReplayStats;
 use App\Models\Solo\Score as SoloScore;
 use App\Models\User;
 use App\Models\UserStatistics;
@@ -17,12 +18,18 @@ use Tests\TestCase;
 class ScoresControllerTest extends TestCase
 {
     private Osu $score;
+    private SoloScore $soloScore;
     private User $user;
     private User $otherUser;
 
     private static function getLegacyScoreReplayViewCount(Osu $score): int
     {
         return $score->replayViewCount()->first()?->play_count ?? 0;
+    }
+
+    private static function getScoreReplayViewCount(SoloScore $score): int
+    {
+        return ScoreReplayStats::find($score->getKey())?->watch_count ?? 0;
     }
 
     private static function getUserReplaysWatchedCount(Osu|SoloScore $score): int
@@ -40,6 +47,7 @@ class ScoresControllerTest extends TestCase
     public function testDownloadApiSameUser()
     {
         $this->expectCountChange(fn () => static::getLegacyScoreReplayViewCount($this->score), 0);
+        $this->expectCountChange(fn () => static::getScoreReplayViewCount($this->soloScore), 0);
         $this->expectCountChange(fn () => static::getUserReplayPopularity($this->score), 0);
         $this->expectCountChange(fn () => static::getUserReplaysWatchedCount($this->score), 0);
 
@@ -73,6 +81,7 @@ class ScoresControllerTest extends TestCase
     public function testDownload()
     {
         $this->expectCountChange(fn () => static::getLegacyScoreReplayViewCount($this->score), 0);
+        $this->expectCountChange(fn () => static::getScoreReplayViewCount($this->soloScore), 0);
         $this->expectCountChange(fn () => static::getUserReplayPopularity($this->score), 0);
         $this->expectCountChange(fn () => static::getUserReplaysWatchedCount($this->score), 0);
 
@@ -86,9 +95,10 @@ class ScoresControllerTest extends TestCase
             ->assertSuccessful();
     }
 
-    public function testDownloadApi(): void
+    public function testDownloadApiZ(): void
     {
         $this->expectCountChange(fn () => static::getLegacyScoreReplayViewCount($this->score), 1);
+        $this->expectCountChange(fn () => static::getScoreReplayViewCount($this->soloScore), 1);
         $this->expectCountChange(fn () => static::getUserReplayPopularity($this->score), 1);
         $this->expectCountChange(fn () => static::getUserReplaysWatchedCount($this->score), 1);
 
@@ -112,6 +122,7 @@ class ScoresControllerTest extends TestCase
             ->assertSuccessful();
 
         $this->expectCountChange(fn () => static::getLegacyScoreReplayViewCount($this->score), 0);
+        $this->expectCountChange(fn () => static::getScoreReplayViewCount($this->soloScore), 0);
         $this->expectCountChange(fn () => static::getUserReplayPopularity($this->score), 0);
         $this->expectCountChange(fn () => static::getUserReplaysWatchedCount($this->score), 0);
 
@@ -239,6 +250,12 @@ class ScoresControllerTest extends TestCase
 
         UserStatistics\Osu::factory()->create(['user_id' => $this->user->user_id]);
         $this->score = Osu::factory()->withReplay()->create(['user_id' => $this->user->user_id]);
+        $this->soloScore = SoloScore::factory()->create([
+            'beatmap_id' => $this->score->beatmap_id,
+            'data' => $this->score->data,
+            'legacy_score_id' => $this->score->getKey(),
+            'user_id' => $this->score->user_id,
+        ]);
     }
 
     private function actAsPasswordClientUser(User $user): static

--- a/tests/Controllers/ScoresControllerTest.php
+++ b/tests/Controllers/ScoresControllerTest.php
@@ -95,7 +95,7 @@ class ScoresControllerTest extends TestCase
             ->assertSuccessful();
     }
 
-    public function testDownloadApiZ(): void
+    public function testDownloadApi(): void
     {
         $this->expectCountChange(fn () => static::getLegacyScoreReplayViewCount($this->score), 1);
         $this->expectCountChange(fn () => static::getScoreReplayViewCount($this->soloScore), 1);


### PR DESCRIPTION
Just the counting part. Migration(?) will be done later after this one is deployed (either adhoc or some fancy command).

Related to #6412