### PR TITLE
Fix error on oauth client with no attached user

### DIFF
--- a/app/Models/OAuth/Token.php
+++ b/app/Models/OAuth/Token.php
@@ -174,8 +174,13 @@ class Token extends PassportToken implements SessionVerificationInterface
         }
 
         // no silly scopes.
-        if ($scopes->contains('*') && $scopes->count() > 1) {
-            throw new InvalidScopeException('* is not valid with other scopes');
+        if ($scopes->contains('*')) {
+            if ($scopes->count() > 1) {
+                throw new InvalidScopeException('* is not valid with other scopes');
+            }
+        } elseif ($client->user === null) {
+            // Only "*" scope is allowed for clients with no user
+            throw new InvalidScopeException('The client is missing owner.');
         }
 
         if ($this->isClientCredentials()) {


### PR DESCRIPTION
Some users are trying weird things. Other alternatives include banning such users or just filling out the user ids.