### PR TITLE
Simplify user profile settings handling

### DIFF
--- a/app/Http/Controllers/AccountController.php
+++ b/app/Http/Controllers/AccountController.php
@@ -282,18 +282,20 @@ class AccountController extends Controller
             'user_list_view:string',
         ]);
 
+        $profileCustomization = $user->userProfileCustomization()->createOrFirst();
+
         try {
             if (!empty($userParams)) {
                 $user->fill($userParams)->saveOrExplode();
             }
 
             if (!empty($profileParams)) {
-                $user->profileCustomization()->fill($profileParams)->saveOrExplode();
+                $profileCustomization->fill($profileParams)->saveOrExplode();
             }
         } catch (ModelNotSavedException $e) {
             return ModelNotSavedException::makeResponse($e, [
                 'user' => $user,
-                'user_profile_customization' => $user->profileCustomization(),
+                'user_profile_customization' => $profileCustomization,
             ]);
         }
 

--- a/app/Libraries/Search/ScoreSearchParams.php
+++ b/app/Libraries/Search/ScoreSearchParams.php
@@ -86,9 +86,8 @@ class ScoreSearchParams extends SearchParams
             return null;
         }
 
-        $profileCustomization = $user !== null
-            ? $user->profileCustomization()
-            : UserProfileCustomization::DEFAULTS;
+        $profileCustomization = $user?->userProfileCustomization
+            ?? UserProfileCustomization::DEFAULTS;
 
         return $profileCustomization['legacy_score_only']
             ? true

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -29,7 +29,6 @@ use Cache;
 use Carbon\Carbon;
 use DB;
 use Ds\Set;
-use Exception;
 use Hash;
 use Illuminate\Auth\Authenticatable;
 use Illuminate\Contracts\Auth\Authenticatable as AuthenticatableContract;
@@ -2186,24 +2185,6 @@ class User extends Model implements AfterCommit, AuthenticatableContract, HasLoc
         }
 
         return $history->pluck('username_last');
-    }
-
-    public function profileCustomization()
-    {
-        return $this->memoize(__FUNCTION__, function () {
-            try {
-                return $this
-                    ->userProfileCustomization()
-                    ->firstOrCreate([]);
-            } catch (Exception $ex) {
-                if (is_sql_unique_exception($ex)) {
-                    // retry on duplicate
-                    return $this->profileCustomization();
-                }
-
-                throw $ex;
-            }
-        });
     }
 
     public function profileBeatmapsetsRanked()

--- a/resources/views/accounts/_edit_options.blade.php
+++ b/resources/views/accounts/_edit_options.blade.php
@@ -3,7 +3,7 @@
     See the LICENCE file in the repository root for full licence text.
 --}}
 @php
-    $customization = Auth::user()->profileCustomization();
+    $customization = Auth::user()->userProfileCustomization ?? App\Models\UserProfileCustomization::DEFAULTS;
 @endphp
 <div class="account-edit">
     <div class="account-edit__section">
@@ -34,7 +34,7 @@
                             @endif
                             <label class="account-edit-entry__checkbox">
                                 @include('objects._switch', ['locals' => [
-                                    'checked' => $customization->beatmapset_download === $name,
+                                    'checked' => $customization['beatmapset_download'] === $name,
                                     'name' => 'user_profile_customization[beatmapset_download]',
                                     'type' => 'radio',
                                     'value' => $name,
@@ -68,7 +68,7 @@
                 <label class="account-edit-entry__checkbox">
                     @include('objects._switch', ['locals' => [
                         'additionalClass'=> 'js-account-edit__input',
-                        'checked' => $customization->beatmapset_title_show_original,
+                        'checked' => $customization['beatmapset_title_show_original'],
                         'name' => 'user_profile_customization[beatmapset_title_show_original]',
                     ]])
 
@@ -93,7 +93,7 @@
                 <label class="account-edit-entry__checkbox">
                     @include('objects._switch', ['locals' => [
                         'additionalClass'=> 'js-account-edit__input',
-                        'checked' => $customization->beatmapset_show_nsfw,
+                        'checked' => $customization['beatmapset_show_nsfw'],
                         'name' => 'user_profile_customization[beatmapset_show_nsfw]',
                     ]])
 

--- a/tests/Models/UserProfileCustomizationTest.php
+++ b/tests/Models/UserProfileCustomizationTest.php
@@ -14,7 +14,7 @@ class UserProfileCustomizationTest extends TestCase
 {
     public function testUpdateNullOptions(): void
     {
-        $profileCustomization = User::factory()->create()->profileCustomization();
+        $profileCustomization = User::factory()->create()->userProfileCustomization()->firstOrCreate();
         $profileCustomization->update(['options' => null]);
 
         $audioVolume = $profileCustomization->audio_volume + 1;
@@ -25,7 +25,7 @@ class UserProfileCustomizationTest extends TestCase
 
     public function testUpdateOption(): void
     {
-        $profileCustomization = User::factory()->create()->profileCustomization();
+        $profileCustomization = User::factory()->create()->userProfileCustomization()->firstOrCreate();
 
         $audioVolume = $profileCustomization->audio_volume + 1;
         $profileCustomization->fresh()->update(['audio_volume' => $audioVolume]);


### PR DESCRIPTION
The current one has a small bug where accessing `->profileCustomization()` wouldn't load `->userProfileCustomization`. Instead of doing a relation loaded check, it seems better to just remove it entirely 🚮 