### PR TITLE
Fix wiki search bar click area

### DIFF
--- a/resources/css/bem/wiki-search.less
+++ b/resources/css/bem/wiki-search.less
@@ -15,7 +15,6 @@
     display: flex;
     flex-direction: row;
 
-    padding: 13px @_gutter;
     font-size: @font-size--wiki-search;
     background-color: hsl(var(--hsl-b6));
     border: @_border-size solid hsl(var(--hsl-b6));
@@ -30,6 +29,7 @@
     .reset-input();
     color: @osu-colour-c1;
     flex: 1;
+    padding: 13px 0 13px @_gutter;
 
     &::placeholder {
       color: @osu-colour-c2;
@@ -41,7 +41,7 @@
     .reset-input();
 
     color: @osu-colour-c1;
-    margin-left: 10px;
+    margin: 0 @_gutter 0 10px;
   }
 
   &__suggestion {


### PR DESCRIPTION
Always found it annoying that clicking the sides on wiki search bar does nothing. Matches other search bars now.

| Before | After | Beatmap listing search and global search |
| --- | --- | --- |
| <img width="245" alt="Screenshot 2024-10-18 at 10 10 01 PM" src="https://github.com/user-attachments/assets/dd82b439-d551-4a97-a21a-7b0e2cbc13e9"> | <img width="151" alt="Screenshot 2024-10-18 at 10 10 36 PM" src="https://github.com/user-attachments/assets/6e9ed8e5-1e3b-40e2-8008-46c2210f6a94"> | <img width="291" alt="Screenshot 2024-10-18 at 10 11 33 PM" src="https://github.com/user-attachments/assets/587e15d1-e3d0-47bf-95d6-034e470ba337"> |