### PR TITLE
Fix incorrect mutual state when blocking user

### DIFF
--- a/app/Models/UserRelation.php
+++ b/app/Models/UserRelation.php
@@ -64,7 +64,7 @@ class UserRelation extends Model
     {
         $selfJoin =
             'COALESCE((
-                SELECT 1
+                SELECT phpbb_zebra.friend
                 FROM phpbb_zebra z
                 WHERE phpbb_zebra.zebra_id = z.user_id
                 AND z.zebra_id = phpbb_zebra.user_id


### PR DESCRIPTION
The value should be ignored anyway but it's weird regardless.