### PR TITLE
Add user block management api

### DIFF
--- a/app/Http/Controllers/BlocksController.php
+++ b/app/Http/Controllers/BlocksController.php
@@ -49,11 +49,9 @@ class BlocksController extends Controller
             abort(404);
         }
 
-        $existingRelation = $currentUser
-            ->relations()
-            ->where('zebra_id', $targetId)
-            ->first();
+        $relationQuery = $currentUser->relations()->where('zebra_id', $targetId);
 
+        $existingRelation = $relationQuery->first();
         if ($existingRelation) {
             $existingRelation->update([
                 'foe' => true,
@@ -70,10 +68,12 @@ class BlocksController extends Controller
             ]);
         }
 
-        return json_collection(
-            $currentUser->relations()->visible()->withMutual()->get(),
-            new UserRelationTransformer(),
-        );
+        return [
+            'user_relation' => json_item(
+                $relationQuery->first(),
+                new UserRelationTransformer(),
+            ),
+        ];
     }
 
     public function destroy($id)
@@ -90,9 +90,6 @@ class BlocksController extends Controller
 
         $user->blocks()->detach($block);
 
-        return json_collection(
-            $user->relations()->visible()->withMutual()->get(),
-            new UserRelationTransformer(),
-        );
+        return response(null, 204);
     }
 }

--- a/resources/js/components/block-button.tsx
+++ b/resources/js/components/block-button.tsx
@@ -14,6 +14,10 @@ import { Spinner } from './spinner';
 
 const bn = 'textual-button';
 
+interface BlockUserResponse {
+  user_relation: UserRelationJson;
+}
+
 interface Props {
   modifiers?: Modifiers;
   onClick?: () => void;
@@ -24,7 +28,7 @@ interface Props {
 @observer
 export default class BlockButton extends React.Component<Props> {
   @observable private loading = false;
-  private xhr?: JQuery.jqXHR<UserRelationJson[]>;
+  private xhr?: JQuery.jqXHR<BlockUserResponse | null>;
 
   @computed
   private get block() {
@@ -116,12 +120,8 @@ export default class BlockButton extends React.Component<Props> {
   };
 
   @action
-  private readonly updateBlocks = (data: UserRelationJson[]) => {
-    if (core.currentUser != null) {
-      core.currentUser.blocks = data.filter((d) => d.relation_type === 'block');
-      core.currentUser.friends = data.filter((d) => d.relation_type === 'friend');
-    }
-
+  private readonly updateBlocks = (data: BlockUserResponse | null) => {
+    core.currentUserModel.updateUserRelation(data?.user_relation, 'blocks', this.props.userId);
     this.props.onClick?.();
   };
 }

--- a/resources/js/core/user/user-model.ts
+++ b/resources/js/core/user/user-model.ts
@@ -57,13 +57,16 @@ export default class UserModel {
 
   @action
   updateUserRelation(userRelation: UserRelationJson | undefined, relationType: 'blocks' | 'friends', userId: number) {
-    const relations = this.core.currentUser?.[relationType]
-      ?? fail('trying to update user relation of guest user');
+    const currentUser = this.core.currentUser ?? fail('trying to update user relation of guest user');
+    const relations = currentUser[relationType];
 
     if (userRelation == null) {
       relations.splice(relations.findIndex((relation) => relation.target_id === userId), 1);
     } else {
       relations.push(userRelation);
     }
+
+    const otherRelations = currentUser[relationType === 'blocks' ? 'friends' : 'blocks'];
+    otherRelations.splice(otherRelations.findIndex((relation) => relation.target_id === userId), 1);
   }
 }

--- a/routes/web.php
+++ b/routes/web.php
@@ -447,6 +447,8 @@ Route::group(['as' => 'api.', 'prefix' => 'api', 'middleware' => ['api', Throttl
             });
         });
 
+        Route::resource('blocks', 'BlocksController', ['only' => ['destroy', 'index', 'store']]);
+
         Route::apiResource('comments', 'CommentsController');
         Route::post('comments/{comment}/vote', 'CommentsController@voteStore')->name('comments.vote');
         Route::delete('comments/{comment}/vote', 'CommentsController@voteDestroy');

--- a/tests/api_routes.json
+++ b/tests/api_routes.json
@@ -298,6 +298,48 @@
         "scopes": []
     },
     {
+        "uri": "api/v2/blocks",
+        "methods": [
+            "GET",
+            "HEAD"
+        ],
+        "controller": "App\\Http\\Controllers\\BlocksController@index",
+        "middlewares": [
+            "App\\Http\\Middleware\\ThrottleRequests:1200,1,api:",
+            "App\\Http\\Middleware\\RequireScopes",
+            "Illuminate\\Auth\\Middleware\\Authenticate"
+        ],
+        "scopes": []
+    },
+    {
+        "uri": "api/v2/blocks",
+        "methods": [
+            "POST"
+        ],
+        "controller": "App\\Http\\Controllers\\BlocksController@store",
+        "middlewares": [
+            "App\\Http\\Middleware\\ThrottleRequests:1200,1,api:",
+            "App\\Http\\Middleware\\RequireScopes",
+            "Illuminate\\Auth\\Middleware\\Authenticate",
+            "App\\Http\\Middleware\\VerifyUser"
+        ],
+        "scopes": []
+    },
+    {
+        "uri": "api/v2/blocks/{block}",
+        "methods": [
+            "DELETE"
+        ],
+        "controller": "App\\Http\\Controllers\\BlocksController@destroy",
+        "middlewares": [
+            "App\\Http\\Middleware\\ThrottleRequests:1200,1,api:",
+            "App\\Http\\Middleware\\RequireScopes",
+            "Illuminate\\Auth\\Middleware\\Authenticate",
+            "App\\Http\\Middleware\\VerifyUser"
+        ],
+        "scopes": []
+    },
+    {
         "uri": "api/v2/comments",
         "methods": [
             "GET",


### PR DESCRIPTION
That the destroy/store endpoint is returning both friends and blocks feels a bit whack 🤨

Also it means three additional requests just to get full relation lists (friend, block, mapper (once added))...

Related to #10789.

- [x] depends on #11581 for handling the new response