### PR TITLE
Move user registration step in `SETUP.md` to be after database seeding

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -208,15 +208,6 @@ p artisan tinker
 
 # Development
 
-## Generating assets
-
-```bash
-# build assets (should be done automatically if using docker)
-yarn run development
-```
-
-Note that if you use the bundled docker compose setup, yarn/webpack will be already run in watch mode.
-
 ## Reset the database + seeding sample data
 
 ```
@@ -235,6 +226,15 @@ php artisan tinker
 ```
 
 Note that seeding sample data (the step above this) is required for user registration to work, otherwise the command above will fail due to missing user groups or otherwise.
+
+## Generating assets
+
+```bash
+# build assets (should be done automatically if using docker)
+yarn run development
+```
+
+Note that if you use the bundled docker compose setup, yarn/webpack will be already run in watch mode.
 
 ## Continuous asset generation while developing
 

--- a/SETUP.md
+++ b/SETUP.md
@@ -96,9 +96,9 @@ Note that older versions of Elasticsearch do not work on ARM-based CPUs.
 
 `osu-elastic-indexer` currently cannot update indices using Elasticsearch 7; existing records can still be queried normally.
 
-### Mysql
+### MySQL
 
-The Mysql images provided by Docker and Mysql have different uids for the `mysql` user, if you are getting permission errors when starting the `db` container like
+The MySQL images provided by Docker and MySQL have different uids for the `mysql` user, if you are getting permission errors when starting the `db` container like
 
     mysqld: File './binlog.index' not found (OS errno 13 - Permission denied)
 

--- a/SETUP.md
+++ b/SETUP.md
@@ -208,15 +208,6 @@ p artisan tinker
 
 # Development
 
-## Creating your initial user
-
-In the repository directory:
-
-```php
-php artisan tinker
->>> (new App\Libraries\UserRegistration(["username" => "yourusername", "user_email" => "your@email.com", "password" => "yourpassword"]))->save();
-```
-
 ## Generating assets
 
 ```bash
@@ -233,6 +224,17 @@ php artisan migrate:fresh --seed
 ```
 
 Run the above command to rebuild the database and populate it with sample data. In order for the seeder to seed beatmaps, you must enter a valid osu! API key as the value of the `OSU_API_KEY` property in the `.env` configuration file, as the seeder obtains beatmap data from the osu! API. The key can be obtained from [the "Legacy API" section of your account settings page](https://osu.ppy.sh/home/account/edit#legacy-api).
+
+## Creating your initial user
+
+In the repository directory:
+
+```php
+php artisan tinker
+>>> (new App\Libraries\UserRegistration(["username" => "yourusername", "user_email" => "your@email.com", "password" => "yourpassword"]))->save();
+```
+
+Note that seeding sample data (the step above this) is required for user registration to work, otherwise the command above will fail due to missing user groups or otherwise.
 
 ## Continuous asset generation while developing
 


### PR DESCRIPTION
As I was going through setting up a local web server, I've noticed user registration does not work, and gives an error:
```
> (new App\Libraries\UserRegistration(["username" => "frenzi", "user_email" => "frenzibyte@gmail.com", "user_password" => "1234"]))->save();

   Error  Call to a member function getKey() on null.
```

I was at a complete loss as to what's causing this, then I opened discord and searched in osu and came across [this](https://discord.com/channels/188630481301012481/188630616286167041/1259342156624302164). Turns out I have to perform the seeding step first so that the `default` user group becomes present for user registration to work (or so is what I can deduce from the error message, it might be something entirely different).

I expect to get things working by just reading the setup documentation from top to bottom, so I just moved the user registration step in this PR to be done after the seeding step.