### PR TITLE
Exclude multiplayer plays with deleted score

### DIFF
--- a/app/Http/Controllers/Multiplayer/Rooms/Playlist/ScoresController.php
+++ b/app/Http/Controllers/Multiplayer/Rooms/Playlist/ScoresController.php
@@ -56,7 +56,7 @@ class ScoresController extends BaseController
         $highScoresQuery = $playlist
             ->highScores()
             ->whereHas('user', fn ($userQuery) => $userQuery->default())
-            ->whereHas('scoreLink');
+            ->whereHas('scoreLink.score');
 
         [$highScores, $hasMore] = $highScoresQuery
             ->clone()

--- a/app/Models/Multiplayer/PlaylistItemUserHighScore.php
+++ b/app/Models/Multiplayer/PlaylistItemUserHighScore.php
@@ -87,7 +87,7 @@ class PlaylistItemUserHighScore extends Model
             $ret[$type] = [
                 'query' => static
                     ::cursorSort($cursorHelper, $placeholder)
-                    ->whereHas('scoreLink')
+                    ->whereHas('scoreLink.score')
                     ->whereHas('user', fn ($userQuery) => $userQuery->default())
                     ->where('playlist_item_id', $scoreLink->playlist_item_id)
                     ->where('user_id', '<>', $scoreLink->user_id),


### PR DESCRIPTION
In cases where score is deleted but not the related multiplayer playlist item score (score link).