### PR TITLE
Speed up first place score query

### DIFF
--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -20,7 +20,6 @@ use App\Models\BeatmapDiscussion;
 use App\Models\Country;
 use App\Models\IpBan;
 use App\Models\Log;
-use App\Models\Solo\Score as SoloScore;
 use App\Models\User;
 use App\Models\UserAccountHistory;
 use App\Transformers\CurrentUserTransformer;
@@ -185,7 +184,7 @@ class UsersController extends Controller
                     ),
                     'firsts' => $this->getExtraSection(
                         'scoresFirsts',
-                        $this->user->scoresFirst($this->mode, true)->visibleUsers()->count()
+                        $this->user->scoresFirst($this->mode, true)->count()
                     ),
                     'pinned' => $this->getExtraSection(
                         'scoresPinned',
@@ -823,15 +822,16 @@ class UsersController extends Controller
             case 'scoresFirsts':
                 $transformer = new ScoreTransformer();
                 $includes = ScoreTransformer::USER_PROFILE_INCLUDES;
-                $scoreQuery = $this->user->scoresFirst($this->mode, true)->unorder();
-                $userFirstsQuery = $scoreQuery->select($scoreQuery->qualifyColumn('score_id'));
-                $query = SoloScore
-                    ::whereIn('legacy_score_id', $userFirstsQuery)
-                    ->where('ruleset_id', Beatmap::MODES[$this->mode])
-                    ->default()
-                    ->reorderBy('id', 'desc')
-                    ->with(ScoreTransformer::USER_PROFILE_INCLUDES_PRELOAD);
+                $query = $this
+                    ->user
+                    ->scoresFirst($this->mode, true)
+                    ->with(array_map(
+                        fn ($include) => "score.{$include}",
+                        ScoreTransformer::USER_PROFILE_INCLUDES_PRELOAD,
+                    ))
+                    ->orderByDesc('score_id');
                 $userRelationColumn = 'user';
+                $collectionFn = fn ($scoreFirst) => $scoreFirst->map->score;
                 break;
             case 'scoresPinned':
                 $transformer = new ScoreTransformer();

--- a/app/Models/LegacyScoreFirst/Fruits.php
+++ b/app/Models/LegacyScoreFirst/Fruits.php
@@ -1,0 +1,17 @@
+<?php
+
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
+declare(strict_types=1);
+
+namespace App\Models\LegacyScoreFirst;
+
+use App\Models\Beatmap;
+
+class Fruits extends Model
+{
+    protected static int $rulesetId = Beatmap::MODES['fruits'];
+
+    protected $table = 'osu_leaders_fruits';
+}

--- a/app/Models/LegacyScoreFirst/Mania.php
+++ b/app/Models/LegacyScoreFirst/Mania.php
@@ -1,0 +1,17 @@
+<?php
+
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
+declare(strict_types=1);
+
+namespace App\Models\LegacyScoreFirst;
+
+use App\Models\Beatmap;
+
+class Mania extends Model
+{
+    protected static int $rulesetId = Beatmap::MODES['mania'];
+
+    protected $table = 'osu_leaders_mania';
+}

--- a/app/Models/LegacyScoreFirst/Model.php
+++ b/app/Models/LegacyScoreFirst/Model.php
@@ -1,0 +1,38 @@
+<?php
+
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
+declare(strict_types=1);
+
+namespace App\Models\LegacyScoreFirst;
+
+use App\Models\Beatmap;
+use App\Models\Model as BaseModel;
+use App\Models\Solo\Score;
+use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+abstract class Model extends BaseModel
+{
+    protected static int $rulesetId;
+
+    public $incrementing = false;
+    public $timestamps = false;
+    protected $primaryKey = 'beatmap_id';
+
+    public function scopeDefault(Builder $query): Builder
+    {
+        return $query->whereHas('beatmap.beatmapset')->whereHas('score');
+    }
+
+    public function beatmap(): BelongsTo
+    {
+        return $this->belongsTo(Beatmap::class, 'beatmap_id');
+    }
+
+    public function score(): BelongsTo
+    {
+        return $this->belongsTo(Score::class, 'score_id', 'legacy_score_id')->where('ruleset_id', static::$rulesetId);
+    }
+}

--- a/app/Models/LegacyScoreFirst/Osu.php
+++ b/app/Models/LegacyScoreFirst/Osu.php
@@ -1,0 +1,17 @@
+<?php
+
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
+declare(strict_types=1);
+
+namespace App\Models\LegacyScoreFirst;
+
+use App\Models\Beatmap;
+
+class Osu extends Model
+{
+    protected static int $rulesetId = Beatmap::MODES['osu'];
+
+    protected $table = 'osu_leaders';
+}

--- a/app/Models/LegacyScoreFirst/Taiko.php
+++ b/app/Models/LegacyScoreFirst/Taiko.php
@@ -1,0 +1,17 @@
+<?php
+
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
+declare(strict_types=1);
+
+namespace App\Models\LegacyScoreFirst;
+
+use App\Models\Beatmap;
+
+class Taiko extends Model
+{
+    protected static int $rulesetId = Beatmap::MODES['taiko'];
+
+    protected $table = 'osu_leaders_taiko';
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -1409,22 +1409,22 @@ class User extends Model implements AfterCommit, AuthenticatableContract, HasLoc
 
     public function scoresFirstOsu()
     {
-        return $this->belongsToMany(Score\Best\Osu::class, 'osu_leaders')->default();
+        return $this->hasMany(LegacyScoreFirst\Osu::class)->default();
     }
 
     public function scoresFirstFruits()
     {
-        return $this->belongsToMany(Score\Best\Fruits::class, 'osu_leaders_fruits')->default();
+        return $this->hasMany(LegacyScoreFirst\Fruits::class)->default();
     }
 
     public function scoresFirstMania()
     {
-        return $this->belongsToMany(Score\Best\Mania::class, 'osu_leaders_mania')->default();
+        return $this->hasMany(LegacyScoreFirst\Mania::class)->default();
     }
 
     public function scoresFirstTaiko()
     {
-        return $this->belongsToMany(Score\Best\Taiko::class, 'osu_leaders_taiko')->default();
+        return $this->hasMany(LegacyScoreFirst\Taiko::class)->default();
     }
 
     public function scoresFirst(string $mode, bool $returnQuery = false)

--- a/app/Transformers/UserCompactTransformer.php
+++ b/app/Transformers/UserCompactTransformer.php
@@ -419,7 +419,7 @@ class UserCompactTransformer extends TransformerAbstract
 
     public function includeScoresFirstCount(User $user)
     {
-        return $this->primitive($user->scoresFirst($this->mode, true)->visibleUsers()->count());
+        return $this->primitive($user->scoresFirst($this->mode, true)->count());
     }
 
     public function includeScoresPinnedCount(User $user)


### PR DESCRIPTION
This adds one extra query but it uses existing order in the leader table instead of reordering it in the score table.

This also skips querying `scores_high` table entirely.