### PR TITLE
Add tooltips to more ruleset icons

### DIFF
--- a/resources/js/beatmapset-panel/index.tsx
+++ b/resources/js/beatmapset-panel/index.tsx
@@ -56,7 +56,7 @@ const BeatmapDot = observer(({ beatmap }: { beatmap: BeatmapJson }) => (
 
 const BeatmapDots = observer(({ compact, beatmaps, mode }: { beatmaps: BeatmapJson[]; compact: boolean; mode: Ruleset }) => (
   <div className='beatmapset-panel__extra-item beatmapset-panel__extra-item--dots'>
-    <div className='beatmapset-panel__beatmap-icon'>
+    <div className='beatmapset-panel__beatmap-icon' title={trans(`beatmaps.mode.${mode}`)}>
       <i className={`fal fa-extra-mode-${mode}`} />
     </div>
     {compact ? (

--- a/resources/views/home/_user_beatmapset.blade.php
+++ b/resources/views/home/_user_beatmapset.blade.php
@@ -15,7 +15,7 @@
     <div class="user-home-beatmapset__meta">
         <div class="user-home-beatmapset__title-container">
             @foreach ($beatmapset->playmodesStr() as $playmode)
-                <div class="user-home-beatmapset__playmode-icon">
+                <div class="user-home-beatmapset__playmode-icon" title="{{ osu_trans("beatmaps.mode.{$playmode}") }}">
                     <span class="fal fa-extra-mode-{{$playmode}}"></span>
                 </div>
             @endforeach


### PR DESCRIPTION
Probably a good QOL for users who don't know what icon is which yet.

<img width="337" alt="Screenshot 2024-10-31 at 12 36 18 PM" src="https://github.com/user-attachments/assets/b710c912-0d38-4a3b-943e-744d249fa12a">

<img width="387" alt="Screenshot 2024-10-31 at 12 36 01 PM" src="https://github.com/user-attachments/assets/abfd8176-5829-434a-b07c-dc9850f44952">

Also matches hover feedback of these:
<img width="154" alt="Screenshot 2024-10-31 at 12 40 57 PM" src="https://github.com/user-attachments/assets/b2d8d282-e371-43da-b4f1-38de39cf9dfc">