### PR TITLE
Fix highest rank tooltip being misaligned on mobile

### DIFF
--- a/resources/js/components/value-display.tsx
+++ b/resources/js/components/value-display.tsx
@@ -16,9 +16,11 @@ interface Props {
 export default function ValueDisplay({ description, label, modifiers, value }: Props) {
   return (
     <div className={classWithModifiers(bn, modifiers)}>
-      <div className={`${bn}__label`}>{label}</div>
-      <div className={`${bn}__value`}>{value}</div>
-      {description != null && <div className={`${bn}__description`}>{description}</div>}
+      <div style={{ width: `max-content` }}>
+        <div className={`${bn}__label`}>{label}</div>
+        <div className={`${bn}__value`}>{value}</div>
+        {description != null && <div className={`${bn}__description`}>{description}</div>}
+      </div>
     </div>
   );
 }

--- a/resources/js/components/value-display.tsx
+++ b/resources/js/components/value-display.tsx
@@ -19,8 +19,8 @@ export default function ValueDisplay({ description, label, modifiers, value }: P
       <div style={{ width: 'max-content' }}>
         <div className={`${bn}__label`}>{label}</div>
         <div className={`${bn}__value`}>{value}</div>
-        {description != null && <div className={`${bn}__description`}>{description}</div>}
       </div>
+      {description != null && <div className={`${bn}__description`}>{description}</div>}
     </div>
   );
 }

--- a/resources/js/components/value-display.tsx
+++ b/resources/js/components/value-display.tsx
@@ -16,7 +16,7 @@ interface Props {
 export default function ValueDisplay({ description, label, modifiers, value }: Props) {
   return (
     <div className={classWithModifiers(bn, modifiers)}>
-      <div style={{ width: `max-content` }}>
+      <div style={{ width: 'max-content' }}>
         <div className={`${bn}__label`}>{label}</div>
         <div className={`${bn}__value`}>{value}</div>
         {description != null && <div className={`${bn}__description`}>{description}</div>}


### PR DESCRIPTION
- Fixes https://github.com/ppy/osu-web/issues/9439

| Before | After |
| --- | --- |
| <img width="396" alt="Screenshot 2024-10-31 at 8 19 26 PM" src="https://github.com/user-attachments/assets/02c5343e-95a1-4d92-8a7a-d9f73f210e3f"> | <img width="328" alt="Screenshot 2024-10-31 at 8 19 18 PM" src="https://github.com/user-attachments/assets/e6ee9b30-45d4-43d9-a642-b8cdc4e05e96"> |

Unsure if this is the correct fix. Wanted to keep the hover/click area width at least the label width, so one digits are still easy to hover/click.