### PR TITLE
Fix weekly streak not reset in some cases

### DIFF
--- a/app/Models/DailyChallengeUserStats.php
+++ b/app/Models/DailyChallengeUserStats.php
@@ -59,7 +59,7 @@ class DailyChallengeUserStats extends Model
             ->get()
             ->keyBy('user_id');
         $statsByUserId = static
-            ::where('last_weekly_streak', '>=', $previousWeek->subDays(1))
+            ::where('last_weekly_streak', '>=', $previousWeek->subWeeks(1))
             ->orWhereIn('user_id', $highScoresByUserId->keys())
             ->get()
             ->keyBy('user_id');

--- a/tests/Models/DailyChallengeUserStatsTest.php
+++ b/tests/Models/DailyChallengeUserStatsTest.php
@@ -108,7 +108,7 @@ class DailyChallengeUserStatsTest extends TestCase
 
         $user = User::factory()->create();
 
-        $lastWeeklyStreak = $playTime->subWeeks(1)->subDays(1);
+        $lastWeeklyStreak = $playTime->subWeeks(2);
         DailyChallengeUserStats::create([
             'user_id' => $user->getKey(),
             'weekly_streak_current' => 3,


### PR DESCRIPTION
If the last play was on start of week, the original check will always pass on the following week and then not selected anymore on the week afterwards.

Resolves #11618

- Last weekly streak: 2024-09-19
- End of the week of the weekly streak: 2024-09-25
- Next week streak start: 2024-09-26
- The latest play needed to keep streak: 2024-10-02 (end of the week)

Before:
| Check date | Query cutoff | Minimum last weekly streak | Result         |
|------------|--------------|----------------------------|----------------|
| 2024-10-02 | 2024-09-18   | 2024-09-19 ✔               | No reset ✔     |
| 2024-10-03 | 2024-09-25   | 2024-09-26 ✔               | Not queried ❌ |

After:
| Check date | Query cutoff | Minimum last weekly streak | Result      |
|------------|--------------|----------------------------|-------------|
| 2024-10-02 | 2024-09-12   | 2024-09-19 ✔               | No break ✔ |
| 2024-10-03 | 2024-09-19   | 2024-09-26 ✔               | Reset ✔   |

- Query cutoff: https://github.com/ppy/osu-web/blob/41ca4cc2331eb06c329250a3594526a451cf3024/app/Models/DailyChallengeUserStats.php#L62