### PR TITLE
Move active tournament banner data to table

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -189,21 +189,6 @@ CLIENT_CHECK_VERSION=false
 # ES_CLIENT_CONNECT_TIMEOUT=0.5
 # ES_SEARCH_TIMEOUT=5s
 
-# TOURNAMENT_BANNER_CURRENT_ID=
-# Image path/url for tournament supporter banner.
-# Will be appended with country abbreviation and `.jpg`. `@2x` version is also required (prepended before `.jpg`).
-# Example:
-#   prefix: https://assets.ppy.sh/tournament-banners/official/twc2018_
-#   image path: https://assets.ppy.sh/tournament-banners/official/twc2018_JP.jpg
-#   image path @2x: https://assets.ppy.sh/tournament-banners/official/twc2018_JP@2x.jpg
-# TOURNAMENT_BANNER_CURRENT_PREFIX=
-
-# TOURNAMENT_BANNER_PREVIOUS_ID=
-# Same as `_CURRENT_PREFIX`.
-# TOURNAMENT_BANNER_PREVIOUS_PREFIX=
-# Winning country code
-# TOURNAMENT_BANNER_PREVIOUS_WINNER_ID=
-
 # {prefix}{filename}.png with {filename} the achievement slug as stored in database.
 # USER_ACHIEVEMENT_ICON_PREFIX=https://assets.ppy.sh/user-achievements/
 

--- a/app/Models/TournamentBanner.php
+++ b/app/Models/TournamentBanner.php
@@ -1,0 +1,25 @@
+<?php
+
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
+class TournamentBanner extends Model
+{
+    public $incrementing = false;
+
+    protected $casts = [
+        'is_active' => 'boolean',
+    ];
+    protected $primaryKey = 'tournament_id';
+
+    public function tournament(): BelongsTo
+    {
+        return $this->belongsTo(Tournament::class, 'tournament_id');
+    }
+}

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -914,6 +914,7 @@ class User extends Model implements AfterCommit, AuthenticatableContract, HasLoc
             'orders',
             'pivot', // laravel built-in relation when using belongsToMany
             'profileBanners',
+            'profileBannersActive',
             'profileBeatmapsetsGraveyard',
             'profileBeatmapsetsLoved',
             'profileBeatmapsetsPending',
@@ -1308,6 +1309,11 @@ class User extends Model implements AfterCommit, AuthenticatableContract, HasLoc
     public function profileBanners()
     {
         return $this->hasMany(ProfileBanner::class);
+    }
+
+    public function profileBannersActive(): HasMany
+    {
+        return $this->profileBanners()->active()->with('tournamentBanner')->orderBy('banner_id');
     }
 
     public function storeAddresses()

--- a/app/Transformers/UserCompactTransformer.php
+++ b/app/Transformers/UserCompactTransformer.php
@@ -159,7 +159,7 @@ class UserCompactTransformer extends TransformerAbstract
 
     public function includeActiveTournamentBanner(User $user)
     {
-        $banner = $user->profileBanners()->active();
+        $banner = $user->profileBannersActive->last();
 
         return $banner === null
             ? $this->primitive(null)
@@ -169,7 +169,7 @@ class UserCompactTransformer extends TransformerAbstract
     public function includeActiveTournamentBanners(User $user)
     {
         return $this->collection(
-            $user->profileBanners()->activeOnly()->orderBy('banner_id')->get(),
+            $user->profileBannersActive,
             new ProfileBannerTransformer(),
         );
     }

--- a/config/osu.php
+++ b/config/osu.php
@@ -201,17 +201,6 @@ return [
     ],
     'twitch_client_id' => presence(env('TWITCH_CLIENT_ID')),
     'twitch_client_secret' => presence(env('TWITCH_CLIENT_SECRET')),
-    'tournament_banner' => [
-        'current' => [
-            'id' => get_int(env('TOURNAMENT_BANNER_CURRENT_ID')),
-            'prefix' => env('TOURNAMENT_BANNER_CURRENT_PREFIX'),
-        ],
-        'previous' => [
-            'id' => get_int(env('TOURNAMENT_BANNER_PREVIOUS_ID')),
-            'prefix' => env('TOURNAMENT_BANNER_PREVIOUS_PREFIX'),
-            'winner_id' => env('TOURNAMENT_BANNER_PREVIOUS_WINNER_ID'),
-        ],
-    ],
     'urls' => [
         'base' => 'https://osu.ppy.sh',
         'bounty-form' => env('OS_BOUNTY_URL'),

--- a/database/migrations/2024_11_06_074123_create_tournament_banners.php
+++ b/database/migrations/2024_11_06_074123_create_tournament_banners.php
@@ -1,0 +1,30 @@
+<?php
+
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('tournament_banners', function (Blueprint $table) {
+            $table->unsignedMediumInteger('tournament_id')->primary();
+            $table->boolean('is_active')->default(false);
+            $table->char('winner_country_acronym', 2)->nullable(true);
+            $table->string('banner_url_prefix');
+            $table->timestampTz('created_at')->useCurrent();
+            $table->timestampTz('updated_at')->useCurrent();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('tournament_banners');
+    }
+};


### PR DESCRIPTION
All the environments

```bash
TOURNAMENT_BANNER_CURRENT_ID=
TOURNAMENT_BANNER_CURRENT_PREFIX=
TOURNAMENT_BANNER_PREVIOUS_ID=
TOURNAMENT_BANNER_PREVIOUS_PREFIX=
TOURNAMENT_BANNER_PREVIOUS_WINNER_ID=
```

are moved to `tournament_banners` table. Should be relatively straightforward.

- [x] change `osu_profile_banners.country_acronym` collation to `utf8mb4_0900_ai_ci` (and might as well change the table collation too)