### PR TITLE
Cache ip2asn db on GitHub Action

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -137,6 +137,12 @@ jobs:
           key: ${{ runner.os }}-composer-${{ hashFiles('composer.lock') }}
           restore-keys: ${{ runner.os }}-composer-
 
+      - name: Cache ip2asn
+        uses: actions/cache@v4
+        with:
+          path: database/ip2asn/
+          key: ip2asn
+
       - run: ./build.sh
 
       - name: Setup indices


### PR DESCRIPTION
Their server isn't exactly the best and caching it for a day is probably fine.