### PR TITLE
Show all active account history

### DIFF
--- a/app/Models/UserAccountHistory.php
+++ b/app/Models/UserAccountHistory.php
@@ -84,7 +84,8 @@ class UserAccountHistory extends Model
     public function scopeRecent($query)
     {
         return $query
-            ->where('timestamp', '>', Carbon::now()->subDays($GLOBALS['cfg']['osu']['user']['ban_persist_days']))
+            ->whereRaw('(UNIX_TIMESTAMP(`timestamp`) + `period`) > ?', time())
+            ->orWhere('timestamp', '>', Carbon::now()->subDays($GLOBALS['cfg']['osu']['user']['ban_persist_days']))
             ->orWhere('permanent', true)
             ->orderBy('timestamp', 'desc');
     }


### PR DESCRIPTION
The permanent check already checks all rows so adding one more thing doesn't change much? 🤷 

Resolves #11590 except non-permanent tournament ban entry is not a thing at the moment.