### PR TITLE
Disable turbo on oauth form buttons

### DIFF
--- a/resources/views/vendor/passport/authorize.blade.php
+++ b/resources/views/vendor/passport/authorize.blade.php
@@ -90,6 +90,7 @@
             <div class="dialog-form__row dialog-form__row--buttons">
                 <form
                     action="{{ route('oauth.authorizations.authorize') }}"
+                    data-turbo="false"
                     method="POST"
                 >
                     @csrf
@@ -100,6 +101,7 @@
 
                 <form
                     action="{{ route('oauth.authorizations.authorize') }}"
+                    data-turbo="false"
                     method="POST"
                 >
                     @csrf


### PR DESCRIPTION
It's controlled by oauth library and it's easier just disabling it at the form (as opposed to returning the redirect script).

Resolves #11658