### PR TITLE
Fix parsing page parameter of ranking page

### DIFF
--- a/app/Http/Controllers/RankingController.php
+++ b/app/Http/Controllers/RankingController.php
@@ -212,8 +212,8 @@ class RankingController extends Controller
 
         $maxResults = $this->maxResults($modeInt, $stats);
         $maxPages = ceil($maxResults / static::PAGE_SIZE);
-        // TODO: less repeatedly getting params out of request.
-        $page = \Number::clamp(get_int(request('cursor.page') ?? request('page') ?? 1), 1, $maxPages);
+        $params = get_params(\Request::all(), null, ['cursor.page:int', 'page']);
+        $page = \Number::clamp($params['cursor']['page'] ?? $params['page'] ?? 1, 1, $maxPages);
 
         $stats = $stats->limit(static::PAGE_SIZE)
             ->offset(static::PAGE_SIZE * ($page - 1))


### PR DESCRIPTION
So I did miss at least one place when updating to laravel builtin function <_<

This is a rare edge case and must be manually typed... I think.