### PR TITLE
Don't override InputContainer error colour when focused

### DIFF
--- a/resources/css/bem/input-container.less
+++ b/resources/css/bem/input-container.less
@@ -2,6 +2,8 @@
 // See the LICENCE file in the repository root for full licence text.
 
 .input-container {
+  @top: input-container;
+
   --label-font-size: @font-size--normal;
   --label-line-height: 1.25;
   --label-height: calc(
@@ -32,6 +34,10 @@
 
   &:focus-within {
     --input-border-colour: var(--input-border-focus-colour);
+
+    .@{top}--error& {
+      --input-border-colour: var(--input-border-error-colour);
+    }
   }
 
   &:hover {

--- a/resources/css/bem/input-container.less
+++ b/resources/css/bem/input-container.less
@@ -18,6 +18,7 @@
   --input-border-hover-colour: hsl(var(--hsl-l3));
   --input-border-focus-colour: hsl(var(--hsl-l1));
   --input-border-error-colour: hsl(var(--hsl-red-2));
+  --input-border-error-focus-colour: hsl(var(--hsl-red-3));
   --input-padding: var(--label-height) var(--input-padding-right)
     var(--input-padding-base) var(--input-padding-base);
   --input-padding-base: 10px;
@@ -54,7 +55,8 @@
 
   &--error {
     --input-border-colour: var(--input-border-error-colour);
-    --input-border-focus-colour: var(--input-border-error-colour);
+    --input-border-focus-colour: var(--input-border-error-focus-colour);
+    --input-border-hover-colour: var(--input-border-error-focus-colour);
   }
 
   &--fill {

--- a/resources/css/bem/input-container.less
+++ b/resources/css/bem/input-container.less
@@ -34,10 +34,6 @@
 
   &:focus-within {
     --input-border-colour: var(--input-border-focus-colour);
-
-    .@{top}--error& {
-      --input-border-colour: var(--input-border-error-colour);
-    }
   }
 
   &:hover {
@@ -58,6 +54,7 @@
 
   &--error {
     --input-border-colour: var(--input-border-error-colour);
+    --input-border-focus-colour: var(--input-border-error-colour);
   }
 
   &--fill {


### PR DESCRIPTION
The error highlight should still remain active when the field is focused. Left the hover highlight alone since it seems logical it should follow what's being hovered but not yet focused? 🤔 