### PR TITLE
Fix acting as null user not reset existing user in test

### DIFF
--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -184,8 +184,9 @@ class TestCase extends BaseTestCase
         $guard = app('auth')->guard($driver);
         $user = $token->getResourceOwner();
 
-        if ($user !== null) {
-            // guard doesn't accept null user.
+        if ($user === null) {
+            $guard->logout();
+        } else {
             $guard->setUser($user);
             $user->withAccessToken($token);
         }


### PR DESCRIPTION
There's this test but it's testing test helper so I'm not sure if it makes sense testing it? 🤔 Can jam it somewhere... (where?)

```php
    public function testWat()
    {
        $user = User::factory()->create();
        $this->actAsScopedUser($user, ['public']);
        $this->assertSame(\Auth::user()->getKey(), $user->getKey());

        $this->actAsScopedUser(null, ['public']);
        $this->assertNull(\Auth::user());
    }
```