### PR TITLE
Return populated room object when joined

### DIFF
--- a/app/Http/Controllers/Multiplayer/RoomsController.php
+++ b/app/Http/Controllers/Multiplayer/RoomsController.php
@@ -118,7 +118,7 @@ class RoomsController extends Controller
 
         $room->join(auth()->user());
 
-        return response([], 204);
+        return $this->createJoinedRoomResponse($room);
     }
 
     public function leaderboard($roomId)
@@ -168,21 +168,7 @@ class RoomsController extends Controller
         }
 
         if (is_api_request()) {
-            return json_item(
-                $room
-                    ->load('host.country')
-                    ->load('playlist.beatmap.beatmapset')
-                    ->load('playlist.beatmap.baseMaxCombo'),
-                'Multiplayer\Room',
-                [
-                    'current_user_score.playlist_item_attempts',
-                    'host.country',
-                    'playlist.beatmap.beatmapset',
-                    'playlist.beatmap.checksum',
-                    'playlist.beatmap.max_combo',
-                    'recent_participants',
-                ]
-            );
+            return $this->createJoinedRoomResponse($room);
         }
 
         if ($room->category === 'daily_challenge') {
@@ -217,22 +203,28 @@ class RoomsController extends Controller
         try {
             $room = (new Room())->startGame(auth()->user(), request()->all());
 
-            return json_item(
-                $room
-                    ->load('host.country')
-                    ->load('playlist.beatmap.beatmapset')
-                    ->load('playlist.beatmap.baseMaxCombo'),
-                'Multiplayer\Room',
-                [
-                    'host.country',
-                    'playlist.beatmap.beatmapset',
-                    'playlist.beatmap.checksum',
-                    'playlist.beatmap.max_combo',
-                    'recent_participants',
-                ]
-            );
+            return $this->createJoinedRoomResponse($room);
         } catch (InvariantException $e) {
             return error_popup($e->getMessage(), $e->getStatusCode());
         }
+    }
+
+    private function createJoinedRoomResponse($room)
+    {
+        return json_item(
+            $room
+                ->load('host.country')
+                ->load('playlist.beatmap.beatmapset')
+                ->load('playlist.beatmap.baseMaxCombo'),
+            'Multiplayer\Room',
+            [
+                'current_user_score.playlist_item_attempts',
+                'host.country',
+                'playlist.beatmap.beatmapset',
+                'playlist.beatmap.checksum',
+                'playlist.beatmap.max_combo',
+                'recent_participants',
+            ]
+        );
     }
 }


### PR DESCRIPTION
While in the lounge, the client polls using `index()` which returns a compact model that in particular excludes the playlist. After the room is joined the playlist becomes important for the obvious reason that the user should be able to start playing, but also for the less-obvious reason that the client expects the playlist to be populated in order to preselect the first available item.

Rather than adding a special condition for the client, it seems to make more sense to return the complete model here and potentially remove the `show()` API request. As far as I can tell the only remaining use (as far as the client's concerned) is to update the recent participants list, but it's otherwise quite wasteful and polls every 5 seconds.  
Beyond that, I believe playlists would be better served by the multiplayer server like daily challenge where statistics are pushed to the client in real time. 

I noticed that the response was already _mostly_ duplicated between `store()` and `show()`, so I took the liberty of splitting it out. Let me know if this is the correct way of doing things :)

Sample returned model:
```json
{
  "id" : 1,
  "name" : "smgi's awesome playlist",
  "category" : "normal",
  "type" : "playlists",
  "user_id" : 156,
  "starts_at" : "2024-11-21T14:04:18+00:00",
  "ends_at" : "2024-11-21T14:34:18+00:00",
  "max_attempts" : null,
  "participant_count" : 0,
  "channel_id" : 1,
  "active" : false,
  "has_password" : false,
  "queue_mode" : "host_only",
  "auto_skip" : false,
  "current_user_score" : {
    "accuracy" : 0,
    "attempts" : 0,
    "completed" : 0,
    "pp" : 0,
    "room_id" : 1,
    "total_score" : 0,
    "user_id" : 156,
    "playlist_item_attempts" : [ ]
  },
  "host" : {
    "avatar_url" : "http://localhost:8080/images/layout/avatar-guest@2x.png",
    "country_code" : null,
    "default_group" : "default",
    "id" : 156,
    "is_active" : true,
    "is_bot" : false,
    "is_deleted" : false,
    "is_online" : true,
    "is_supporter" : false,
    "last_visit" : "2024-11-21T15:03:48+00:00",
    "pm_friends_only" : false,
    "profile_colour" : null,
    "username" : "smgi",
    "country" : null
  },
  "playlist" : [ {
    "id" : 1,
    "room_id" : 1,
    "beatmap_id" : 830459,
    "ruleset_id" : 0,
    "allowed_mods" : [ ],
    "required_mods" : [ ],
    "expired" : false,
    "owner_id" : 156,
    "playlist_order" : null,
    "played_at" : null,
    "beatmap" : {
      "beatmapset_id" : 379370,
      "difficulty_rating" : 1.86,
      "id" : 830459,
      "mode" : "osu",
      "status" : "ranked",
      "total_length" : 147,
      "user_id" : 4,
      "version" : "Normal",
      "beatmapset" : {
        "artist" : "SoundTeMP",
        "artist_unicode" : "SoundTeMP",
        "covers" : {
          "cover" : "http://localhost:8080/uploads/beatmaps/379370/covers/cover.jpg?0",
          "cover@2x" : "http://localhost:8080/uploads/beatmaps/379370/covers/cover@2x.jpg?0",
          "card" : "http://localhost:8080/uploads/beatmaps/379370/covers/card.jpg?0",
          "card@2x" : "http://localhost:8080/uploads/beatmaps/379370/covers/card@2x.jpg?0",
          "list" : "http://localhost:8080/uploads/beatmaps/379370/covers/list.jpg?0",
          "list@2x" : "http://localhost:8080/uploads/beatmaps/379370/covers/list@2x.jpg?0",
          "slimcover" : "http://localhost:8080/uploads/beatmaps/379370/covers/slimcover.jpg?0",
          "slimcover@2x" : "http://localhost:8080/uploads/beatmaps/379370/covers/slimcover@2x.jpg?0"
        },
        "creator" : "neonat",
        "favourite_count" : 51,
        "hype" : null,
        "id" : 379370,
        "nsfw" : false,
        "offset" : 0,
        "play_count" : 10556,
        "preview_url" : "//b.ppy.sh/preview/379370.mp3",
        "source" : "Ragnarok Online",
        "spotlight" : false,
        "status" : "ranked",
        "title" : "Christmas in 13th Month (Vesuvia Ecky's Poetic Mix)",
        "title_unicode" : "Christmas in 13th Month (Vesuvia Ecky's Poetic Mix)",
        "track_id" : null,
        "user_id" : 8,
        "video" : false
      },
      "checksum" : "821afc7f47448c51edf71d004fbb3e23",
      "max_combo" : null
    }
  } ],
  "recent_participants" : [ ]
}
```