### PR TITLE
Use default mysql authentication plugin

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -110,7 +110,6 @@ services:
       MYSQL_ALLOW_EMPTY_PASSWORD: "yes"
     ports:
       - "${MYSQL_EXTERNAL_PORT:-127.0.0.1:3306}:3306"
-    command: --default-authentication-plugin=mysql_native_password
     healthcheck:
       # important to use 127.0.0.1 instead of localhost as mysql starts twice.
       # the first time it listens on sockets but isn't actually ready


### PR DESCRIPTION
The native password will be gone in 9.0.

As it turned out there's implementation of `caching_sha2_password` on mariadb but just for the client. And depending on the distro, one may need to install additional package to get the relevant plugin to be able to connect to the database (`mariadb-connector-c` on alpine linux).