### PR TITLE
Fix timing of calling boot on initial page load

### DIFF
--- a/resources/js/core/react-turbolinks.ts
+++ b/resources/js/core/react-turbolinks.ts
@@ -110,9 +110,10 @@ export default class ReactTurbolinks {
     // Delayed to wait until cacheSnapshot finishes. The delay matches Turbolinks' defer.
     window.setTimeout(() => {
       this.destroy();
-      this.loadScripts();
-      this.boot();
-      this.timeoutScroll = window.setTimeout(this.scrollOnNewVisit, 100);
+      this.loadScripts().then(() => {
+        this.boot();
+        this.timeoutScroll = window.setTimeout(this.scrollOnNewVisit, 100);
+      });
     }, 1);
   };
 


### PR DESCRIPTION
Missed this when turning the `loadScripts` async.