### PR TITLE
Revert back to external uuid function

### DIFF
--- a/package.json
+++ b/package.json
@@ -93,6 +93,7 @@
     "tsconfig-paths-webpack-plugin": "^3.2.0",
     "typescript": "^5.2.2",
     "unified": "^10.1.2",
+    "uuid": "^11.0.3",
     "watchpack": "^2.4.0",
     "webpack": "^5.94.0",
     "webpack-cli": "^5.1.4",

--- a/resources/js/models/chat/create-announcement.ts
+++ b/resources/js/models/chat/create-announcement.ts
@@ -4,6 +4,7 @@
 import UserJson from 'interfaces/user-json';
 import { action, autorun, computed, makeObservable, observable } from 'mobx';
 import { present } from 'utils/string';
+import { v4 as uuidv4 } from 'uuid';
 import { maxMessageLength } from './channel';
 
 interface LocalStorageProps extends Record<InputKey, string> {
@@ -33,7 +34,7 @@ export default class CreateAnnouncement {
   @observable validUsers = new Map<number, UserJson>();
 
   private initialized = false;
-  private readonly uuid = crypto.randomUUID();
+  private readonly uuid = uuidv4();
 
   @computed
   get errors() {

--- a/resources/js/models/chat/message.ts
+++ b/resources/js/models/chat/message.ts
@@ -6,13 +6,14 @@ import { action, computed, makeObservable, observable } from 'mobx';
 import User from 'models/user';
 import * as moment from 'moment';
 import core from 'osu-core-singleton';
+import { v4 as uuidv4 } from 'uuid';
 
 export default class Message {
   @observable channelId = -1;
   @observable content = '';
   @observable errored = false;
   @observable isAction = false;
-  @observable messageId: number | string = crypto.randomUUID();
+  @observable messageId: number | string = uuidv4();
   @observable persisted = false;
   @observable senderId = -1;
   @observable timestamp: string = moment().toISOString();

--- a/resources/js/utils/turbolinks.ts
+++ b/resources/js/utils/turbolinks.ts
@@ -2,6 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 import { VisitOptions } from '@hotwired/turbo';
+import { v4 as uuidv4 } from 'uuid';
 
 export function currentUrl() {
   return window.newUrl ?? document.location;
@@ -59,7 +60,7 @@ export function updateHistory(url: string, action: 'push' | 'replace') {
   const newLocation = new URL(url, document.baseURI);
 
   const callback = () => {
-    Turbo.session.history[action](newLocation, crypto.randomUUID());
+    Turbo.session.history[action](newLocation, uuidv4());
     Turbo.session.view.lastRenderedLocation = newLocation;
   };
   if (action === 'replace' && window.newUrl == null) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -7611,6 +7611,11 @@ utils-merge@1.0.1:
   resolved "https://registry.yarnpkg.com/utils-merge/-/utils-merge-1.0.1.tgz#9f95710f50a267947b2ccc124741c1028427e713"
   integrity sha1-n5VxD1CiZ5R7LMwSR0HBAoQn5xM=
 
+uuid@^11.0.3:
+  version "11.0.3"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-11.0.3.tgz#248451cac9d1a4a4128033e765d137e2b2c49a3d"
+  integrity sha512-d0z310fCWv5dJwnX1Y/MncBAqGMKEzlBb1AOf7z9K8ALnd0utBX/msg/fA0+sbyN1ihbMsLhrBlnl1ak7Wa0rg==
+
 uuid@^8.3.0:
   version "8.3.2"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"


### PR DESCRIPTION
It breaks local test with docker due to non-localhost test domain. There's probably a way to get around that with some chromium flags but the whole secure context is just a bit annoying.

Good job, WICG/uuid#23 people.