### PR TITLE
Remove unused user score route

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -41,7 +41,6 @@ Route::group(['middleware' => ['web']], function () {
         Route::resource('packs', 'BeatmapPacksController', ['only' => ['index', 'show']]);
 
         Route::group(['as' => 'beatmaps.', 'prefix' => '{beatmap}'], function () {
-            Route::get('scores/users/{user}', 'BeatmapsController@userScore');
             Route::get('scores', 'BeatmapsController@scores')->name('scores');
             Route::get('solo-scores', 'BeatmapsController@soloScores')->name('solo-scores');
             Route::put('update-owner', 'BeatmapsController@updateOwner')->name('update-owner');


### PR DESCRIPTION
It's not used by non-api, I think? (It's not named). I think it was accidentally committed with #7015 when I wanted to check it without getting a token?