### PR TITLE
Adjust daily challenge tier thresholds to match expectations

### DIFF
--- a/resources/js/profile-page/daily-challenge.tsx
+++ b/resources/js/profile-page/daily-challenge.tsx
@@ -38,7 +38,7 @@ function tierStyle(days: number) {
 }
 
 function tierStylePlaycount(count: number) {
-  return tierStyle(count / 3);
+  return tierStyle(Math.floor(count / 3));
 }
 
 function tierStyleWeekly(weeks: number) {

--- a/resources/js/profile-page/daily-challenge.tsx
+++ b/resources/js/profile-page/daily-challenge.tsx
@@ -22,7 +22,7 @@ function tier(days: number) {
     [Number.NEGATIVE_INFINITY, 'iron'],
   ] as const;
   for (const [minDays, value] of tiers) {
-    if (days > minDays) {
+    if (days >= minDays) {
       return value;
     }
   }


### PR DESCRIPTION
See conversation in https://github.com/ppy/osu-wiki/pull/12392#discussion_r1861519201

Color now changes when you _reach_ the expected threshold, not surpass it.

`Math.floor` in tierStylePlaycount is to ensure consistent results given javascript's BS with floats, and to ensure consistent behavior w/ the client (see <https://github.com/ppy/osu/pull/30906>)