### PR TITLE
Fix beatmapset preload on room

### DIFF
--- a/app/Http/Controllers/Multiplayer/RoomsController.php
+++ b/app/Http/Controllers/Multiplayer/RoomsController.php
@@ -212,10 +212,11 @@ class RoomsController extends Controller
     private function createJoinedRoomResponse($room)
     {
         return json_item(
-            $room
-                ->load('host.country')
-                ->load('playlist.beatmap.beatmapset')
-                ->load('playlist.beatmap.baseMaxCombo'),
+            $room->loadMissing([
+                'host',
+                'playlist.beatmap.beatmapset',
+                'playlist.beatmap.baseMaxCombo',
+            ]),
             'Multiplayer\Room',
             [
                 'current_user_score.playlist_item_attempts',


### PR DESCRIPTION
Doing another `load` overrides existing loaded relations.