### PR TITLE
Limit room name length to match database

### DIFF
--- a/app/Models/Multiplayer/Room.php
+++ b/app/Models/Multiplayer/Room.php
@@ -603,6 +603,10 @@ class Room extends Model
             throw new InvariantException('room must have at least one playlist item');
         }
 
+        if (mb_strlen($this->name) > 100) {
+            throw new InvariantException(osu_trans('multiplayer.room.errors.name_too_long'));
+        }
+
         PlaylistItem::assertBeatmapsExist($playlistItems);
 
         $this->getConnection()->transaction(function () use ($host, $playlistItems) {

--- a/resources/lang/en/multiplayer.php
+++ b/resources/lang/en/multiplayer.php
@@ -19,6 +19,7 @@ return [
 
         'errors' => [
             'duration_too_long' => 'Duration is too long.',
+            'name_too_long' => 'Room name is too long.',
         ],
 
         'status' => [


### PR DESCRIPTION
Could've used the length validator but the model doesn't have it setup and there's a lot of other existing checks done in a different way.