### PR TITLE
Update to latest less css

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "jquery-ujs": "^1.2.3",
     "jquery.scrollto": "^2.1.2",
     "lang.js": "^1.1.14",
-    "less": "^3.9.0",
+    "less": "^4.2.1",
     "less-loader": "^11.1.3",
     "lodash": "^4.17.19",
     "mdast-util-gfm-autolink-literal": "^1.0.3",

--- a/resources/css/bem/circular-progress.less
+++ b/resources/css/bem/circular-progress.less
@@ -81,8 +81,8 @@
   &__label {
     position: absolute;
     z-index: 1;
-    width: 1 / @label-size;
-    line-height: 1 / @label-size;
+    width: (1 / @label-size);
+    line-height: (1 / @label-size);
     font-size: @label-size;
     text-align: center;
     white-space: nowrap;

--- a/resources/css/bem/loading-overlay.less
+++ b/resources/css/bem/loading-overlay.less
@@ -3,7 +3,7 @@
 
 @circle-size: 64px;
 @animation-length: 1.6s;
-@animation-delay: @animation-length / 4;
+@animation-delay: (@animation-length / 4);
 
 .loading-overlay {
   @_top: loading-overlay;
@@ -144,7 +144,7 @@
     animation-fill-mode: forwards;
     will-change: opacity;
 
-    @animation-delay-start: @animation-delay*1 / 8;
+    @animation-delay-start: (@animation-delay / 8);
 
     .@{_top}--visible & {
       animation-name: loading-overlay--follow-point;

--- a/resources/css/bem/page-contents.less
+++ b/resources/css/bem/page-contents.less
@@ -30,8 +30,8 @@
     padding: 20px 20px 10px;
 
     @media @desktop {
-      flex-basis: 100% / 3;
-      max-width: 100% / 3;
+      flex-basis: (100% / 3);
+      max-width: (100% / 3);
 
       & + & {
         border-width: 0 0 0 1px;

--- a/resources/css/bem/profile-hue-selector.less
+++ b/resources/css/bem/profile-hue-selector.less
@@ -22,7 +22,7 @@
 
     .ui-slider &.ui-slider-handle {
       .default-border-radius();
-      margin-left: @handle-width / -2;
+      margin-left: (@handle-width / -2);
       top: 0;
       width: @handle-width;
       height: 100%;

--- a/resources/css/bem/store-slider.less
+++ b/resources/css/bem/store-slider.less
@@ -29,7 +29,7 @@
 
   &__fake-callout {
     position: absolute;
-    left: @slider-handle-width / 2;
+    left: (@slider-handle-width / 2);
     padding-bottom: @slider-callout--arrow-height;
     transform: translateX(-50%);
     bottom: calc(100% + @slider-callout--arrow-gap);

--- a/resources/css/bem/supporter-icon.less
+++ b/resources/css/bem/supporter-icon.less
@@ -26,7 +26,7 @@
   &--user-card {
     height: @user-card-icon-size;
     width: @user-card-icon-size;
-    font-size: @user-card-icon-size / 2;
+    font-size: (@user-card-icon-size / 2);
     border-radius: 50%;
     padding: 1px 0 0;
   }

--- a/resources/css/bem/user-action-button.less
+++ b/resources/css/bem/user-action-button.less
@@ -71,7 +71,7 @@
   &--user-card {
     height: @user-card-icon-size;
     width: @user-card-icon-size;
-    font-size: @user-card-icon-size / 2;
+    font-size: (@user-card-icon-size / 2);
     border-radius: 50%;
   }
 

--- a/resources/css/jquery-ui/slider.less
+++ b/resources/css/jquery-ui/slider.less
@@ -37,8 +37,8 @@
   height: @slider-height;
 
   .ui-slider-handle {
-    top: -(@slider-handle-height - @slider-height) / 2;
-    margin-left: -@slider-handle-width / 2;
+    top: (-(@slider-handle-height - @slider-height) / 2);
+    margin-left: (-@slider-handle-width / 2);
   }
 
   .ui-slider-range {

--- a/yarn.lock
+++ b/yarn.lock
@@ -3791,7 +3791,7 @@ iconv-lite@0.4.24:
   dependencies:
     safer-buffer ">= 2.1.2 < 3"
 
-iconv-lite@0.6:
+iconv-lite@0.6, iconv-lite@^0.6.3:
   version "0.6.3"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.6.3.tgz#a52f80bf38da1952eb5c681790719871a1a72501"
   integrity sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==
@@ -4668,20 +4668,21 @@ less-loader@^11.1.3:
   resolved "https://registry.yarnpkg.com/less-loader/-/less-loader-11.1.3.tgz#1bb62d6ca9bf00a177c02793b54baac40f9be694"
   integrity sha512-A5b7O8dH9xpxvkosNrP0dFp2i/dISOJa9WwGF3WJflfqIERE2ybxh1BFDj5CovC2+jCE4M354mk90hN6ziXlVw==
 
-less@^3.9.0:
-  version "3.13.1"
-  resolved "https://registry.yarnpkg.com/less/-/less-3.13.1.tgz#0ebc91d2a0e9c0c6735b83d496b0ab0583077909"
-  integrity sha512-SwA1aQXGUvp+P5XdZslUOhhLnClSLIjWvJhmd+Vgib5BFIr9lMNlQwmwUNOjXThF/A0x+MCYYPeWEfeWiLRnTw==
+less@^4.2.1:
+  version "4.2.1"
+  resolved "https://registry.yarnpkg.com/less/-/less-4.2.1.tgz#fe4c9848525ab44614c0cf2c00abd8d031bb619a"
+  integrity sha512-CasaJidTIhWmjcqv0Uj5vccMI7pJgfD9lMkKtlnTHAdJdYK/7l8pM9tumLyJ0zhbD4KJLo/YvTj+xznQd5NBhg==
   dependencies:
     copy-anything "^2.0.1"
-    tslib "^1.10.0"
+    parse-node-version "^1.0.1"
+    tslib "^2.3.0"
   optionalDependencies:
     errno "^0.1.1"
     graceful-fs "^4.1.2"
     image-size "~0.5.0"
     make-dir "^2.1.0"
     mime "^1.4.1"
-    native-request "^1.0.5"
+    needle "^3.1.0"
     source-map "~0.6.0"
 
 levn@^0.4.1:
@@ -5391,11 +5392,6 @@ nanomatch@^1.2.9:
     snapdragon "^0.8.1"
     to-regex "^3.0.1"
 
-native-request@^1.0.5:
-  version "1.0.8"
-  resolved "https://registry.yarnpkg.com/native-request/-/native-request-1.0.8.tgz#8f66bf606e0f7ea27c0e5995eb2f5d03e33ae6fb"
-  integrity sha512-vU2JojJVelUGp6jRcLwToPoWGxSx23z/0iX+I77J3Ht17rf2INGjrhOoQnjVo60nQd8wVsgzKkPfRXBiVdD2ag==
-
 natural-compare-lite@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/natural-compare-lite/-/natural-compare-lite-1.4.0.tgz#17b09581988979fddafe0201e931ba933c96cbb4"
@@ -5405,6 +5401,14 @@ natural-compare@^1.4.0:
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/natural-compare/-/natural-compare-1.4.0.tgz#4abebfeed7541f2c27acfb29bdbbd15c8d5ba4f7"
   integrity sha1-Sr6/7tdUHywnrPspvbvRXI1bpPc=
+
+needle@^3.1.0:
+  version "3.3.1"
+  resolved "https://registry.yarnpkg.com/needle/-/needle-3.3.1.tgz#63f75aec580c2e77e209f3f324e2cdf3d29bd049"
+  integrity sha512-6k0YULvhpw+RoLNiQCRKOl09Rv1dPLr8hHnVjHqdolKwDrdNyk+Hmrthi4lIGPPz3r39dLx0hsF5s40sZ3Us4Q==
+  dependencies:
+    iconv-lite "^0.6.3"
+    sax "^1.2.4"
 
 negotiator@0.6.2:
   version "0.6.2"
@@ -5751,6 +5755,11 @@ parse-json@^5.0.0, parse-json@^5.2.0:
     error-ex "^1.3.1"
     json-parse-even-better-errors "^2.3.0"
     lines-and-columns "^1.1.6"
+
+parse-node-version@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/parse-node-version/-/parse-node-version-1.0.1.tgz#e2b5dbede00e7fa9bc363607f53327e8b073189b"
+  integrity sha512-3YHlOa/JgH6Mnpr05jP9eDG254US9ek25LyIxZlDItp2iJtwyaXQb57lBYLdT3MowkUFYEV2XXNAYIPlESvJlA==
 
 parseurl@~1.3.3:
   version "1.3.3"
@@ -6627,6 +6636,11 @@ safe-regex@^1.1.0:
   resolved "https://registry.yarnpkg.com/safer-buffer/-/safer-buffer-2.1.2.tgz#44fa161b0187b9549dd84bb91802f9bd8385cd6a"
   integrity sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==
 
+sax@^1.2.4:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/sax/-/sax-1.4.1.tgz#44cc8988377f126304d3b3fc1010c733b929ef0f"
+  integrity sha512-+aWOz7yVScEGoKNd4PA10LZ8sk0A/z5+nXQG5giUO5rprX9jgYsTdov9qCchZiPIZezbZH+jRut8nPodFAX4Jg==
+
 scheduler@^0.20.2:
   version "0.20.2"
   resolved "https://registry.yarnpkg.com/scheduler/-/scheduler-0.20.2.tgz#4baee39436e34aa93b4874bddcbf0fe8b8b50e91"
@@ -7397,10 +7411,15 @@ tsconfig-paths@^3.9.0:
     minimist "^1.2.0"
     strip-bom "^3.0.0"
 
-tslib@^1.10.0, tslib@^1.8.1:
+tslib@^1.8.1:
   version "1.14.1"
   resolved "https://registry.yarnpkg.com/tslib/-/tslib-1.14.1.tgz#cf2d38bdc34a134bcaf1091c41f6619e2f672d00"
   integrity sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==
+
+tslib@^2.3.0:
+  version "2.8.1"
+  resolved "https://registry.yarnpkg.com/tslib/-/tslib-2.8.1.tgz#612efe4ed235d567e8aba5f2a5fab70280ade83f"
+  integrity sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==
 
 tsutils@^3.21.0:
   version "3.21.0"


### PR DESCRIPTION
I needed (maybe) css native `min()` somewhere else but it exploded on current version without a literal string workaround ಠ_ಠ

Tested by diffing each branch's output css.

There are a few existing `~"/"` and other workarounds which no longer needed but that's for another day...