### PR TITLE
Remove unnecessary process declaration

### DIFF
--- a/resources/js/globals.d.ts
+++ b/resources/js/globals.d.ts
@@ -35,18 +35,6 @@ interface Window {
 }
 // #endregion
 
-// #region interfaces for using process.env
-interface Process {
-  env: ProcessEnv;
-}
-
-interface ProcessEnv {
-  [key: string]: string | undefined;
-}
-
-declare const process: Process;
-// #endregion
-
 // our helpers
 declare const tooltipDefault: import('legacy-modules').TooltipDefault;
 


### PR DESCRIPTION
They are already defined in `@types/node` with the same `string | undefined` type.