### PR TITLE
Add link to own team from user popup menu

### DIFF
--- a/resources/lang/en/layout.php
+++ b/resources/lang/en/layout.php
@@ -201,6 +201,7 @@ return [
             'profile' => 'My Profile',
             'scoring_mode_toggle' => 'Classic scoring',
             'scoring_mode_toggle_tooltip' => 'Adjust score values to feel more like classic uncapped scoring',
+            'team' => 'My Team',
         ],
     ],
 

--- a/resources/views/layout/_popup_user.blade.php
+++ b/resources/views/layout/_popup_user.blade.php
@@ -31,6 +31,12 @@
         {{ osu_trans('layout.popup_user.links.profile') }}
     </a>
 
+    @if (($team = $currentUser->team) !== null)
+        <a class="simple-menu__item" href="{{ route('teams.show', $team) }}">
+            {{ osu_trans('layout.popup_user.links.team') }}
+        </a>
+    @endif
+
     <a class="simple-menu__item" href="{{ route('friends.index') }}">
         {{ osu_trans('layout.popup_user.links.friends') }}
     </a>


### PR DESCRIPTION
Seems useful? Dunno if "My Team" title makes sense here.

- [x] depends on #11721 because `->teamMembership` isn't as useful (even though in this case it should sufficient but the `->team` is used and loaded somewhere else)