### PR TITLE
Fix flag size on team page

### DIFF
--- a/resources/css/bem/profile-info.less
+++ b/resources/css/bem/profile-info.less
@@ -61,6 +61,7 @@
     align-self: flex-end;
     margin-bottom: var(--vertical-padding);
     background-image: var(--avatar);
+    background-size: contain;
     .default-box-shadow();
   }
 


### PR DESCRIPTION
I wonder if the image itself should be resized to 240x120 instead of 256x128 (or the avatar area should be of that size instead, which also integer scaled with current user avatar) ಠ_ಠ