### PR TITLE
Fix switching locale doesn't set js locale correctly

### DIFF
--- a/resources/views/layout/metadata.blade.php
+++ b/resources/views/layout/metadata.blade.php
@@ -96,9 +96,9 @@
 <script src="{{ unmix('js/runtime.js') }}" data-turbo-eval="false"></script>
 <script src="{{ unmix('js/vendor.js') }}" data-turbo-eval="false"></script>
 
-<script src="{{ unmix("js/locales/{$currentLocale}.js") }}" data-turbo-eval="false"></script>
+<script src="{{ unmix("js/locales/{$currentLocale}.js") }}" data-turbo-track="reload"></script>
 @if ($fallbackLocale !== $currentLocale)
-    <script src="{{ unmix("js/locales/{$fallbackLocale}.js") }}" data-turbo-eval="false"></script>
+    <script src="{{ unmix("js/locales/{$fallbackLocale}.js") }}" data-turbo-track="reload"></script>
 @endif
 
 <script src="{{ unmix('js/commons.js') }}" data-turbo-eval="false"></script>


### PR DESCRIPTION
Resolves #11707. Or maybe works around? There's currently no way to change js locale without full reload.