### PR TITLE
Add submission-relevant events to database via LIO endpoints

### DIFF
--- a/app/Http/Controllers/InterOp/BeatmapsetsController.php
+++ b/app/Http/Controllers/InterOp/BeatmapsetsController.php
@@ -6,7 +6,6 @@
 namespace App\Http\Controllers\InterOp;
 
 use App\Http\Controllers\Controller;
-use App\Http\Requests\Request;
 use App\Jobs\BeatmapsetDelete;
 use App\Jobs\Notifications\UserBeatmapsetNew;
 use App\Jobs\Notifications\UserBeatmapsetRevive;
@@ -24,8 +23,9 @@ class BeatmapsetsController extends Controller
 
         (new UserBeatmapsetNew($beatmapset))->dispatch();
 
-        if (api_version() >= 20241213)
+        if (request()->boolean('create_event')) {
             Event::generate('beatmapsetUpload', ['beatmapset' => $beatmapset]);
+        }
 
         return response(null, 204);
     }
@@ -36,8 +36,9 @@ class BeatmapsetsController extends Controller
 
         (new UserBeatmapsetRevive($beatmapset))->dispatch();
 
-        if (api_version() >= 20241213)
+        if (request()->boolean('create_event')) {
             Event::generate('beatmapsetRevive', ['beatmapset' => $beatmapset]);
+        }
 
         return response(null, 204);
     }

--- a/app/Models/Event.php
+++ b/app/Models/Event.php
@@ -125,10 +125,10 @@ class Event extends Model
                 $beatmapsetParams = static::beatmapsetParams($beatmapset);
                 $userParams = static::userParams($beatmapset->user);
 
-                $textClean = "[{$beatmapsetParams['url_clean']} {$beatmapsetParams['title']}] has been revived from eternal slumber by [{$userParams['url_clean']} {$userParams['username']}]";
+                $textClean = "[{$beatmapsetParams['url_clean']} {$beatmapsetParams['title']}] has been revived from eternal slumber by [{$userParams['url_clean']} {$userParams['username']}].";
 
                 $params = [
-                    'text' => "<a href='{$beatmapsetParams['url']}'>{$beatmapsetParams['title']}</a> has been revived from eternal slumber by <b><a href='{$userParams['url']}'>{$userParams['username']}</a></b>",
+                    'text' => "<a href='{$beatmapsetParams['url']}'>{$beatmapsetParams['title']}</a> has been revived from eternal slumber by <b><a href='{$userParams['url']}'>{$userParams['username']}</a></b>.",
                     'text_clean' => $textClean,
                     'beatmapset_id' => $beatmapset->getKey(),
                     'user_id' => $beatmapset->user->getKey(),
@@ -167,7 +167,7 @@ class Event extends Model
                 $textClean = "[{$userParams['url_clean']} {$userParams['username']}] has submitted a new beatmap [{$beatmapsetParams['url_clean']} {$beatmapsetParams['title']}]";
 
                 $params = [
-                    'text' => "<b><a href='{$userParams['url']}'>{$userParams['username']}</a></b> has submitted a new beatmap \"<a href='{$beatmapsetParams['url']}'>{$beatmapsetParams['title']}\"</a>",
+                    'text' => "<b><a href='{$userParams['url']}'>{$userParams['username']}</a></b> has submitted a new beatmap \"<a href='{$beatmapsetParams['url']}'>{$beatmapsetParams['title']}</a>\"",
                     'text_clean' => $textClean,
                     'beatmapset_id' => $beatmapset->getKey(),
                     'user_id' => $beatmapset->user->getKey(),

--- a/app/Models/Event.php
+++ b/app/Models/Event.php
@@ -92,11 +92,10 @@ class Event extends Model
                 $userParams = static::userParams($options['beatmapset']->user);
                 $approval = e($beatmapset->status());
 
-                $textClean = "[{$beatmapsetParams['url_clean']} {$beatmapsetParams['title']}] by [{$userParams['url_clean']} {$userParams['username']}] has just been {$approval}!";
-
+                $template = '%s by %s has just been %s!';
                 $params = [
-                    'text' => "<a href='{$beatmapsetParams['url']}'>{$beatmapsetParams['title']}</a> by <b><a href='{$userParams['url']}'>{$userParams['username']}</a></b> has just been {$approval}!",
-                    'text_clean' => $textClean,
+                    'text' => sprintf($template, "<a href='{$beatmapsetParams['url']}'>{$beatmapsetParams['title']}</a>", "<b><a href='{$userParams['url']}'>{$userParams['username']}</a></b>", $approval),
+                    'text_clean' => sprintf($template, "[{$beatmapsetParams['url_clean']} {$beatmapsetParams['title']}]", "[{$userParams['url_clean']} {$userParams['username']}]", $approval),
                     'beatmap_id' => 0,
                     'beatmapset_id' => $beatmapset->getKey(),
                     'user_id' => $beatmapset->user->getKey(),
@@ -125,11 +124,10 @@ class Event extends Model
                 $beatmapsetParams = static::beatmapsetParams($beatmapset);
                 $userParams = static::userParams($beatmapset->user);
 
-                $textClean = "[{$beatmapsetParams['url_clean']} {$beatmapsetParams['title']}] has been revived from eternal slumber by [{$userParams['url_clean']} {$userParams['username']}].";
-
+                $template = '%s has been revived from eternal slumber by %s.';
                 $params = [
-                    'text' => "<a href='{$beatmapsetParams['url']}'>{$beatmapsetParams['title']}</a> has been revived from eternal slumber by <b><a href='{$userParams['url']}'>{$userParams['username']}</a></b>.",
-                    'text_clean' => $textClean,
+                    'text' => sprintf($template, "<a href='{$beatmapsetParams['url']}'>{$beatmapsetParams['title']}</a>", "<b><a href='{$userParams['url']}'>{$userParams['username']}</a></b>"),
+                    'text_clean' => sprintf($template, "[{$beatmapsetParams['url_clean']} {$beatmapsetParams['title']}]", "[{$userParams['url_clean']} {$userParams['username']}]"),
                     'beatmapset_id' => $beatmapset->getKey(),
                     'user_id' => $beatmapset->user->getKey(),
                     'private' => false,
@@ -146,11 +144,10 @@ class Event extends Model
                 $user = $options['user'];
                 $userParams = static::userParams($user);
 
-                $textClean = "[{$userParams['url_clean']} {$userParams['username']}] has updated the beatmap [{$beatmapsetParams['url_clean']} {$beatmapsetParams['title']}]";
-
+                $template = '%s has updated the beatmap "%s"';
                 $params = [
-                    'text' => "<b><a href='{$userParams['url']}'>{$userParams['username']}</a></b> has updated the beatmap \"<a href='{$beatmapsetParams['url']}'>{$beatmapsetParams['title']}</a>\"",
-                    'text_clean' => $textClean,
+                    'text' => sprintf($template, "<b><a href='{$userParams['url']}'>{$userParams['username']}</a></b>", "<a href='{$beatmapsetParams['url']}'>{$beatmapsetParams['title']}</a>"),
+                    'text_clean' => sprintf($template, "[{$userParams['url_clean']} {$userParams['username']}]", "[{$beatmapsetParams['url_clean']} {$beatmapsetParams['title']}]"),
                     'beatmapset_id' => $beatmapset->getKey(),
                     'user_id' => $user->getKey(),
                     'private' => false,
@@ -164,11 +161,10 @@ class Event extends Model
                 $beatmapsetParams = static::beatmapsetParams($beatmapset);
                 $userParams = static::userParams($beatmapset->user);
 
-                $textClean = "[{$userParams['url_clean']} {$userParams['username']}] has submitted a new beatmap [{$beatmapsetParams['url_clean']} {$beatmapsetParams['title']}]";
-
+                $template = '%s has submitted a new beatmap "%s"';
                 $params = [
-                    'text' => "<b><a href='{$userParams['url']}'>{$userParams['username']}</a></b> has submitted a new beatmap \"<a href='{$beatmapsetParams['url']}'>{$beatmapsetParams['title']}</a>\"",
-                    'text_clean' => $textClean,
+                    'text' => sprintf($template, "<b><a href='{$userParams['url']}'>{$userParams['username']}</a></b>", "<a href='{$beatmapsetParams['url']}'>{$beatmapsetParams['title']}</a>"),
+                    'text_clean' => sprintf($template, "[{$userParams['url_clean']} {$userParams['username']}]", "[{$beatmapsetParams['url_clean']} {$beatmapsetParams['title']}]"),
                     'beatmapset_id' => $beatmapset->getKey(),
                     'user_id' => $beatmapset->user->getKey(),
                     'private' => false,

--- a/routes/web.php
+++ b/routes/web.php
@@ -588,6 +588,7 @@ Route::group(['prefix' => '_lio', 'middleware' => 'lio', 'as' => 'interop.'], fu
             Route::group(['prefix' => '{beatmapset}'], function () {
                 Route::post('broadcast-new', 'BeatmapsetsController@broadcastNew')->name('broadcast-new');
                 Route::post('broadcast-revive', 'BeatmapsetsController@broadcastRevive')->name('broadcast-revive');
+                Route::post('broadcast-update', 'BeatmapsetsController@broadcastUpdate')->name('broadcast-update');
                 Route::post('disqualify', 'BeatmapsetsController@disqualify')->name('disqualify');
             });
         });


### PR DESCRIPTION
RFC.

This is needed for new BSS. osu-web-10 originally would write rows to `osu_events` on new beatmap, on beatmap update, and on revive. I would normally just reimplement that in https://github.com/ppy/osu-server-beatmap-submission and call it a day, but the logic is annoying because it contains stuff like stripping tags and other html garbage that I really don't want to touch, and that web already has implemented, so I figured that I can just parasite off of the existing LIO calls that look vaguely relevant to do the job (and add another one for update I guess since that one didn't exist).

In order to avoid old BSS double-writing these event rows I made this conditional on `x-api-version` header. This is probably a war crime, but I figured I probably should not try and invent anything new. If you have better ideas then I'm all ears.

For cross-reference purposes:
- https://github.com/peppy/osu-web-10/blob/466291788ab74605ffd100a24a939c2dbd10ef4a/www/web/osu-osz2-bmsubmit-upload.php#L292-L298
- https://github.com/peppy/osu-web-10/blob/master/www/web/include.bmsubmit.php#L96