### PR TITLE
Require multiplayer api to join multiplayer room

### DIFF
--- a/app/Singletons/OsuAuthorize.php
+++ b/app/Singletons/OsuAuthorize.php
@@ -1027,7 +1027,7 @@ class OsuAuthorize
      * @return string
      * @throws AuthorizationCheckException
      */
-    public function checkChatChannelJoin(?User $user, Channel $channel): string
+    public function checkChatChannelJoin(?User $user, Channel $channel): ?string
     {
         $prefix = 'chat.';
 
@@ -1039,13 +1039,9 @@ class OsuAuthorize
 
         $this->ensureCleanRecord($user, $prefix);
 
-        // This check is only for when joining the channel directly; joining via the Room
-        // will always add the user to the channel.
+        // joining multiplayer room is done through room endpoint
         if ($channel->isMultiplayer()) {
-            $room = Room::hasParticipated($user)->find($channel->room_id);
-            if ($room !== null) {
-                return 'ok';
-            }
+            return null;
         }
 
         // allow joining of 'tournament' matches (for lazer/tournament client)

--- a/tests/Controllers/Chat/ChannelsControllerTest.php
+++ b/tests/Controllers/Chat/ChannelsControllerTest.php
@@ -205,7 +205,7 @@ class ChannelsControllerTest extends TestCase
             'user' => $this->user->getKey(),
         ]));
 
-        $request->assertStatus(200)->assertJsonFragment(['channel_id' => $scoreLink->playlistItem->room->channel_id, 'type' => Channel::TYPES['multiplayer']]);
+        $request->assertStatus(403);
     }
 
     //endregion


### PR DESCRIPTION
Mainly to disallow people from rejoining room after they're kicked and the room password changed. It also makes more sense because it should have same check as joining multiplayer room instead of generic chat room.

The downside is there's currently no way to join multiplayer room through other than client api but apparently we don't really want to support that at the moment? 🤷 @peppy 