### PR TITLE
Fix contest admin download

### DIFF
--- a/resources/views/admin/contests/show.blade.php
+++ b/resources/views/admin/contests/show.blade.php
@@ -39,6 +39,7 @@
                 <form
                     action="{{ route('admin.contests.get-zip', $contest->id) }}"
                     data-loading-overlay="0"
+                    data-turbo="false"
                     method="POST"
                 >
                     @csrf


### PR DESCRIPTION
Annoyingly there's no simple way to disable form-based download globally ಠ_ಠ

Resolves #11745