### PR TITLE
Explicit typescript types and rename webpack define const

### DIFF
--- a/resources/js/globals.d.ts
+++ b/resources/js/globals.d.ts
@@ -35,16 +35,8 @@ interface Window {
 }
 // #endregion
 
-// #region interfaces for using process.env
-interface Process {
-  env: ProcessEnv;
-}
-
-interface ProcessEnv {
-  [key: string]: string | undefined;
-}
-
-declare const process: Process;
+// #region defined through webpack DefinePlugin
+declare const docsUrl: string;
 // #endregion
 
 // our helpers

--- a/resources/js/legacy-api-key/form.tsx
+++ b/resources/js/legacy-api-key/form.tsx
@@ -72,7 +72,7 @@ export default class Form extends React.Component<Props> {
           <div>
             <StringWithComponent
               mappings={{ link: (
-                <a href={`${process.env.DOCS_URL}#terms-of-use`}>
+                <a href={`${docsUrl}#terms-of-use`}>
                   {trans('oauth.new_client.terms_of_use.link')}
                 </a>
               ) }}

--- a/resources/js/oauth/new-client.tsx
+++ b/resources/js/oauth/new-client.tsx
@@ -82,7 +82,7 @@ export class NewClient extends React.Component {
           <div>
             <StringWithComponent
               mappings={{ link: (
-                <a href={`${process.env.DOCS_URL}#terms-of-use`}>
+                <a href={`${docsUrl}#terms-of-use`}>
                   {trans('oauth.new_client.terms_of_use.link')}
                 </a>
               ) }}

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,6 +14,13 @@
     "strictNullChecks": true,
     "strictPropertyInitialization": true,
     "target": "es2015",
+    "types": [
+      "cloudflare-turnstile",
+      "jquery.fileupload",
+      "jquery.scrollto",
+      "jqueryui",
+      "timeago"
+    ],
     "useDefineForClassFields": true
   },
   "include": [

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -94,7 +94,7 @@ const plugins = [
     ReactDOM: 'react-dom',
   }),
   new webpack.DefinePlugin({
-    'process.env.DOCS_URL': JSON.stringify(process.env.DOCS_URL || 'https://docs.ppy.sh'),
+    docsUrl: JSON.stringify(process.env.DOCS_URL ?? 'https://docs.ppy.sh'),
   }),
   new webpack.IgnorePlugin({
     // don't add moment locales to bundle.


### PR DESCRIPTION
Alternative to #11726. I think those are the minimum set of explicit types config required.

Renamed the variable to reduce confusion as it's a preprocessing done through webpack and has nothing to do with node's `process.env`.

This also fixes typing for `setTimeout` and stuff without having to use `window.setTimeout`. I'm not updating them here though.