### PR TITLE
Add disband team button

### DIFF
--- a/app/Http/Controllers/TeamsController.php
+++ b/app/Http/Controllers/TeamsController.php
@@ -19,6 +19,17 @@ class TeamsController extends Controller
         $this->middleware('auth', ['only' => ['part']]);
     }
 
+    public function destroy(string $id): Response
+    {
+        $team = Team::findOrFail($id);
+        priv_check('TeamUpdate', $team)->ensureCan();
+
+        $team->delete();
+        \Session::flash('popup', osu_trans('teams.destroy.ok'));
+
+        return ujs_redirect(route('home'));
+    }
+
     public function edit(string $id): Response
     {
         $team = Team::findOrFail($id);

--- a/app/Models/Team.php
+++ b/app/Models/Team.php
@@ -76,6 +76,19 @@ class Team extends Model
             : bbcode((new BBCodeForDB($description))->generate());
     }
 
+    public function delete()
+    {
+        $ret = parent::delete();
+
+        if ($ret) {
+            $this->header()->delete();
+            $this->logo()->delete();
+            $this->members()->delete();
+        }
+
+        return $ret;
+    }
+
     public function header(): Uploader
     {
         return $this->header ??= new Uploader(

--- a/app/Models/Team.php
+++ b/app/Models/Team.php
@@ -78,15 +78,18 @@ class Team extends Model
 
     public function delete()
     {
-        $ret = parent::delete();
+        $this->header()->delete();
+        $this->logo()->delete();
 
-        if ($ret) {
-            $this->header()->delete();
-            $this->logo()->delete();
-            $this->members()->delete();
-        }
+        return $this->getConnection()->transaction(function () {
+            $ret = parent::delete();
 
-        return $ret;
+            if ($ret) {
+                $this->members()->delete();
+            }
+
+            return $ret;
+        });
     }
 
     public function header(): Uploader

--- a/resources/lang/en/teams.php
+++ b/resources/lang/en/teams.php
@@ -4,6 +4,10 @@
 // See the LICENCE file in the repository root for full licence text.
 
 return [
+    'destroy' => [
+        'ok' => 'Team removed',
+    ],
+
     'edit' => [
         'saved' => 'Settings saved successfully',
         'title' => 'Team Settings',
@@ -66,6 +70,7 @@ return [
 
     'show' => [
         'bar' => [
+            'destroy' => 'Disband Team',
             'part' => 'Leave Team',
         ],
 

--- a/resources/views/teams/show.blade.php
+++ b/resources/views/teams/show.blade.php
@@ -18,6 +18,9 @@
     if (priv_check('TeamPart', $team)->can()) {
         $buttons->add('part');
     }
+    if (priv_check('TeamUpdate', $team)->can()) {
+        $buttons->add('destroy');
+    }
 @endphp
 
 @extends('master', [
@@ -76,6 +79,18 @@
         </div>
         @if (!$buttons->isEmpty())
             <div class="profile-detail-bar profile-detail-bar--team">
+                @if ($buttons->contains('destroy'))
+                    <form
+                        action="{{ route('teams.destroy', $team) }}"
+                        data-turbo-confirm="{{ osu_trans('common.confirmation') }}"
+                        method="POST"
+                    >
+                        <input type="hidden" name="_method" value="DELETE">
+                        <button class="team-action-button team-action-button--part">
+                            {{ osu_trans('teams.show.bar.destroy') }}
+                        </button>
+                    </form>
+                @endif
                 @if ($buttons->contains('part'))
                     <form
                         action="{{ route('teams.part', ['team' => $team]) }}"

--- a/routes/web.php
+++ b/routes/web.php
@@ -300,7 +300,7 @@ Route::group(['middleware' => ['web']], function () {
         Route::post('part', 'TeamsController@part')->name('part');
         Route::resource('members', 'Teams\MembersController', ['only' => ['destroy', 'index']]);
     });
-    Route::resource('teams', 'TeamsController', ['only' => ['edit', 'show', 'update']]);
+    Route::resource('teams', 'TeamsController', ['only' => ['destroy', 'edit', 'show', 'update']]);
 
     Route::post('users/check-username-availability', 'UsersController@checkUsernameAvailability')->name('users.check-username-availability');
     Route::get('users/lookup', 'Users\LookupController@index')->name('users.lookup');

--- a/tests/Models/TeamTest.php
+++ b/tests/Models/TeamTest.php
@@ -23,7 +23,10 @@ class TeamTest extends TestCase
 
         $this->expectCountChange(fn () => Team::count(), -1);
         $this->expectCountChange(fn () => TeamMember::count(), -2);
+        $this->expectCountChange(fn () => $otherTeam->members()->count(), 0);
 
         $team->fresh()->delete();
+
+        $this->assertNotNull($otherTeam->fresh());
     }
 }

--- a/tests/Models/TeamTest.php
+++ b/tests/Models/TeamTest.php
@@ -1,0 +1,29 @@
+<?php
+
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
+declare(strict_types=1);
+
+namespace Tests\Models;
+
+use App\Models\Team;
+use App\Models\TeamMember;
+use App\Models\User;
+use Tests\TestCase;
+
+class TeamTest extends TestCase
+{
+    public function testDelete(): void
+    {
+        $team = Team::factory()->create();
+        $team->members()->create(['user_id' => User::factory()->create()->getKey()]);
+        $otherTeam = Team::factory()->create();
+        $otherTeam->members()->create(['user_id' => User::factory()->create()->getKey()]);
+
+        $this->expectCountChange(fn () => Team::count(), -1);
+        $this->expectCountChange(fn () => TeamMember::count(), -2);
+
+        $team->fresh()->delete();
+    }
+}


### PR DESCRIPTION
This PR should contain all the things involved in deleting a team 🤔 (well, in the sense of whatever implemented at the moment which doesn't include pending team application because the model doesn't exist yet and the team chat channel)

Which currently just involves deleting the team itself and related files and member entries ┐(ﾟヮﾟ)┌

Extra things I can think of:
1. requiring the team to be empty first (but why)
2. notifying the members