### PR TITLE
Exclude bot and no profile special groups from being set as guest mappers

### DIFF
--- a/app/Http/Controllers/Users/LookupController.php
+++ b/app/Http/Controllers/Users/LookupController.php
@@ -22,7 +22,12 @@ class LookupController extends Controller
     public function index()
     {
         // TODO: referer check?
-        $ids = array_slice(array_reject_null(get_arr(request('ids'), presence(...)) ?? []), 0, 50);
+        $params = get_params(request()->all(), null, [
+            'exclude_bots:bool',
+            'ids:string[]',
+        ]);
+
+        $ids = array_slice(array_reject_null(get_arr($params['ids'] ?? [], presence(...))), 0, 50);
 
         $numericIds = [];
         $stringIds = [];
@@ -35,12 +40,15 @@ class LookupController extends Controller
         }
 
         $users = User::where(fn ($q) => $q->whereIn('user_id', $numericIds)->orWhereIn('username', $stringIds))
-            ->defaultForLookup()
-            ->with(UserCompactTransformer::CARD_INCLUDES_PRELOAD)
-            ->get();
+            ->default()
+            ->with(UserCompactTransformer::CARD_INCLUDES_PRELOAD);
+
+        if ($params['exclude_bots'] ?? false) {
+            $users = $users->withoutBots();
+        }
 
         return [
-            'users' => json_collection($users, new UserCompactTransformer(), UserCompactTransformer::CARD_INCLUDES),
+            'users' => json_collection($users->get(), new UserCompactTransformer(), UserCompactTransformer::CARD_INCLUDES),
         ];
     }
 }

--- a/app/Http/Controllers/Users/LookupController.php
+++ b/app/Http/Controllers/Users/LookupController.php
@@ -35,8 +35,7 @@ class LookupController extends Controller
         }
 
         $users = User::where(fn ($q) => $q->whereIn('user_id', $numericIds)->orWhereIn('username', $stringIds))
-            ->where('group_id', '<>', app('groups')->byIdentifier('no_profile')->getKey())
-            ->default()
+            ->defaultForLookup()
             ->with(UserCompactTransformer::CARD_INCLUDES_PRELOAD)
             ->get();
 

--- a/app/Http/Controllers/Users/LookupController.php
+++ b/app/Http/Controllers/Users/LookupController.php
@@ -22,7 +22,7 @@ class LookupController extends Controller
     public function index()
     {
         // TODO: referer check?
-        $params = get_params(request()->all(), null, [
+        $params = get_params(\Request::all(), null, [
             'exclude_bots:bool',
             'ids:string[]',
         ]);

--- a/app/Http/Controllers/Users/LookupController.php
+++ b/app/Http/Controllers/Users/LookupController.php
@@ -41,6 +41,7 @@ class LookupController extends Controller
 
         $users = User::where(fn ($q) => $q->whereIn('user_id', $numericIds)->orWhereIn('username', $stringIds))
             ->default()
+            ->withoutNoProfile()
             ->with(UserCompactTransformer::CARD_INCLUDES_PRELOAD);
 
         if ($params['exclude_bots'] ?? false) {

--- a/app/Libraries/Beatmapset/ChangeBeatmapOwners.php
+++ b/app/Libraries/Beatmapset/ChangeBeatmapOwners.php
@@ -43,7 +43,7 @@ class ChangeBeatmapOwners
 
         $newUserIds = $this->userIds->diff($currentOwners);
 
-        if (User::whereIn('user_id', $newUserIds->toArray())->defaultForLookup()->count() !== $newUserIds->count()) {
+        if (User::whereIn('user_id', $newUserIds->toArray())->default()->withoutBots()->count() !== $newUserIds->count()) {
             throw new InvariantException('invalid user_id');
         }
 

--- a/app/Libraries/Beatmapset/ChangeBeatmapOwners.php
+++ b/app/Libraries/Beatmapset/ChangeBeatmapOwners.php
@@ -43,7 +43,7 @@ class ChangeBeatmapOwners
 
         $newUserIds = $this->userIds->diff($currentOwners);
 
-        if (User::whereIn('user_id', $newUserIds->toArray())->default()->withoutBots()->count() !== $newUserIds->count()) {
+        if (User::whereIn('user_id', $newUserIds->toArray())->default()->withoutBots()->withoutNoProfile()->count() !== $newUserIds->count()) {
             throw new InvariantException('invalid user_id');
         }
 

--- a/app/Libraries/Beatmapset/ChangeBeatmapOwners.php
+++ b/app/Libraries/Beatmapset/ChangeBeatmapOwners.php
@@ -43,7 +43,7 @@ class ChangeBeatmapOwners
 
         $newUserIds = $this->userIds->diff($currentOwners);
 
-        if (User::whereIn('user_id', $newUserIds->toArray())->default()->count() !== $newUserIds->count()) {
+        if (User::whereIn('user_id', $newUserIds->toArray())->defaultForLookup()->count() !== $newUserIds->count()) {
             throw new InvariantException('invalid user_id');
         }
 

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -2032,6 +2032,15 @@ class User extends Model implements AfterCommit, AuthenticatableContract, HasLoc
         ]);
     }
 
+    public function scopeDefaultForLookup(Builder $query): Builder
+    {
+        $groups = app('groups');
+
+        return $query
+            ->whereNotIn('group_id', [$groups->byIdentifier('no_profile')->getKey(), $groups->byIdentifier('bot')->getKey()])
+            ->default();
+    }
+
     public function scopeOnline($query)
     {
         return $query

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -2032,13 +2032,14 @@ class User extends Model implements AfterCommit, AuthenticatableContract, HasLoc
         ]);
     }
 
-    public function scopeDefaultForLookup(Builder $query): Builder
+    public function scopeWithoutBots(Builder $query): Builder
     {
         $groups = app('groups');
 
-        return $query
-            ->whereNotIn('group_id', [$groups->byIdentifier('no_profile')->getKey(), $groups->byIdentifier('bot')->getKey()])
-            ->default();
+        return $query->whereNotIn(
+            'group_id',
+            [$groups->byIdentifier('no_profile')->getKey(), $groups->byIdentifier('bot')->getKey()],
+        );
     }
 
     public function scopeOnline($query)

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -2032,21 +2032,21 @@ class User extends Model implements AfterCommit, AuthenticatableContract, HasLoc
         ]);
     }
 
-    public function scopeWithoutBots(Builder $query): Builder
-    {
-        $groups = app('groups');
-
-        return $query->whereNotIn(
-            'group_id',
-            [$groups->byIdentifier('no_profile')->getKey(), $groups->byIdentifier('bot')->getKey()],
-        );
-    }
-
     public function scopeOnline($query)
     {
         return $query
             ->where('user_allow_viewonline', true)
             ->where('user_lastvisit', '>', time() - $GLOBALS['cfg']['osu']['user']['online_window']);
+    }
+
+    public function scopeWithoutBots(Builder $query): Builder
+    {
+        return $query->whereNot('group_id', app('groups')->byIdentifier('bot')->getKey());
+    }
+
+    public function scopeWithoutNoProfile(Builder $query): Builder
+    {
+        return $query->whereNot('group_id', app('groups')->byIdentifier('no_profile')->getKey());
     }
 
     public function checkPassword($password)

--- a/resources/js/beatmap-discussions/beatmap-owner-editor.tsx
+++ b/resources/js/beatmap-discussions/beatmap-owner-editor.tsx
@@ -189,6 +189,7 @@ export default class BeatmapOwnerEditor extends React.Component<Props> {
         <div className={classWithModifiers('beatmap-owner-editor-owners', { editing: this.editing })}>
           {this.editing ? (
             <UsernameInput
+              excludeBots
               initialUsers={this.owners}
               // initialValue not set for owner editor as value is reset when cancelled.
               modifiers='beatmap-owner-editor'

--- a/resources/js/chat/create-announcement.tsx
+++ b/resources/js/chat/create-announcement.tsx
@@ -81,6 +81,7 @@ export default class CreateAnnouncement extends React.Component<Props> {
               <div className='chat-form-users'>
                 <UserCardBrick user={core.currentUserOrFail} />
                 <UsernameInput
+                  excludeBots
                   id='chat-form-users'
                   ignoreCurrentUser
                   name='users'

--- a/resources/js/components/username-input.tsx
+++ b/resources/js/components/username-input.tsx
@@ -15,6 +15,7 @@ import { Spinner } from './spinner';
 import UserCardBrick from './user-card-brick';
 
 interface Props {
+  excludeBots?: boolean;
   id?: string;
   ignoreCurrentUser?: boolean;
   initialUsers?: UserJson[];
@@ -166,7 +167,7 @@ export default class UsernameInput extends React.PureComponent<Props> {
     }
 
     try {
-      this.xhr = apiLookupUsers(userIds);
+      this.xhr = apiLookupUsers(userIds, this.props.excludeBots);
       const response = await this.xhr;
       this.extractValidUsers(response.users);
     } catch (error) {

--- a/resources/js/store/store-supporter-tag.tsx
+++ b/resources/js/store/store-supporter-tag.tsx
@@ -224,7 +224,7 @@ export default class StoreSupporterTag extends React.Component<Props> {
 
   @action
   private readonly getUser = (username: string) => {
-    this.xhr = apiLookupUsers([`@${username}`]);
+    this.xhr = apiLookupUsers([`@${username}`], true);
 
     this.xhr
       .done((response) => runInAction(() => {

--- a/resources/js/utils/user.ts
+++ b/resources/js/utils/user.ts
@@ -4,9 +4,9 @@
 import UserJson from 'interfaces/user-json';
 import { route } from 'laroute';
 
-export function apiLookupUsers(idsOrUsernames: (string | null | undefined)[]) {
+export function apiLookupUsers(idsOrUsernames: (string | null | undefined)[], excludeBots?: boolean) {
   return $.ajax(route('users.lookup'), {
-    data: { ids: idsOrUsernames },
+    data: { exclude_bots: excludeBots, ids: idsOrUsernames },
     dataType: 'json',
   }) as JQuery.jqXHR<{ users: UserJson[] }>;
 }


### PR DESCRIPTION
closes #11752

Also changes Chat Announcements and supporter tag gift lookups from the UI to exclude those groups, but I didn't change the actual check where those are applied yet.
