### PR TITLE
Rework score token validation

### DIFF
--- a/app/Http/Controllers/Multiplayer/Rooms/Playlist/ScoresController.php
+++ b/app/Http/Controllers/Multiplayer/Rooms/Playlist/ScoresController.php
@@ -5,7 +5,6 @@
 
 namespace App\Http\Controllers\Multiplayer\Rooms\Playlist;
 
-use App\Exceptions\InvariantException;
 use App\Http\Controllers\Controller as BaseController;
 use App\Libraries\ClientCheck;
 use App\Models\Multiplayer\PlaylistItem;
@@ -182,15 +181,10 @@ class ScoresController extends BaseController
         $playlistItem = $room->playlist()->findOrFail($playlistId);
         $user = \Auth::user();
         $request = \Request::instance();
-        $params = $request->all();
-
-        if (get_string($params['beatmap_hash'] ?? null) !== $playlistItem->beatmap->checksum) {
-            throw new InvariantException(osu_trans('score_tokens.create.beatmap_hash_invalid'));
-        }
 
         $buildId = ClientCheck::parseToken($request)['buildId'];
 
-        $scoreToken = $room->startPlay($user, $playlistItem, $buildId);
+        $scoreToken = $room->startPlay($user, $playlistItem, $buildId, $request->all());
 
         return json_item($scoreToken, new ScoreTokenTransformer());
     }

--- a/app/Http/Controllers/Multiplayer/Rooms/Playlist/ScoresController.php
+++ b/app/Http/Controllers/Multiplayer/Rooms/Playlist/ScoresController.php
@@ -182,9 +182,10 @@ class ScoresController extends BaseController
         $user = \Auth::user();
         $request = \Request::instance();
 
-        $buildId = ClientCheck::parseToken($request)['buildId'];
-
-        $scoreToken = $room->startPlay($user, $playlistItem, $buildId, $request->all());
+        $scoreToken = $room->startPlay($user, $playlistItem, [
+            ...$request->all(),
+            'build_id' => ClientCheck::parseToken($request)['buildId'],
+        ]);
 
         return json_item($scoreToken, new ScoreTokenTransformer());
     }

--- a/app/Http/Controllers/ScoreTokensController.php
+++ b/app/Http/Controllers/ScoreTokensController.php
@@ -30,11 +30,9 @@ class ScoreTokensController extends BaseController
         $user = auth()->user();
         $request = \Request::instance();
 
-        $buildId = ClientCheck::parseToken($request)['buildId'];
-
         $scoreToken = new ScoreToken([
             'beatmap_id' => $beatmap->getKey(),
-            'build_id' => $buildId,
+            'build_id' => ClientCheck::parseToken($request)['buildId'],
             'user_id' => $user->getKey(),
             ...get_params($request->all(), null, [
                 'beatmap_hash',

--- a/app/Http/Controllers/ScoreTokensController.php
+++ b/app/Http/Controllers/ScoreTokensController.php
@@ -29,33 +29,22 @@ class ScoreTokensController extends BaseController
         $beatmap = Beatmap::increasesStatistics()->findOrFail($beatmapId);
         $user = auth()->user();
         $request = \Request::instance();
-        $params = get_params($request->all(), null, [
-            'beatmap_hash',
-            'ruleset_id:int',
-        ]);
-
-        $checks = [
-            'beatmap_hash' => fn (string $value): bool => $value === $beatmap->checksum,
-            'ruleset_id' => fn (int $value): bool => Beatmap::modeStr($value) !== null && $beatmap->canBeConvertedTo($value),
-        ];
-        foreach ($checks as $key => $testFn) {
-            if (!isset($params[$key])) {
-                throw new InvariantException("missing {$key}");
-            }
-            if (!$testFn($params[$key])) {
-                throw new InvariantException("invalid {$key}");
-            }
-        }
 
         $buildId = ClientCheck::parseToken($request)['buildId'];
 
+        $scoreToken = new ScoreToken([
+            'beatmap_id' => $beatmap->getKey(),
+            'build_id' => $buildId,
+            'user_id' => $user->getKey(),
+            ...get_params($request->all(), null, [
+                'beatmap_hash',
+                'ruleset_id:int',
+            ]),
+        ]);
+        $scoreToken->setRelation('beatmap', $beatmap);
+
         try {
-            $scoreToken = ScoreToken::create([
-                'beatmap_id' => $beatmap->getKey(),
-                'build_id' => $buildId,
-                'ruleset_id' => $params['ruleset_id'],
-                'user_id' => $user->getKey(),
-            ]);
+            $scoreToken->saveOrExplode();
         } catch (PDOException $e) {
             // TODO: move this to be a validation inside Score model
             throw new InvariantException('failed creating score token');

--- a/app/Models/Multiplayer/Room.php
+++ b/app/Models/Multiplayer/Room.php
@@ -658,13 +658,13 @@ class Room extends Model
         $this->save();
     }
 
-    public function startPlay(User $user, PlaylistItem $playlistItem, int $buildId, array $rawParams): ScoreToken
+    public function startPlay(User $user, PlaylistItem $playlistItem, array $rawParams): ScoreToken
     {
         priv_check_user($user, 'MultiplayerScoreSubmit', $this)->ensureCan();
 
         $this->assertValidStartPlay($user, $playlistItem);
 
-        return $this->getConnection()->transaction(function () use ($buildId, $playlistItem, $rawParams, $user) {
+        return $this->getConnection()->transaction(function () use ($playlistItem, $rawParams, $user) {
             $agg = UserScoreAggregate::new($user, $this);
             if ($agg->wasRecentlyCreated) {
                 $this->incrementInstance('participant_count');
@@ -678,7 +678,7 @@ class Room extends Model
             return ScoreToken::create([
                 'beatmap_hash' => get_string($rawParams['beatmap_hash'] ?? null),
                 'beatmap_id' => $playlistItem->beatmap_id,
-                'build_id' => $buildId,
+                'build_id' => $rawParams['build_id'],
                 'playlist_item_id' => $playlistItem->getKey(),
                 'ruleset_id' => $playlistItem->ruleset_id,
                 'user_id' => $user->getKey(),

--- a/app/Models/Multiplayer/Room.php
+++ b/app/Models/Multiplayer/Room.php
@@ -658,13 +658,13 @@ class Room extends Model
         $this->save();
     }
 
-    public function startPlay(User $user, PlaylistItem $playlistItem, int $buildId)
+    public function startPlay(User $user, PlaylistItem $playlistItem, int $buildId, array $rawParams): ScoreToken
     {
         priv_check_user($user, 'MultiplayerScoreSubmit', $this)->ensureCan();
 
         $this->assertValidStartPlay($user, $playlistItem);
 
-        return $this->getConnection()->transaction(function () use ($buildId, $user, $playlistItem) {
+        return $this->getConnection()->transaction(function () use ($buildId, $playlistItem, $rawParams, $user) {
             $agg = UserScoreAggregate::new($user, $this);
             if ($agg->wasRecentlyCreated) {
                 $this->incrementInstance('participant_count');
@@ -676,6 +676,7 @@ class Room extends Model
             $playlistItemAgg->updateUserAttempts();
 
             return ScoreToken::create([
+                'beatmap_hash' => get_string($rawParams['beatmap_hash'] ?? null),
                 'beatmap_id' => $playlistItem->beatmap_id,
                 'build_id' => $buildId,
                 'playlist_item_id' => $playlistItem->getKey(),

--- a/app/Models/ScoreToken.php
+++ b/app/Models/ScoreToken.php
@@ -5,6 +5,7 @@
 
 namespace App\Models;
 
+use App\Exceptions\InvariantException;
 use App\Models\Multiplayer\PlaylistItem;
 use App\Models\Solo\Score;
 use Illuminate\Database\Eloquent\Relations\BelongsTo;
@@ -25,6 +26,8 @@ use Illuminate\Database\Eloquent\Relations\BelongsTo;
  */
 class ScoreToken extends Model
 {
+    public ?string $beatmapHash = null;
+
     public function beatmap()
     {
         return $this->belongsTo(Beatmap::class, 'beatmap_id');
@@ -73,5 +76,35 @@ class ScoreToken extends Model
             'score',
             'user' => $this->getRelationValue($key),
         };
+    }
+
+    public function setBeatmapHashAttribute(?string $value): void
+    {
+        $this->beatmapHash = $value;
+    }
+
+    public function assertValid(): void
+    {
+        $beatmap = $this->beatmap;
+        if ($this->beatmapHash !== $beatmap->checksum) {
+            throw new InvariantException(osu_trans('score_tokens.create.beatmap_hash_invalid'));
+        }
+
+        $rulesetId = $this->ruleset_id;
+        if ($rulesetId === null) {
+            throw new InvariantException('missing ruleset_id');
+        }
+        if (Beatmap::modeStr($rulesetId) === null || !$beatmap->canBeConvertedTo($rulesetId)) {
+            throw new InvariantException('invalid ruleset_id');
+        }
+    }
+
+    public function save(array $options = []): bool
+    {
+        if (!$this->exists) {
+            $this->assertValid();
+        }
+
+        return parent::save($options);
     }
 }

--- a/database/factories/ScoreTokenFactory.php
+++ b/database/factories/ScoreTokenFactory.php
@@ -23,7 +23,8 @@ class ScoreTokenFactory extends Factory
             'build_id' => Build::factory(),
             'user_id' => User::factory(),
 
-            // depends on beatmap_id
+            // depend on beatmap_id
+            'beatmap_hash' => fn (array $attr) => Beatmap::find($attr['beatmap_id'])->checksum,
             'ruleset_id' => fn (array $attr) => Beatmap::find($attr['beatmap_id'])->playmode,
         ];
     }

--- a/tests/Controllers/Multiplayer/Rooms/Playlist/ScoresControllerTest.php
+++ b/tests/Controllers/Multiplayer/Rooms/Playlist/ScoresControllerTest.php
@@ -169,7 +169,7 @@ class ScoresControllerTest extends TestCase
         $playlistItem = PlaylistItem::factory()->create();
         $room = $playlistItem->room;
         $build = Build::factory()->create(['allow_ranking' => true]);
-        $scoreToken = $room->startPlay($user, $playlistItem, 0);
+        $scoreToken = static::roomStartPlay($user, $playlistItem);
 
         $this->withHeaders(['x-token' => static::createClientToken($build)]);
 

--- a/tests/Controllers/ScoreTokensControllerTest.php
+++ b/tests/Controllers/ScoreTokensControllerTest.php
@@ -45,7 +45,7 @@ class ScoreTokensControllerTest extends TestCase
     /**
      * @dataProvider dataProviderForTestStoreInvalidParameter
      */
-    public function testStoreInvalidParameter(string $paramKey, ?string $paramValue, int $status): void
+    public function testStoreInvalidParameter(string $paramKey, ?string $paramValue, int $status, string $errorMessage): void
     {
         $origClientCheckVersion = $GLOBALS['cfg']['osu']['client']['check_version'];
         config_set('osu.client.check_version', true);
@@ -77,14 +77,6 @@ class ScoreTokensControllerTest extends TestCase
         ];
 
         $this->expectCountChange(fn () => ScoreToken::count(), 0);
-
-        $errorMessage = $paramValue === null ? 'missing' : 'invalid';
-        $errorMessage .= ' ';
-        $errorMessage .= $paramKey === 'client_token'
-            ? ($paramValue === null
-                ? 'token header'
-                : 'client hash'
-            ) : $paramKey;
 
         $this->json(
             'POST',
@@ -161,14 +153,14 @@ class ScoreTokensControllerTest extends TestCase
     public static function dataProviderForTestStoreInvalidParameter(): array
     {
         return [
-            'invalid client token' => ['client_token', md5('invalid_'), 422],
-            'missing client token' => ['client_token', null, 422],
+            'invalid client token' => ['client_token', md5('invalid_'), 422, 'invalid client hash'],
+            'missing client token' => ['client_token', null, 422, 'missing token header'],
 
-            'invalid ruleset id' => ['ruleset_id', '5', 422],
-            'missing ruleset id' => ['ruleset_id', null, 422],
+            'invalid ruleset id' => ['ruleset_id', '5', 422, 'invalid ruleset_id'],
+            'missing ruleset id' => ['ruleset_id', null, 422, 'missing ruleset_id'],
 
-            'invalid beatmap hash' => ['beatmap_hash', 'xxx', 422],
-            'missing beatmap hash' => ['beatmap_hash', null, 422],
+            'invalid beatmap hash' => ['beatmap_hash', 'xxx', 422, 'invalid or missing beatmap_hash'],
+            'missing beatmap hash' => ['beatmap_hash', null, 422, 'invalid or missing beatmap_hash'],
         ];
     }
 

--- a/tests/Models/Multiplayer/RoomTest.php
+++ b/tests/Models/Multiplayer/RoomTest.php
@@ -124,7 +124,7 @@ class RoomTest extends TestCase
         ]);
 
         $this->expectException(InvariantException::class);
-        $room->startPlay($user, $playlistItem, 0);
+        static::roomStartPlay($user, $playlistItem);
     }
 
     public function testStartPlay(): void
@@ -137,7 +137,7 @@ class RoomTest extends TestCase
         $this->expectCountChange(fn () => $room->userHighScores()->count(), 1);
         $this->expectCountChange(fn () => $playlistItem->scoreTokens()->count(), 1);
 
-        $room->startPlay($user, $playlistItem, 0);
+        static::roomStartPlay($user, $playlistItem);
         $room->refresh();
 
         $this->assertSame($user->getKey(), $playlistItem->scoreTokens()->last()->user_id);
@@ -150,14 +150,14 @@ class RoomTest extends TestCase
         $playlistItem1 = PlaylistItem::factory()->create(['room_id' => $room]);
         $playlistItem2 = PlaylistItem::factory()->create(['room_id' => $room]);
 
-        $room->startPlay($user, $playlistItem1, 0);
+        static::roomStartPlay($user, $playlistItem1);
         $this->assertTrue(true);
 
-        $room->startPlay($user, $playlistItem2, 0);
+        static::roomStartPlay($user, $playlistItem2);
         $this->assertTrue(true);
 
         $this->expectException(InvariantException::class);
-        $room->startPlay($user, $playlistItem1, 0);
+        static::roomStartPlay($user, $playlistItem1);
     }
 
     public function testMaxAttemptsForItemReached()
@@ -174,19 +174,19 @@ class RoomTest extends TestCase
         ]);
 
         $initialCount = $playlistItem1->scoreTokens()->count();
-        $room->startPlay($user, $playlistItem1, 0);
+        static::roomStartPlay($user, $playlistItem1);
         $this->assertSame($initialCount + 1, $playlistItem1->scoreTokens()->count());
 
         $initialCount = $playlistItem1->scoreTokens()->count();
         try {
-            $room->startPlay($user, $playlistItem1, 0);
+            static::roomStartPlay($user, $playlistItem1);
         } catch (Exception $ex) {
             $this->assertTrue($ex instanceof InvariantException);
         }
         $this->assertSame($initialCount, $playlistItem1->scoreTokens()->count());
 
         $initialCount = $playlistItem2->scoreTokens()->count();
-        $room->startPlay($user, $playlistItem2, 0);
+        static::roomStartPlay($user, $playlistItem2);
         $this->assertSame($initialCount + 1, $playlistItem2->scoreTokens()->count());
     }
 

--- a/tests/Models/Multiplayer/UserScoreAggregateTest.php
+++ b/tests/Models/Multiplayer/UserScoreAggregateTest.php
@@ -173,7 +173,7 @@ class UserScoreAggregateTest extends TestCase
         $user = User::factory()->create();
         $playlistItem = $this->createPlaylistItem();
 
-        $this->room->startPlay($user, $playlistItem, 0);
+        static::roomStartPlay($user, $playlistItem);
         $agg = UserScoreAggregate::new($user, $this->room);
 
         $this->assertSame(1, $agg->attempts);

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -16,6 +16,7 @@ use App\Models\Build;
 use App\Models\Multiplayer\PlaylistItem;
 use App\Models\Multiplayer\ScoreLink;
 use App\Models\OAuth\Client;
+use App\Models\ScoreToken;
 use App\Models\User;
 use Artisan;
 use Carbon\CarbonInterface;
@@ -111,7 +112,7 @@ class TestCase extends BaseTestCase
     protected static function roomAddPlay(User $user, PlaylistItem $playlistItem, array $scoreParams): ScoreLink
     {
         return $playlistItem->room->completePlay(
-            $playlistItem->room->startPlay($user, $playlistItem, 0),
+            static::roomStartPlay($user, $playlistItem),
             [
                 'accuracy' => 0.5,
                 'beatmap_id' => $playlistItem->beatmap_id,
@@ -123,6 +124,16 @@ class TestCase extends BaseTestCase
                 'user_id' => $user->getKey(),
                 ...$scoreParams,
             ],
+        );
+    }
+
+    protected static function roomStartPlay(User $user, PlaylistItem $playlistItem): ScoreToken
+    {
+        return $playlistItem->room->startPlay(
+            $user,
+            $playlistItem,
+            0,
+            ['beatmap_hash' => $playlistItem->beatmap->checksum]
         );
     }
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -129,12 +129,10 @@ class TestCase extends BaseTestCase
 
     protected static function roomStartPlay(User $user, PlaylistItem $playlistItem): ScoreToken
     {
-        return $playlistItem->room->startPlay(
-            $user,
-            $playlistItem,
-            0,
-            ['beatmap_hash' => $playlistItem->beatmap->checksum]
-        );
+        return $playlistItem->room->startPlay($user, $playlistItem, [
+            'beatmap_hash' => $playlistItem->beatmap->checksum,
+            'build_id' => 0,
+        ]);
     }
 
     protected function setUp(): void


### PR DESCRIPTION
Combining hash and ruleset validation in the token model itself. build id stays as is because it's quite a bit more involved.

The way `beatmap_hash` is passed and validated is rather questionable 👀 