### PR TITLE
Add Docker User Mirror

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -103,13 +103,14 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Services
-        run: './user-mirror docker compose up --wait
+        run: './user-mirror docker compose up --quiet-pull --wait
           beatmap-difficulty-lookup-cache
           db
           elasticsearch
           notification-server
           redis
-          score-indexer'
+          score-indexer
+          '
 
       - name: Setup node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -106,7 +106,8 @@ jobs:
         run: |
           ./user-mirror docker compose up --wait --wait-timeout 600; \
           sleep 10 && \
-          [ $(docker compose ps --status exited --format '{{if ne .ExitCode 0}}{{.Name}}\t{{.ExitCode}}{{end}}' | awk NF | wc -l) -eq 0 ] && docker compose down
+          [ $(docker compose ps --status exited --format '{{if ne .ExitCode 0}}{{.Name}}\t{{.ExitCode}}{{end}}' | awk NF | wc -l) -eq 0 ] && \
+          docker compose down
 
   tests:
     strategy:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -92,23 +92,6 @@ env:
   SLACK_ENDPOINT: https://myconan.net/null/
 
 jobs:
-  docker-dev-test:
-    name: Docker Dev Test
-    runs-on: ubuntu-latest
-    steps:
-      - name: Checkout
-        uses: actions/checkout@v4
-      
-      - name: Run prepare.sh
-        run: ./docker/development/prepare.sh
-      
-      - name: Run docker compose up
-        run: |
-          ./user-mirror docker compose up --wait --wait-timeout 600; \
-          sleep 10 && \
-          [ $(docker compose ps --status exited --format '{{if ne .ExitCode 0}}{{.Name}}\t{{.ExitCode}}{{end}}' | awk NF | wc -l) -eq 0 ] && \
-          docker compose down
-
   tests:
     strategy:
       matrix:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -109,8 +109,7 @@ jobs:
           elasticsearch
           notification-server
           redis
-          score-indexer
-        '
+          score-indexer'
 
       - name: Setup node.js
         uses: actions/setup-node@v4

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -92,6 +92,22 @@ env:
   SLACK_ENDPOINT: https://myconan.net/null/
 
 jobs:
+  docker-dev-test:
+    name: Docker Dev Test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      
+      - name: Run prepare.sh
+        run: ./docker/development/prepare.sh
+      
+      - name: Run docker compose up
+        run: |
+          ./user-mirror docker compose up --wait --wait-timeout 600; \
+          sleep 10 && \
+          [ $(docker compose ps --status exited --format '{{if ne .ExitCode 0}}{{.Name}}\t{{.ExitCode}}{{end}}' | awk NF | wc -l) -eq 0 ] && docker compose down
+
   tests:
     strategy:
       matrix:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -103,7 +103,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Services
-        run: './user-mirror docker compose up --quiet-pull --wait
+        run: './user-mirror docker compose up --wait
           beatmap-difficulty-lookup-cache
           db
           elasticsearch

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -103,7 +103,7 @@ jobs:
         uses: actions/checkout@v4
 
       - name: Services
-        run: 'docker compose up --quiet-pull --wait
+        run: './user-mirror docker compose up --quiet-pull --wait
           beatmap-difficulty-lookup-cache
           db
           elasticsearch

--- a/Dockerfile.development
+++ b/Dockerfile.development
@@ -46,5 +46,5 @@ ARG GOSU_VERSION=1.17
 ARG SETPRIV_VERSION=2.40.1
 ARG UTIL_LINUX_VERSION=2.39.3
 RUN chmod +x /entrypoint && /entrypoint --setup --verbose
-ENTRYPOINT ["/entrypoint", "--", "/app/docker/development/entrypoint.sh"]
+ENTRYPOINT ["/entrypoint", "--", "./docker/development/run.sh"]
 CMD ["octane"]

--- a/Dockerfile.development
+++ b/Dockerfile.development
@@ -15,7 +15,6 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get install -y \
     chromium-driver \
     default-mysql-client \
     git \
-    gosu \
     jhead \
     nodejs \
     php8.3 \
@@ -47,4 +46,5 @@ ARG GOSU_VERSION=1.17
 ARG SETPRIV_VERSION=2.40.1
 ARG UTIL_LINUX_VERSION=2.39.3
 RUN chmod +x /entrypoint && /entrypoint --debug --setup
-ENTRYPOINT ["/entrypoint", "--"]
+ENTRYPOINT ["/entrypoint", "--", "/app/docker/development/entrypoint.sh"]
+CMD ["octane"]

--- a/Dockerfile.development
+++ b/Dockerfile.development
@@ -45,6 +45,6 @@ COPY entrypoint.sh /entrypoint
 ARG GOSU_VERSION=1.17
 ARG SETPRIV_VERSION=2.40.1
 ARG UTIL_LINUX_VERSION=2.39.3
-RUN chmod +x /entrypoint && /entrypoint --debug --setup
+RUN chmod +x /entrypoint && /entrypoint --setup --verbose
 ENTRYPOINT ["/entrypoint", "--", "/app/docker/development/entrypoint.sh"]
 CMD ["octane"]

--- a/Dockerfile.development
+++ b/Dockerfile.development
@@ -46,5 +46,5 @@ COPY entrypoint.sh /entrypoint
 ARG GOSU_VERSION=1.17
 ARG SETPRIV_VERSION=2.40.1
 ARG UTIL_LINUX_VERSION=2.39.3
-RUN chmod +x /entrypoint && /entrypoint --setup
+RUN chmod +x /entrypoint && /entrypoint --debug --setup
 ENTRYPOINT ["/entrypoint", "--"]

--- a/Dockerfile.development
+++ b/Dockerfile.development
@@ -42,7 +42,9 @@ COPY chromium /usr/bin/
 
 WORKDIR /app
 
-RUN groupadd osuweb && useradd -g osuweb -d /app/.docker osuweb
-
-ENTRYPOINT ["/app/docker/development/entrypoint.sh"]
-CMD ["octane"]
+COPY entrypoint.sh /entrypoint
+ARG GOSU_VERSION=1.17
+ARG SETPRIV_VERSION=2.40.1
+ARG UTIL_LINUX_VERSION=2.39.3
+RUN chmod +x /entrypoint && /entrypoint --setup
+ENTRYPOINT ["/entrypoint", "--"]

--- a/bin/docker_dev.sh
+++ b/bin/docker_dev.sh
@@ -2,4 +2,4 @@
 
 cd "$(dirname "$0")/.."
 
-./docker/development/prepare.sh && exec docker compose up "$@"
+./docker/development/prepare.sh && ./user-mirror docker compose up "$@"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,7 @@ x-web: &x-web
   build:
     context: ./docker/development
     dockerfile: ../../Dockerfile.development
-  entrypoint: [/entrypoint, --, osuweb, ./docker/development/run.sh]
+  entrypoint: [/entrypoint, --debug, --, osuweb, ./docker/development/run.sh]
   command: [octane]
   init: true
   volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,9 +38,6 @@ services:
   php:
     <<: *x-web
     command: ['octane', '--watch']
-    depends_on:
-      assets:
-        condition: service_healthy
     deploy:
       restart_policy:
         condition: on-failure
@@ -54,14 +51,16 @@ services:
       APP_ENV: dusk.local
       OCTANE_STATE_FILE: /tmp/octane-state.json
 
+  dev:
+    <<: *x-web
+    command: ['yarn', 'dev']
+
   assets:
     <<: *x-web
     command: ['watch']
-    healthcheck:
-      test: ["CMD", "sh", "-c", "[ $(find public/assets -maxdepth 1 -mindepth 1 | wc -l) -ge 5 ]"]
-      timeout: 3s
-      start_interval: 1s
-      start_period: 20s
+    depends_on:
+      dev:
+        condition: service_completed_successfully
 
   job:
     <<: *x-web

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,8 +21,6 @@ x-web: &x-web
   build:
     context: ./docker/development
     dockerfile: ../../Dockerfile.development
-  entrypoint: [/entrypoint, --debug, --, ./docker/development/run.sh]
-  command: [octane]
   init: true
   volumes:
     - .:/app

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -15,6 +15,8 @@ x-web: &x-web
   build:
     context: ./docker/development
     dockerfile: ../../Dockerfile.development
+  entrypoint: [/entrypoint, --, osuweb, ./docker/development/run.sh]
+  command: [octane]
   init: true
   volumes:
     - .:/app

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,11 +2,17 @@ x-env: &x-env
   APP_KEY: "${APP_KEY}"
   BEATMAPS_DIFFICULTY_CACHE_SERVER_URL: http://beatmap-difficulty-lookup-cache:8080
   BROADCAST_DRIVER: redis
+  CAPABILITIES: # setpriv --bounding-set options. Must be a subset of cap_add. See https://www.man7.org/linux/man-pages/man1/setpriv.1.html#OPTIONS
+  CHOWN_LIST: # Set by Docker User Mirror
   DB_CONNECTION_STRING: Server=db;Database=osu;Uid=osuweb;
   DB_HOST: db
   ES_HOST: http://elasticsearch:9200
   ES_SOLO_SCORES_HOST: http://elasticsearch:9200
   GITHUB_TOKEN: "${GITHUB_TOKEN}"
+  HOST_MAPPED_GROUP: # Set by Docker User Mirror
+  HOST_MAPPED_GID: # Set by Docker User Mirror
+  HOST_MAPPED_USER: # Set by Docker User Mirror
+  HOST_MAPPED_UID: # Set by Docker User Mirror
   NOTIFICATION_REDIS_HOST: redis
   PASSPORT_PUBLIC_KEY: "${PASSPORT_PUBLIC_KEY:-}"
   REDIS_HOST: redis
@@ -20,6 +26,13 @@ x-web: &x-web
   init: true
   volumes:
     - .:/app
+  cap_add:
+    # Minimum permissions for Docker User Mirror entrypoint:
+    - CAP_SETGID # Needed to switch from root to another user.
+    - CAP_SETUID # Needed to switch from root to another user.
+    - CAP_SETPCAP # Needed to change permissions when switching users.
+    - CAP_CHOWN # Needed to write changes to /etc/gshadow and /etc/shadow.
+    - CAP_DAC_OVERRIDE # Needed for Podman.
   environment:
     <<: *x-env
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,7 +21,7 @@ x-web: &x-web
   build:
     context: ./docker/development
     dockerfile: ../../Dockerfile.development
-  entrypoint: [/entrypoint, --debug, --, osuweb, ./docker/development/run.sh]
+  entrypoint: [/entrypoint, --debug, --, ./docker/development/run.sh]
   command: [octane]
   init: true
   volumes:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -38,6 +38,9 @@ services:
   php:
     <<: *x-web
     command: ['octane', '--watch']
+    depends_on:
+      assets:
+        condition: service_healthy
     deploy:
       restart_policy:
         condition: on-failure
@@ -54,6 +57,11 @@ services:
   assets:
     <<: *x-web
     command: ['watch']
+    healthcheck:
+      test: ["CMD", "sh", "-c", "[ $(find public/assets -maxdepth 1 -mindepth 1 | wc -l) -ge 5 ]"]
+      timeout: 3s
+      start_interval: 1s
+      start_period: 20s
 
   job:
     <<: *x-web

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -51,16 +51,9 @@ services:
       APP_ENV: dusk.local
       OCTANE_STATE_FILE: /tmp/octane-state.json
 
-  dev:
-    <<: *x-web
-    command: ['yarn', 'dev']
-
   assets:
     <<: *x-web
     command: ['watch']
-    depends_on:
-      dev:
-        condition: service_completed_successfully
 
   job:
     <<: *x-web

--- a/docker/development/entrypoint.sh
+++ b/docker/development/entrypoint.sh
@@ -285,7 +285,7 @@ else
 
     # Set the ownership of a set of items to the user.
     if [ -n "$CHOWN_LIST" ]; then
-        echo "$CHOWN_LIST" | xargs chown -c "$HOST_MAPPED_UID:$HOST_MAPPED_GID" >&3;
+        echo "$CHOWN_LIST" | xargs chown -c "$HOST_MAPPED_UID:$HOST_MAPPED_GID" >&3 | true;
     fi
 
     # Execute using $HOST_MAPPED_UID.

--- a/docker/development/entrypoint.sh
+++ b/docker/development/entrypoint.sh
@@ -3,8 +3,9 @@
 # License: MIT
 set -eC;
 
-VERSION='0.0.19-072e903';
+VERSION='0.0.20-7d4d3c6';
 exec 3>/dev/null;
+exec 4>/dev/null;
 
 check_gosu() {
     command -v gosu && \
@@ -124,16 +125,15 @@ version_to_release_tag() {
 # Parse options.
 while [ $# -gt 0 ]; do
     case $1 in
-        --debug)
-            exec 3>&1;
-            exec 4>&2;
-            ;;
         --setup)
-            exec 3>&1;
             o_setup=true;
             ;;
         --update)
             o_update=true;
+            ;;
+        --verbose)
+            exec 3>&1;
+            exec 4>&2;
             ;;
         --version)
             echo "Version: ${VERSION}";
@@ -286,7 +286,7 @@ else
 
     # Set the ownership of a set of items to the user.
     if [ -n "$CHOWN_LIST" ]; then
-        echo "$CHOWN_LIST" | xargs chown -c "$HOST_MAPPED_UID:$HOST_MAPPED_GID" >&3 2>&4 | true;
+        echo "$CHOWN_LIST" | xargs chown -c "$HOST_MAPPED_UID:$HOST_MAPPED_GID" >&3 2>&4 || true;
     fi
 
     # Execute using $HOST_MAPPED_UID.

--- a/docker/development/entrypoint.sh
+++ b/docker/development/entrypoint.sh
@@ -1,13 +1,308 @@
 #!/bin/sh
+# Source: https://github.com/AJGranowski/docker-user-mirror
+# License: MIT
+set -eC;
 
-uid=$(stat -c "%u" .)
-gid=$(stat -c "%g" .)
+VERSION='0.0.19-072e903';
+exec 3>/dev/null;
 
-if [ "$uid" != 0 ]; then
-    usermod -u "$uid" -o osuweb > /dev/null
-    groupmod -g "$gid" -o osuweb > /dev/null
+check_gosu() {
+    command -v gosu && \
+    gosu --version && \
+    gosu nobody true;
+}
+
+check_setpriv() {
+    command -v setpriv && \
+    setpriv --version && \
+    setpriv --reuid="$(id -u nobody)" --regid="$(id -g nobody)" --clear-groups true;
+}
+
+# Download a release file.
+# Args: release filename, output filename, release tag (defaults to latest release it not provided)
+download_file() {
+    if [ $# -eq 3 ]; then
+        curl --fail -Ls -o "$2" "https://github.com/AJGranowski/docker-user-mirror/releases/download/$3/$1";
+    elif [ $# -eq 2 ]; then
+        curl --fail -Ls -o "$2" "https://github.com/AJGranowski/docker-user-mirror/releases/latest/download/$1";
+    else
+        echo 'Expected at least two arguments.' >&2;
+        return 1;
+    fi
+}
+
+# Query GitHub for the latest release tag.
+get_latest_release_tag() {
+    response="$(curl -Ls -w '%{http_code}' 'https://api.github.com/repos/AJGranowski/docker-user-mirror/releases/latest')";
+    case "$(echo "$response" | tail -1)" in
+        2*)
+            echo "$response" | \
+            grep -E '^\s*"tag_name":' | \
+            sed -E 's/.*"tag_name": "([^"]+)".*/\1/g'
+        ;;
+        *) false;;
+    esac
+}
+
+# Get the version ID of a release.
+# Args: release tag (defaults to latest release it not provided)
+get_release_version() {
+    if [ $# -eq 0 ]; then
+        response="$(curl -Ls -w '\n%{http_code}' 'https://github.com/AJGranowski/docker-user-mirror/releases/latest/download/version')";
+    else
+        response="$(curl -Ls -w '\n%{http_code}' "https://github.com/AJGranowski/docker-user-mirror/releases/download/$1/version")";
+    fi
+
+    case "$(echo "$response" | tail -1)" in
+        2*)
+            echo "$response" | head -1
+            ;;
+        *) false;;
+    esac
+}
+
+print_user() {
+    grep -e "^$1:" /etc/passwd;
+}
+
+# Query GitHub to check if a release tag exists.
+release_tag_exists() {
+    case "$(curl -Ls -o /dev/null -w '%{http_code}' "https://api.github.com/repos/AJGranowski/docker-user-mirror/releases/tags/$1")" in
+        2*) true;;
+        *) false;;
+    esac
+}
+
+# Check for updates, and download the latest version.
+update() {
+    if ! latest_version="$(get_release_version)"; then
+        echo 'Unable to fetch the latest version. Try again in a few minutes.' >&2;
+        return 1;
+    fi
+
+    if [ "$VERSION" = "$latest_version" ]; then
+        echo 'Up to date.';
+    else
+        if ! release_tag_exists "$(version_to_release_tag)"; then
+            echo 'Critical update required!';
+            echo '    This version has been deleted, signaling either a critical bug or vulnerability. Update immediately.'
+        else
+            echo 'New update available.'
+        fi
+    fi
+
+    echo "    Current version: $VERSION";
+    echo "    Latest version:  $latest_version";
+
+    if [ "$VERSION" = "$latest_version" ]; then
+        return 0;
+    fi
+
+    if [ "$o_yes" != true ]; then
+        echo '\nInstall the update? (y/n)';
+        read yn;
+        case $yn in
+            y*) ;;
+            n*) return 0;;
+        esac
+    fi
+
+    echo 'Installing update...';
+    download_file 'entrypoint' "${0}.tmp";
+    mv "${0}.tmp" "$0" && echo "${latest_version} installed!"; exit 0;
+}
+
+# Convert "$VERSION" to "release-**" format.
+version_to_release_tag() {
+    if [ $# -eq 0 ]; then
+        echo "$VERSION" | sed -E 's/([^-]*).*/release-\1/g'
+    else
+        echo "$1" | sed -E 's/([^-]*).*/release-\1/g'
+    fi
+}
+
+# Parse options.
+while [ $# -gt 0 ]; do
+    case $1 in
+        --debug)
+            exec 3>&1;
+            ;;
+        --setup)
+            exec 3>&1;
+            o_setup=true;
+            ;;
+        --update)
+            o_update=true;
+            ;;
+        --version)
+            echo "Version: ${VERSION}";
+            exit 0;
+            ;;
+        -y|--yes)
+            o_yes=true;
+            ;;
+        --)
+            shift;
+            break;
+            ;;
+        *)
+            break;
+            ;;
+    esac
+    shift;
+done
+
+if [ "$o_update" = true ]; then
+    if update; then
+        exit 0;
+    else
+        exit 1;
+    fi
 fi
 
-chown -f "${uid}:${gid}" .docker/js-build/assets .docker/js-build/builds
+if [ "$o_setup" = true ]; then
+    set -euxC;
 
-exec gosu osuweb ./docker/development/run.sh "$@"
+    if ! check_setpriv >/dev/null 2>&1; then
+        echo 'setpriv is not installed or is out of date. Attempting to install setpriv...';
+
+        # Attempt to install setpriv with apk.
+        if (apk update && apk -s add setpriv) >/dev/null 2>&1; then
+            apk add --no-cache "setpriv>=$SETPRIV_VERSION";
+            hash -r;
+            check_setpriv;
+            echo 'setpriv installed!';
+
+        # Attempt to install setpriv from util-linux with apt-get.
+        elif (apt-get update && apt-get install --dry-run util-linux) >/dev/null 2>&1; then
+            apt-get satisfy --no-install-recommends -y "util-linux (>=$UTIL_LINUX_VERSION)";
+            hash -r;
+            check_setpriv;
+            echo 'setpriv installed!';
+
+        # Attempt to install gosu as a fallback.
+        elif ! check_gosu >/dev/null 2>&1; then
+            echo 'gosu is not installed or is out of date. Attempting to install gosu...';
+
+            unameArch="$(uname -m)";
+            case "$unameArch" in
+                aarch64) dpkgArch='arm64' ;;
+                armv[67]*) dpkgArch='armhf' ;;
+                i[3456]86) dpkgArch='i386' ;;
+                ppc64le) dpkgArch='ppc64el' ;;
+                riscv64 | s390x) dpkgArch="$unameArch" ;;
+                x86_64) dpkgArch='amd64' ;;
+                *) echo >&2 "error: unknown/unsupported architecture '$unameArch'"; exit 1 ;;
+            esac
+
+            mkdir -p /usr/local/bin/;
+            wget -O /usr/local/bin/gosu "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch";
+            wget -O /usr/local/bin/gosu.asc "https://github.com/tianon/gosu/releases/download/$GOSU_VERSION/gosu-$dpkgArch.asc";
+
+            GNUPGHOME="$(mktemp -d)";
+            if command -v gpg >/dev/null; then
+                gpg --batch --keyserver hkps://keys.openpgp.org --recv-keys B42F6819007F00F88E364FD4036A9C25BF357DD4;
+                gpg --batch --verify /usr/local/bin/gosu.asc /usr/local/bin/gosu;
+                gpgconf --kill all;
+            fi
+            rm -rf "$GNUPGHOME" /usr/local/bin/gosu.asc;
+            chmod +x /usr/local/bin/gosu;
+            check_gosu;
+        fi
+    fi
+else
+    set -eC;
+
+    if [ -z "$HOST_MAPPED_GID" ]; then
+        printf 'HOST_MAPPED_GID is unset\n' >&2;
+        guard_failure=true;
+    fi
+
+    if [ -z "$HOST_MAPPED_GROUP" ]; then
+        printf 'HOST_MAPPED_GROUP is unset\n' >&2;
+        guard_failure=true;
+    fi
+
+    if [ -z "$HOST_MAPPED_UID" ]; then
+        printf 'HOST_MAPPED_UID is unset\n' >&2;
+        guard_failure=true;
+    fi
+
+    if [ -z "$HOST_MAPPED_USER" ]; then
+        printf 'HOST_MAPPED_USER is unset\n' >&2;
+        guard_failure=true;
+    fi
+
+    if [ "$guard_failure" = true ]; then
+        exit 1;
+    fi
+
+    echo "CAPABILITIES=$CAPABILITIES" >&3;
+    echo "HOST_MAPPED_GROUP=$HOST_MAPPED_GROUP" >&3;
+    echo "HOST_MAPPED_GID=$HOST_MAPPED_GID" >&3;
+    echo "HOST_MAPPED_USER=$HOST_MAPPED_USER" >&3;
+    echo "HOST_MAPPED_UID=$HOST_MAPPED_UID" >&3;
+
+    # Create/replace user if non-root.
+    if [ $HOST_MAPPED_UID -ne 0 ] && [ "$HOST_MAPPED_USER" != 'root' ]; then
+        if id -u "$HOST_MAPPED_USER" >/dev/null 2>&1; then
+            echo "Removing user matching $HOST_MAPPED_USER: $(print_user $HOST_MAPPED_USER)" >&3;
+            if command -v userdel >/dev/null; then
+                userdel "$HOST_MAPPED_USER";
+            else
+                deluser "$HOST_MAPPED_USER" 2>/dev/null;
+            fi
+        fi
+
+        uid_username="$(awk -F: "\$3 == $HOST_MAPPED_UID {print \$1}" /etc/passwd)";
+        if id -u "$uid_username" >/dev/null 2>&1; then
+            echo "Removing user matching UID $HOST_MAPPED_UID: $(print_user $uid_username)" >&3;
+            if command -v userdel >/dev/null; then
+                userdel "$uid_username";
+            else
+                deluser "$uid_username" 2>/dev/null;
+            fi
+        fi
+
+        if command -v groupadd >/dev/null; then
+            groupadd -g $HOST_MAPPED_GID "$HOST_MAPPED_GROUP" || true;
+        else
+            addgroup -g $HOST_MAPPED_GID "$HOST_MAPPED_GROUP" || true;
+        fi
+        gid_groupname="$(awk -F: "\$3 == $HOST_MAPPED_GID {print \$1}" /etc/group)";
+
+        if command -v useradd >/dev/null; then
+            useradd -g $HOST_MAPPED_GID -m -s /bin/sh -u $HOST_MAPPED_UID $HOST_MAPPED_USER 2>&3;
+        else
+            adduser -D -G "$gid_groupname" -s /bin/sh -u $HOST_MAPPED_UID $HOST_MAPPED_USER 2>&3;
+        fi
+        echo "Created user: $(print_user "$HOST_MAPPED_USER")" >&3;
+
+        HOME_DIR="/home/$HOST_MAPPED_USER";
+    else
+        HOME_DIR="/root";
+    fi
+
+    # Set the ownership of a set of items to the user.
+    if [ -n "$CHOWN_LIST" ]; then
+        echo "$CHOWN_LIST" | xargs chown -c "$HOST_MAPPED_UID:$HOST_MAPPED_GID" >&3;
+    fi
+
+    # Execute using $HOST_MAPPED_UID.
+    if check_setpriv >/dev/null 2>&1; then
+        if [ -n "$CAPABILITIES" ]; then
+            capabilities="-all,$CAPABILITIES";
+        else
+            capabilities='-all';
+        fi
+
+        echo "HOME=$HOME_DIR LOGNAME=$HOST_MAPPED_USER SHELL=/bin/sh USER=$HOST_MAPPED_USER setpriv --bounding-set \"$capabilities\" --init-groups --no-new-privs --reuid=$HOST_MAPPED_UID --regid=$HOST_MAPPED_GID ..." >&3;
+        HOME="$HOME_DIR" LOGNAME="$HOST_MAPPED_USER" SHELL='/bin/sh' USER="$HOST_MAPPED_USER" setpriv --bounding-set "$capabilities" --init-groups --no-new-privs --reuid=$HOST_MAPPED_UID --regid=$HOST_MAPPED_GID "$@";
+    elif command -v gosu >/dev/null; then
+        echo "HOME=$HOME_DIR LOGNAME=$HOST_MAPPED_USER SHELL=/bin/sh USER=$HOST_MAPPED_USER gosu "$HOST_MAPPED_UID:$HOST_MAPPED_GID" ..." >&3;
+        HOME="$HOME_DIR" LOGNAME="$HOST_MAPPED_USER" SHELL='/bin/sh' USER="$HOST_MAPPED_USER" gosu "$HOST_MAPPED_UID:$HOST_MAPPED_GID" "$@";
+    else
+        printf 'Unable to set user\n' >&2;
+        exit 1;
+    fi
+fi

--- a/docker/development/entrypoint.sh
+++ b/docker/development/entrypoint.sh
@@ -126,6 +126,7 @@ while [ $# -gt 0 ]; do
     case $1 in
         --debug)
             exec 3>&1;
+            exec 4>&2;
             ;;
         --setup)
             exec 3>&1;
@@ -285,7 +286,7 @@ else
 
     # Set the ownership of a set of items to the user.
     if [ -n "$CHOWN_LIST" ]; then
-        echo "$CHOWN_LIST" | xargs chown -c "$HOST_MAPPED_UID:$HOST_MAPPED_GID" >&3 | true;
+        echo "$CHOWN_LIST" | xargs chown -c "$HOST_MAPPED_UID:$HOST_MAPPED_GID" >&3 2>&4 | true;
     fi
 
     # Execute using $HOST_MAPPED_UID.

--- a/docker/development/prepare.sh
+++ b/docker/development/prepare.sh
@@ -19,6 +19,11 @@ _run_dusk() {
     ./user-mirror docker compose run --rm -e APP_ENV=dusk.local php "$@"
 }
 
+if [ -d .env ]; then
+    echo ".env is a directory. Removing it"
+    rmdir .env
+fi
+
 if [ ! -f .env ]; then
     echo "Copying default env file"
     cp .env.example .env
@@ -42,9 +47,19 @@ if ! grep -q '^APP_KEY=.' .env; then
     _run artisan key:generate
 fi
 
+if [ -d .env.testing ]; then
+    echo ".env.testing is a directory. Removing it"
+    rmdir .env.testing
+fi
+
 if [ ! -f .env.testing ]; then
     echo "Copying default test env file"
     cp .env.testing.example .env.testing
+fi
+
+if [ -d .env.dusk.local ]; then
+    echo ".env.dusk.local is a directory. Removing it"
+    rmdir .env.dusk.local
 fi
 
 if [ ! -f .env.dusk.local ]; then
@@ -61,6 +76,7 @@ fi
 
 if [ ! -f storage/oauth-public.key ]; then
     echo "Generating passport key pair"
+    touch storage/oauth-public.key
     _run artisan passport:keys --force
 fi
 

--- a/docker/development/prepare.sh
+++ b/docker/development/prepare.sh
@@ -61,6 +61,7 @@ fi
 
 if [ ! -f storage/oauth-public.key ]; then
     echo "Generating passport key pair"
+    touch storage/oauth-public.key
     _run artisan passport:keys
 fi
 

--- a/docker/development/prepare.sh
+++ b/docker/development/prepare.sh
@@ -61,7 +61,6 @@ fi
 
 if [ ! -f storage/oauth-public.key ]; then
     echo "Generating passport key pair"
-    touch storage/oauth-public.key
     _run artisan passport:keys --force
 fi
 

--- a/docker/development/prepare.sh
+++ b/docker/development/prepare.sh
@@ -89,4 +89,6 @@ if [ ! -f database/ip2asn/v6.tsv ]; then
     _run artisan ip2asn:update
 fi
 
+./user-mirror docker compose run --rm dev
+
 echo "Preparation completed. Adjust .env file if needed and run './user-mirror docker compose up' followed by running migration."

--- a/docker/development/prepare.sh
+++ b/docker/development/prepare.sh
@@ -12,11 +12,11 @@ if [ ! -f artisan ]; then
 fi
 
 _run() {
-    docker compose run --rm php "$@"
+    ./user-mirror docker compose run --rm php "$@"
 }
 
 _run_dusk() {
-    docker compose run --rm -e APP_ENV=dusk.local php "$@"
+    ./user-mirror docker compose run --rm -e APP_ENV=dusk.local php "$@"
 }
 
 if [ ! -f .env ]; then
@@ -73,4 +73,4 @@ if [ ! -f database/ip2asn/v6.tsv ]; then
     _run artisan ip2asn:update
 fi
 
-echo "Preparation completed. Adjust .env file if needed and run 'docker compose up' followed by running migration."
+echo "Preparation completed. Adjust .env file if needed and run './user-mirror docker compose up' followed by running migration."

--- a/docker/development/prepare.sh
+++ b/docker/development/prepare.sh
@@ -89,6 +89,4 @@ if [ ! -f database/ip2asn/v6.tsv ]; then
     _run artisan ip2asn:update
 fi
 
-./user-mirror docker compose run --rm dev
-
 echo "Preparation completed. Adjust .env file if needed and run './user-mirror docker compose up' followed by running migration."

--- a/docker/development/prepare.sh
+++ b/docker/development/prepare.sh
@@ -62,7 +62,7 @@ fi
 if [ ! -f storage/oauth-public.key ]; then
     echo "Generating passport key pair"
     touch storage/oauth-public.key
-    _run artisan passport:keys
+    _run artisan passport:keys --force
 fi
 
 if [ ! -f .docker/.my.cnf ]; then

--- a/user-mirror
+++ b/user-mirror
@@ -2,7 +2,7 @@
 # Source: https://github.com/AJGranowski/docker-user-mirror
 # License: MIT
 set -eC;
-VERSION='0.0.18-73f6d42';
+VERSION='0.0.19-072e903';
 
 # Create container(s) and return the container ID(s).
 container_create() {
@@ -161,8 +161,8 @@ update() {
         esac
     fi
 
-    echo "Installing update...";
-    download_file "$(basename "$0")" "${0}.tmp";
+    echo 'Installing update...';
+    download_file 'user-mirror' "${0}.tmp";
     mv "${0}.tmp" "$0" && echo "${latest_version} installed!"; exit 0;
 }
 

--- a/user-mirror
+++ b/user-mirror
@@ -2,7 +2,7 @@
 # Source: https://github.com/AJGranowski/docker-user-mirror
 # License: MIT
 set -eC;
-VERSION='0.0.19-072e903';
+VERSION='0.0.20-7d4d3c6';
 
 # Create container(s) and return the container ID(s).
 container_create() {

--- a/user-mirror
+++ b/user-mirror
@@ -1,0 +1,372 @@
+#!/bin/sh
+# Source: https://github.com/AJGranowski/docker-user-mirror
+# License: MIT
+set -eC;
+VERSION='0.0.18-73f6d42';
+
+# Create container(s) and return the container ID(s).
+container_create() {
+    if [ -n "$REPLACED_COMMAND" ]; then
+        "$@";
+    elif [ -n "$COMPOSE_FILES" ]; then
+        $COMPOSE_ENGINE --progress quiet --file "$COMPOSE_FILES" create >/dev/null 2>&1;
+        $COMPOSE_ENGINE --progress quiet --file "$COMPOSE_FILES" ps -a --status created --format '{{.ID}}';
+    else
+        $COMPOSE_ENGINE --progress quiet create >/dev/null 2>&1;
+        $COMPOSE_ENGINE --progress quiet ps -a --status created --format '{{.ID}}';
+    fi
+}
+
+# Download a release file.
+# Args: release filename, output filename, release tag (defaults to latest release it not provided)
+download_file() {
+    if [ $# -eq 3 ]; then
+        curl --fail -Ls -o "$2" "https://github.com/AJGranowski/docker-user-mirror/releases/download/$3/$1";
+    elif [ $# -eq 2 ]; then
+        curl --fail -Ls -o "$2" "https://github.com/AJGranowski/docker-user-mirror/releases/latest/download/$1";
+    else
+        echo 'Expected at least two arguments.' >&2;
+        return 1;
+    fi
+}
+
+# Query GitHub for the latest release tag.
+get_latest_release_tag() {
+    response="$(curl -Ls -w '%{http_code}' 'https://api.github.com/repos/AJGranowski/docker-user-mirror/releases/latest')";
+    case "$(echo "$response" | tail -1)" in
+        2*)
+            echo "$response" | \
+            grep -E '^\s*"tag_name":' | \
+            sed -E 's/.*"tag_name": "([^"]+)".*/\1/g'
+        ;;
+        *) false;;
+    esac
+}
+
+# Get the version ID of a release.
+# Args: release tag (defaults to latest release it not provided)
+get_release_version() {
+    if [ $# -eq 0 ]; then
+        response="$(curl -Ls -w '\n%{http_code}' 'https://github.com/AJGranowski/docker-user-mirror/releases/latest/download/version')";
+    else
+        response="$(curl -Ls -w '\n%{http_code}' "https://github.com/AJGranowski/docker-user-mirror/releases/download/$1/version")";
+    fi
+
+    case "$(echo "$response" | tail -1)" in
+        2*)
+            echo "$response" | head -1
+            ;;
+        *) false;;
+    esac
+}
+
+# Create host items and populate chown list
+# Args: container ID (retrieved from container_create)
+prepare_environment() {
+    # Create a list of all read/write mount destinations so they can be chown'd in the container at runtime.
+    if [ -z "$CHOWN_LIST" ]; then
+        CHOWN_LIST="$($CONTAINER_ENGINE inspect --format '{{range .Mounts}}{{if .RW}}"{{print .Destination}}" {{end}}{{end}}' "$1")";
+    else
+        CHOWN_LIST="$CHOWN_LIST $($CONTAINER_ENGINE inspect --format '{{range .Mounts}}{{if .RW}}"{{print .Destination}}" {{end}}{{end}}' "$1")";
+    fi
+
+    # Loop through bind mounts that have a non-empty mode (`create_host_path: true` sets this), and mkdir those source paths on the host.
+    while read create_path; do
+        if [ -z "$create_path" ]; then
+            break;
+        fi
+
+        mkdir -p "$create_path" >/dev/null 2>&1 || true;
+    done <<EOF
+$($CONTAINER_ENGINE inspect --format '{{range .Mounts}}{{if and (eq .Type "bind") .Mode}}{{println .Source}}{{end}}{{end}}' "$1")
+EOF
+    # Loop though every pair of bind mounts and all mounts to create nested directories and files on the host.
+    #   (for example, a volume mount within a bind mount will need to be created on the host relative to the bind mount)
+    while read edge_source; do
+        if [ -z "$edge_source" ]; then
+            break;
+        fi
+
+        read edge_destination;
+
+        while read node_source; do
+            if [ -z "$node_source" ]; then
+                break;
+            fi
+
+            read node_destination;
+
+            # Find replace
+            resolved_node_destination="$(echo "$node_destination" | sed -e "s|^${edge_destination}/|${edge_source}/|g")";
+
+            if [ "$resolved_node_destination" = "$node_destination" ]; then
+                # Skip this pair if no resolution was made.
+                continue;
+            fi
+
+            if [ -f "$node_source" ]; then
+                mkdir -p "$(dirname "$resolved_node_destination")" >/dev/null 2>&1 || true;
+                touch "$resolved_node_destination";
+            else
+                mkdir -p "$resolved_node_destination" >/dev/null 2>&1 || true;
+            fi
+        done <<EOF
+$($CONTAINER_ENGINE inspect --format '{{range .Mounts}}{{println .Source}}{{println .Destination}}{{end}}' "$1")
+EOF
+
+    done <<EOF
+$($CONTAINER_ENGINE inspect --format '{{range .Mounts}}{{if eq .Type "bind"}}{{println .Source}}{{println .Destination}}{{end}}{{end}}' "$1")
+EOF
+}
+
+# Query GitHub to check if a release tag exists.
+release_tag_exists() {
+    case "$(curl -Ls -o /dev/null -w '%{http_code}' "https://api.github.com/repos/AJGranowski/docker-user-mirror/releases/tags/$1")" in
+        2*) true;;
+        *) false;;
+    esac
+}
+
+# Check for updates, and download the latest version.
+update() {
+    if ! latest_version="$(get_release_version)"; then
+        echo 'Unable to fetch the latest version. Try again in a few minutes.' >&2;
+        return 1;
+    fi
+
+    if [ "$VERSION" = "$latest_version" ]; then
+        echo 'Up to date.';
+    else
+        if ! release_tag_exists "$(version_to_release_tag)"; then
+            echo 'Critical update required!';
+            echo '    This version has been deleted, signaling either a critical bug or vulnerability. Update immediately.'
+        else
+            echo 'New update available.'
+        fi
+    fi
+
+    echo "    Current version: $VERSION";
+    echo "    Latest version:  $latest_version";
+
+    if [ "$VERSION" = "$latest_version" ]; then
+        return 0;
+    fi
+
+    if [ "$o_yes" != true ]; then
+        echo '\nInstall the update? (y/n)';
+        read yn;
+        case $yn in
+            y*) ;;
+            n*) return 0;;
+        esac
+    fi
+
+    echo "Installing update...";
+    download_file "$(basename "$0")" "${0}.tmp";
+    mv "${0}.tmp" "$0" && echo "${latest_version} installed!"; exit 0;
+}
+
+# Convert "$VERSION" to "release-**" format.
+version_to_release_tag() {
+    if [ $# -eq 0 ]; then
+        echo "$VERSION" | sed -E 's/([^-]*).*/release-\1/g'
+    else
+        echo "$1" | sed -E 's/([^-]*).*/release-\1/g'
+    fi
+}
+
+# Parse options.
+while [ $# -gt 0 ]; do
+    case $1 in
+        --docker)
+            COMPOSE_ENGINE='docker compose';
+            CONTAINER_ENGINE='docker';
+            ;;
+        --docker-compose)
+            COMPOSE_ENGINE='docker-compose';
+            CONTAINER_ENGINE='docker';
+            ;;
+        --podman)
+            COMPOSE_ENGINE='podman compose';
+            CONTAINER_ENGINE='podman';
+            ;;
+        --podman-compose)
+            COMPOSE_ENGINE='podman-compose';
+            CONTAINER_ENGINE='podman';
+            ;;
+        --update)
+            o_update=true;
+            ;;
+        --version)
+            echo "Version: ${VERSION}";
+            exit 0;
+            ;;
+        -y|--yes)
+            o_yes=true;
+            ;;
+        --)
+            shift;
+            break;
+            ;;
+        -*)
+            printf 'Unknown option %s\n' $1 >&2;
+            exit 1;
+            ;;
+        *)
+            break;
+            ;;
+    esac
+    shift;
+done
+
+if [ "$o_update" = true ]; then
+    if update; then
+        exit 0;
+    else
+        exit 1;
+    fi
+fi
+
+# Parse the command if no engine declared.
+if [ -z "$COMPOSE_ENGINE" ] || [ -z "$CONTAINER_ENGINE" ]; then
+    case $1 in
+        docker-compose)
+            COMPOSE_ENGINE='docker-compose';
+            CONTAINER_ENGINE='docker';
+            ;;
+        podman)
+            COMPOSE_ENGINE='podman compose';
+            CONTAINER_ENGINE='podman';
+            ;;
+        podman-compose)
+            COMPOSE_ENGINE='podman-compose';
+            CONTAINER_ENGINE='podman';
+            ;;
+        *)
+            COMPOSE_ENGINE='docker compose';
+            CONTAINER_ENGINE='docker';
+            ;;
+    esac
+fi
+
+# To get the arguments from a non-compose invocation, we'll change "exec" and "run" to "create", and then use that new
+#   command string to create (but not start) a container for parsing. This is a workaround for POSIX shell only having
+#   one array object (the argument list).
+COMPOSE_FILES="";
+first_iteration=true;
+search_for_replace=4;
+for arg do
+    if [ "$first_iteration" = true ]; then
+        unset first_iteration;
+        shift $#;
+    fi
+
+    if [ $search_for_replace -gt 0 ]; then
+        case $arg in
+            compose)
+                set -- "$@" "$arg";
+                search_for_replace=0;
+                ;;
+            run)
+                REPLACED_COMMAND="$arg";
+                set -- "$@" "create";
+                search_for_replace=0;
+                ;;
+            *)
+                set -- "$@" "$arg";
+                ;;
+        esac
+
+        # Decrement for non-option arguments.
+        case $arg in
+            -*)
+                ;;
+            *)
+                search_for_replace=$(($search_for_replace - 1));
+                ;;
+        esac
+    else
+        case $arg in
+            -f|--file)
+                COMPOSE_FILES="$1";
+                ;;
+        esac
+        set -- "$@" "$arg";
+    fi
+done
+
+# If Docker and not rootless, then we have some work to do.
+if [ "$CONTAINER_ENGINE" = "docker" ] && ! docker info -f '{{println .SecurityOptions}}' | grep 'rootless' 1>/dev/null; then
+    HOST_MAPPED_GROUP="$(id -gn)";
+    HOST_MAPPED_GID="$(id -g)";
+    HOST_MAPPED_USER="$(id -un)";
+    HOST_MAPPED_UID="$(id -u)";
+
+    # Loop through the containers created by this command.
+    while read temp_container_id; do
+        prepare_environment "$temp_container_id"
+
+        # Cleanup.
+        $CONTAINER_ENGINE container rm "$temp_container_id" >/dev/null 2>&1;
+    done <<EOF
+$(container_create "$@")
+EOF
+else
+    HOST_MAPPED_GROUP='root';
+    HOST_MAPPED_GID=0;
+    HOST_MAPPED_USER='root';
+    HOST_MAPPED_UID=0;
+fi
+
+# Restore the args list we may have mangled before, and insert runtime arguments.
+first_iteration=true;
+search_for_insert=4;
+for arg do
+    if [ "$first_iteration" = true ]; then
+        unset first_iteration;
+        shift $#;
+    fi
+
+    if [ $search_for_insert -gt 0 ]; then
+        case $arg in
+            create|exec|run)
+                if [ -n "$REPLACED_COMMAND" ]; then
+                    set -- "$@" "$REPLACED_COMMAND";
+                else
+                    set -- "$@" "$arg";
+                fi
+
+                set -- "$@" '-e' "HOST_MAPPED_GID=$HOST_MAPPED_GID" '-e' "HOST_MAPPED_GROUP=$HOST_MAPPED_GROUP" '-e' "HOST_MAPPED_UID=$HOST_MAPPED_UID" '-e' "HOST_MAPPED_USER=$HOST_MAPPED_USER";
+                if [ -n "$CHOWN_LIST" ]; then
+                    set -- "$@" '-e' "CHOWN_LIST=$CHOWN_LIST";
+                fi
+
+                search_for_insert=0;
+                ;;
+            *)
+                set -- "$@" "$arg";
+                ;;
+        esac
+
+        # Decrement for non-option arguments.
+        case $arg in
+            -*)
+                ;;
+            *)
+                search_for_insert=$(($search_for_insert - 1));
+                ;;
+        esac
+    else
+        set -- "$@" "$arg";
+    fi
+done
+
+export HOST_MAPPED_GROUP;
+export HOST_MAPPED_GID;
+export HOST_MAPPED_USER;
+export HOST_MAPPED_UID;
+if [ -n "$CHOWN_LIST" ]; then
+    export CHOWN_LIST;
+fi
+
+"$@";


### PR DESCRIPTION
## What are these changes?
This change adds [**Docker User Mirror**](https://github.com/AJGranowski/docker-user-mirror).

## Why are these changes being made?

This change resolves:
* #11777

The [current approach](https://github.com/ppy/osu-web/blob/88dc4d289bb24d2cc748da02dbbb817cff1d22eb/docker/development/entrypoint.sh) mirrors the host user well, but relies on hard coded paths to fix ownership issues. Rather than hard coding these paths, we should automate the Docker environment setup using information already contained in the compose file. I made a project called Docker User Mirror that does just that, and I think it would be a great fit for this project!

This change replaces `entrypoint.sh` with two scripts:
1. `user-mirror`: Creates items on the host before the Docker daemon does (so they're owned by the current host user rather than root), and passes environment variables into the container to mirror the host user.
2. `entrypoint`: Mirrors the host user, sets the ownership of a list of items to that mirrored user, and steps down from root to that user using [`setpriv`](https://www.man7.org/linux/man-pages/man1/setpriv.1.html) to execute a command.

(there's also a bit of glue added to `docker-compose.yml` and `Dockerfile.development`)

Fairly simple user experience: rather than running `docker ...` you instead run `./user-mirror docker ...`

## Notes

* I didn't touch any documentation. Let me know what you would like to see there.