### PR TITLE
Fix first-time run of `docker_dev.sh`

### DIFF
--- a/docker/development/run.sh
+++ b/docker/development/run.sh
@@ -20,7 +20,19 @@ _migrate() {
 }
 
 _octane() {
-  exec ./artisan octane:start --host=0.0.0.0 "$@"
+    echo_counter=0
+    manifest_path='./public/assets/manifest.json'
+    while [ ! -f "$manifest_path" ]; do
+        if [ "$echo_counter" -le 0 ]; then
+            echo_counter=5
+            echo "waiting to start octane: ${manifest_path##*/} not found" >&2
+        fi
+
+        : $(( echo_counter -= 1 ))
+        sleep 1
+    done
+
+    exec ./artisan octane:start --host=0.0.0.0 "$@"
 }
 
 _schedule() {


### PR DESCRIPTION
## What are these changes?
This change makes octane commands wait a bit for `manifest.json` to exist if it's missing.

## Why are these changes being made?

The first run of `bin/docker_dev.sh` causes both `nginx` and `php-dusk` fail.

php:
```
Exception
The manifest does not exist.
at app/Singletons/AssetsManifest.php:22
   18▕     {
   19▕         $manifestPath = public_path('assets/manifest.json');
   20▕
   21▕         if (!file_exists($manifestPath)) {
➜ 22▕             throw new Exception('The manifest does not exist.');
   23▕         }
   24▕
   25▕         $this->manifest = json_decode(file_get_contents($manifestPath), true);
   26▕     }
1   app/Providers/AppServiceProvider.php:96
    App\Singletons\AssetsManifest::__construct()
```

php-dusk:
```
php-dusk exited with code 157
```

nginx:
```
[emerg] host not found in upstream "php-dusk" in /etc/nginx/conf.d/default.conf:53
nginx exited with code 1
```

Successive runs pass and serve the website, suggesting a race condition in `docker compose up`. Running `docker compose run --rm assets` beforehand seems to fix this.