### PR TITLE
Fix env file setup for dusk.local

### DIFF
--- a/docker/development/prepare.sh
+++ b/docker/development/prepare.sh
@@ -23,7 +23,7 @@ for envfile in .env .env.testing .env.dusk.local; do
     if [ "${envfile}" != .env.testing ] && ! grep -q '^APP_KEY=.' "${envfile}"; then
         echo "Generating app key for env file '${envfile}'"
         sed -i -e '/^APP_KEY=.*/d' "${envfile}"
-        : "${APP_KEY="base64:$(head -c 32 /dev/urandom | base64)"}"
+        : ${APP_KEY="base64:$(head -c 32 /dev/urandom | base64)"}
         echo "APP_KEY=${APP_KEY}" >> "${envfile}"
     fi
 done


### PR DESCRIPTION
Also fixed bug of github token being echoed to console if set.

Note that the `APP_ENV` in `.env.dusk.local` isn't actually used when using docker compose as it overrides the value with the one in `.env`.