### PR TITLE
Don't preload singletons

### DIFF
--- a/config/octane.php
+++ b/config/octane.php
@@ -1,7 +1,6 @@
 <?php
 
 use App\Listeners\OctaneResetLocalCache;
-use App\Providers\AppServiceProvider;
 use Laravel\Octane\Contracts\OperationTerminated;
 use Laravel\Octane\Events\RequestHandled;
 use Laravel\Octane\Events\RequestReceived;
@@ -121,7 +120,6 @@ return [
 
     'warm' => [
         ...Octane::defaultServicesToWarm(),
-        ...array_keys(AppServiceProvider::SINGLETONS),
     ],
 
     'flush' => [


### PR DESCRIPTION
Alternative fix for #11779. I think I put it there for benchmarking purpose but otherwise it's probably fine to init the singletons on first access.