### PR TITLE
Move team disband button to settings page

### DIFF
--- a/resources/css/bem/team-action-button.less
+++ b/resources/css/bem/team-action-button.less
@@ -24,6 +24,11 @@
     background: var(--bg-hover);
   }
 
+  &--disabled {
+    pointer-events: none;
+    opacity: 0.7;
+  }
+
   &--part {
     --bg: hsl(var(--hsl-red-3));
     --bg-hover: hsl(var(--hsl-red-2));

--- a/resources/css/bem/team-settings.less
+++ b/resources/css/bem/team-settings.less
@@ -5,6 +5,11 @@
   display: grid;
   gap: 5px;
 
+  &__buttons {
+    display: flex;
+    gap: 10px;
+  }
+
   &__description-preview {
     --padding: 10px;
     padding: var(--padding) 0;

--- a/resources/views/teams/edit.blade.php
+++ b/resources/views/teams/edit.blade.php
@@ -173,14 +173,22 @@
                         <div class="team-settings__item team-settings__item--buttons">
                             <div>
                                 <a
+                                    class="btn-osu-big btn-osu-big--danger btn-osu-big--rounded-thin"
+                                    data-turbo-confirm="{{ osu_trans('common.confirmation') }}"
+                                    data-turbo-method="DELETE"
+                                    href="{{ route('teams.destroy', $team) }}"
+                                >
+                                    {{ osu_trans('teams.show.bar.destroy') }}
+                                </a>
+                            </div>
+
+                            <div class="team-settings__buttons">
+                                <a
                                     class="btn-osu-big btn-osu-big--rounded-thin"
                                     href="{{ route('teams.show', ['team' => $team]) }}"
                                 >
                                     {{ osu_trans('common.buttons.cancel') }}
                                 </a>
-                            </div>
-
-                            <div>
                                 <button class="btn-osu-big btn-osu-big--rounded-thin">
                                     {{ osu_trans('common.buttons.save') }}
                                 </button>

--- a/resources/views/teams/show.blade.php
+++ b/resources/views/teams/show.blade.php
@@ -13,14 +13,6 @@
     $teamMembers['member'] ??= [];
     $teamMembers['leader'] ??= $toJson([$team->members()->make(['user_id' => $team->leader_id])->userOrDeleted()]);
     $headerUrl = $team->header()->url();
-
-    $buttons = new Ds\Set();
-    if (priv_check('TeamPart', $team)->can()) {
-        $buttons->add('part');
-    }
-    if (priv_check('TeamUpdate', $team)->can()) {
-        $buttons->add('destroy');
-    }
 @endphp
 
 @extends('master', [
@@ -77,31 +69,27 @@
                 </div>
             </div>
         </div>
-        @if (!$buttons->isEmpty())
+        @if (Auth::user()?->team?->getKey() === $team->getKey())
             <div class="profile-detail-bar profile-detail-bar--team">
-                @if ($buttons->contains('destroy'))
-                    <form
-                        action="{{ route('teams.destroy', $team) }}"
-                        data-turbo-confirm="{{ osu_trans('common.confirmation') }}"
-                        method="POST"
+                @php
+                    $partPriv = priv_check('TeamPart', $team);
+                    $canPart = $partPriv->can();
+                @endphp
+                <form
+                    action="{{ route('teams.part', ['team' => $team]) }}"
+                    data-turbo-confirm="{{ osu_trans('common.confirmation') }}"
+                    title="{{ $partPriv->message() }}"
+                    method="POST"
+                >
+                    <button
+                        class="{{ class_with_modifiers('team-action-button', 'part', ['disabled' => !$canPart]) }}"
+                        @if (!$canPart)
+                            disabled
+                        @endif
                     >
-                        <input type="hidden" name="_method" value="DELETE">
-                        <button class="team-action-button team-action-button--part">
-                            {{ osu_trans('teams.show.bar.destroy') }}
-                        </button>
-                    </form>
-                @endif
-                @if ($buttons->contains('part'))
-                    <form
-                        action="{{ route('teams.part', ['team' => $team]) }}"
-                        data-turbo-confirm="{{ osu_trans('common.confirmation') }}"
-                        method="POST"
-                    >
-                        <button class="team-action-button team-action-button--part">
-                            {{ osu_trans('teams.show.bar.part') }}
-                        </button>
-                    </form>
-                @endif
+                        {{ osu_trans('teams.show.bar.part') }}
+                    </button>
+                </form>
             </div>
         @endif
         <div class="user-profile-pages user-profile-pages--no-tabs">


### PR DESCRIPTION
Seems to make more logical sense and the original design had it there as well. I still want the cancel/back/team page button but there's no good place to put it 🤔 (also can probably use a better label)