### PR TITLE
Dev environment should start creating users with id 2

### DIFF
--- a/database/migrations/2025_01_21_000001_update_user_start_id.php
+++ b/database/migrations/2025_01_21_000001_update_user_start_id.php
@@ -1,0 +1,21 @@
+<?php
+
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        DB::statement('ALTER TABLE phpbb_users AUTO_INCREMENT=2');
+    }
+
+    public function down(): void
+    {
+        DB::statement('ALTER TABLE phpbb_users AUTO_INCREMENT=1');
+    }
+};


### PR DESCRIPTION
Will start adding users at `id=2` ( leaving `id=1` open for _guest_ ) going forward in the `phpbb_users` table.  

https://dev.mysql.com/doc/refman/8.4/en/example-auto-increment.html