### PR TITLE
Adjust username change cost

### DIFF
--- a/app/Models/UsernameChangeHistory.php
+++ b/app/Models/UsernameChangeHistory.php
@@ -21,6 +21,11 @@ class UsernameChangeHistory extends Model
     protected $table = 'osu_username_change_history';
     protected $primaryKey = 'change_id';
 
+    public function scopePaid($query)
+    {
+        $query->whereIn('type', ['support', 'paid']); // changed by support counts as paid.
+    }
+
     public function scopeVisible($query)
     {
         $query->whereIn('type', ['support', 'paid', 'admin']);

--- a/database/factories/UsernameChangeHistoryFactory.php
+++ b/database/factories/UsernameChangeHistoryFactory.php
@@ -1,0 +1,31 @@
+<?php
+
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
+declare(strict_types=1);
+
+namespace Database\Factories;
+
+use App\Models\User;
+use App\Models\UsernameChangeHistory;
+use Carbon\Carbon;
+
+class UsernameChangeHistoryFactory extends Factory
+{
+    protected $model = UsernameChangeHistory::class;
+
+    public function definition(): array
+    {
+        return [
+            'timestamp' => Carbon::now(),
+            'type' => 'paid',
+            'user_id' => User::factory(),
+
+            // depend on user_id; the username will be incorrect when factorying multiple names at once,
+            // so they should be handled separately if realistic name changes are wanted.
+            'username' => fn (array $attr) => User::find($attr['user_id'])->username,
+            'username_last' => fn (array $attr) => "{$attr['username']}_prev",
+        ];
+    }
+}

--- a/tests/Models/UserTest.php
+++ b/tests/Models/UserTest.php
@@ -10,11 +10,26 @@ namespace Tests\Models;
 use App\Libraries\Session\Store;
 use App\Models\OAuth\Token;
 use App\Models\User;
+use App\Models\UsernameChangeHistory;
 use Database\Factories\OAuth\RefreshTokenFactory;
 use Tests\TestCase;
 
 class UserTest extends TestCase
 {
+    public static function dataProviderForUsernameChangeCost()
+    {
+        return [
+            [0, 0],
+            [1, 8],
+            [2, 16],
+            [3, 32],
+            [4, 64],
+            [5, 100],
+            [6, 100],
+            [10, 100],
+        ];
+    }
+
     /**
      * @dataProvider dataProviderForAttributeTwitter
      */
@@ -23,6 +38,18 @@ class UserTest extends TestCase
         $user = new User(['user_twitter' => $setValue]);
 
         $this->assertSame($getValue, $user->user_twitter);
+    }
+
+    /**
+     * @dataProvider dataProviderForUsernameChangeCost
+     */
+    public function testChangeUsernameChangeCost(int $changes, int $cost)
+    {
+        $user = User::factory()
+            ->has(UsernameChangeHistory::factory()->count($changes)->state(['type' => 'paid']))
+            ->create();
+
+        $this->assertSame($user->usernameChangeCost(), $cost);
     }
 
     public function testEmailLoginDisabled()

--- a/tests/Models/UserTest.php
+++ b/tests/Models/UserTest.php
@@ -182,7 +182,7 @@ class UserTest extends TestCase
             ->has(UsernameChangeHistory::factory()->count($changes))
             ->create();
 
-        $this->assertSame($user->usernameChangeCost(), $cost);
+        $this->assertSame($cost, $user->usernameChangeCost());
     }
 
     /**
@@ -198,7 +198,7 @@ class UserTest extends TestCase
 
         $this->travelBack();
 
-        $this->assertSame($user->usernameChangeCost(), $cost);
+        $this->assertSame($cost, $user->usernameChangeCost());
     }
 
     /**
@@ -210,7 +210,7 @@ class UserTest extends TestCase
             ->has(UsernameChangeHistory::factory()->state(['type' => $type]))
             ->create();
 
-        $this->assertSame($user->usernameChangeCost(), $cost);
+        $this->assertSame($cost, $user->usernameChangeCost());
     }
 
     /**
@@ -230,7 +230,7 @@ class UserTest extends TestCase
 
         UsernameChangeHistory::factory()->state(['type' => $type, 'user_id' => $user])->create();
 
-        $this->assertSame($user->usernameChangeCost(), $cost);
+        $this->assertSame($cost, $user->usernameChangeCost());
     }
 
     /**


### PR DESCRIPTION
closes #11790

The new logic is the price goes up 1 tier for every paid change, and down 1 tier for every year since the last paid change, to a minimum of 1.