### PR TITLE
Fix handling of github 404 error

### DIFF
--- a/app/Libraries/OsuWiki.php
+++ b/app/Libraries/OsuWiki.php
@@ -148,7 +148,7 @@ class OsuWiki
         } catch (GithubException $e) {
             $message = $e->getMessage();
 
-            if ($message === 'Not Found') {
+            if ($e->getCode() === 404) {
                 throw new GitHubNotFoundException($message);
             } elseif (starts_with($message, 'This API returns blobs up to 1 MB in size.')) {
                 throw new GitHubTooLargeException($message);


### PR DESCRIPTION
They changed their 404 message recently. And then I noticed the status code is in the exception so it's probably better to just use it.