### PR TITLE
put header-nav-v4 in front of blurred menu image

### DIFF
--- a/resources/css/bem/header-nav-v4.less
+++ b/resources/css/bem/header-nav-v4.less
@@ -14,6 +14,7 @@
   padding: 0;
   font-size: @font-size--normal;
   position: relative;
+  z-index: 1;
 
   @media @desktop {
     --header-nav-item-padding-y: 15px;


### PR DESCRIPTION
This adds a `z-index: 1` to the `dashboard   friends   watchlists   account settings` menu at the top on the start page, so it's in front of the blurred background image that is currently on top of the menu.

This makes the colors pop more as well as making the border color consistent on the active item as well as just the rest of the bar.

Before:

![image](https://github.com/user-attachments/assets/cea58ef8-6720-4def-af70-5e983bcebe42)

After:

![image](https://github.com/user-attachments/assets/d6e8b137-9b11-4f65-9cc3-8d7495731e81)

---

<details>
<summary>Artificial purple image</summary>

The effect is most notable when the menu image has a lot of dark purple / areas of color close to the menu bar color (example using an image of just a solid purple block):

Before:

![image](https://github.com/user-attachments/assets/dd9d72d1-fa50-4d18-a20e-879216415fe3)

After:

![image](https://github.com/user-attachments/assets/8b218ead-179a-4bd4-8b18-c57ea7d5b242)

</details>

---

<details>
<summary>Artificial white image</summary>

However it might not look as good with very light / white headers: (border color now matches the big blob though)

Before:

![image](https://github.com/user-attachments/assets/8c486783-1fed-454c-b45d-b301520d069a)

After:

![image](https://github.com/user-attachments/assets/94fc013f-d252-4013-b1d1-d83e76b43e8e)

</details>