### PR TITLE
Add typescript strict bind check

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -49,7 +49,7 @@ jobs:
       - name: Install js dependencies
         run: yarn --frozen-lockfile
 
-      - run: 'yarn lint --max-warnings 86 > /dev/null'
+      - run: 'yarn lint --max-warnings 82 > /dev/null'
 
       - run: yarn pretty
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,6 +11,7 @@
     "noUnusedLocals": true,
     "resolveJsonModule": true,
     "sourceMap": true,
+    "strictBindCallApply": true,
     "strictNullChecks": true,
     "strictPropertyInitialization": true,
     "target": "es2015",


### PR DESCRIPTION
This config changes `.bind` to return the correct typing instead of any which actually reduces eslint warnings...