### PR TITLE
Simpler username cost reduction

### DIFF
--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -317,14 +317,15 @@ class User extends Model implements AfterCommit, AuthenticatableContract, HasLoc
 
     public function usernameChangeCost()
     {
-        $tier = min($this->usernameChangeHistory()->paid()->count(), 5);
+        $minTier = $this->usernameChangeHistory()->paid()->exists() ? 1 : 0;
 
-        if ($tier > 1) {
-            $lastChange = $this->usernameChangeHistory()->paid()->last()?->timestamp;
-            if ($lastChange !== null) {
-                $tier = max($tier - $lastChange->diffInYears(Carbon::now(), false), 1);
-            }
-        }
+        $tier = max(
+            $this->usernameChangeHistory()
+                ->paid()
+                ->where('timestamp', '>', Carbon::now()->subYears(3))
+                ->count(),
+            $minTier,
+        );
 
         return match ($tier) {
             0 => 0,

--- a/tests/Models/UserTest.php
+++ b/tests/Models/UserTest.php
@@ -42,21 +42,6 @@ class UserTest extends TestCase
         ];
     }
 
-    public static function dataProviderForUsernameChangeCostLastChange()
-    {
-        // assume there are 6 changes (max tier + 1)
-        return [
-            [0, 100],
-            [1, 64],
-            [2, 32],
-            [3, 16],
-            [4, 8],
-            [5, 8],
-            [6, 8],
-            [10, 8],
-        ];
-    }
-
     public static function dataProviderForUsernameChangeCostType()
     {
         return [
@@ -68,14 +53,16 @@ class UserTest extends TestCase
         ];
     }
 
-    public static function dataProviderForUsernameChangeCostTypeLastChange()
+    public static function dataProviderForUsernameChangeCostWindow()
     {
+        // years with no name changes, cost
+        // test is setup with name change every 6 months.
         return [
-            ['admin', 8],
-            ['inactive', 8],
-            ['paid', 32],
-            ['revert', 8],
-            ['support', 32],
+            [0, 100],
+            [1, 32],
+            [2, 8],
+            [3, 8],
+            [4, 8],
         ];
     }
 
@@ -186,22 +173,6 @@ class UserTest extends TestCase
     }
 
     /**
-     * @dataProvider dataProviderForUsernameChangeCostLastChange
-     */
-    public function testUsernameChangeCostLastChange(int $years, int $cost)
-    {
-        $this->travelTo(CarbonImmutable::now()->subYears($years));
-
-        $user = User::factory()
-            ->has(UsernameChangeHistory::factory()->count(6)) // 6 = max tier + 1
-            ->create();
-
-        $this->travelBack();
-
-        $this->assertSame($cost, $user->usernameChangeCost());
-    }
-
-    /**
      * @dataProvider dataProviderForUsernameChangeCostType
      */
     public function testUsernameChangeCostType(string $type, int $cost)
@@ -214,22 +185,25 @@ class UserTest extends TestCase
     }
 
     /**
-     * This tests the correct last UsernameChangeHistory is used when applying the cost changes.
-     *
-     * @dataProvider dataProviderForUsernameChangeCostTypeLastChange
+     * @dataProvider dataProviderForUsernameChangeCostWindow
      */
-    public function testUsernameChangeCostTypeLastChange(string $type, int $cost)
+    public function testUsernameChangeCostWindow(int $years, int $cost)
     {
-        $this->travelTo(CarbonImmutable::now()->subYears(1));
+        $now = CarbonImmutable::now();
+        $this->travelTo(CarbonImmutable::now()->subYears(3));
 
-        $user = User::factory()
-            ->has(UsernameChangeHistory::factory()->count(2))
-            ->create();
+        $user = User::factory()->create();
+        while (CarbonImmutable::now()->isBefore($now)) {
+            $user->usernameChangeHistory()->create([
+                'timestamp' => CarbonImmutable::now(),
+                'type' => 'paid',
+                'username' => 'marty',
+            ]);
 
-        $this->travelBack();
+            $this->travelTo(CarbonImmutable::now()->addMonths(6));
+        }
 
-        UsernameChangeHistory::factory()->state(['type' => $type, 'user_id' => $user])->create();
-
+        $this->travelTo($now->addYears($years));
         $this->assertSame($cost, $user->usernameChangeCost());
     }
 


### PR DESCRIPTION
Simpler username change cost instead of the one originally in #11809.

It now just uses a window of the last 3 years. If a previous name change exists, the minimum cost is `8`, regardless if there was 0 or 1 changes in the last 3 years.