### PR TITLE
Add "osu-api-v2-js" to the list of API wrappers

### DIFF
--- a/resources/views/docs/info.md.blade.php
+++ b/resources/views/docs/info.md.blade.php
@@ -27,6 +27,7 @@ Below is a list of some language-specific wrappers maintained by the community. 
 - [osu.py](https://github.com/sheppsu/osu.py) (python)
 - [rosu-v2](https://github.com/MaxOhn/rosu-v2) (rust)
 - [osu.js](https://github.com/L-Mario564/osu.js) (javascript/typescript)
+- [osu-api-v2-js](https://github.com/TTTaevas/osu-api-v2-js) (javascript/typescript)
 
 # Changelog
 


### PR DESCRIPTION
[osu-api-v2-js](https://github.com/TTTaevas/osu-api-v2-js) is a package I've ended up making after interacting quite a bit with osu!'s api
It is available on [npm](https://www.npmjs.com/package/osu-api-v2-js), I use it for some other project of mine and apparently, [some people have been using it for their own projects](https://github.com/TTTaevas/osu-api-v2-js/network/dependents?dependent_type=REPOSITORY)

So I think it would be a good idea to add it to the list of wrappers that is featured in the api's documentation