### PR TITLE
Fix docs nav button resetting scroll position

### DIFF
--- a/resources/js/docs/sidebar-toggle.ts
+++ b/resources/js/docs/sidebar-toggle.ts
@@ -19,7 +19,8 @@ export default class SidebarToggle {
     this.navButton.addEventListener('click', this.onClickNavButton);
   }
 
-  private readonly onClickNavButton = () => {
+  private readonly onClickNavButton = (e: MouseEvent) => {
+    e.preventDefault();
     this.menuWrapper.classList.toggle('open');
     this.navButton.classList.toggle('open');
   };


### PR DESCRIPTION
I wonder if selecting anything in the navigation should also close it instead of having to close manually.