### PR TITLE
Update echeck status when rejected by Paypal

### DIFF
--- a/app/Libraries/Payments/PaymentProcessor.php
+++ b/app/Libraries/Payments/PaymentProcessor.php
@@ -227,7 +227,7 @@ abstract class PaymentProcessor implements \ArrayAccess
         $this->signature->assertValid();
 
         $order = $this->getOrder();
-        if (($this->params['payment_type']) === 'echeck') {
+        if ($this->params['payment_type'] === 'echeck') {
             $order->update(['tracking_code' => Order::ECHECK_DENIED]);
         }
 

--- a/app/Libraries/Payments/PaymentProcessor.php
+++ b/app/Libraries/Payments/PaymentProcessor.php
@@ -227,6 +227,9 @@ abstract class PaymentProcessor implements \ArrayAccess
         $this->signature->assertValid();
 
         $order = $this->getOrder();
+        if (($this->params['payment_type']) === 'echeck') {
+            $order->update(['tracking_code' => Order::ECHECK_DENIED]);
+        }
 
         datadog_increment('store.payments.rejected', ['provider' => $this->getPaymentProvider()]);
     }

--- a/app/Libraries/Payments/PaymentProcessor.php
+++ b/app/Libraries/Payments/PaymentProcessor.php
@@ -226,11 +226,6 @@ abstract class PaymentProcessor implements \ArrayAccess
         //  the whole transaction doesn't make it explode.
         $this->signature->assertValid();
 
-        $order = $this->getOrder();
-        if ($this->params['payment_type'] === 'echeck') {
-            $order->update(['tracking_code' => Order::ECHECK_DENIED]);
-        }
-
         datadog_increment('store.payments.rejected', ['provider' => $this->getPaymentProvider()]);
     }
 

--- a/app/Libraries/Payments/PaypalPaymentProcessor.php
+++ b/app/Libraries/Payments/PaypalPaymentProcessor.php
@@ -92,6 +92,16 @@ class PaypalPaymentProcessor extends PaymentProcessor
         return $this['payment_status'] ?? $this['txn_type'];
     }
 
+    public function rejected()
+    {
+        parent::rejected();
+
+        $order = $this->getOrder();
+        if ($this->params['payment_type'] === 'echeck') {
+            $order->update(['tracking_code' => Order::ECHECK_DENIED]);
+        }
+    }
+
     public function validateTransaction(): bool
     {
         $this->signature->assertValid();

--- a/app/Models/Store/Order.php
+++ b/app/Models/Store/Order.php
@@ -437,11 +437,6 @@ class Order extends Model
         return in_array($this->status, [static::STATUS_PAID, static::STATUS_DELIVERED], true);
     }
 
-    public function isPendingEcheck(): bool
-    {
-        return $this->tracking_code === static::PENDING_ECHECK;
-    }
-
     public function isShipped(): bool
     {
         return $this->status === static::STATUS_SHIPPED;

--- a/app/Models/Store/Order.php
+++ b/app/Models/Store/Order.php
@@ -53,6 +53,7 @@ class Order extends Model
     use SoftDeletes;
 
     const ECHECK_CLEARED = 'ECHECK CLEARED';
+    const ECHECK_DENIED = 'ECHECK DENIED';
     const ORDER_NUMBER_REGEX = '/^(?<prefix>[A-Za-z]+)-(?<userId>\d+)-(?<orderId>\d+)$/';
     const PENDING_ECHECK = 'PENDING ECHECK';
 

--- a/resources/lang/en/store.php
+++ b/resources/lang/en/store.php
@@ -55,6 +55,7 @@ return [
         'contact' => 'Contact:',
         'date' => 'Date:',
         'echeck_delay' => 'As your payment was an eCheck, please allow up to 10 extra days for the payment to clear through PayPal!',
+        'echeck_denied' => 'The eCheck payment was rejected by PayPal.',
         'hide_from_activity' => 'osu!supporter tags in this order are not displayed in your recent activities.',
         'sent_via' => 'Sent Via:',
         'shipping_to' => 'Shipping To:',

--- a/resources/views/store/orders/_status.blade.php
+++ b/resources/views/store/orders/_status.blade.php
@@ -2,6 +2,16 @@
     Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
     See the LICENCE file in the repository root for full licence text.
 --}}
+@php
+    use App\Models\Store\Order;
+
+    $echeckStatus = match ($order->tracking_code) {
+        Order::ECHECK_DENIED => 'echeck_denied',
+        Order::PENDING_ECHECK => 'echeck_delay',
+        default => null,
+    };
+@endphp
+
 <div class="store-page">
     <h3 class="store-text store-text--title">{{ osu_trans('store.order.status.title') }}</h3>
 
@@ -56,9 +66,9 @@
             </p>
         @endif
 
-        @if ($order->isPendingEcheck())
+        @if ($echeckStatus !== null)
             <p>
-                {{ osu_trans('store.invoice.echeck_delay') }}
+                {{ osu_trans("store.invoice.{$echeckStatus}") }}
             </p>
         @endif
     @endif


### PR DESCRIPTION
There are a bunch of `Order`s that are in the eCheck pending state when the eChecks have been rejected already.
This adds extra handling to the IPN to mark the eCheck as rejected (`payment_status=Denied` `payment_type=echeck`).