### PR TITLE
Reject submission of score 0

### DIFF
--- a/app/Models/Solo/Score.php
+++ b/app/Models/Solo/Score.php
@@ -287,7 +287,7 @@ class Score extends Model implements Traits\ReportableInterface
         }
 
         // int (as per es schema)
-        if ($this->total_score === null || $this->total_score < 0 || $this->total_score > 2147483647) {
+        if ($this->total_score === null || $this->total_score <= 0 || $this->total_score > 2147483647) {
             throw new InvariantException('Invalid total_score.');
         }
 


### PR DESCRIPTION
I think this may be confusing if client is still sending such scores? Note that this applies to solo scores as well.

Reference: https://github.com/ppy/osu/issues/31808#issuecomment-2639579715