### PR TITLE
Add missing attribute quote

### DIFF
--- a/resources/views/layout/_page_header_v4.blade.php
+++ b/resources/views/layout/_page_header_v4.blade.php
@@ -74,7 +74,7 @@
                                     >
                                         <span
                                             class="fake-bold"
-                                            data-content={{ $link['title'] }}
+                                            data-content="{{ $link['title'] }}"
                                         >{{ $link['title'] }}</span>
                                     </a>
                                 @else


### PR DESCRIPTION
Confusing me for a while trying to figure why things move around.

This is just the first problem though. The other one being normal weight text can be wider than bolded which means things still move when switching weight 🥲 