### PR TITLE
Allow user mods in multiplayer freestyle

### DIFF
--- a/app/Models/Multiplayer/ScoreLink.php
+++ b/app/Models/Multiplayer/ScoreLink.php
@@ -34,7 +34,7 @@ class ScoreLink extends Model
             $playlistItem = $token->playlistItem()->firstOrFail();
             $requiredMods = array_column($playlistItem->required_mods, 'acronym');
             $mods = array_column($score->data->mods, 'acronym');
-            $mods = app('mods')->excludeModsAlwaysValidForSubmission($playlistItem->ruleset_id, $mods);
+            $mods = app('mods')->excludeModsAlwaysValidForSubmission($score->ruleset_id, $mods);
 
             if (!empty($requiredMods)) {
                 if (!empty(array_diff($requiredMods, $mods))) {

--- a/app/Models/Multiplayer/ScoreLink.php
+++ b/app/Models/Multiplayer/ScoreLink.php
@@ -42,9 +42,11 @@ class ScoreLink extends Model
                 }
             }
 
-            $allowedMods = array_column($playlistItem->allowed_mods, 'acronym');
-            if (!empty(array_diff($mods, $requiredMods, $allowedMods))) {
-                throw new InvariantException('This play includes mods that are not allowed.');
+            if (!$playlistItem->freestyle) {
+                $allowedMods = array_column($playlistItem->allowed_mods, 'acronym');
+                if (!empty(array_diff($mods, $requiredMods, $allowedMods))) {
+                    throw new InvariantException('This play includes mods that are not allowed.');
+                }
             }
 
             $token->score()->associate($score)->saveOrExplode();


### PR DESCRIPTION
I considered two paths here - the first is to list every allowed mod in `allowed_mods`, and the second is to make freestyle act as a bypass. Listing every mod gets messy and wastes DB space (every playlist item is retained forever), so I've gone down the second path.

A future consideration may be that freemods is usually an all-or-nothing selection. We may want to change `freestyle` into a flags enum `{ ruleset | mods | beatmap }` and invert `allowed_mods` as `disallowed_mods`.

If you (@nanaya, @peppy) believe that's better to be done now, I can look down that path, but I'm hoping it's just as easily done in a future change.