### PR TITLE
Add team chat channel

### DIFF
--- a/app/Http/Controllers/Teams/ApplicationsController.php
+++ b/app/Http/Controllers/Teams/ApplicationsController.php
@@ -8,7 +8,6 @@ declare(strict_types=1);
 namespace App\Http\Controllers\Teams;
 
 use App\Http\Controllers\Controller;
-use App\Jobs\Notifications\TeamApplicationAccept;
 use App\Jobs\Notifications\TeamApplicationReject;
 use App\Models\Team;
 use App\Models\TeamApplication;
@@ -30,12 +29,8 @@ class ApplicationsController extends Controller
 
         priv_check('TeamApplicationAccept', $application)->ensureCan();
 
-        \DB::transaction(function () use ($application, $team) {
-            $application->delete();
-            $team->members()->create(['user_id' => $application->getKey()]);
-        });
+        $team->addMember($application);
 
-        (new TeamApplicationAccept($application, \Auth::user()))->dispatch();
         \Session::flash('popup', osu_trans('teams.applications.accept.ok'));
 
         return response(null, 204);

--- a/app/Http/Controllers/Teams/MembersController.php
+++ b/app/Http/Controllers/Teams/MembersController.php
@@ -9,7 +9,6 @@ namespace App\Http\Controllers\Teams;
 
 use App\Http\Controllers\Controller;
 use App\Models\Team;
-use App\Models\TeamMember;
 use Symfony\Component\HttpFoundation\Response;
 
 class MembersController extends Controller
@@ -27,14 +26,12 @@ class MembersController extends Controller
             'team_id' => $teamId,
             'user_id' => $userId,
         ])->firstOrFail();
+        $team = $teamMember->team;
 
-        if ($teamMember->user_id === \Auth::user()->getKey()) {
-            abort(422, 'can not remove self from team');
-        }
+        priv_check('TeamUpdate', $team)->ensureCan();
 
-        priv_check('TeamUpdate', $teamMember->team)->ensureCan();
+        $team->removeMember($teamMember);
 
-        $teamMember->delete();
         \Session::flash('popup', osu_trans('teams.members.destroy.success'));
 
         return response(null, 204);

--- a/app/Http/Controllers/TeamsController.php
+++ b/app/Http/Controllers/TeamsController.php
@@ -145,8 +145,10 @@ class TeamsController extends Controller
         $team = (new Team([...$params, 'leader_id' => $user->getKey()]));
         try {
             \DB::transaction(function () use ($team, $user) {
+                $channel = $team->createChannel();
                 $team->saveOrExplode();
                 $team->members()->create(['user_id' => $user->getKey()]);
+                $channel->addUser($user);
             });
         } catch (ModelNotSavedException) {
             return ext_view('teams.create', compact('team'), status: 422);

--- a/app/Singletons/OsuAuthorize.php
+++ b/app/Singletons/OsuAuthorize.php
@@ -48,6 +48,7 @@ class OsuAuthorize
         static $set;
 
         $set ??= new Ds\Set([
+            'ChannelPart',
             'ContestJudge',
             'IsNotOAuth',
             'IsOwnClient',
@@ -1046,7 +1047,8 @@ class OsuAuthorize
         $this->ensureCleanRecord($user, $prefix);
 
         // joining multiplayer room is done through room endpoint
-        if ($channel->isMultiplayer()) {
+        // team channel handling is done through team model
+        if ($channel->isMultiplayer() || $channel->isTeam()) {
             return null;
         }
 
@@ -1070,7 +1072,8 @@ class OsuAuthorize
 
         $this->ensureLoggedIn($user);
 
-        if ($channel->type !== Channel::TYPES['private']) {
+        // team channel handling is done through team model
+        if (!$channel->isTeam() && $channel->type !== Channel::TYPES['private']) {
             return 'ok';
         }
 

--- a/database/factories/TeamFactory.php
+++ b/database/factories/TeamFactory.php
@@ -7,6 +7,7 @@ declare(strict_types=1);
 
 namespace Database\Factories;
 
+use App\Models\Chat\Channel;
 use App\Models\Team;
 use App\Models\User;
 
@@ -27,6 +28,7 @@ class TeamFactory extends Factory
             'name' => fn () => strtr($this->faker->unique()->userName(), '.', ' '),
             'short_name' => fn () => substr(strtr($this->faker->unique()->userName(), '.', ' '), 0, 4),
             'leader_id' => User::factory(),
+            'channel_id' => Channel::factory(),
         ];
     }
 }

--- a/database/migrations/2025_02_18_074224_add_channel_id_to_teams.php
+++ b/database/migrations/2025_02_18_074224_add_channel_id_to_teams.php
@@ -1,0 +1,27 @@
+<?php
+
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('teams', function (Blueprint $table) {
+            $table->unsignedInteger('channel_id')->nullable(false)->after('leader_id');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('teams', function (Blueprint $table) {
+            $table->dropColumn('channel_id');
+        });
+    }
+};

--- a/database/migrations/2025_02_18_210000_add_team_type_to_channels.php
+++ b/database/migrations/2025_02_18_210000_add_team_type_to_channels.php
@@ -1,0 +1,39 @@
+<?php
+
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
+use Illuminate\Database\Migrations\Migration;
+
+class AddTeamTypeToChannels extends Migration
+{
+    public function up(): void
+    {
+        DB::connection('mysql-chat')->statement("ALTER TABLE `channels` MODIFY `type` ENUM(
+            'PUBLIC',
+            'PRIVATE',
+            'MULTIPLAYER',
+            'SPECTATOR',
+            'TEMPORARY',
+            'PM',
+            'GROUP',
+            'ANNOUNCE',
+            'TEAM'
+        ) NOT NULL DEFAULT 'TEMPORARY'");
+    }
+
+    public function down()
+    {
+        DB::connection('mysql-chat')->table('channels')->where('type', 'TEAM')->update(['type' => 'TEMPORARY']);
+        DB::connection('mysql-chat')->statement("ALTER TABLE `channels` MODIFY `type` ENUM(
+            'PUBLIC',
+            'PRIVATE',
+            'MULTIPLAYER',
+            'SPECTATOR',
+            'TEMPORARY',
+            'PM',
+            'GROUP',
+            'ANNOUNCE'
+        ) NOT NULL DEFAULT 'TEMPORARY'");
+    }
+}

--- a/resources/js/chat/conversation-list-item.tsx
+++ b/resources/js/chat/conversation-list-item.tsx
@@ -18,6 +18,10 @@ interface Props {
 export default class ConversationListItem extends React.Component<Props> {
   private readonly ref = React.createRef<HTMLDivElement>();
 
+  get canPart() {
+    return this.props.channel.type !== 'TEAM';
+  }
+
   @computed
   get selected() {
     return this.props.channel.channelId === core.dataStore.chatState.selectedChannel?.channelId;
@@ -48,9 +52,11 @@ export default class ConversationListItem extends React.Component<Props> {
           ? <div className={`${baseClassName}__unread-indicator`} />
           : null}
 
-        <button className={`${baseClassName}__close-button`} onClick={this.part}>
-          <i className='fas fa-times' />
-        </button>
+        {this.canPart &&
+          <button className={`${baseClassName}__close-button`} onClick={this.part}>
+            <i className='fas fa-times' />
+          </button>
+        }
 
         <button className={`${baseClassName}__tile`} onClick={this.switch}>
           <div className={`${baseClassName}__avatar`}>

--- a/resources/js/chat/conversation-list.tsx
+++ b/resources/js/chat/conversation-list.tsx
@@ -15,6 +15,7 @@ const icons: Record<SupportedChannelType, string> = {
   GROUP: 'fas fa-user-group', // just give it an icon; nothing returns this yet.
   PM: 'fas fa-envelope',
   PUBLIC: 'fas fa-comments',
+  TEAM: 'fas fa-users',
 };
 
 function renderChannels(type: SupportedChannelType) {

--- a/resources/js/interfaces/chat/channel-json.ts
+++ b/resources/js/interfaces/chat/channel-json.ts
@@ -1,7 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
-export const supportedChannelTypes = ['ANNOUNCE', 'PUBLIC', 'GROUP', 'PM'] as const;
+export const supportedChannelTypes = ['ANNOUNCE', 'PUBLIC', 'TEAM', 'GROUP', 'PM'] as const;
 export type SupportedChannelType = (typeof supportedChannelTypes)[number];
 export const supportedTypeLookup = new Set(supportedChannelTypes) as Set<ChannelType>;
 

--- a/resources/js/stores/channel-store.ts
+++ b/resources/js/stores/channel-store.ts
@@ -47,6 +47,7 @@ const channelSorts = {
     return a.lastMessageId > b.lastMessageId ? -1 : 1;
   },
   PUBLIC: alphabeticalSort,
+  TEAM: alphabeticalSort,
 };
 
 @dispatchListener

--- a/resources/lang/en/chat.php
+++ b/resources/lang/en/chat.php
@@ -27,6 +27,7 @@ return [
                 'GROUP' => 'Groups',
                 'PM' => 'Direct messages',
                 'PUBLIC' => 'Channels',
+                'TEAM' => 'Team',
             ],
         ],
     ],

--- a/resources/lang/en/teams.php
+++ b/resources/lang/en/teams.php
@@ -120,6 +120,7 @@ return [
 
     'show' => [
         'bar' => [
+            'chat' => 'Team Chat',
             'destroy' => 'Disband Team',
             'join' => 'Request Join',
             'join_cancel' => 'Cancel Join',

--- a/resources/views/teams/show.blade.php
+++ b/resources/views/teams/show.blade.php
@@ -52,6 +52,12 @@
         </div>
         <div class="profile-detail-bar profile-detail-bar--team">
             @if ($currentUser?->team?->getKey() === $team->getKey())
+                <a
+                    class="team-action-button"
+                    href="{{ route('chat.index', ['channel_id' => $team->channel_id]) }}"
+                >
+                    {{ osu_trans('teams.show.bar.chat') }}
+                </a>
                 @php
                     $partPriv = priv_check('TeamPart', $team);
                     $canPart = $partPriv->can();

--- a/tests/Controllers/TeamsControllerTest.php
+++ b/tests/Controllers/TeamsControllerTest.php
@@ -42,6 +42,7 @@ class TeamsControllerTest extends TestCase
         $team = $user->fresh()->team;
         $this->assertNotNull($team);
         $this->assertSame($user->getKey(), $team->leader_id);
+        $this->assertNotNull($team->channel);
     }
 
     public function testStoreAlreadyPartOfTeam()

--- a/tests/Models/Chat/ChannelTest.php
+++ b/tests/Models/Chat/ChannelTest.php
@@ -11,6 +11,8 @@ use App\Events\ChatChannelEvent;
 use App\Jobs\Notifications\ChannelAnnouncement;
 use App\Libraries\User\AvatarHelper;
 use App\Models\Chat\Channel;
+use App\Models\Chat\Message;
+use App\Models\Chat\UserChannel;
 use App\Models\User;
 use App\Models\UserRelation;
 use Event;
@@ -209,6 +211,18 @@ class ChannelTest extends TestCase
 
         Event::assertDispatched(fn (ChatChannelEvent $event) => $event->action === 'join', 2);
         Event::assertNotDispatched(fn (ChatChannelEvent $event) => $event->action !== 'join');
+    }
+
+    public function testDelete(): void
+    {
+        $message = Message::factory()->create();
+        $message->channel->addUser($message->sender);
+
+        $this->expectCountChange(fn () => Channel::count(), -1);
+        $this->expectCountChange(fn () => UserChannel::count(), -1);
+        $this->expectCountChange(fn () => Message::count(), -1);
+
+        $message->channel->delete();
     }
 
     public function testGetPMChannelName()


### PR DESCRIPTION
Existing team will need to have the chat manually created. Something like `Team::where('channel_id', 0)->get()->each(function ($t) { $ch = $t->createChannel(); $t->save(); $t->members->each(fn ($m) => $ch->addUser($m->user)); })`

Also the team name is copied as channel name because it's shown in conversation list and stuff and doing additional query just for the team name would be a bit silly.