### PR TITLE
Add general handler for image processor exception

### DIFF
--- a/app/Exceptions/ImageProcessorException.php
+++ b/app/Exceptions/ImageProcessorException.php
@@ -5,9 +5,7 @@
 
 namespace App\Exceptions;
 
-use Exception;
-
-class ImageProcessorException extends Exception
+class ImageProcessorException extends InvariantException
 {
     // doesn't really contain anything
 }

--- a/app/Http/Controllers/AccountController.php
+++ b/app/Http/Controllers/AccountController.php
@@ -5,7 +5,6 @@
 
 namespace App\Http\Controllers;
 
-use App\Exceptions\ImageProcessorException;
 use App\Exceptions\ModelNotSavedException;
 use App\Libraries\Session\Store as SessionStore;
 use App\Libraries\SessionVerification;
@@ -94,12 +93,8 @@ class AccountController extends Controller
             return error_popup(osu_trans('errors.supporter_only'));
         }
 
-        try {
-            $user->cover()->set($params['cover_id'], $params['cover_file']);
-            $user->save();
-        } catch (ImageProcessorException $e) {
-            return error_popup($e->getMessage());
-        }
+        $user->cover()->set($params['cover_id'], $params['cover_file']);
+        $user->save();
 
         return json_item($user, new CurrentUserTransformer());
     }

--- a/app/Http/Controllers/AccountController.php
+++ b/app/Http/Controllers/AccountController.php
@@ -77,11 +77,7 @@ class AccountController extends Controller
     {
         $user = auth()->user();
 
-        try {
-            AvatarHelper::set($user, Request::file('avatar_file'));
-        } catch (ImageProcessorException $e) {
-            return error_popup($e->getMessage());
-        }
+        AvatarHelper::set($user, Request::file('avatar_file'));
 
         return json_item($user, new CurrentUserTransformer());
     }

--- a/app/Http/Controllers/Forum/ForumCoversController.php
+++ b/app/Http/Controllers/Forum/ForumCoversController.php
@@ -5,7 +5,6 @@
 
 namespace App\Http\Controllers\Forum;
 
-use App\Exceptions\ImageProcessorException;
 use App\Models\Forum\Forum;
 use App\Models\Forum\ForumCover;
 use App\Transformers\Forum\ForumCoverTransformer;
@@ -45,15 +44,11 @@ class ForumCoversController extends Controller
             abort(422);
         }
 
-        try {
-            $cover = ForumCover::upload(
-                Request::file('cover_file')->getRealPath(),
-                Auth::user(),
-                $forum
-            );
-        } catch (ImageProcessorException $e) {
-            return error_popup($e->getMessage());
-        }
+        $cover = ForumCover::upload(
+            Request::file('cover_file')->getRealPath(),
+            Auth::user(),
+            $forum
+        );
 
         return json_item($cover, new ForumCoverTransformer());
     }
@@ -74,14 +69,10 @@ class ForumCoversController extends Controller
         $cover = ForumCover::findOrFail($id);
 
         if (Request::hasFile('cover_file') === true) {
-            try {
-                $cover = $cover->updateFile(
-                    Request::file('cover_file')->getRealPath(),
-                    Auth::user()
-                );
-            } catch (ImageProcessorException $e) {
-                return error_popup($e->getMessage());
-            }
+            $cover = $cover->updateFile(
+                Request::file('cover_file')->getRealPath(),
+                Auth::user()
+            );
         }
 
         return json_item($cover, new ForumCoverTransformer());

--- a/app/Http/Controllers/Forum/TopicCoversController.php
+++ b/app/Http/Controllers/Forum/TopicCoversController.php
@@ -58,15 +58,11 @@ class TopicCoversController extends Controller
 
         priv_check('ForumTopicCoverStore', $forum)->ensureCan();
 
-        try {
-            $cover = TopicCover::upload(
-                $params['cover_file'],
-                Auth::user(),
-                $topic ?? null,
-            );
-        } catch (ImageProcessorException $e) {
-            return error_popup($e->getMessage());
-        }
+        $cover = TopicCover::upload(
+            $params['cover_file'],
+            Auth::user(),
+            $topic ?? null,
+        );
 
         return json_item($cover, new TopicCoverTransformer());
     }

--- a/app/Http/Controllers/Forum/TopicCoversController.php
+++ b/app/Http/Controllers/Forum/TopicCoversController.php
@@ -5,7 +5,6 @@
 
 namespace App\Http\Controllers\Forum;
 
-use App\Exceptions\ImageProcessorException;
 use App\Models\Forum\Forum;
 use App\Models\Forum\Topic;
 use App\Models\Forum\TopicCover;
@@ -87,14 +86,10 @@ class TopicCoversController extends Controller
         priv_check('ForumTopicCoverEdit', $cover)->ensureCan();
 
         if (Request::hasFile('cover_file') === true) {
-            try {
-                $cover = $cover->updateFile(
-                    Request::file('cover_file')->getRealPath(),
-                    Auth::user()
-                );
-            } catch (ImageProcessorException $e) {
-                return error_popup($e->getMessage());
-            }
+            $cover = $cover->updateFile(
+                Request::file('cover_file')->getRealPath(),
+                Auth::user()
+            );
         }
 
         return json_item($cover, new TopicCoverTransformer());


### PR DESCRIPTION
Removing the same handler... which is already what the default handler does.

Also fixes error 500 when thrown somewhere else currently not having explicit handler like team settings.