### PR TITLE
 Remove mail notification for team join/reject

### DIFF
--- a/app/Jobs/Notifications/TeamApplicationBase.php
+++ b/app/Jobs/Notifications/TeamApplicationBase.php
@@ -12,7 +12,7 @@ use App\Models\User;
 
 abstract class TeamApplicationBase extends BroadcastNotificationBase
 {
-    const DELIVERY_MODE_DEFAULTS = ['mail' => true, 'push' => true];
+    const DELIVERY_MODE_DEFAULTS = ['mail' => false, 'push' => true];
 
     protected Team $team;
     protected int $userId;


### PR DESCRIPTION
There's no settings for it and it's probably fine with just push notification.