### PR TITLE
Fix chat channel not displaying some new messages

### DIFF
--- a/resources/js/chat/chat-state-store.ts
+++ b/resources/js/chat/chat-state-store.ts
@@ -100,6 +100,7 @@ export default class ChatStateStore implements DispatchListener {
       } else {
         this.pingService.stop();
         dispatch(new SocketMessageSendAction({ event: 'chat.end' }));
+        this.channelStore.channels.forEach((channel) => channel.needsRefresh = true);
       }
     });
 
@@ -274,7 +275,6 @@ export default class ChatStateStore implements DispatchListener {
   private handleSocketStateChanged(event: SocketStateChangedAction) {
     this.isConnected = event.connected;
     if (!event.connected) {
-      this.channelStore.channels.forEach((channel) => channel.needsRefresh = true);
       this.isReady = false;
     }
   }

--- a/resources/js/chat/chat-state-store.ts
+++ b/resources/js/chat/chat-state-store.ts
@@ -113,8 +113,6 @@ export default class ChatStateStore implements DispatchListener {
         }
 
         runInAction(() => {
-          this.selectedChannel?.load();
-
           this.isReady = true;
         });
       }


### PR DESCRIPTION
Fixes the case where after chat and a channel was loaded and then chat was navigated away from, messages sent to that channel, would not be loaded when navigating back to that channel.

Basically, messages sent to a previously loaded channel, during the period chat is not the active page, would not be loaded. (This becomes more obvious with the upcoming Team chat link)