### PR TITLE
Enforce specified aspect ratio even on smaller image

### DIFF
--- a/app/Libraries/ImageProcessor.php
+++ b/app/Libraries/ImageProcessor.php
@@ -83,35 +83,47 @@ class ImageProcessor
             $this->inputDim[0] <= $this->targetDim[0] &&
             $this->inputDim[1] <= $this->targetDim[1]
         ) {
-            if ($this->inputFileSize < $this->targetFileSize) {
+            if (
+                $this->inputFileSize < $this->targetFileSize &&
+                $this->inputDim[0] === $this->targetDim[0] &&
+                $this->inputDim[1] === $this->targetDim[1]
+            ) {
                 return;
             }
 
-            $image = $inputImage;
-        } else {
-            $start = [0, 0];
-            $inDim = [$this->inputDim[0], $this->inputDim[1]];
-            $outDim = [$this->targetDim[0], $this->targetDim[1]];
-
-            // figure out how to crop.
-            if ($this->inputDim[0] / $this->inputDim[1] >= $this->targetDim[0] / $this->targetDim[1]) {
-                $inDim[0] = $this->targetDim[0] / $this->targetDim[1] * $this->inputDim[1];
-                $start[0] = ($this->inputDim[0] - $inDim[0]) / 2;
-            } else {
-                $inDim[1] = $this->targetDim[1] / $this->targetDim[0] * $this->inputDim[0];
-                $start[1] = ($this->inputDim[1] - $inDim[1]) / 2;
-            }
-
-            // don't scale if input image is smaller.
-            if ($inDim[0] < $outDim[0] || $inDim[1] < $outDim[1]) {
-                $outDim = $inDim;
-            }
-
-            $image = imagecreatetruecolor($outDim[0], $outDim[1]);
-            imagesavealpha($image, true);
-            imagefill($image, 0, 0, imagecolorallocatealpha($image, 0, 0, 0, 127));
-            imagecopyresampled($image, $inputImage, 0, 0, $start[0], $start[1], $outDim[0], $outDim[1], $inDim[0], $inDim[1]);
+            $newHeight = $this->inputDim[0] * $this->targetDim[1] / $this->targetDim[0];
+            $this->targetDim = $newHeight <= $this->inputDim[1]
+                ? [
+                    $this->inputDim[0],
+                    $newHeight,
+                ] : [
+                    $this->inputDim[1] * $this->targetDim[0] / $this->targetDim[1],
+                    $this->inputDim[1],
+                ];
         }
+
+        $start = [0, 0];
+        $inDim = [$this->inputDim[0], $this->inputDim[1]];
+        $outDim = [$this->targetDim[0], $this->targetDim[1]];
+
+        // figure out how to crop.
+        if ($this->inputDim[0] / $this->inputDim[1] >= $this->targetDim[0] / $this->targetDim[1]) {
+            $inDim[0] = $this->targetDim[0] / $this->targetDim[1] * $this->inputDim[1];
+            $start[0] = ($this->inputDim[0] - $inDim[0]) / 2;
+        } else {
+            $inDim[1] = $this->targetDim[1] / $this->targetDim[0] * $this->inputDim[0];
+            $start[1] = ($this->inputDim[1] - $inDim[1]) / 2;
+        }
+
+        // don't scale if input image is smaller.
+        if ($inDim[0] < $outDim[0] || $inDim[1] < $outDim[1]) {
+            $outDim = $inDim;
+        }
+
+        $image = imagecreatetruecolor($outDim[0], $outDim[1]);
+        imagesavealpha($image, true);
+        imagefill($image, 0, 0, imagecolorallocatealpha($image, 0, 0, 0, 127));
+        imagecopyresampled($image, $inputImage, 0, 0, $start[0], $start[1], $outDim[0], $outDim[1], $inDim[0], $inDim[1]);
 
         $toJpeg = true;
 


### PR DESCRIPTION
For example, instead of 1200x450 image stored as is for something that's 2000x500, it's cropped to 1200x300.