### PR TITLE
Adjust team empty slots display

### DIFF
--- a/app/Models/Team.php
+++ b/app/Models/Team.php
@@ -168,7 +168,7 @@ class Team extends Model
         $max = $this->maxMembers();
         $current = $this->members->count();
 
-        return max(0, $max - $current);
+        return $max - $current;
     }
 
     public function flag(): Uploader

--- a/resources/views/teams/members/index.blade.php
+++ b/resources/views/teams/members/index.blade.php
@@ -84,7 +84,7 @@
                     {{ osu_trans('teams.members.index.applications.title') }}
                 </h2>
                 <p>
-                    {{ osu_trans('teams.members.index.applications.empty_slots') }}: {{ $team->emptySlots() }}
+                    {{ osu_trans('teams.members.index.applications.empty_slots') }}: {{ i18n_number_format($team->emptySlots()) }}
                 </p>
                 @if ($team->applications->isEmpty())
                     {{ osu_trans('teams.members.index.applications.empty') }}


### PR DESCRIPTION
- format number
- show negative number so it's clear whether or not getting a supporter tag will actually net additional slots