### PR TITLE
Fix error when listing event of deleted beatmapset

### DIFF
--- a/app/Models/BeatmapDiscussion.php
+++ b/app/Models/BeatmapDiscussion.php
@@ -249,6 +249,7 @@ class BeatmapDiscussion extends Model
     public function canGrantKudosu()
     {
         return in_array($this->attributes['message_type'] ?? null, static::KUDOSUABLE_TYPES, true) &&
+            $this->beatmapset !== null &&
             $this->user_id !== $this->beatmapset->user_id &&
             !$this->trashed() &&
             !$this->kudosu_denied;


### PR DESCRIPTION
It seems like this is the only missing null check.

Resolves [this sentry thing](<https://sentry.ppy.sh/organizations/ppy/issues/74976>).