### PR TITLE
Fix discussion page error with no visible beatmap

### DIFF
--- a/resources/js/stores/beatmapset-discussions-show-store.ts
+++ b/resources/js/stores/beatmapset-discussions-show-store.ts
@@ -19,10 +19,16 @@ export default class BeatmapsetDiscussionsShowStore implements BeatmapsetDiscuss
       }
     }
 
-    return mapBy(
-      this.beatmapset.beatmaps.filter((beatmap) => beatmap.deleted_at == null || hasDiscussion.has(beatmap.id)),
-      'id',
-    );
+    let visibleBeatmaps = this
+      .beatmapset
+      .beatmaps
+      .filter((beatmap) => beatmap.deleted_at == null || hasDiscussion.has(beatmap.id));
+
+    if (visibleBeatmaps.length === 0) {
+      visibleBeatmaps = [this.beatmapset.beatmaps[0]];
+    }
+
+    return mapBy(visibleBeatmaps, 'id');
   }
 
   @computed


### PR DESCRIPTION
If there's discussion on the general section but none on any specific beatmaps, the store's `beatmaps` property ended up empty and crashes on discussions-state:402 (finding current beatmap id).

- deleted beatmapset
- deleted beatmaps (all of them)
- no discussion on any specific beatmaps
- there's discussion on general all section (not sure if actually needed to trigger the error)