### PR TITLE
Set max-height of team summary to constant pixel amount

### DIFF
--- a/resources/css/bem/team-summary.less
+++ b/resources/css/bem/team-summary.less
@@ -9,7 +9,7 @@
   gap: 20px;
   grid-template-columns: 1fr;
   align-items: start;
-  max-height: calc(70 * var(--vh));
+  max-height: 400px;
   overflow-y: scroll;
 
   @media @desktop {


### PR DESCRIPTION
Having the height of the team summary change based on browser height is not only weird, but annoying if your browser window changes size for any reason. For example:

https://github.com/user-attachments/assets/6dc0bb1c-a6bd-4c02-aa73-9d07af3411c0

I chose 400px since that's the max height of the me! page on player profiles. Could easily be changed to fit whatever needs.