### PR TITLE
Specify chromium package for install

### DIFF
--- a/Dockerfile.development
+++ b/Dockerfile.development
@@ -12,6 +12,7 @@ RUN echo "deb [signed-by=/usr/share/keyrings/nodesource.gpg] https://deb.nodesou
 RUN apt-get update
 RUN DEBIAN_FRONTEND=noninteractive apt-get install -y \
     build-essential \
+    chromium \
     chromium-driver \
     default-mysql-client \
     git \


### PR DESCRIPTION
It was previously dependency of chromium-driver but not anymore in 134 (or at least 133.0.6943.141-2).