### PR TITLE
Fix es document reindex output

### DIFF
--- a/app/Console/Commands/EsIndexDocuments.php
+++ b/app/Console/Commands/EsIndexDocuments.php
@@ -109,8 +109,8 @@ class EsIndexDocuments extends Command
             $this->info("{$pretext} {$type} into {$indexName}");
 
             $progressCallback = function ($progress, $message) use ($bar) {
-                $bar->setProgress($progress);
                 $bar->setMessage($message);
+                $bar->setProgress($progress);
             };
             if (!$this->inplace && $type === $first) {
                 // create new index if the first type for this index, otherwise

--- a/app/Console/Commands/EsIndexDocuments.php
+++ b/app/Console/Commands/EsIndexDocuments.php
@@ -104,20 +104,21 @@ class EsIndexDocuments extends Command
 
         foreach ($types as $type) {
             $bar = $this->output->createProgressBar();
+            $bar->setFormat(' %current% [%bar%] %message%');
 
             $this->info("{$pretext} {$type} into {$indexName}");
 
+            $progressCallback = function ($progress, $message) use ($bar) {
+                $bar->setProgress($progress);
+                $bar->setMessage($message);
+            };
             if (!$this->inplace && $type === $first) {
                 // create new index if the first type for this index, otherwise
                 // index in place.
-                $type::esIndexIntoNew(Es::CHUNK_SIZE, $indexName, function ($progress) use ($bar) {
-                    $bar->setProgress($progress);
-                });
+                $type::esIndexIntoNew(Es::CHUNK_SIZE, $indexName, $progressCallback);
             } else {
                 $options = ['index' => $indexName];
-                $type::esReindexAll(Es::CHUNK_SIZE, 0, $options, function ($progress) use ($bar) {
-                    $bar->setProgress($progress);
-                });
+                $type::esReindexAll(Es::CHUNK_SIZE, 0, $options, $progressCallback);
             }
 
             $bar->finish();

--- a/app/Console/Commands/EsIndexWiki.php
+++ b/app/Console/Commands/EsIndexWiki.php
@@ -136,10 +136,13 @@ class EsIndexWiki extends Command
         $total = count($paths);
         $this->line("Total: {$total} documents");
         $bar = $this->output->createProgressBar($total);
+        $bar->setFormat(' %current% [%bar%] %message%');
+        $logger = fn ($message) => $bar->setMessage($message);
 
         foreach ($paths as $path => $_inEs) {
             $pagePath = Page::parsePagePath($path);
             $page = new Page($pagePath['path'], $pagePath['locale']);
+            $page->logger = $logger;
             $page->sync(true, $this->indexName);
 
             if (!$page->isVisible()) {

--- a/app/Models/Traits/Es/BaseDbIndexable.php
+++ b/app/Models/Traits/Es/BaseDbIndexable.php
@@ -60,9 +60,11 @@ trait BaseDbIndexable
                 $count += count($result['items']);
             }
 
-            Log::info(static::class." next: {$models->last()->getKey()}");
-            if ($progress) {
-                $progress($count);
+            $message = "next: {$models->last()->getKey()}";
+            if ($progress === null) {
+                Log::info(static::class.' '.$message);
+            } else {
+                $progress($count, $message);
             }
         });
 

--- a/app/Models/Wiki/Page.php
+++ b/app/Models/Wiki/Page.php
@@ -21,7 +21,6 @@ use App\Traits\Memoizes;
 use Carbon\Carbon;
 use Ds\Set;
 use Exception;
-use Log;
 
 class Page implements WikiObject
 {
@@ -41,6 +40,7 @@ class Page implements WikiObject
     ];
 
     public $locale;
+    public \Closure $logger;
     public $path;
     public $requestedLocale;
 
@@ -459,6 +459,12 @@ class Page implements WikiObject
 
     private function log($action)
     {
-        Log::info("wiki ({$action}): {$this->pagePath()}");
+        $message = "wiki ({$action}): {$this->pagePath()}";
+
+        if (isset($this->logger)) {
+            ($this->logger)($message);
+        } else {
+            \Log::info($message);
+        }
     }
 }


### PR DESCRIPTION
The new default stdout logging broke the progress bar. That said, there's no obvious way to resume anyway so it's barely useful.