### PR TITLE
Add country filter for score ranking

### DIFF
--- a/app/Http/Controllers/RankingController.php
+++ b/app/Http/Controllers/RankingController.php
@@ -94,7 +94,7 @@ class RankingController extends Controller
                 abort(404);
             }
 
-            if (isset($this->params['country']) && $type === 'performance') {
+            if (isset($this->params['country']) && static::hasCountryFilter($type)) {
                 $this->countryStats = CountryStatistics::where('display', 1)
                     ->where('country_code', $this->params['country'])
                     ->where('mode', Beatmap::modeInt($mode))
@@ -108,7 +108,7 @@ class RankingController extends Controller
             }
 
             $this->defaultViewVars['country'] = $this->country;
-            if ($type === 'performance') {
+            if (static::hasCountryFilter($type)) {
                 $this->defaultViewVars['countries'] = json_collection(
                     Country::whereHasRuleset($mode)->get(),
                     new SelectOptionTransformer(),
@@ -132,12 +132,17 @@ class RankingController extends Controller
             'multiplayer' => route('multiplayer.rooms.show', ['room' => 'latest']),
             'seasons' => route('seasons.show', ['season' => 'latest']),
             default => route('rankings', [
-                'country' => $country !== null && $type === 'performance' ? $country->getKey() : null,
+                'country' => $country !== null && static::hasCountryFilter($type) ? $country->getKey() : null,
                 'mode' => $rulesetName,
                 'spotlight' => $spotlight !== null && $type === 'charts' ? $spotlight->getKey() : null,
                 'type' => $type,
             ]),
         };
+    }
+
+    private static function hasCountryFilter(string $type): bool
+    {
+        return $type === 'performance' || $type === 'score';
     }
 
     /**
@@ -203,9 +208,17 @@ class RankingController extends Controller
 
                 $stats->orderBy('rank_score', 'desc');
             } else { // 'score'
+                if ($this->country !== null) {
+                    $stats->where('country_acronym', $this->country['acronym']);
+                    // preferrable to ranked_score when filtering by country.
+                    // On a few countries the default index is slightly better but much worse on the rest.
+                    $forceIndex = 'country_ranked_score';
+                } else {
+                    // force to order by ranked_score instead of sucking down entire users table first.
+                    $forceIndex = 'ranked_score';
+                }
+
                 $stats->orderBy('ranked_score', 'desc');
-                // force to order by ranked_score instead of sucking down entire users table first.
-                $forceIndex = 'ranked_score';
             }
 
             if ($this->friendsOnly) {

--- a/database/migrations/2025_03_18_065831_add_country_ranked_score_index_to_stats_tables.php
+++ b/database/migrations/2025_03_18_065831_add_country_ranked_score_index_to_stats_tables.php
@@ -28,6 +28,7 @@ return new class extends Migration
         foreach (static::TABLE_VARIANTS as $table) {
             Schema::table($table, function (Blueprint $table) {
                 $table->bigInteger('ranked_score')->default(0)->after('rank_score_index');
+                $table->index('ranked_score', 'ranked_score');
             });
         }
 
@@ -48,6 +49,7 @@ return new class extends Migration
 
         foreach (static::TABLE_VARIANTS as $table) {
             Schema::table($table, function (Blueprint $table) {
+                $table->dropIndex('ranked_score', 'ranked_score');
                 $table->dropColumn('ranked_score');
             });
         }

--- a/database/migrations/2025_03_18_065831_add_country_ranked_score_index_to_stats_tables.php
+++ b/database/migrations/2025_03_18_065831_add_country_ranked_score_index_to_stats_tables.php
@@ -1,0 +1,55 @@
+<?php
+
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    const TABLES = [
+        'osu_user_stats',
+        'osu_user_stats_fruits',
+        'osu_user_stats_mania',
+        'osu_user_stats_taiko',
+    ];
+
+    const TABLE_VARIANTS = [
+        'osu_user_stats_mania_4k',
+        'osu_user_stats_mania_7k',
+    ];
+
+    public function up(): void
+    {
+        foreach (static::TABLE_VARIANTS as $table) {
+            Schema::table($table, function (Blueprint $table) {
+                $table->bigInteger('ranked_score')->default(0)->after('rank_score_index');
+            });
+        }
+
+        foreach ([...static::TABLES, ...static::TABLE_VARIANTS] as $table) {
+            Schema::table($table, function (Blueprint $table) {
+                $table->index(['country_acronym', 'ranked_score'], 'country_ranked_score');
+            });
+        }
+    }
+
+    public function down(): void
+    {
+        foreach ([...static::TABLES, ...static::TABLE_VARIANTS] as $table) {
+            Schema::table($table, function (Blueprint $table) {
+                $table->dropIndex('country_ranked_score');
+            });
+        }
+
+        foreach (static::TABLE_VARIANTS as $table) {
+            Schema::table($table, function (Blueprint $table) {
+                $table->dropColumn('ranked_score');
+            });
+        }
+    }
+};

--- a/resources/views/rankings/score.blade.php
+++ b/resources/views/rankings/score.blade.php
@@ -7,6 +7,7 @@
 @section('ranking-header')
     <div class="osu-page osu-page--ranking-info">
         <div class="grid-items grid-items--ranking-filter">
+            @include('rankings._country_filter')
             @include('rankings._user_filter')
         </div>
     </div>


### PR DESCRIPTION
The final goal is to allow same filters between performance and score sorting option just like on team ranking page (and reducing number of menu items). The index is similar to the one used for performance so performance characteristics should be the same.

The columns are also added for variant statistics but the process for updating it isn't in place (yet?) so it's still one step short from being able to have sort buttons.

Migration entry is `2025_03_18_065831_add_country_ranked_score_index_to_stats_tables`.