### PR TITLE
Fix max combo query scope

### DIFF
--- a/app/Models/Beatmap.php
+++ b/app/Models/Beatmap.php
@@ -166,21 +166,18 @@ class Beatmap extends Model implements AfterCommit
 
     public function scopeWithMaxCombo($query)
     {
-        $mods = BeatmapDifficultyAttrib::NO_MODS;
-        $attrib = BeatmapDifficultyAttrib::MAX_COMBO;
-        $attribTable = (new BeatmapDifficultyAttrib())->tableName();
-        $mode = $this->qualifyColumn('playmode');
-        $id = $this->qualifyColumn('beatmap_id');
+        $valueQuery = BeatmapDifficultyAttrib
+            ::select('value')
+            ->whereColumn([
+                'beatmap_id' => $this->qualifyColumn('beatmap_id'),
+                'mode' => $this->qualifyColumn('playmode'),
+            ])
+            ->where([
+                'attrib_id' => BeatmapDifficultyAttrib::MAX_COMBO,
+                'mods' => BeatmapDifficultyAttrib::NO_MODS,
+            ]);
 
-        return $query
-            ->addSelect(['attrib_max_combo' => DB::raw("(
-                SELECT value
-                FROM {$attribTable}
-                WHERE beatmap_id = {$id}
-                    AND mode = {$mode}
-                    AND mods = {$mods}
-                    AND attrib_id = {$attrib}
-            )")]);
+        return $query->addSelect(['attrib_max_combo' => $valueQuery]);
     }
 
     public function scopeWithUserPlaycount(Builder $query, ?int $userId): Builder


### PR DESCRIPTION
Using DB::raw gives different result compared to proper Builder.

ಠ_ಠ

The result is beatmapset search - which only uses this scope - doesn't actually select `beatmap.*`.