### PR TITLE
Add space between note message and user

### DIFF
--- a/resources/css/bem/profile-extra-recent-infringements.less
+++ b/resources/css/bem/profile-extra-recent-infringements.less
@@ -76,9 +76,5 @@
 
   &__actor {
     color: @osu-colour-l1;
-
-    &::before {
-      content: "";
-    }
   }
 }

--- a/resources/js/profile-page/account-standing.tsx
+++ b/resources/js/profile-page/account-standing.tsx
@@ -43,6 +43,7 @@ const ColumnDescription = ({ history }: ColumnProps) => (
 
     {history.actor != null && (
       <span className={`${bn}__actor`}>
+        {' '}
         <StringWithComponent
           mappings={{ username: <UserLink user={history.actor} /> }}
           pattern={trans('users.show.extra.account_standing.recent_infringements.actor')}


### PR DESCRIPTION
The space got removed during mass css update which changed all `" "` to `""`.

Changed it to add space from react side instead as it seems simpler.