### PR TITLE
Prevent chat channel event from affecting passed models

### DIFF
--- a/app/Events/ChatChannelEvent.php
+++ b/app/Events/ChatChannelEvent.php
@@ -13,8 +13,13 @@ use Illuminate\Contracts\Broadcasting\ShouldBroadcastNow;
 
 class ChatChannelEvent extends BroadcastableEventBase implements ShouldBroadcastNow
 {
-    public function __construct(public ChatChannel $channel, public User $user, public string $action)
+    private ChatChannel $channel;
+    private User $user;
+
+    public function __construct(ChatChannel $channel, User $user, public string $action)
     {
+        $this->channel = clone $channel;
+        $this->user = clone $user;
     }
 
     public function broadcastAs()


### PR DESCRIPTION
It's not currently visible in test due to the events not being actually triggered but laravel 11 actually dispatches the events and thus affecting a bunch of tests related to memoization.

That said, `clone` is kinda shallow but it's enough to pass the tests...

I personally would probably rather just nuke the memoization tests and pass fresh objects for the other broken tests 🤷‍♀️

Can be tested on laravel 10 by updating this check to `false` https://github.com/ppy/osu-web/blob/63290b63392e82c34b148e59bbba27ee7d0f0388/app/Events/BroadcastableEventBase.php#L21