### PR TITLE
Fix parsing multiple quoted search options

### DIFF
--- a/app/Libraries/Search/BeatmapsetQueryParser.php
+++ b/app/Libraries/Search/BeatmapsetQueryParser.php
@@ -15,7 +15,8 @@ class BeatmapsetQueryParser
         $options = [];
 
         // reference: https://github.com/ppy/osu/blob/f6baf49ad6b42c662a729ad05e18bd99bc48b4c7/osu.Game/Screens/Select/FilterQueryParser.cs
-        $keywords = preg_replace_callback('#\b(?<key>\w+)(?<op>(:|=|(>|<)(:|=)?))(?<value>(".*")|(\S*))#i', function ($m) use (&$options) {
+        // adjusted for multiple quoted options (with side effect of inner quotes must be escaped)
+        $keywords = preg_replace_callback('#\b(?<key>\w+)(?<op>(:|=|(>|<)(:|=)?))(?<value>("{1,2})(?:\\\"|.)*?\7|\S*)#i', function ($m) use (&$options) {
             $key = strtolower($m['key']);
             $op = str_replace(':', '=', $m['op']);
             switch ($key) {
@@ -240,7 +241,7 @@ class BeatmapsetQueryParser
     private static function makeTextOption(string $operator, string $value): ?string
     {
         return $operator === '='
-            ? presence(preg_replace('/^"(.*)"$/', '$1', $value))
+            ? presence(strtr(preg_replace('/^"(.*)"$/', '$1', $value), ['\\"' => '"']))
             : null;
     }
 

--- a/resources/js/beatmapsets-show/header.tsx
+++ b/resources/js/beatmapsets-show/header.tsx
@@ -14,7 +14,7 @@ import { observer } from 'mobx-react';
 import core from 'osu-core-singleton';
 import * as React from 'react';
 import { hasGuestOwners } from 'utils/beatmap-helper';
-import { downloadLimited, getArtist, getTitle, toggleFavourite } from 'utils/beatmapset-helper';
+import { downloadLimited, getArtist, getTitle, makeSearchQueryOption, toggleFavourite } from 'utils/beatmapset-helper';
 import { classWithModifiers } from 'utils/css';
 import { formatNumber } from 'utils/html';
 import { trans } from 'utils/lang';
@@ -146,7 +146,7 @@ export default class Header extends React.Component<Props> {
           <span className='beatmapset-header__details-text beatmapset-header__details-text--title'>
             <a
               className='beatmapset-header__details-text-link'
-              href={route('beatmapsets.index', { q: `title=""${getTitle(this.controller.beatmapset)}""` })}
+              href={route('beatmapsets.index', { q: makeSearchQueryOption('title', getTitle(this.controller.beatmapset)) })}
             >
               {getTitle(this.controller.beatmapset)}
             </a>
@@ -163,7 +163,7 @@ export default class Header extends React.Component<Props> {
           <span className='beatmapset-header__details-text beatmapset-header__details-text--artist'>
             <a
               className='beatmapset-header__details-text-link'
-              href={route('beatmapsets.index', { q: `artist=""${getArtist(this.controller.beatmapset)}""` })}
+              href={route('beatmapsets.index', { q: makeSearchQueryOption('artist', getArtist(this.controller.beatmapset)) })}
             >
               {getArtist(this.controller.beatmapset)}
             </a>

--- a/resources/js/beatmapsets-show/info.tsx
+++ b/resources/js/beatmapsets-show/info.tsx
@@ -13,6 +13,7 @@ import { action, computed, makeObservable, observable, runInAction } from 'mobx'
 import { observer } from 'mobx-react';
 import * as React from 'react';
 import { onErrorWithClick } from 'utils/ajax';
+import { makeSearchQueryOption } from 'utils/beatmapset-helper';
 import { formatNumber } from 'utils/html';
 import { trans } from 'utils/lang';
 import { present } from 'utils/string';
@@ -163,7 +164,7 @@ export default class Info extends React.Component<Props> {
               </h3>
               <a
                 className='beatmapset-info__link'
-                href={route('beatmapsets.index', { q: `source=""${this.controller.beatmapset.source}""` })}
+                href={route('beatmapsets.index', { q: makeSearchQueryOption('source', this.controller.beatmapset.source) })}
               >
                 {this.controller.beatmapset.source}
               </a>

--- a/resources/js/utils/beatmapset-helper.ts
+++ b/resources/js/utils/beatmapset-helper.ts
@@ -34,6 +34,10 @@ export function getTitle(beatmapset: BeatmapsetJson) {
   return beatmapset.title;
 }
 
+export function makeSearchQueryOption(key: string, value: string) {
+  return `${key}=""${value.replace(/"/g, '\\"')}""`;
+}
+
 export function showVisual(beatmapset: BeatmapsetJson) {
   return !beatmapset.nsfw || core.userPreferences.get('beatmapset_show_nsfw');
 }

--- a/tests/Libraries/Search/BeatmapsetQueryParserTest.php
+++ b/tests/Libraries/Search/BeatmapsetQueryParserTest.php
@@ -45,10 +45,13 @@ class BeatmapsetQueryParserTest extends TestCase
             ['ranked>2018/05/01', ['keywords' => null, 'options' => ['ranked' => ['gte' => static::parseTime('2018-05-02')]]]],
             ['ranked>="2020-07-21 12:30:30 +09:00"', ['keywords' => null, 'options' => ['ranked' => ['gte' => static::parseTime('2020-07-21 03:30:30')]]]],
             ['ranked="2020-07-21 12:30:30 +09:00"', ['keywords' => null, 'options' => ['ranked' => ['gte' => static::parseTime('2020-07-21 03:30:30'), 'lt' => static::parseTime('2020-07-21 03:30:31')]]]],
+            ['ranked>="2020-07-21 12:30:30 +09:00" ranked<="2020-08-21 13:40:40 +09:00"', ['keywords' => null, 'options' => ['ranked' => ['gte' => static::parseTime('2020-07-21 03:30:30'), 'lt' => static::parseTime('2020-08-21 04:40:41')]]]],
             ['ranked="invalid date format"', ['keywords' => 'ranked="invalid date format"', 'options' => []]],
             ['tag=hello', ['keywords' => null, 'options' => ['tag' => ['hello']]]],
             ['tag=hello tag=world', ['keywords' => null, 'options' => ['tag' => ['hello', 'world']]]],
             ['tag="hello world"', ['keywords' => null, 'options' => ['tag' => ['hello world']]]],
+            ['tag="hello world" tag="foo bar"', ['keywords' => null, 'options' => ['tag' => ['hello world', 'foo bar']]]],
+            ['tag="hello world"aa tag="foo bar"', ['keywords' => 'aa', 'options' => ['tag' => ['hello world', 'foo bar']]]],
 
             // multiple options
             ['artist=hello creator:world', ['keywords' => null, 'options' => ['artist' => 'hello', 'creator' => 'world']]],
@@ -88,7 +91,7 @@ class BeatmapsetQueryParserTest extends TestCase
             ['find me songs by artist=singer please', ['keywords' => 'find me songs by  please', 'options' => ['artist' => 'singer']]],
             ['really like artist="name with space" yes', ['keywords' => 'really like  yes', 'options' => ['artist' => 'name with space']]],
             ['weird artist=double"quote', ['keywords' => 'weird', 'options' => ['artist' => 'double"quote']]],
-            ['weird artist="nested "quote"" thing', ['keywords' => 'weird  thing', 'options' => ['artist' => 'nested "quote"']]],
+            ['weird artist="nested \"quote\"" thing', ['keywords' => 'weird  thing', 'options' => ['artist' => 'nested "quote"']]],
             ['artist=><something', ['keywords' => null, 'options' => ['artist' => '><something']]],
             ['unrecognised=keyword', ['keywords' => 'unrecognised=keyword', 'options' => []]],
             ['cs=nope', ['keywords' => 'cs=nope', 'options' => []]],


### PR DESCRIPTION
mm regexp. This disallows `artist="something "weird""`; inner quotes must be escaped `\"`.

The behaviour for `tag="hello world"aa` is a bit weird ┐( ･_･)┌