### PR TITLE
Fix user card length on supporter store page

### DIFF
--- a/resources/css/bem/store-supporter-tag.less
+++ b/resources/css/bem/store-supporter-tag.less
@@ -20,7 +20,7 @@
   &__user-search {
     display: grid;
     grid-gap: 5px;
-    grid-template-columns: minmax(@user-card-width, 1fr);
+    grid-template-columns: minmax(0, @user-card-width * 1.5);
 
     justify-content: center;
   }


### PR DESCRIPTION
It's kinda silly isn't it.

1.5&times; seems like a fine width especially considering some cards now can use the additional width.