### PR TITLE
Show more accurate order state message after xsolla redirect

### DIFF
--- a/app/Http/Controllers/Payments/XsollaController.php
+++ b/app/Http/Controllers/Payments/XsollaController.php
@@ -7,7 +7,6 @@ namespace App\Http\Controllers\Payments;
 
 use App\Exceptions\InvalidSignatureException;
 use App\Exceptions\Store\OrderException;
-use App\Libraries\OrderCheckout;
 use App\Libraries\Payments\XsollaPaymentProcessor;
 use App\Libraries\Payments\XsollaSignature;
 use App\Libraries\Payments\XsollaUserNotFoundException;

--- a/app/Http/Controllers/Payments/XsollaController.php
+++ b/app/Http/Controllers/Payments/XsollaController.php
@@ -106,9 +106,9 @@ class XsollaController extends Controller
     public function completed()
     {
         $orderNumber = Request::input('foreignInvoice') ?? '';
-        $order = OrderCheckout::for($orderNumber)->completeCheckout();
+        $order = Order::whereOrderNumber($orderNumber)->firstOrFail();
 
-        return redirect(route('store.invoice.show', ['invoice' => $order->order_id, 'thanks' => 1]));
+        return redirect(route('store.invoice.show', ['invoice' => $order->getKey(), 'thanks' => 1]));
     }
 
     private function errorResponse(string $message, string $code, int $status)


### PR DESCRIPTION
Leaves the order showing the more accurate `confirmation pending` message instead of the `preparing/paid` message after being redirected by the Paystation widget