### PR TITLE
Fix handling ranking page parameters

### DIFF
--- a/app/Http/Controllers/RankingController.php
+++ b/app/Http/Controllers/RankingController.php
@@ -55,18 +55,23 @@ class RankingController extends Controller
         $this->middleware('require-scopes:public');
 
         $this->middleware(function ($request, $next) {
-            $this->params = get_params(array_merge($request->all(), $request->route()->parameters()), null, [
-                'country', // overridden later for view
-                'filter',
-                'mode',
-                'spotlight:int', // will be overriden by spotlight object for view
-                'type',
-                'variant',
-            ]);
+            $this->params = [
+                ...get_params($request->all(), null, [
+                    'country', // overridden later for view
+                    'filter',
+                    'spotlight:int', // will be overriden by spotlight object for view
+                    'variant',
+                ]),
+                ...get_params($request->route()->parameters(), null, [
+                    'mode',
+                    'sort',
+                    'type',
+                ], ['null_missing' => true]),
+            ];
 
             // these parts of the route are optional.
-            $mode = $this->params['mode'] ?? null;
-            $type = $this->params['type'] ?? null;
+            $mode = $this->params['mode'];
+            $type = $this->params['type'];
 
             $this->params['filter'] = $this->params['filter'] ?? null;
             $this->friendsOnly = auth()->check() && $this->params['filter'] === 'friends';


### PR DESCRIPTION
Adding `type` query string parameter will incorrectly pass initial parameter check but then breaks when actually attempted to be rendered as the controller action strictly uses route path parameter.

Reference: https://sentry.ppy.sh/organizations/ppy/issues/77839