### PR TITLE
Return user tag ruleset ID when listing all tags

### DIFF
--- a/app/Transformers/TagTransformer.php
+++ b/app/Transformers/TagTransformer.php
@@ -16,6 +16,7 @@ class TagTransformer extends TransformerAbstract
         return [
             'id' => $item->getKey(),
             'name' => $item->name,
+            'ruleset_id' => $item->ruleset_id,
             'description' => $item->description,
         ];
     }


### PR DESCRIPTION
Follow-up from https://github.com/ppy/osu-web/pull/12059

The client uses `GET /api/v2/tags` to retrieve all possible tags, caches the result of that for the entire gameplay session, and then uses that cached result to display a list of all possible tags to choose from on the appropriate voting control.

Without this change, it was not possible to determine whether a user tag is specific to a ruleset or not via the aforementioned API endpoint.