### PR TITLE
Validate mods against freestyle allowance

### DIFF
--- a/app/Models/Multiplayer/PlaylistItem.php
+++ b/app/Models/Multiplayer/PlaylistItem.php
@@ -172,13 +172,6 @@ class PlaylistItem extends Model
 
     private function assertValidMods()
     {
-        if ($this->freestyle) {
-            if (count($this->allowed_mods) !== 0 || count($this->required_mods) !== 0) {
-                throw new InvariantException("mod isn't allowed in freestyle");
-            }
-            return;
-        }
-
         $allowedModIds = array_column($this->allowed_mods, 'acronym');
         $requiredModIds = array_column($this->required_mods, 'acronym');
 
@@ -189,8 +182,8 @@ class PlaylistItem extends Model
 
         $isRealtimeRoom = $this->room->isRealtime();
         $modsHelper = app('mods');
-        $modsHelper->assertValidForMultiplayer($this->ruleset_id, $allowedModIds, $isRealtimeRoom, false);
-        $modsHelper->assertValidForMultiplayer($this->ruleset_id, $requiredModIds, $isRealtimeRoom, true);
+        $modsHelper->assertValidForMultiplayer($this->ruleset_id, $allowedModIds, $isRealtimeRoom, false, $this->freestyle);
+        $modsHelper->assertValidForMultiplayer($this->ruleset_id, $requiredModIds, $isRealtimeRoom, true, $this->freestyle);
         $modsHelper->assertValidMultiplayerExclusivity($this->ruleset_id, $requiredModIds, $allowedModIds);
     }
 }

--- a/app/Singletons/Mods.php
+++ b/app/Singletons/Mods.php
@@ -92,7 +92,7 @@ class Mods
         }
     }
 
-    public function assertValidForMultiplayer(int $rulesetId, array $ids, bool $isRealtime, bool $isRequired): void
+    public function assertValidForMultiplayer(int $rulesetId, array $ids, bool $isRealtime, bool $isRequired, bool $isFreestyle): void
     {
         $this->validateSelection($rulesetId, $ids);
 
@@ -104,6 +104,10 @@ class Mods
 
         foreach ($ids as $id) {
             $mod = $this->mods[$rulesetId][$id];
+
+            if ($isFreestyle && !$mod['ValidForFreestyle']) {
+                throw new InvariantException("mod cannot be set on freestyle items: {$id}");
+            }
 
             if (!$mod[$attr]) {
                 $messageType = $isRequired ? 'required' : 'allowed';

--- a/database/factories/Multiplayer/PlaylistItemFactory.php
+++ b/database/factories/Multiplayer/PlaylistItemFactory.php
@@ -26,6 +26,7 @@ class PlaylistItemFactory extends Factory
             'allowed_mods' => [],
             'required_mods' => [],
             'owner_id' => User::factory(),
+            'freestyle' => false,
         ];
     }
 }

--- a/tests/Models/Multiplayer/PlaylistItemTest.php
+++ b/tests/Models/Multiplayer/PlaylistItemTest.php
@@ -41,6 +41,7 @@ class PlaylistItemTest extends TestCase
             'owner_id' => $user->getKey(),
             'required_mods' => [],
             'allowed_mods' => [],
+            'freestyle' => false,
         ]);
 
         $this->expectNotToPerformAssertions();
@@ -61,6 +62,7 @@ class PlaylistItemTest extends TestCase
             'owner_id' => $user->getKey(),
             'required_mods' => [],
             'allowed_mods' => [],
+            'freestyle' => false,
         ]);
 
         $this->expectNotToPerformAssertions();
@@ -81,6 +83,7 @@ class PlaylistItemTest extends TestCase
             'owner_id' => $user->getKey(),
             'required_mods' => [],
             'allowed_mods' => [],
+            'freestyle' => false,
         ]);
 
         $this->expectException(InvariantException::class);


### PR DESCRIPTION
- [ ] Depends on https://github.com/ppy/osu-tools/pull/257

Freestyle items are allowed to include any allowed/required mods that are also allowed via `ValidForFreestyle`.