### PR TITLE
Fix username availability time display

### DIFF
--- a/app/Libraries/UsernameValidation.php
+++ b/app/Libraries/UsernameValidation.php
@@ -35,15 +35,14 @@ class UsernameValidation
         if (($availableDate = User::checkWhenUsernameAvailable($username)) > Carbon::now()) {
             $remaining = Carbon::now()->diff($availableDate, false);
 
-            // the times are +1 to round up the interval; e.g. 5 days, 2 hours will show 6 days
-            if ($remaining->days + 1 >= User::INACTIVE_DAYS) {
+            if ($remaining->totalDays >= User::INACTIVE_DAYS) {
                 //no need to mention the inactivity period of the account is actively in use.
                 $errors->add('username', '.username_in_use');
-            } elseif ($remaining->days > 0) {
+            } elseif ($remaining->totalDays > 0) {
                 $errors->add(
                     'username',
                     '.username_available_in',
-                    ['duration' => osu_trans_choice('common.count.days', $remaining->days + 1)]
+                    ['duration' => osu_trans_choice('common.count.days', ((int) $remaining->totalDays) + 1)]
                 );
             } elseif ($remaining->h > 0) {
                 $errors->add(


### PR DESCRIPTION
Carbon 3's `diff()->days` is currently broken (briannesbitt/Carbon#3018). It should've only affected the display, not actual availability.