### PR TITLE
Deprecate beatmap solo scores endpoint

### DIFF
--- a/app/Http/Controllers/BeatmapsController.php
+++ b/app/Http/Controllers/BeatmapsController.php
@@ -44,6 +44,7 @@ class BeatmapsController extends Controller
         }
     }
 
+    // TODO: move this to scores() and remove soloScores(). Probably sometime after October 2025.
     private static function beatmapScores(string $id, ?string $scoreTransformerType, ?bool $isLegacy): array
     {
         $beatmap = Beatmap::findOrFail($id);
@@ -368,6 +369,8 @@ class BeatmapsController extends Controller
      * Get Beatmap scores (non-legacy)
      *
      * Returns the top scores for a beatmap.
+     *
+     * This endpoint is deprecated. Use [Get Beatmap scores](#get-beatmap-scores) with appropriate api version header instead.
      *
      * ---
      *

--- a/resources/views/docs/info.md.blade.php
+++ b/resources/views/docs/info.md.blade.php
@@ -36,6 +36,9 @@ For a full list of changes, see the
 
 ## Breaking Changes
 
+### 2025-04-10
+- `/beatmaps/{beatmap}/solo-scores` endpoint has been deprecated. Use `/beatmaps/{beatmap}/scores` instead.
+
 ### 2024-07-30
 - `key` parameter for Get User endpoint has been deprecated. Prefix username with `@` to lookup by username instead.
 


### PR DESCRIPTION
The other endpoint already supports what this one does. Just need the correct header (which client is already doing).