### PR TITLE
Use correct check for room aggregate completed value

### DIFF
--- a/app/Models/Multiplayer/PlaylistItemUserHighScore.php
+++ b/app/Models/Multiplayer/PlaylistItemUserHighScore.php
@@ -6,6 +6,7 @@
 namespace App\Models\Multiplayer;
 
 use App\Models\Model;
+use App\Models\Solo\Score;
 use App\Models\Traits\WithDbCursorHelper;
 use App\Models\User;
 use Illuminate\Database\Eloquent\Builder;
@@ -101,6 +102,11 @@ class PlaylistItemUserHighScore extends Model
     public function playlistItem(): BelongsTo
     {
         return $this->belongsTo(PlaylistItem::class);
+    }
+
+    public function score(): BelongsTo
+    {
+        return $this->belongsTo(Score::class, 'score_id');
     }
 
     public function scoreLink()

--- a/app/Models/Multiplayer/UserScoreAggregate.php
+++ b/app/Models/Multiplayer/UserScoreAggregate.php
@@ -94,12 +94,14 @@ class UserScoreAggregate extends Model
         $playlistItemAggs = PlaylistItemUserHighScore
             ::whereHas('playlistItem', fn ($q) => $q->where('room_id', $this->room_id))
             ->where('user_id', $this->user_id)
+            ->with('score')
             ->get();
 
         $ret = [];
         foreach ($playlistItemAggs as $agg) {
             $ret[] = [
                 'attempts' => $agg->attempts,
+                'completed' => $agg->score?->passed ?? false,
                 'id' => $agg->playlist_item_id,
             ];
         }

--- a/app/Models/Multiplayer/UserScoreAggregate.php
+++ b/app/Models/Multiplayer/UserScoreAggregate.php
@@ -205,7 +205,7 @@ class UserScoreAggregate extends Model
     {
         $agg = PlaylistItemUserHighScore
             ::whereHas('playlistItem', fn ($q) => $q->where('room_id', $this->room_id))
-            ->whereNotNull('score_id')
+            ->whereHas('score', fn ($q) => $q->where('passed', true))
             ->selectRaw('
                 SUM(accuracy) AS accuracy_sum,
                 SUM(total_score) AS total_score_sum,


### PR DESCRIPTION
Recent change to failing plays on realtime mode still being recorded (including the score_id) means its existence doesn't imply passing anymore.

- [ ] depends on #12094