### PR TITLE
Remove temporary apiVersion check in /rooms endpoint

### DIFF
--- a/app/Http/Controllers/Multiplayer/RoomsController.php
+++ b/app/Http/Controllers/Multiplayer/RoomsController.php
@@ -49,15 +49,8 @@ class RoomsController extends Controller
         $includes = ['host.country', 'playlist.beatmap'];
 
         $search = Room::search($params);
-        $query = $search['query'];
 
-        // temporary workaround for lazer client failing to deserialise `daily_challenge` room category
-        // can be removed 20241129
-        if ($apiVersion < 20240529) {
-            $query->whereNot('category', 'daily_challenge');
-        }
-
-        $rooms = $query
+        $rooms = $search['query']
             ->with($includes)
             ->withRecentParticipantIds()
             ->get();


### PR DESCRIPTION
According to the documentation, comment and the discussion in this pull request #11240 I think we can remove the api version check in the `/rooms` endpoint.