### PR TITLE
Fix dusk failing logout test

### DIFF
--- a/tests/Browser/LoginTest.php
+++ b/tests/Browser/LoginTest.php
@@ -47,6 +47,7 @@ class LoginTest extends DuskTestCase
             $browser->loginAs($user)
                 ->visit('/')
                 ->click('.js-user-login--menu') // bring up user menu
+                ->waitFor('.js-user-header-popup .js-logout-link')
                 ->click('.js-user-header-popup .js-logout-link') // click the logout 'button'
                 ->acceptDialog()
                 ->waitFor('.landing-hero__bg-container')


### PR DESCRIPTION
Sometimes the popup takes a while to load and fails logout test.