### PR TITLE
Add database table for storing lazer multiplayer room events

### DIFF
--- a/database/migrations/2025_04_17_113658_create_multiplayer_room_events_table.php
+++ b/database/migrations/2025_04_17_113658_create_multiplayer_room_events_table.php
@@ -1,0 +1,37 @@
+<?php
+
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('multiplayer_realtime_room_events', function (Blueprint $table) {
+            $table->bigIncrements('id');
+            $table->unsignedBigInteger('room_id');
+            $table->string('event_type');
+            $table->unsignedBigInteger('playlist_item_id')->nullable();
+            $table->unsignedInteger('user_id')->nullable();
+            $table->timestamps();
+            $table->json('event_detail')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('multiplayer_realtime_room_events');
+    }
+};


### PR DESCRIPTION
The goal of this table is to power display of multiplayer match history for lazer rooms, e.g. https://github.com/ppy/osu-web/issues/10455.

If you squint a bit, you'll notice that the table structure is *extremely* similar to `osu_mp.events`, but to spell things out:

- `event_id` (PK): Self-explanatory.
- `room_id` (FK referencing `multiplayer_rooms`): Self-explanatory.
- `event_type`: Self-explanatory. Appears to cover all of the same types of events that the old table does, plus `game_aborted` which the tournament people asked for. Maybe there's room for future expansion, but for now I don't see anything else that may need logging here.
- `playlist_item_id` (FK referencing `multiplayer_playlist_items`, optional): Valid if `event_type` is `game_{started,aborted}`. Points at the game in question.
- `user_id` (FK referencing `phpbb_users`, optional): If the event can be associated with a user, it will be via this column.
- `{created,updated}_at`: Decided to just let laravel generate this one, although osu-web won't really be writing to this table, and I expect 99.999% of records (if not all) to just contain the same value twice here. Not sure. Maybe this can be a single timestamp column or something, please advise.
- `event_detail` (json, optional): This is somewhat new. The goal of this column is to store extra data, in particular in the case of `game_started` events. The specific data I want to store there are: the game mode at the time of starting (be it head-to-head, or team vs, or whichever), and also who's on what team in the room (if team vs). This information is currently not stored anywhere in the database; only the latest game mode is preserved, and the team composition is only stored in memory of the spectator server. This came up recently in https://github.com/ppy/osu/pull/32680#discussion_r2033123830.

  Potentially, this could also be used to do things like store the users' total scores at the end of the match, which we presumably want to be 'frozen in time' at the point of match completion for archival purposes; because in lazer multiplayer scores just land in the `scores` table and will be treated the same way as solo scores, any potential rebalances could have a side effect of rewriting multiplayer match history if this sort of thing is not done preventatively. (The old `osu_mp` structure is immune from this because it completely mirrors score rows into its `game_scores` table.)

Note that currently the assumption is that this table will store events for all rooms going forward, because there is no correspondent of the `osu_mp.matches.keep_forever` flag anywhere for lazer multiplayer rooms. Up for discussion as to whether we want to have one.

My goal is to get this in and start populating this table parallel to or even before any of the display work that uses this table goes in, just so that if things fail to meet deadlines that have been given for some planned tournaments, the data is in place, it just would be displayed a bit later.

Would appreciate opinions on the shape of this one from @peppy and @smoogipoo as well as the web team.