### PR TITLE
Add `nominated_beatmapset_count` to API docs

### DIFF
--- a/resources/views/docs/_structures/user.md
+++ b/resources/views/docs/_structures/user.md
@@ -60,6 +60,7 @@ kudosu                     | [User.Kudosu](#user-kudosu) | |
 loved_beatmapset_count     | integer | |
 mapping_follower_count     | integer | |
 monthly_playcounts         | [UserMonthlyPlaycount](#usermonthlyplaycount)[] | |
+nominated_beatmapset_count | integer | |
 page                       | | |
 pending_beatmapset_count   | | |
 previous_usernames         | | |


### PR DESCRIPTION
`nominated_beatmapset_count` is one of the "beatmapset_count" properties that is returned through [Get User](https://osu.ppy.sh/docs/#get-user) but it's the only one that wasn't actually documented

This PR adds it to the list where it belongs, the same list as `ranked_beatmapset_count` and the such