### PR TITLE
Don't include user tags from general query search

### DIFF
--- a/app/Libraries/Search/BeatmapsetSearch.php
+++ b/app/Libraries/Search/BeatmapsetSearch.php
@@ -61,12 +61,6 @@ class BeatmapsetSearch extends RecordSearch
                     ->should(['term' => ['_id' => ['value' => $this->params->queryString, 'boost' => 100]]])
                     ->should(QueryHelper::queryString($this->params->queryString, $partialMatchFields, 'or', 1 / count($terms)))
                     ->should(QueryHelper::queryString($this->params->queryString, [], 'and'))
-                    ->should([
-                        'nested' => [
-                            'path' => 'beatmaps',
-                            'query' => QueryHelper::queryString($this->params->queryString, ['beatmaps.top_tags'], 'or', 0.5 / count($terms)),
-                        ],
-                    ])
             );
         }
 


### PR DESCRIPTION
Simplest fix I can think of 🤷 Resolves #12084.

currently, given map with tag "what" and no user tag, with search query `-what`:

- ``->should(['term' => ['_id' => ['value' => $this->params->queryString, 'boost' => 100]]])``
  no match -> no hit (correct)
- ``->should(QueryHelper::queryString($this->params->queryString, $partialMatchFields, 'or', 1 / count($terms)))``
  matches excluded term -> no hit (correct)
- ``->should(QueryHelper::queryString($this->params->queryString, [], 'and'))``
  matches excluded term -> no hit (correct)
- ``->should(['nested' => ['path' => 'beatmaps', ...]])``
  doesn't match excluded term -> hit (incorrect)

See https://github.com/ppy/osu-web/pull/12131#issuecomment-3645279424