### PR TITLE
Send notification on new team join requests

### DIFF
--- a/app/Jobs/Notifications/BroadcastNotificationBase.php
+++ b/app/Jobs/Notifications/BroadcastNotificationBase.php
@@ -177,7 +177,7 @@ abstract class BroadcastNotificationBase implements ShouldQueue
         $deliverySettings = static::applyDeliverySettings($receiverIds);
 
         if (empty($deliverySettings)) {
-            return;
+            return null;
         }
 
         $notification = $this->makeNotification();
@@ -215,6 +215,11 @@ abstract class BroadcastNotificationBase implements ShouldQueue
         if (!empty($pushReceiverIds)) {
             (new NewPrivateNotificationEvent($notification, $pushReceiverIds))->broadcast();
         }
+
+        return [
+            'notification' => $notification,
+            'receiverIds' => $receiverIds,
+        ];
     }
 
     public function makeNotification(): Notification

--- a/app/Jobs/Notifications/TeamApplicationStore.php
+++ b/app/Jobs/Notifications/TeamApplicationStore.php
@@ -1,0 +1,46 @@
+<?php
+
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
+declare(strict_types=1);
+
+namespace App\Jobs\Notifications;
+
+use App\Models\User;
+
+class TeamApplicationStore extends TeamApplicationBase
+{
+    public function getListeningUserIds(): array
+    {
+        return [$this->team->leader_id];
+    }
+
+    public function getDetails(): array
+    {
+        return [
+            ...parent::getDetails(),
+            'title' => User::find($this->userId)?->username ?? '',
+        ];
+    }
+
+    public function handle()
+    {
+        $currentAppllication = $this->team->applications()->firstWhere([
+            'notification_id' => null,
+            'user_id' => $this->userId,
+        ]);
+
+        if ($currentAppllication === null) {
+            return null;
+        }
+
+        $data = parent::handle();
+
+        if ($data !== null) {
+            $currentAppllication->update(['notification_id' => $data['notification']->getKey()]);
+        }
+
+        return $data;
+    }
+}

--- a/app/Models/Notification.php
+++ b/app/Models/Notification.php
@@ -45,6 +45,7 @@ class Notification extends Model
     const FORUM_TOPIC_REPLY = 'forum_topic_reply';
     const TEAM_APPLICATION_ACCEPT = 'team_application_accept';
     const TEAM_APPLICATION_REJECT = 'team_application_reject';
+    const TEAM_APPLICATION_STORE = 'team_application_store';
     const USER_ACHIEVEMENT_UNLOCK = 'user_achievement_unlock';
     const USER_BEATMAPSET_NEW = 'user_beatmapset_new';
     const USER_BEATMAPSET_REVIVE = 'user_beatmapset_revive';
@@ -70,6 +71,7 @@ class Notification extends Model
         self::FORUM_TOPIC_REPLY => 'forum_topic_reply',
         self::TEAM_APPLICATION_ACCEPT => 'team_application',
         self::TEAM_APPLICATION_REJECT => 'team_application',
+        self::TEAM_APPLICATION_STORE => 'team_application',
         self::USER_ACHIEVEMENT_UNLOCK => 'user_achievement_unlock',
         self::USER_BEATMAPSET_NEW => 'user_beatmapset_new',
         self::USER_BEATMAPSET_REVIVE => 'user_beatmapset_new',

--- a/app/Models/TeamApplication.php
+++ b/app/Models/TeamApplication.php
@@ -40,7 +40,7 @@ class TeamApplication extends Model
             UserNotification::batchDestroy(
                 $this->team->leader_id,
                 BatchIdentities::fromParams([
-                    'notifications' => [['id' => $notification->getKey()]],
+                    'notifications' => [$notification->toIdentityJson()],
                 ]),
             );
         }

--- a/database/migrations/2025_04_22_121439_add_notification_id_to_team_applications.php
+++ b/database/migrations/2025_04_22_121439_add_notification_id_to_team_applications.php
@@ -1,0 +1,27 @@
+<?php
+
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('team_applications', function (Blueprint $table) {
+            $table->bigInteger('notification_id')->nullable()->after('team_id');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('team_applications', function (Blueprint $table) {
+            $table->dropColumn('notification_id');
+        });
+    }
+};

--- a/resources/js/notification-maps/category.ts
+++ b/resources/js/notification-maps/category.ts
@@ -41,6 +41,7 @@ export const nameToCategory: Partial<Record<string, string>> = {
   forum_topic_reply: 'forum_topic_reply',
   team_application_accept: 'team_application',
   team_application_reject: 'team_application',
+  team_application_store: 'team_application',
   user_achievement_unlock: 'user_achievement_unlock',
   user_beatmapset_new: 'user_beatmapset_new',
   user_beatmapset_revive: 'user_beatmapset_new',

--- a/resources/js/notification-maps/icons.ts
+++ b/resources/js/notification-maps/icons.ts
@@ -39,6 +39,7 @@ export const nameToIcons: IconsMap = {
   forum_topic_reply: ['fas fa-comment-medical'],
   team_application_accept: ['fas fa-users', 'fas fa-check'],
   team_application_reject: ['fas fa-users', 'fas fa-times'],
+  team_application_store: ['fas fa-users', 'fas fa-scroll'],
   user_achievement_unlock: ['fas fa-trophy'],
   user_beatmapset_new: ['fas fa-music'],
   user_beatmapset_revive: ['fas fa-trash-restore'],
@@ -64,6 +65,7 @@ export const nameToIconsCompact: IconsMap = {
   forum_topic_reply: ['fas fa-comment-medical'],
   team_application_accept: ['fas fa-check'],
   team_application_reject: ['fas fa-times'],
+  team_application_store: ['fas fa-scroll'],
   user_beatmapset_new: ['fas fa-music'],
   user_beatmapset_revive: ['fas fa-trash-restore'],
 };

--- a/resources/js/notification-maps/message.ts
+++ b/resources/js/notification-maps/message.ts
@@ -90,6 +90,8 @@ export function formatMessageGroup(item: Notification) {
     };
 
     return trans(`notifications.item.${item.displayType}.${item.category}.${item.category}_group`, replacements);
+  } else if (item.category === 'team_application') {
+    return trans('notifications.item.team.team_application.team_application_group');
   }
 
   return item.title;

--- a/resources/js/notification-maps/url.ts
+++ b/resources/js/notification-maps/url.ts
@@ -77,6 +77,7 @@ export function urlSingular(item: Notification) {
       return route('forum.posts.show', { post: item.details.postId });
     case 'team_application_accept':
     case 'team_application_reject':
+    case 'team_application_store':
       return route('teams.show', { team: item.objectId });
     case 'user_achievement_unlock':
       return userAchievementUrl(item);

--- a/resources/lang/en/notifications.php
+++ b/resources/lang/en/notifications.php
@@ -167,8 +167,13 @@ return [
 
                 'team_application_accept' => "You're now member of team :title",
                 'team_application_accept_compact' => "You're now member of team :title",
+
+                'team_application_group' => 'Team join request updates',
+
                 'team_application_reject' => 'Your request to join team :title has been declined',
                 'team_application_reject_compact' => 'Your request to join team :title has been declined',
+                'team_application_store' => ':title requested to join your team',
+                'team_application_store_compact' => ':title requested to join your team',
             ],
         ],
 
@@ -260,6 +265,7 @@ return [
             'team_application' => [
                 'team_application_accept' => "You're now member of team :title",
                 'team_application_reject' => 'Your request to join team :title has been declined',
+                'team_application_store' => ':title requested to join your team',
             ],
         ],
 


### PR DESCRIPTION
And delete if it cancelled accordingly... which makes sense I guess? 🤔 

<del>(and I think it revealed a bug in that deleting notifications doesn't update the count correctly on the frontend)</del> looks like it just needs a very specific format of identity json.

Resolves #11907.