### PR TITLE
Better beatmap search query parsing

### DIFF
--- a/app/Libraries/Search/BeatmapsetSearch.php
+++ b/app/Libraries/Search/BeatmapsetSearch.php
@@ -52,40 +52,33 @@ class BeatmapsetSearch extends RecordSearch
         $includes = $parsed->includesForQueryString();
         $excludes = $parsed->excludesForQueryString();
 
-        if (present($this->params->queryString)) {
-            // the subscoping is not necessary but prevents unintentional accidents when combining other matchers
-            $bool = (new BoolQuery())
+        if (present($includes)) {
+            $base = max(1, count($parsed->includes));
+
+            $query->must(new BoolQuery())
                 // results must contain at least one of the terms and boosted by containing all of them,
                 // or match the id of the beatmapset.
-                ->shouldMatch(1);
+                ->shouldMatch(1)
+                ->should(['term' => ['_id' => ['value' => $includes, 'boost' => 100]]])
+                ->should(QueryHelper::queryString($includes, $partialMatchFields, 'or', 1 / $base))
+                ->should(QueryHelper::queryString($includes, [], 'and'))
+                ->should([
+                    'nested' => [
+                        'path' => 'beatmaps',
+                        'query' => QueryHelper::queryString($includes, ['beatmaps.top_tags'], 'or', 0.5 / $base),
+                    ],
+                ]);
+        }
 
-            if (present($includes)) {
-                $base = max(1, count($parsed->includes));
-
-                $bool
-                    ->should(['term' => ['_id' => ['value' => $includes, 'boost' => 100]]])
-                    ->should(QueryHelper::queryString($includes, $partialMatchFields, 'or', 1 / $base))
-                    ->should(QueryHelper::queryString($includes, [], 'and'))
-                    ->should([
-                        'nested' => [
-                            'path' => 'beatmaps',
-                            'query' => QueryHelper::queryString($includes, ['beatmaps.top_tags'], 'or', 0.5 / $base),
-                        ],
-                    ]);
-            }
-
-            if (present($excludes)) {
-                $bool
-                    ->mustNot(QueryHelper::queryString($excludes, [], 'or'))
-                    ->mustNot([
-                        'nested' => [
-                            'path' => 'beatmaps',
-                            'query' => QueryHelper::queryString($excludes, ['beatmaps.top_tags'], 'or'),
-                        ],
-                    ]);
-            }
-
-            $query->must($bool);
+        if (present($excludes)) {
+            $query
+                ->mustNot(QueryHelper::queryString($excludes, [], 'or'))
+                ->mustNot([
+                    'nested' => [
+                        'path' => 'beatmaps',
+                        'query' => QueryHelper::queryString($excludes, ['beatmaps.top_tags'], 'or'),
+                    ],
+                ]);
         }
 
         $this->addBlockedUsersFilter($query);

--- a/app/Libraries/Search/QueryStringParser.php
+++ b/app/Libraries/Search/QueryStringParser.php
@@ -7,9 +7,9 @@ namespace App\Libraries\Search;
 
 class QueryStringParser
 {
-    const EXCLUDE_QUOTED_REGEX = '/-(")(?<value>(\\"|.)*?)"/';
+    const EXCLUDE_QUOTED_REGEX = '/-(")(?<value>(\\\"|.)*?)"/';
     const EXCLUDE_REGEX = '/-(?<value>\S+)/';
-    const QUOTED_REGEX = '/(")(?<value>(\\"|.)*?)"/';
+    const QUOTED_REGEX = '/(")(?<value>(\\\"|.)*?)"/';
 
     public array $excludes = [];
     public array $includes = [];
@@ -22,7 +22,6 @@ class QueryStringParser
                 return '';
             },
             static::QUOTED_REGEX => function ($m) {
-                \Log::debug($m);
                 $this->includes[] = $m['value'];
                 return '';
             },

--- a/app/Libraries/Search/QueryStringParser.php
+++ b/app/Libraries/Search/QueryStringParser.php
@@ -1,0 +1,56 @@
+<?php
+
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
+namespace App\Libraries\Search;
+
+class QueryStringParser
+{
+    const EXCLUDE_QUOTED_REGEX = '/-(")(?<value>(\\"|.)*?)"/';
+    const EXCLUDE_REGEX = '/-(?<value>\S+)/';
+    const QUOTED_REGEX = '/(")(?<value>(\\"|.)*?)"/';
+
+    public array $excludes = [];
+    public array $includes = [];
+
+    public function __construct(public string $queryString)
+    {
+        $remainder = preg_replace_callback_array([
+            static::EXCLUDE_QUOTED_REGEX => function ($m) {
+                $this->excludes[] = $m['value'];
+                return '';
+            },
+            static::QUOTED_REGEX => function ($m) {
+                \Log::debug($m);
+                $this->includes[] = $m['value'];
+                return '';
+            },
+            static::EXCLUDE_REGEX => function ($m) {
+                $this->excludes[] = $m['value'];
+                return '';
+            },
+
+        ], $queryString);
+
+        \Log::debug($this->includes);
+
+        $tok = strtok($remainder, ' ');
+
+        while ($tok !== false) {
+            $this->includes[] = $tok;
+            $tok = strtok(' ');
+        }
+    }
+
+    public function includesForQueryString()
+    {
+
+        return implode(' ', $this->includes);
+    }
+
+    public function excludesForQueryString()
+    {
+        return implode(' ', $this->excludes);
+    }
+}

--- a/app/Libraries/Search/QueryStringParser.php
+++ b/app/Libraries/Search/QueryStringParser.php
@@ -7,9 +7,9 @@ namespace App\Libraries\Search;
 
 class QueryStringParser
 {
-    const EXCLUDE_QUOTED_REGEX = '/-(")(?<value>(\\\"|.)*?)"/';
+    const EXCLUDE_QUOTED_REGEX = '/-(?<value>"(\\\"|.)*?")/';
     const EXCLUDE_REGEX = '/-(?<value>\S+)/';
-    const QUOTED_REGEX = '/(")(?<value>(\\\"|.)*?)"/';
+    const QUOTED_REGEX = '/(?<value>"(\\\"|.)*?")/';
 
     public array $excludes = [];
     public array $includes = [];
@@ -29,10 +29,7 @@ class QueryStringParser
                 $this->excludes[] = $m['value'];
                 return '';
             },
-
         ], $queryString);
-
-        \Log::debug($this->includes);
 
         $tok = strtok($remainder, ' ');
 
@@ -44,7 +41,6 @@ class QueryStringParser
 
     public function includesForQueryString()
     {
-
         return implode(' ', $this->includes);
     }
 

--- a/app/Libraries/Search/QueryStringParser.php
+++ b/app/Libraries/Search/QueryStringParser.php
@@ -14,6 +14,9 @@ class QueryStringParser
     public array $excludes = [];
     public array $includes = [];
 
+    private ?string $excludesQueryString;
+    private ?string $includesQueryString;
+
     public function __construct(public string $queryString)
     {
         $remainder = preg_replace_callback_array([
@@ -41,11 +44,11 @@ class QueryStringParser
 
     public function includesForQueryString()
     {
-        return implode(' ', $this->includes);
+        return $this->includesQueryString ??= implode(' ', $this->includes);
     }
 
     public function excludesForQueryString()
     {
-        return implode(' ', $this->excludes);
+        return $this->excludesQueryString ??= implode(' ', $this->excludes);
     }
 }


### PR DESCRIPTION
Addresses the issue that the Lucene query string parsing doesn't fit our requirements for handling terms that should be excluded. Parses and extracts quoted and excluded terms so we can build a better query.

`a b -c -d` should match Beatmapsets with Beatmaps that contain `a` or `b`, with greater weight to those containing both, and exclude sets containing beatmaps that contain `c` or `d`

fixes #12084
fixes #10916

- [ ] apply parsing to other filters
- [ ] tests

Excluding terms from only tags (or other filters) currently doesn't work completely due to parsing issue #12135, so excluding results still has to be done like `tag="meta/featured artist" -style`, the issue being it will exclude *everything* that has `style` in the text fields used for search (which is a reason we didn't explictly support this directly and it was just a side effect of `simple_query_string`'s parsing.