### PR TITLE
Show Daycore scores on Half Time leaderboards

### DIFF
--- a/app/Singletons/Mods.php
+++ b/app/Singletons/Mods.php
@@ -14,6 +14,7 @@ class Mods
 {
     // A => B: mod A implies mod B.
     const IMPLIED_MODS = [
+        'DC' => 'HT',
         'NC' => 'DT',
         'PF' => 'SD',
     ];


### PR DESCRIPTION
This matches how Nightcore scores show on Double Time leaderboards.

The reason this one-liner achieves that is

https://github.com/ppy/osu-web/blob/ba50432cce23fa520cebf22d1c60a9f1295608fe/app/Libraries/Search/ScoreSearch.php#L171-L174

`IMPLIED_MODS` looks to also be used in some 'legacy' places but as far as I can tell none of them should fall over from this and some don't even look used.

Addresses https://github.com/ppy/osu/discussions/33214.