### PR TITLE
Clean up multiplayer related ts interfaces

### DIFF
--- a/app/Models/Multiplayer/PlaylistItem.php
+++ b/app/Models/Multiplayer/PlaylistItem.php
@@ -37,6 +37,7 @@ class PlaylistItem extends Model
         'allowed_mods' => 'object',
         'expired' => 'boolean',
         'freestyle' => 'boolean',
+        'played_at' => 'datetime',
         'required_mods' => 'object',
     ];
 

--- a/app/Transformers/Multiplayer/PlaylistItemTransformer.php
+++ b/app/Transformers/Multiplayer/PlaylistItemTransformer.php
@@ -23,6 +23,7 @@ class PlaylistItemTransformer extends TransformerAbstract
             'id' => $item->id,
             'room_id' => $item->room_id,
             'beatmap_id' => $item->beatmap_id,
+            'created_at' => json_time($item->created_at),
             'ruleset_id' => $item->ruleset_id,
             'allowed_mods' => $item->allowed_mods,
             'required_mods' => $item->required_mods,
@@ -30,7 +31,7 @@ class PlaylistItemTransformer extends TransformerAbstract
             'expired' => $item->expired,
             'owner_id' => $item->owner_id,
             'playlist_order' => $item->playlist_order,
-            'played_at' => $item->played_at,
+            'played_at' => json_time($item->played_at),
         ];
     }
 

--- a/resources/js/interfaces/legacy-match-event-json.ts
+++ b/resources/js/interfaces/legacy-match-event-json.ts
@@ -3,14 +3,6 @@
 
 import LegacyMatchGameJson from './legacy-match-game-json';
 
-export default interface LegacyMatchEventJson {
-  detail: LegacyMatchEventDetail;
-  game?: LegacyMatchGameJson;
-  id: number;
-  timestamp: string;
-  user_id?: number;
-}
-
 export type LegacyMatchEventType =
   | 'host-changed'
   | 'match-created'
@@ -23,4 +15,12 @@ export type LegacyMatchEventType =
 export interface LegacyMatchEventDetail {
   text?: string;
   type: LegacyMatchEventType;
+}
+
+export default interface LegacyMatchEventJson {
+  detail: LegacyMatchEventDetail;
+  game?: LegacyMatchGameJson;
+  id: number;
+  timestamp: string;
+  user_id: null | number;
 }

--- a/resources/js/interfaces/legacy-match-game-json.ts
+++ b/resources/js/interfaces/legacy-match-game-json.ts
@@ -5,21 +5,6 @@ import BeatmapJson from './beatmap-json';
 import Ruleset from './ruleset';
 import { LegacyMatchScoreJson } from './score-json';
 
-export default interface LegacyMatchGameJson {
-  beatmap?: BeatmapJson;
-  beatmap_id: number;
-  end_time?: string;
-  id: number;
-  mode: Ruleset;
-  mode_int: number;
-  mods: string[]; // TODO: use ModJson
-  scores: LegacyMatchScoreJson[]; // TODO: use SoloScoreJson
-  scoring_type: LegacyMatchScoringType;
-  start_time: string;
-  team_type: LegacyMatchTeamType;
-}
-
-
 export type LegacyMatchScoringType =
   | 'accuracy'
   | 'combo'
@@ -31,3 +16,17 @@ export type LegacyMatchTeamType =
   | 'tag-coop'
   | 'tag-team-vs'
   | 'team-vs';
+
+export default interface LegacyMatchGameJson {
+  beatmap?: BeatmapJson;
+  beatmap_id: number;
+  end_time: null | string;
+  id: number;
+  mode: Ruleset;
+  mode_int: number;
+  mods: string[];
+  scores: LegacyMatchScoreJson[];
+  scoring_type: LegacyMatchScoringType;
+  start_time: string;
+  team_type: LegacyMatchTeamType;
+}

--- a/resources/js/interfaces/legacy-match-json.ts
+++ b/resources/js/interfaces/legacy-match-json.ts
@@ -2,7 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 export default interface LegacyMatchJson {
-  end_time?: string;
+  end_time: null | string;
   id: number;
   name: string;
   start_time: string;

--- a/resources/js/interfaces/playlist-item-json.ts
+++ b/resources/js/interfaces/playlist-item-json.ts
@@ -1,17 +1,19 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
-import BeatmapJson from 'interfaces/beatmap-json';
-import ModJson from 'interfaces/mod-json';
-import ScoreModJson from 'interfaces/score-mod-json';
+import BeatmapJson from './beatmap-json';
+import ScoreModJson from './score-mod-json';
 
 export default interface PlaylistItemJson {
-  allowed_mods: ModJson;
+  allowed_mods: ScoreModJson[];
   beatmap?: BeatmapJson;
   beatmap_id: number;
+  created_at: string;
   expired: boolean;
+  freestyle: boolean;
   id: number;
-  required_mods: ScoreModJson;
+  played_at: null | string;
+  required_mods: ScoreModJson[];
   room_id: number;
   ruleset_id: number;
 }


### PR DESCRIPTION
- nullable using actual null instead of optional (undefined)
- use explicit json time function to cast played_at
- add create time to playlist item transformer (to match legacy game start_time)
- remove a few outdated todos
  - legacy match score is now based on new format
  - I don't think we'll change the mods to use the new format
    - conversion will be done frontend side as needed
- fix incorrect playlist item mods related typing