### PR TITLE
Add realtime multiplayer event history page

### DIFF
--- a/app/Http/Controllers/Multiplayer/RoomsController.php
+++ b/app/Http/Controllers/Multiplayer/RoomsController.php
@@ -126,7 +126,7 @@ class RoomsController extends Controller
             ->selectRaw('MIN(id) first_event_id, MAX(id) last_event_id')
             ->first();
 
-        return [
+        $json = [
             'beatmaps' => json_collection($beatmaps, new BeatmapCompactTransformer()),
             'beatmapsets' => json_collection($beatmapsets, new BeatmapsetCompactTransformer()),
             'current_playlist_item_id' => $room->current_playlist_item_id,
@@ -137,6 +137,8 @@ class RoomsController extends Controller
             'room' => json_item($room, new RoomTransformer()),
             'users' => $users,
         ];
+
+        return is_json_request() ? $json : ext_view('multiplayer.rooms.events', ['json' => $json]);
     }
 
     /**

--- a/resources/css/bem/mp-history-game.less
+++ b/resources/css/bem/mp-history-game.less
@@ -114,6 +114,7 @@
     @media @desktop {
       // shape name mods combo acc score rank
       grid-template-columns: 50px 1fr auto auto auto auto auto;
+      column-gap: 0;
     }
 
     &--no-teams {

--- a/resources/css/bem/mp-history-player-score.less
+++ b/resources/css/bem/mp-history-player-score.less
@@ -14,8 +14,20 @@
     grid-column: 1 / -1;
   }
 
+  &__beatmap-version {
+    font-size: @font-size--title-small;
+    // forces the link to be a block and applies overflow truncation
+    display: flex;
+  }
+
+  &__country-flag {
+    align-self: center;
+  }
+
   &__shapes {
+    width: auto; // follows grid
     background-size: cover;
+
     border-radius: @border-radius-base 0 0 @border-radius-base;
 
     @media @desktop {
@@ -26,57 +38,72 @@
   }
 
   &__main {
-    flex-grow: 1;
-
-    padding: 5px 20px 15px 7.5px;
-
-    display: flex;
-    flex-direction: column;
-    justify-content: space-between;
+    padding: 10px 20px;
+    display: grid;
+    // for mods and rank element (in mobile), using order and grid-column combination
+    grid-template-columns: 1fr auto;
+    gap: 5px;
 
     @media @desktop {
+      padding-left: 0;
+      padding-right: 20px;
       display: grid;
       grid-template-columns: subgrid;
       grid-column: 2 / -1;
+      gap: 0; // TODO: using "0 20px" here causes overflow in stats area in firefox
+      align-items: center;
     }
   }
 
   &__info-box {
     display: flex;
-    flex-direction: column;
+    grid-column: 1 / -1;
 
-    height: 100%;
+    @media @desktop {
+      padding: 0 10px; // TODO: replace with gap at __main if fixed in firefox
+      grid-column: initial;
+    }
 
-    &--user {
-      align-items: flex-start;
-      flex-direction: row;
-      gap: 10px;
-
+    &--mods {
+      order: 1;
+      grid-column: 1 / 2;
       @media @desktop {
-        flex-direction: column;
-        gap: 5px;
+        order: 0;
+        grid-column: initial;
       }
     }
 
     &--rank {
-      margin-top: 10px;
-
+      order: 1;
+      grid-column: 2 / 3;
       @media @desktop {
-        margin-top: 5px; // balances out row margin
-        margin-left: 15px; // matches 20px margin right
-        justify-content: center;
+        padding-right: 0; // TODO: replace with gap at __main if fixed in firefox
+        order: 0;
+        grid-column: initial;
       }
     }
 
     &--stats {
-      align-items: flex-end;
-      flex-direction: row;
+      flex-direction: row-reverse;
+      align-items: baseline;
       gap: 2px;
 
       @media @desktop {
+        align-items: center;
         display: grid;
         grid-template-columns: subgrid;
-        grid-column: 2 / 6;
+        grid-column: 3 / 6;
+        gap: 3px 0;
+      }
+    }
+
+    &--user {
+      flex-direction: column;
+      justify-content: center;
+      gap: 5px;
+      min-width: 0;
+      @media @desktop {
+        padding-left: 0; // TODO: replace with gap at __main if fixed in firefox
       }
     }
   }
@@ -86,13 +113,18 @@
     font-size: 18px;
   }
 
+  &__username-box {
+    display: flex;
+    gap: 5px;
+  }
+
   &__stat-row {
     display: flex;
     justify-content: flex-end;
     align-items: baseline;
     flex-direction: column;
     flex: 1;
-    gap: 0 10px;
+    gap: 3px;
 
     @media @desktop {
       flex-direction: row;
@@ -101,6 +133,8 @@
     }
 
     &--first {
+      flex-direction: column-reverse;
+
       @media @desktop {
         display: grid;
         grid-template-columns: subgrid;
@@ -128,13 +162,15 @@
   &__stat-label {
     padding-right: 3px;
     color: @osu-colour-c2;
-    font-size: @font-size--small;
+
+    font-size: 10px;
     text-transform: uppercase;
   }
 
   &__stat-number {
     font-weight: 700;
     color: @osu-colour-c1;
+    line-height: 1;
 
     &--small {
       font-size: 12px;

--- a/resources/js/entrypoints/multiplayer-room-events.tsx
+++ b/resources/js/entrypoints/multiplayer-room-events.tsx
@@ -1,0 +1,11 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
+import MultiplayerRoomEvents from 'multiplayer-room-events';
+import core from 'osu-core-singleton';
+import React from 'react';
+import { parseJson } from 'utils/json';
+
+core.reactTurbolinks.register('multiplayer-room-events', () => (
+  <MultiplayerRoomEvents events={parseJson('json-events')} />
+));

--- a/resources/js/legacy-match/content.tsx
+++ b/resources/js/legacy-match/content.tsx
@@ -191,6 +191,7 @@ export default class Content extends React.PureComponent<Props> {
     this.autoloadTimeout = setTimeout(this.autoload, refreshTimeout);
   }
 
+  @action
   private readonly loadNext = () => {
     if (!this.hasNext || this.loadingNext) {
       return;
@@ -205,6 +206,7 @@ export default class Content extends React.PureComponent<Props> {
     }));
   };
 
+  @action
   private readonly loadPrevious = () => {
     if (!this.hasPrevious || this.loadingPrevious) {
       return;

--- a/resources/js/legacy-match/content.tsx
+++ b/resources/js/legacy-match/content.tsx
@@ -8,6 +8,8 @@ import { PlaylistItemJsonForMultiplayerEvent } from 'interfaces/playlist-item-js
 import RealtimeRoomEventJson from 'interfaces/realtime-room-event-json';
 import RoomJson from 'interfaces/room-json';
 import UserJson from 'interfaces/user-json';
+import { last } from 'lodash';
+import { action, makeObservable, observable, reaction } from 'mobx';
 import { observer } from 'mobx-react';
 import * as React from 'react';
 import { classWithModifiers } from 'utils/css';
@@ -16,11 +18,16 @@ import { trans } from 'utils/lang';
 import Event from './event';
 import Game from './game';
 
+export const fetchLimit = 100;
+export const maximumEvents = 500;
+const refreshTimeout = 10000;
+
 export interface Data {
   beatmaps: Partial<Record<number, BeatmapJson>>;
   beatmapsets: Partial<Record<number, BeatmapsetJson>>;
   currentPlaylistItemId: null | number;
   events: RealtimeRoomEventJson[];
+  firstEventId: number;
   lastEventId: number;
   playlistItems: Partial<Record<number, PlaylistItemJsonForMultiplayerEvent>>;
   room: RoomJson;
@@ -29,13 +36,8 @@ export interface Data {
 
 interface Props {
   data: Data;
-  hasNext: boolean;
-  hasPrevious: boolean;
-  isAutoloading: boolean;
-  loadingNext: boolean;
-  loadingPrevious: boolean;
-  loadNext: () => void;
-  loadPrevious: () => void;
+  loadNext: () => JQuery.jqXHR<void>;
+  loadPrevious: () => JQuery.jqXHR<void>;
 }
 
 interface Snapshot {
@@ -53,47 +55,95 @@ export interface TeamScores {
 
 @observer
 export default class Content extends React.PureComponent<Props> {
+  private autoloadTimeout: undefined | number;
   private inEvent = false;
+  @observable private loadingNext = false;
+  @observable private loadingPrevious = false;
   private scoresCache: Partial<Record<number, TeamScores>> = {};
+  private snapshot: Snapshot | undefined;
+  private readonly snapshotReaction;
 
-  componentDidUpdate(prevProps: Readonly<Props>, prevState: Readonly<unknown>, snapshot?: Snapshot) {
-    if (snapshot?.scrollToLastEvent) {
-      $(window).stop().scrollTo(document.body.scrollHeight, 500);
-    } else if (snapshot?.reference) {
-      const referenceCurrent = snapshot.reference.fn();
-      const documentScrollTopCurrent = window.scrollY;
-      const documentScrollTopTarget = documentScrollTopCurrent + referenceCurrent - snapshot.reference.prev;
-      window.scrollTo(window.scrollX, documentScrollTopTarget);
-    }
+  private get hasLatest(): boolean {
+    const lastEvent = last(this.props.data.events);
+
+    return lastEvent != null && lastEvent.id === this.props.data.lastEventId;
   }
 
-  getSnapshotBeforeUpdate(prevProps: Readonly<Props>): Snapshot {
-    const snapshot: Snapshot = {
-      scrollToLastEvent: prevProps.isAutoloading && this.props.isAutoloading && bottomPageDistance() < 10,
-    };
+  private get hasNext(): boolean {
+    return this.isOngoing || !this.hasLatest;
+  }
 
-    if (!snapshot.scrollToLastEvent) {
-      const hadEvents = prevProps.data.events != null && prevProps.data.events.length > 0;
-      const hasEvents = this.props.data.events != null && this.props.data.events.length > 0;
-      if (hadEvents && hasEvents) {
-        let referenceFn: () => number;
+  private get hasPrevious(): boolean {
+    const firstEvent = this.props.data.events[0];
 
-        // This is to allow events to be added without moving currently
-        // visible events on viewport.
-        if (prevProps.data.events[0].id > this.props.data.events[0].id) {
-          referenceFn = () => document.body.scrollHeight;
-        } else {
-          referenceFn = () => 0;
-        }
+    return firstEvent != null && firstEvent.id !== this.props.data.firstEventId;
+  }
 
-        snapshot.reference = {
-          fn: referenceFn,
-          prev: referenceFn(),
+  private get isAutoloading(): boolean {
+    return this.isOngoing && this.hasLatest;
+  }
+
+  private get isOngoing(): boolean {
+    return this.props.data.room.ends_at == null;
+  }
+
+  constructor(props: Props) {
+    super(props);
+    makeObservable(this);
+
+    this.snapshotReaction = reaction(
+      () => ({
+        firstEventId: this.props.data.events[0]?.id,
+        isAutoloading: this.isAutoloading,
+      }),
+      (value, prevValue) => {
+        this.snapshot = {
+          scrollToLastEvent: prevValue.isAutoloading && value.isAutoloading && bottomPageDistance() < 10,
         };
-      }
-    }
 
-    return snapshot;
+        if (!this.snapshot.scrollToLastEvent) {
+          const hadEvents = prevValue.firstEventId != null;
+          const hasEvents = value.firstEventId != null;
+          if (hadEvents && hasEvents) {
+            let referenceFn: () => number;
+
+            // This is to allow events to be added without moving currently
+            // visible events on viewport.
+            if (prevValue.firstEventId > value.firstEventId) {
+              referenceFn = () => document.body.scrollHeight;
+            } else {
+              referenceFn = () => 0;
+            }
+
+            this.snapshot.reference = {
+              fn: referenceFn,
+              prev: referenceFn(),
+            };
+          }
+        }
+      },
+    );
+  }
+
+  componentDidMount() {
+    this.delayedAutoload();
+  }
+
+  componentDidUpdate() {
+    if (this.snapshot?.scrollToLastEvent) {
+      $(window).stop().scrollTo(document.body.scrollHeight, 500);
+    } else if (this.snapshot?.reference) {
+      const referenceCurrent = this.snapshot.reference.fn();
+      const documentScrollTopCurrent = window.scrollY;
+      const documentScrollTopTarget = documentScrollTopCurrent + referenceCurrent - this.snapshot.reference.prev;
+      window.scrollTo(window.scrollX, documentScrollTopTarget);
+    }
+    this.snapshot = undefined;
+  }
+
+  componentWillUnmount() {
+    clearTimeout(this.autoloadTimeout);
+    this.snapshotReaction();
   }
 
   render() {
@@ -102,27 +152,33 @@ export default class Content extends React.PureComponent<Props> {
     return (
       <div className='mp-history-content'>
         <h3 className='mp-history-content__item'>{this.props.data.room.name}</h3>
-        {this.props.hasPrevious &&
+        {this.hasPrevious &&
           <div className={classWithModifiers('mp-history-content__item', ['more'])}>
             <ShowMoreLink
-              callback={this.props.loadPrevious}
+              callback={this.loadPrevious}
               direction='up'
               hasMore
-              loading={this.props.loadingPrevious} />
+              loading={this.loadingPrevious} />
           </div>}
         {this.props.data.events.map((event) => this.renderEvent(event))}
         {this.closeEventsGroup()}
-        {this.props.hasNext &&
+        {this.hasNext &&
           <div className={classWithModifiers('mp-history-content__item', ['more'])}>
-            {this.props.isAutoloading && <div className='mp-history-content__autoload-label'>{trans('matches.match.in_progress_spinner_label')}</div>}
+            {this.isAutoloading && <div className='mp-history-content__autoload-label'>{trans('matches.match.in_progress_spinner_label')}</div>}
             <ShowMoreLink
-              callback={this.props.loadNext}
+              callback={this.loadNext}
               hasMore
-              loading={this.props.isAutoloading || this.props.loadingNext} />
+              loading={this.isAutoloading || this.loadingNext} />
           </div>}
       </div>
     );
   }
+
+  private readonly autoload = () => {
+    if (this.isAutoloading) {
+      this.loadNext();
+    }
+  };
 
   private closeEventsGroup() {
     if (this.inEvent) {
@@ -130,6 +186,36 @@ export default class Content extends React.PureComponent<Props> {
       return <div className={classWithModifiers('mp-history-content__item', ['event', 'event-close'])} />;
     }
   }
+
+  private delayedAutoload() {
+    this.autoloadTimeout = setTimeout(this.autoload, refreshTimeout);
+  }
+
+  private readonly loadNext = () => {
+    if (!this.hasNext || this.loadingNext) {
+      return;
+    }
+
+    clearTimeout(this.autoloadTimeout);
+    this.loadingNext = true;
+
+    this.props.loadNext().always(action(() => {
+      this.loadingNext = false;
+      this.delayedAutoload();
+    }));
+  };
+
+  private readonly loadPrevious = () => {
+    if (!this.hasPrevious || this.loadingPrevious) {
+      return;
+    }
+
+    this.loadingPrevious = true;
+
+    this.props.loadPrevious().always(action(() => {
+      this.loadingPrevious = false;
+    }));
+  };
 
   private openEventsGroup() {
     if (!this.inEvent) {

--- a/resources/js/legacy-match/game-header.tsx
+++ b/resources/js/legacy-match/game-header.tsx
@@ -28,9 +28,20 @@ export default observer(function GameHeader(props: Props) {
   const beatmapset = props.data.beatmapsets[beatmap.beatmapset_id] ?? deletedBeatmapset();
 
   let title = getTitle(beatmapset);
-  const version = beatmap.version;
-  if (version !== '') {
-    title += ` [${version}]`;
+  let url: string | undefined;
+  if (props.playlistItem.freestyle) {
+    if (beatmapset.id !== 0) {
+      url = route('beatmapsets.show', { beatmapset: beatmapset.id });
+    }
+  } else {
+    if (beatmap.id !== 0) {
+      url = route('beatmaps.show', { beatmap: beatmap.id });
+    }
+
+    const version = beatmap.version;
+    if (version !== '') {
+      title += ` [${version}]`;
+    }
   }
 
   const startTime = <TimeWithTooltip dateTime={props.playlistItem.created_at} format={timeFormat} />;
@@ -41,7 +52,7 @@ export default observer(function GameHeader(props: Props) {
   return (
     <a
       className='mp-history-game__header'
-      href={beatmap.id != null ? route('beatmaps.show', { beatmap: beatmap.id }) : undefined}>
+      href={url}>
       <BeatmapsetCover
         beatmapset={beatmapset}
         modifiers='full'
@@ -51,7 +62,11 @@ export default observer(function GameHeader(props: Props) {
         {endTime != null
           ? <span className='mp-history-game__stat'>{startTime} - {endTime}</span>
           : <span className='mp-history-game__stat'>{startTime} {trans('matches.match.in-progress')}</span>}
-        <span className='mp-history-game__stat'>{trans(`beatmaps.mode.${rulesets[props.playlistItem.ruleset_id]}`)}</span>
+        <span className='mp-history-game__stat'>
+          {props.playlistItem.freestyle
+            ? trans('matches.game.freestyle')
+            : trans(`beatmaps.mode.${rulesets[props.playlistItem.ruleset_id]}`)}
+        </span>
         <span className='mp-history-game__stat'>{trans(`matches.game.scoring-type.${props.playlistItem.legacy_scoring_type ?? 'score'}`)}</span>
       </div>
       <div className='mp-history-game__metadata-box'>

--- a/resources/js/legacy-match/score.tsx
+++ b/resources/js/legacy-match/score.tsx
@@ -3,6 +3,7 @@
 
 import FlagCountry from 'components/flag-country';
 import Mod from 'components/mod';
+import UserLink from 'components/user-link';
 import { PlaylistItemJsonForMultiplayerEvent } from 'interfaces/playlist-item-json';
 import { rulesets } from 'interfaces/ruleset';
 import ScoreJson from 'interfaces/score-json';
@@ -23,6 +24,19 @@ interface Props {
 
 const firstRow = ['combo', 'accuracy', 'score'];
 
+function renderVersion(props: Props) {
+  const beatmap = props.data.beatmaps[props.score.beatmap_id];
+  const version = beatmap?.version ?? trans('matches.match.beatmap-deleted');
+
+  return (
+    <a href={route('beatmaps.show', { beatmap: props.score.beatmap_id })}>
+      <span
+        className={`fal fa-extra-mode-${rulesets[props.score.ruleset_id]}`}
+      /> {version}
+    </a>
+  );
+}
+
 export default observer(function Score(props: Props) {
   const user = props.data.users[props.score.user_id];
 
@@ -39,18 +53,32 @@ export default observer(function Score(props: Props) {
         style={{ backgroundImage: `url(/images/layout/mp-history/shapes-team-${team}.svg)` }} />
       <div className='mp-history-player-score__main'>
         <div className={classWithModifiers('mp-history-player-score__info-box', ['user'])}>
-          <div>
-            <a className='mp-history-player-score__username' href={route('users.show', { user: user.id })}>{user.username}</a>
+          <div className='mp-history-player-score__username-box'>
+            <a
+              className='mp-history-player-score__country-flag'
+              href={route('rankings', {
+                country: user.country?.code,
+                mode: rulesets[props.score.ruleset_id],
+                type: 'performance',
+              })}
+            >
+              <FlagCountry country={user.country} modifiers={'medium'} />
+            </a>
+
+            <UserLink className='mp-history-player-score__username u-ellipsis-overflow' user={user} />
           </div>
-          <a href={route('rankings', { country: user.country?.code, mode: rulesets[props.score.ruleset_id], type: 'performance' })}>
-            <FlagCountry country={user.country} modifiers={'medium'} />
-          </a>
+
+          {props.playlistItem.freestyle && (
+            <span className='mp-history-player-score__beatmap-version'>
+              {renderVersion(props)}
+            </span>
+          )}
         </div>
-        <div className={classWithModifiers('mp-history-player-score__info-box', ['stats'])}>
-          <div className={classWithModifiers('mp-history-player-score__stat-row', ['first'])}>
-            <div className='mp-history-player-score__mods'>
-              {props.score.mods.map((mod) => <Mod key={mod.acronym} mod={mod} />)}
-            </div>
+        <div className={classWithModifiers('mp-history-player-score__info-box', 'mods')}>
+          {props.score.mods.map((mod) => <Mod key={mod.acronym} mod={mod} />)}
+        </div>
+        <div className={classWithModifiers('mp-history-player-score__info-box', 'stats')}>
+          <div className={classWithModifiers('mp-history-player-score__stat-row', 'first')}>
             {firstRow.map((m) => {
               let modifier = 'medium';
               let value;

--- a/resources/js/multiplayer-room-events/index.tsx
+++ b/resources/js/multiplayer-room-events/index.tsx
@@ -1,0 +1,126 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
+import HeaderV4 from 'components/header-v4';
+import BeatmapJson from 'interfaces/beatmap-json';
+import BeatmapsetJson from 'interfaces/beatmapset-json';
+import { PlaylistItemJsonForMultiplayerEvent } from 'interfaces/playlist-item-json';
+import RealtimeRoomEventJson from 'interfaces/realtime-room-event-json';
+import RoomJson from 'interfaces/room-json';
+import UserJson from 'interfaces/user-json';
+import { route } from 'laroute';
+import Content, { Data, fetchLimit, maximumEvents } from 'legacy-match/content';
+import { keyBy, last } from 'lodash';
+import { makeObservable, observable, runInAction } from 'mobx';
+import { observer } from 'mobx-react';
+import * as React from 'react';
+import { classWithModifiers } from 'utils/css';
+import { trans } from 'utils/lang';
+
+interface MultiplayerRoomEventsJson {
+  beatmaps: BeatmapJson[];
+  beatmapsets: BeatmapsetJson[];
+  current_playlist_item_id: null | number;
+  events: RealtimeRoomEventJson[];
+  first_event_id: number;
+  last_event_id: number;
+  playlist_items: PlaylistItemJsonForMultiplayerEvent[];
+  room: RoomJson;
+  users: UserJson[];
+}
+
+interface Props {
+  events: MultiplayerRoomEventsJson;
+}
+
+function dataFromJson(existingData: Data | null, json: MultiplayerRoomEventsJson, prepend: boolean): Data {
+  let events = existingData?.events ?? [];
+  if (json.events.length > 0) {
+    if (prepend) {
+      events = json.events.concat(events).slice(0, maximumEvents);
+    } else {
+      events = events.concat(json.events).slice(-maximumEvents);
+    }
+  }
+
+  const beatmaps = Object.assign(existingData?.beatmaps ?? {}, keyBy(json.beatmaps, 'id'));
+  const beatmapsets = Object.assign(existingData?.beatmapsets ?? {}, keyBy(json.beatmapsets, 'id'));
+  const playlistItems = Object.assign(existingData?.playlistItems ?? {}, keyBy(json.playlist_items, 'id'));
+  const users = Object.assign(existingData?.users ?? {}, keyBy(json.users, 'id'));
+
+  return {
+    beatmaps,
+    beatmapsets,
+    currentPlaylistItemId: json.current_playlist_item_id,
+    events,
+    firstEventId: json.first_event_id,
+    lastEventId: json.last_event_id,
+    playlistItems,
+    room: json.room,
+    users,
+  };
+}
+
+
+@observer
+export default class MultiplayerRoomEvents extends React.Component<Props> {
+  @observable private data: Data;
+
+  constructor(props: Props) {
+    super(props);
+
+    this.data = dataFromJson(null, props.events, false);
+    makeObservable(this);
+  }
+
+  render() {
+    return (
+      <>
+        <HeaderV4 theme='mp-history' />
+        <div className={classWithModifiers('osu-page', 'generic')}>
+          <p>
+            <a
+              className='btn-osu-big btn-osu-big--rounded-thin'
+              href={route('multiplayer.rooms.show', { room: this.data.room.id })}
+            >
+              <span className='fas fa-arrow-left' /> {trans('multiplayer.room.view_summary')}
+            </a>
+          </p>
+          <Content
+            data={this.data}
+            loadNext={this.loadNext}
+            loadPrevious={this.loadPrevious}
+          />
+        </div>
+      </>
+    );
+  }
+
+  private readonly loadNext = (): JQuery.jqXHR<void> => $.ajax(
+    route('multiplayer.rooms.events', { room: this.data.room.id }),
+    {
+      data: {
+        after: last(this.data.events)?.id,
+        limit: fetchLimit,
+      },
+      dataType: 'JSON',
+      method: 'GET',
+    })
+    .done((json: MultiplayerRoomEventsJson) => runInAction(() => {
+      this.data = dataFromJson(this.data, json, false);
+    }));
+
+  private readonly loadPrevious = (): JQuery.jqXHR<void> => $.ajax(
+    route('multiplayer.rooms.events', { room: this.data.room.id }),
+    {
+      data: {
+        before: this.data.events[0]?.id,
+        limit: fetchLimit,
+      },
+      dataType: 'JSON',
+      method: 'GET',
+    })
+    .done((json: MultiplayerRoomEventsJson) => runInAction(() => {
+      this.data = dataFromJson(this.data, json, true);
+    }));
+}

--- a/resources/lang/en/matches.php
+++ b/resources/lang/en/matches.php
@@ -54,6 +54,8 @@ return [
         ],
     ],
     'game' => [
+        'freestyle' => 'Frestyle',
+
         'scoring-type' => [
             'score' => 'Highest Score',
             'accuracy' => 'Highest Accuracy',

--- a/resources/lang/en/multiplayer.php
+++ b/resources/lang/en/multiplayer.php
@@ -16,6 +16,8 @@ return [
         'map_count' => ':count_delimited map|:count_delimited maps',
         'player_count' => ':count_delimited player|:count_delimited players',
         'time_left' => ':time left',
+        'view_history' => 'View History',
+        'view_summary' => 'View Summary',
 
         'errors' => [
             'duration_too_long' => 'Duration is too long.',

--- a/resources/lang/en/page_title.php
+++ b/resources/lang/en/page_title.php
@@ -129,6 +129,11 @@ return [
             '_' => 'wiki',
         ],
     ],
+    'multiplayer' => [
+        'rooms_controller' => [
+            'events' => 'room history',
+        ],
+    ],
     'passport' => [
         'authorization_controller' => [
             '_' => 'authorize app',

--- a/resources/views/multiplayer/rooms/events.blade.php
+++ b/resources/views/multiplayer/rooms/events.blade.php
@@ -1,0 +1,15 @@
+{{--
+    Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+    See the LICENCE file in the repository root for full licence text.
+--}}
+@extends('master', [
+    'titlePrepend' => $json['room']['name'],
+])
+
+@section('content')
+    <div class="u-contents js-react--multiplayer-room-events"></div>
+    <script id="json-events" type="application/json">
+        {!! json_encode($json) !!}
+    </script>
+    @include('layout._react_js', ['src' => 'js/multiplayer-room-events.js'])
+@endsection

--- a/resources/views/multiplayer/rooms/show.blade.php
+++ b/resources/views/multiplayer/rooms/show.blade.php
@@ -77,6 +77,17 @@
     @include('multiplayer.rooms._rankings_table', compact('scores'))
 @endsection
 
+@section('scores-header')
+    @if ($room->isRealtime())
+        <a
+            class="btn-osu-big btn-osu-big--rounded-thin"
+            href="{{ route('multiplayer.rooms.events', ['room' => $room->getKey()]) }}"
+        >
+            {{ osu_trans('multiplayer.room.view_history') }}
+        </a>
+    @endif
+@endsection
+
 @section('ranking-footer')
     @include('rankings._beatmapsets', compact('beatmapsets'))
 @endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -276,6 +276,7 @@ Route::group(['middleware' => ['web']], function () {
     Route::put('legal/{locale}/{path}', 'LegalController@update');
 
     Route::group(['prefix' => 'multiplayer', 'as' => 'multiplayer.', 'namespace' => 'Multiplayer'], function () {
+        Route::get('rooms/{room}/events', 'RoomsController@events')->name('rooms.events');
         Route::resource('rooms', 'RoomsController', ['only' => ['show']]);
     });
 


### PR DESCRIPTION
🤷 

Resolves the realtime part of #10455. I thought there's request for similar thing but for playlist but I couldn't find it.

<del>I think the main component can use a bit more code sharing with the legacy one but it'll be a bit involved and slightly annoying to type so maybe later if I feel like it when rebasing and stuff.</del> Done, but the components should probably be moved to `components` (maybe later because I don't want to deal with renames while keeping track of history here)

depends on:
- [x] #12215
- [x] #12193