### PR TITLE
Add API endpoint for pinning scores

### DIFF
--- a/app/Http/Controllers/ScorePinsController.php
+++ b/app/Http/Controllers/ScorePinsController.php
@@ -10,6 +10,9 @@ use App\Models\ScorePin;
 use App\Models\Solo;
 use Exception;
 
+/**
+ * @group Scores
+ */
 class ScorePinsController extends Controller
 {
     public function __construct()
@@ -19,6 +22,21 @@ class ScorePinsController extends Controller
         parent::__construct();
     }
 
+    /**
+     * Unpin Score
+     *
+     * Unpins a score from the user's profile.
+     *
+     * ---
+     *
+     * ### Response Format
+     *
+     * _empty response_
+     *
+     * @urlParam score integer required The id of the [Score](#score) to unpin.
+     *
+     * @response 204
+     */
     public function destroy($scoreId)
     {
         \Auth::user()->scorePins()->whereKey($scoreId)->delete();
@@ -26,6 +44,24 @@ class ScorePinsController extends Controller
         return response()->noContent();
     }
 
+    /**
+     * Reorder Pinned Score
+     *
+     * Changes pinned position of a score on the user's profile.
+     *
+     * ---
+     *
+     * ### Response Format
+     *
+     * _empty response_
+     *
+     * @urlParam score integer required The id of the [Score](#score) to move.
+     *
+     * @bodyParam after_score_id integer The id of the [Score](#score) to move the score after. At least one of `after_score_id` or `before_score_id` is required.
+     * @bodyParam before_score_id integer The id of the [Score](#score) to move the score before. No-example
+     *
+     * @response 204
+     */
     public function reorder($scoreId)
     {
         $params = get_params(\Request::all(), null, [
@@ -67,6 +103,21 @@ class ScorePinsController extends Controller
         return response()->noContent();
     }
 
+    /**
+     * Pin Score
+     *
+     * Pins a score to the user's profile.
+     *
+     * ---
+     *
+     * ### Response Format
+     *
+     * _empty response_
+     *
+     * @urlParam score integer required The id of the [Score](#score) to pin.
+     *
+     * @response 204
+     */
     public function store($scoreId)
     {
         $score = Solo\Score::find($scoreId);

--- a/routes/web.php
+++ b/routes/web.php
@@ -522,6 +522,12 @@ Route::group(['as' => 'api.', 'prefix' => 'api', 'middleware' => ['api', Throttl
             Route::get('/', 'ScoresController@index');
         });
 
+        Route::group(['prefix' => 'score-pins/{score}', 'as' => 'score-pins.'], function () {
+            Route::post('reorder', 'ScorePinsController@reorder')->name('reorder');
+            Route::delete('/', 'ScorePinsController@destroy')->name('destroy');
+            Route::put('/', 'ScorePinsController@store')->name('store');
+        });
+
         // Beatmapsets
         //   GET /api/v2/beatmapsets/search/:filters
         Route::get('beatmapsets/search', 'BeatmapsetsController@search');

--- a/tests/api_routes.json
+++ b/tests/api_routes.json
@@ -1144,6 +1144,45 @@
         ]
     },
     {
+        "uri": "api/v2/score-pins/{score}/reorder",
+        "methods": [
+            "POST"
+        ],
+        "controller": "App\\Http\\Controllers\\ScorePinsController@reorder",
+        "middlewares": [
+            "App\\Http\\Middleware\\ThrottleRequests:1200,1,api:",
+            "App\\Http\\Middleware\\RequireScopes",
+            "Illuminate\\Auth\\Middleware\\Authenticate"
+        ],
+        "scopes": []
+    },
+    {
+        "uri": "api/v2/score-pins/{score}",
+        "methods": [
+            "DELETE"
+        ],
+        "controller": "App\\Http\\Controllers\\ScorePinsController@destroy",
+        "middlewares": [
+            "App\\Http\\Middleware\\ThrottleRequests:1200,1,api:",
+            "App\\Http\\Middleware\\RequireScopes",
+            "Illuminate\\Auth\\Middleware\\Authenticate"
+        ],
+        "scopes": []
+    },
+    {
+        "uri": "api/v2/score-pins/{score}",
+        "methods": [
+            "PUT"
+        ],
+        "controller": "App\\Http\\Controllers\\ScorePinsController@store",
+        "middlewares": [
+            "App\\Http\\Middleware\\ThrottleRequests:1200,1,api:",
+            "App\\Http\\Middleware\\RequireScopes",
+            "Illuminate\\Auth\\Middleware\\Authenticate"
+        ],
+        "scopes": []
+    },
+    {
         "uri": "api/v2/beatmapsets/search",
         "methods": [
             "GET",


### PR DESCRIPTION
closes #12198

pin `PUT /api/v2/score-pins/{score_id}`
unpin `DELETE /api/v2/score-pins/{score_id} `
move pin position `POST /api/v2/score-pins/{score_id}/reorder` with `after_score_id` **or** `before_score_id` as body params
