### PR TITLE
Remove incorrect user rank count adjustment logic

### DIFF
--- a/tests/Models/Score/Best/ModelTest.php
+++ b/tests/Models/Score/Best/ModelTest.php
@@ -7,7 +7,6 @@ namespace Tests\Models\Score\Best;
 
 use App\Models\Beatmap;
 use App\Models\Score\Best\Model;
-use App\Models\UserStatistics;
 use Tests\TestCase;
 
 class ModelTest extends TestCase
@@ -25,66 +24,5 @@ class ModelTest extends TestCase
         $this->expectCountChange(fn () => $class::count(), -1);
 
         $score->delete();
-    }
-
-    public function testDeleteAlsoDecrementUserRankCount()
-    {
-        $ruleset = static::getRandomRuleset();
-        $class = Model::getClass($ruleset);
-        $score = $class::factory()->create(['rank' => 'X']);
-        $stats = UserStatistics\Model::getClass($ruleset)::factory()->create([
-            'user_id' => $score->user_id,
-            'x_rank_count' => 10,
-        ]);
-
-        $this->expectCountChange(fn () => $stats->fresh()->x_rank_count, -1);
-
-        $score->delete();
-    }
-
-    public function testDeleteNonPersonalBestKeepUserRankCount()
-    {
-        $ruleset = static::getRandomRuleset();
-        $class = Model::getClass($ruleset);
-        $bestScore = $class::factory()->create(['rank' => 'X']);
-        $score = $class::factory()->create([
-            'beatmap_id' => $bestScore->beatmap_id,
-            'rank' => 'A',
-            'score' => $bestScore->score - 10,
-            'user_id' => $bestScore->user_id,
-        ]);
-        $stats = UserStatistics\Model::getClass($ruleset)::factory()->create([
-            'a_rank_count' => 10,
-            'user_id' => $score->user_id,
-            'x_rank_count' => 10,
-        ]);
-
-        $this->expectCountChange(fn () => $stats->fresh()->a_rank_count, 0);
-        $this->expectCountChange(fn () => $stats->fresh()->x_rank_count, 0);
-
-        $score->delete();
-    }
-
-    public function testDeletePersonalBestUpdateUserRankCountWhenThereIsOtherScore()
-    {
-        $ruleset = static::getRandomRuleset();
-        $class = Model::getClass($ruleset);
-        $bestScore = $class::factory()->create(['rank' => 'X']);
-        $score = $class::factory()->create([
-            'beatmap_id' => $bestScore->beatmap_id,
-            'rank' => 'A',
-            'score' => $bestScore->score - 10,
-            'user_id' => $bestScore->user_id,
-        ]);
-        $stats = UserStatistics\Model::getClass($ruleset)::factory()->create([
-            'a_rank_count' => 10,
-            'user_id' => $score->user_id,
-            'x_rank_count' => 10,
-        ]);
-
-        $this->expectCountChange(fn () => $stats->fresh()->a_rank_count, 1);
-        $this->expectCountChange(fn () => $stats->fresh()->x_rank_count, -1);
-
-        $bestScore->delete();
     }
 }


### PR DESCRIPTION
It can't be blindly applied due to qualified maps no longer increment the count.

It's also wrong anyway because it doesn't account solo/new scores.

Reference: ppy/osu-infrastructure#32