### PR TITLE
Simplify score pin parameters

### DIFF
--- a/resources/js/core/user/score-pins.ts
+++ b/resources/js/core/user/score-pins.ts
@@ -13,13 +13,11 @@ export default class ScorePins {
   }
 
   apiPin(score: ScoreJson, toPin: boolean) {
-    const pin = score.current_user_attributes.pin;
-    if (pin == null) {
+    if (score.current_user_attributes.pin == null) {
       throw new Error("can't pin score without current user attributes");
     }
 
-    return $.ajax(route('score-pins.store'), {
-      data: pin,
+    return $.ajax(route('score-pins.store', { score: score.id }), {
       dataType: 'json',
       method: toPin ? 'POST' : 'DELETE',
     }).done(action(() => {

--- a/resources/js/profile-page/controller.tsx
+++ b/resources/js/profile-page/controller.tsx
@@ -8,7 +8,6 @@ import CurrentUserJson from 'interfaces/current-user-json';
 import EventJson from 'interfaces/event-json';
 import KudosuHistoryJson from 'interfaces/kudosu-history-json';
 import Ruleset from 'interfaces/ruleset';
-import { ScoreCurrentUserPinJson } from 'interfaces/score-json';
 import ScoreJson, { isScoreJsonForUser, ScoreJsonForUser } from 'interfaces/score-json';
 import UserCoverJson from 'interfaces/user-cover-json';
 import UserCoverPresetJson from 'interfaces/user-cover-preset-json';
@@ -82,13 +81,6 @@ interface LazyPages {
 }
 
 export type Page = ProfileExtraPage | 'main';
-
-type ScorePinReorderParamsBase = Pick<ScoreCurrentUserPinJson, 'score_id'>;
-
-interface ScorePinReorderParams extends ScorePinReorderParamsBase {
-  order1?: ScorePinReorderParamsBase;
-  order3?: ScorePinReorderParamsBase;
-}
 
 interface State {
   currentPage: Page;
@@ -196,18 +188,14 @@ export default class Controller {
     items.splice(newIndex, 0, target);
     this.saveState();
 
-    const params: ScorePinReorderParams = target.current_user_attributes.pin;
-    const adjacentParams = adjacentScore.current_user_attributes.pin;
-    if (currentIndex > newIndex) {
+    const params = currentIndex > newIndex
       // target will be above existing item at index
-      params.order3 = adjacentParams;
-    } else {
+      ? { order3_score_id: adjacentScore.id }
       // target will be below existing item at index
-      params.order1 = adjacentParams;
-    }
+      : { order1_score_id: adjacentScore.id };
 
     showLoadingOverlay();
-    $.ajax(route('score-pins.reorder'), {
+    $.ajax(route('score-pins.reorder', { score: target.id }), {
       data: params,
       dataType: 'json',
       method: 'PUT',

--- a/routes/web.php
+++ b/routes/web.php
@@ -110,9 +110,11 @@ Route::group(['middleware' => ['web']], function () {
         Route::get('{rulesetOrScore}/{score?}', 'ScoresController@show')->name('show');
     });
 
-    Route::delete('score-pins', 'ScorePinsController@destroy')->name('score-pins.destroy');
-    Route::put('score-pins', 'ScorePinsController@reorder')->name('score-pins.reorder');
-    Route::resource('score-pins', 'ScorePinsController', ['only' => ['store']]);
+    Route::group(['prefix' => 'score-pins/{score}', 'as' => 'score-pins.'], function () {
+        Route::put('reorder', 'ScorePinsController@reorder')->name('reorder');
+        Route::delete('/', 'ScorePinsController@destroy')->name('destroy');
+        Route::post('/', 'ScorePinsController@store')->name('store');
+    });
 
     Route::resource('client-verifications', 'ClientVerificationsController', ['only' => ['create', 'store']]);
 

--- a/tests/Controllers/ScorePinsControllerTest.php
+++ b/tests/Controllers/ScorePinsControllerTest.php
@@ -44,7 +44,7 @@ class ScorePinsControllerTest extends TestCase
         $this->actAsUser($pin->user, true);
 
         $this
-            ->delete(route('score-pins.destroy', static::makeParams($pin->score)))
+            ->delete(route('score-pins.destroy', $pin->score))
             ->assertSuccessful();
     }
 
@@ -58,7 +58,7 @@ class ScorePinsControllerTest extends TestCase
         $this->actAsUser($otherUser, true);
 
         $this
-            ->delete(route('score-pins.destroy', static::makeParams($pin->score)))
+            ->delete(route('score-pins.destroy', $pin->score))
             ->assertSuccessful();
     }
 
@@ -69,7 +69,7 @@ class ScorePinsControllerTest extends TestCase
         $this->expectCountChange(fn () => ScorePin::count(), 0);
 
         $this
-            ->delete(route('score-pins.destroy', static::makeParams($pin->score)))
+            ->delete(route('score-pins.destroy', $pin->score))
             ->assertStatus(401);
     }
 
@@ -84,9 +84,8 @@ class ScorePinsControllerTest extends TestCase
 
         $this->actAsUser($user, true);
         $this
-            ->put(route('score-pins.reorder'), [
-                ...static::makeParams($pins[0]->score),
-                'order1' => static::makeParams($pins[1]->score),
+            ->put(route('score-pins.reorder', $pins[0]->score), [
+                'order1_score_id' => $pins[1]->score->getKey(),
             ])->assertSuccessful();
 
         $pins->map->refresh();
@@ -104,9 +103,8 @@ class ScorePinsControllerTest extends TestCase
 
         $this->actAsUser($user, true);
         $this
-            ->put(route('score-pins.reorder'), [
-                ...static::makeParams($pins[0]->score),
-                'order1' => static::makeParams($pins[1]->score),
+            ->put(route('score-pins.reorder', $pins[0]->score), [
+                'order1_score_id' => $pins[1]->score->getKey(),
             ])->assertSuccessful();
 
         $pins->map->refresh();
@@ -125,9 +123,8 @@ class ScorePinsControllerTest extends TestCase
 
         $this->actAsUser($user, true);
         $this
-            ->put(route('score-pins.reorder'), [
-                ...static::makeParams($pins[1]->score),
-                'order3' => static::makeParams($pins[0]->score),
+            ->put(route('score-pins.reorder', $pins[1]->score), [
+                'order3_score_id' => $pins[0]->score->getKey(),
             ])->assertSuccessful();
 
         $pins->map->refresh();
@@ -145,9 +142,8 @@ class ScorePinsControllerTest extends TestCase
 
         $this->actAsUser($user, true);
         $this
-            ->put(route('score-pins.reorder'), [
-                ...static::makeParams($pins[2]->score),
-                'order1' => static::makeParams($pins[0]->score),
+            ->put(route('score-pins.reorder', $pins[2]->score), [
+                'order1_score_id' => $pins[0]->score->getKey(),
             ])->assertSuccessful();
 
         $pins->map->refresh();
@@ -164,7 +160,7 @@ class ScorePinsControllerTest extends TestCase
         $this->actAsUser($score->user, true);
 
         $this
-            ->post(route('score-pins.store'), static::makeParams($score))
+            ->post(route('score-pins.store', $score))
             ->assertSuccessful();
     }
 
@@ -175,7 +171,7 @@ class ScorePinsControllerTest extends TestCase
         $this->expectCountChange(fn () => ScorePin::count(), 0);
 
         $this
-            ->post(route('score-pins.store'), static::makeParams($score))
+            ->post(route('score-pins.store', $score))
             ->assertStatus(401);
     }
 
@@ -189,7 +185,7 @@ class ScorePinsControllerTest extends TestCase
         $this->actAsUser($otherUser, true);
 
         $this
-            ->post(route('score-pins.store'), static::makeParams($score))
+            ->post(route('score-pins.store', $score))
             ->assertStatus(403);
     }
 
@@ -206,7 +202,7 @@ class ScorePinsControllerTest extends TestCase
         $this->actAsUser($user, true);
 
         $this
-            ->post(route('score-pins.store'), static::makeParams($score2))
+            ->post(route('score-pins.store', $score2))
             ->assertSuccessful();
 
         $pin2 = $user->scorePins()->find($score2->getKey());
@@ -223,7 +219,7 @@ class ScorePinsControllerTest extends TestCase
         $this->actAsUser($score->user, true);
 
         $this
-            ->post(route('score-pins.store'), static::makeParams($score))
+            ->post(route('score-pins.store', $score))
             ->assertSuccessful();
     }
 
@@ -236,7 +232,7 @@ class ScorePinsControllerTest extends TestCase
         $this->actAsUser(User::factory()->create(), true);
 
         $this
-            ->post(route('score-pins.store'), ['score_id' => 1])
+            ->post(route('score-pins.store', ['score' => 1]))
             ->assertStatus(422);
     }
 
@@ -256,7 +252,7 @@ class ScorePinsControllerTest extends TestCase
         $this->actAsUser($user, true);
 
         $this
-            ->post(route('score-pins.store'), static::makeParams($score2))
+            ->post(route('score-pins.store', $score2))
             ->assertStatus(403);
     }
 
@@ -276,7 +272,7 @@ class ScorePinsControllerTest extends TestCase
         $this->actAsUser($user, true);
 
         $this
-            ->post(route('score-pins.store'), static::makeParams($score2))
+            ->post(route('score-pins.store', $score2))
             ->assertSuccessful();
     }
 }


### PR DESCRIPTION
As I noticed the whole controller still has leftover from dealing with multiple types of score.

Dunno if `order1`/`order3` should be changed to something different like `before`/`after` or `below`/`above` although in those case it needs a bit of thinking whether which is relative to which - whether `below_score_id` means the specified `below_score_id` score should be above or below `scoreId`. The original idea is that the target score (`scoreId`) is always `order2`...