### PR TITLE
Add hits per play statistic to profile page

### DIFF
--- a/resources/js/profile-page/stats.tsx
+++ b/resources/js/profile-page/stats.tsx
@@ -14,6 +14,7 @@ const entryKeys = [
   'play_count',
   'total_score',
   'total_hits',
+  'hits_per_play',
   'maximum_combo',
   'replays_watched_by_others',
 ] as const;
@@ -24,13 +25,21 @@ interface Props {
   stats: UserStatisticsJson;
 }
 
+function getHitsPerPlay(stats: UserStatisticsJson) {
+  return stats.play_count === 0
+    ? 0
+    : Math.floor(stats.total_hits / stats.play_count);
+}
+
 export default class Stats extends React.PureComponent<Props> {
   render() {
     return <div className='profile-stats'>{entryKeys.map(this.renderEntry)}</div>;
   }
 
   private formatValue(key: EntryKey) {
-    const val = this.props.stats[key];
+    const val = key === 'hits_per_play'
+      ? getHitsPerPlay(this.props.stats)
+      : this.props.stats[key];
 
     if (key === 'hit_accuracy') {
       return `${formatNumber(val, 2)}%`;

--- a/resources/lang/en/users.php
+++ b/resources/lang/en/users.php
@@ -486,6 +486,7 @@ return [
         ],
         'stats' => [
             'hit_accuracy' => 'Hit Accuracy',
+            'hits_per_play' => 'Hits Per Play',
             'level' => 'Level :level',
             'level_progress' => 'progress to next level',
             'maximum_combo' => 'Maximum Combo',


### PR DESCRIPTION
Resolves #2780.

Opted for flooring as it looks better alongside other statistics in my opinion, but displaying up to 2 decimals would probably also work. Happy with either.

<img width="273" alt="image" src="https://github.com/user-attachments/assets/12171a5c-a801-428c-81c0-e64cbd8cff1f" />
