### PR TITLE
Add option to disable bancho when creating build from github

### DIFF
--- a/app/Models/Build.php
+++ b/app/Models/Build.php
@@ -72,6 +72,8 @@ class Build extends Model implements Commentable
 
         $build = $stream->builds()->firstOrCreate([
             'version' => $version,
+        ], [
+            'allow_bancho' => $stream->default_allow_bancho,
         ]);
 
         $lastChange = Carbon::parse($data['release']['created_at']);

--- a/app/Models/UpdateStream.php
+++ b/app/Models/UpdateStream.php
@@ -11,6 +11,7 @@ use Carbon\Carbon;
  * @property \Illuminate\Database\Eloquent\Collection $builds Build
  * @property \Illuminate\Database\Eloquent\Collection $changelogEntries ChangelogEntry
  * @property \Illuminate\Database\Eloquent\Collection $changelogs Changelog
+ * @property bool $default_allow_bancho
  * @property string $name
  * @property string|null $pretty_name
  * @property string|null $repository
@@ -20,6 +21,9 @@ class UpdateStream extends Model
 {
     public $timestamps = false;
 
+    protected $casts = [
+        'default_allow_bancho' => 'boolean',
+    ];
     protected $connection = 'mysql-updates';
     protected $table = 'streams';
     protected $primaryKey = 'stream_id';

--- a/database/migrations/2025_06_13_095407_add_default_allow_bancho_to_streams.php
+++ b/database/migrations/2025_06_13_095407_add_default_allow_bancho_to_streams.php
@@ -1,0 +1,27 @@
+<?php
+
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::connection('mysql-updates')->table('streams', function (Blueprint $table) {
+            $table->boolean('default_allow_bancho')->default(true);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::connection('mysql-updates')->table('streams', function (Blueprint $table) {
+            $table->dropColumn('default_allow_bancho');
+        });
+    }
+};

--- a/tests/Models/BuildTest.php
+++ b/tests/Models/BuildTest.php
@@ -1,0 +1,53 @@
+<?php
+
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
+declare(strict_types=1);
+
+namespace Tests\Models;
+
+use App\Models\Build;
+use App\Models\Repository;
+use App\Models\UpdateStream;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Tests\TestCase;
+
+class BuildTest extends TestCase
+{
+    public static function dataProviderForImportFromGithubNewReleaseSetsAllowBanchoCorrectly(): array
+    {
+        return [
+            [true],
+            [false],
+        ];
+    }
+
+    #[DataProvider('dataProviderForImportFromGithubNewReleaseSetsAllowBanchoCorrectly')]
+    public function testImportFromGithubNewReleaseSetsAllowBanchoCorrectly(bool $allowBancho)
+    {
+        $stream = UpdateStream::create([
+            'name' => 'teststream',
+            'pretty_name' => 'test stream',
+            'default_allow_bancho' => $allowBancho,
+        ]);
+        $repository = Repository::create([
+            'build_on_release' => true,
+            'name' => 'test-repository',
+            'stream_id' => $stream->getKey(),
+        ]);
+
+        $this->expectCountChange(fn () => $stream->builds()->count(), 1);
+
+        $build = Build::importFromGithubNewRelease([
+            'repository' => ['full_name' => $repository->name],
+            'release' => [
+                'created_at' => json_time(new \DateTime()),
+                'tag_name' => '2020.101.0',
+            ],
+        ]);
+
+        $this->assertNotNull($build);
+        $this->assertSame($allowBancho, $build->allow_bancho);
+    }
+}


### PR DESCRIPTION
Per-stream option `default_allow_bancho`. Mainly for web so its builds don't create history entry in `build_propagation_histories`.

Although I wonder if it should be `default_build_attributes` instead...?