### PR TITLE
Improve support for multiple update streams on changelog entries

### DIFF
--- a/app/Models/Build.php
+++ b/app/Models/Build.php
@@ -82,8 +82,7 @@ class Build extends Model implements Commentable
         $changelogEntry = new ChangelogEntry();
 
         $newChangelogEntryIds = $stream
-            ->changelogEntries()
-            ->orphans($stream->getKey())
+            ->orphanChangelogEntries()
             ->where($changelogEntry->qualifyColumn('created_at'), '<=', $lastChange)
             ->pluck($changelogEntry->qualifyColumn('id'));
 

--- a/app/Models/Build.php
+++ b/app/Models/Build.php
@@ -38,6 +38,7 @@ class Build extends Model implements Commentable
     protected $casts = [
         'allow_bancho' => 'boolean',
         'date' => 'datetime',
+        'private' => 'boolean',
     ];
 
     private $cache = [];
@@ -119,7 +120,7 @@ class Build extends Model implements Commentable
 
     public function scopeDefault($query)
     {
-        $query->whereIn('stream_id', $GLOBALS['cfg']['osu']['changelog']['update_streams']);
+        $query->where('private', false)->whereIn('stream_id', $GLOBALS['cfg']['osu']['changelog']['update_streams']);
     }
 
     public function propagationHistories()

--- a/app/Models/Repository.php
+++ b/app/Models/Repository.php
@@ -27,6 +27,11 @@ class Repository extends Model
         return static::firstOrCreate(['name' => $data['full_name']]);
     }
 
+    public static function updateStreamBridgeTable(): string
+    {
+        return $GLOBALS['cfg']['database']['connections']['mysql']['database'].'.repository_update_stream';
+    }
+
     public function mainUpdateStream()
     {
         return $this->belongsTo(UpdateStream::class, 'stream_id');
@@ -34,9 +39,12 @@ class Repository extends Model
 
     public function updateStreams()
     {
-        $bridgeTable = $GLOBALS['cfg']['database']['connections']['mysql']['database'].'.repository_update_stream';
-
-        return $this->belongsToMany(UpdateStream::class, $bridgeTable, null, 'stream_id');
+        return $this->belongsToMany(
+            UpdateStream::class,
+            static::updateStreamBridgeTable(),
+            null,
+            'stream_id',
+        );
     }
 
     public function changelogEntries()

--- a/app/Models/UpdateStream.php
+++ b/app/Models/UpdateStream.php
@@ -6,6 +6,7 @@
 namespace App\Models;
 
 use Carbon\Carbon;
+use Illuminate\Contracts\Database\Eloquent\Builder;
 
 /**
  * @property \Illuminate\Database\Eloquent\Collection $builds Build
@@ -65,7 +66,7 @@ class UpdateStream extends Model
     public function createBuild()
     {
         $entryIds = model_pluck(
-            $this->changelogEntries()->orphans($this->getKey()),
+            $this->orphanChangelogEntries(),
             'id',
             ChangelogEntry::class
         );
@@ -79,6 +80,17 @@ class UpdateStream extends Model
         $build->changelogEntries()->attach($entryIds);
 
         return $build;
+    }
+
+    public function orphanChangelogEntries(): Builder
+    {
+        $query = $this->changelogEntries()->orphans($this->getKey());
+
+        if ($this->parent_id !== null) {
+            $query->orphans($this->parent_id);
+        }
+
+        return $query;
     }
 
     public function latestBuild()

--- a/app/Models/UpdateStream.php
+++ b/app/Models/UpdateStream.php
@@ -40,7 +40,14 @@ class UpdateStream extends Model
 
     public function changelogEntries()
     {
-        return $this->hasManyThrough(ChangelogEntry::class, Repository::class);
+        return $this->belongsToMany(
+            ChangelogEntry::class,
+            Repository::updateStreamBridgeTable(),
+            null,
+            'repository_id',
+            'stream_id',
+            'repository_id',
+        );
     }
 
     public function scopeWhereHasBuilds($query)

--- a/database/migrations/2025_06_16_080509_add_private_to_builds.php
+++ b/database/migrations/2025_06_16_080509_add_private_to_builds.php
@@ -1,0 +1,27 @@
+<?php
+
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('osu_builds', function (Blueprint $table) {
+            $table->boolean('private')->default(false);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('osu_builds', function (Blueprint $table) {
+            $table->dropColumn('private');
+        });
+    }
+};

--- a/database/migrations/2025_06_16_115140_add_parent_id_to_streams.php
+++ b/database/migrations/2025_06_16_115140_add_parent_id_to_streams.php
@@ -1,0 +1,27 @@
+<?php
+
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::connection('mysql-updates')->table('streams', function (Blueprint $table) {
+            $table->unsignedInteger('parent_id')->nullable(true);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::connection('mysql-updates')->table('streams', function (Blueprint $table) {
+            $table->dropColumn('parent_id');
+        });
+    }
+};


### PR DESCRIPTION
Changelog entry and update stream are supposed to be connected through a different table, `repository_update_stream` but never implemented. The `stream_id` in `repositories` is only to specify the default stream when there's no stream name in the tag (`1111-streamname`).

- `repository_update_stream` needs to be filled in with existing repository/stream and also tachyon
- existing changelog entries (that's linked to tachyon related repositories) need to be linked with a tachyon build entry otherwise next tachyon release build will link all of them
  - the build will need `private` flag enabled (new column) as it'll have like thousands of changelog entries
  - or maybe not, just set the tachyon stream's parent to lazer (new column `streams.parent_id`)