### PR TITLE
Filter out playlists with nonexistent beatmaps

### DIFF
--- a/app/Models/Multiplayer/Room.php
+++ b/app/Models/Multiplayer/Room.php
@@ -128,7 +128,7 @@ class Room extends Model
         [$rooms, $hasMore] = $search['query']->with([
             'playlist.beatmap',
             'host',
-        ])->getWithHasMore();
+        ])->whereHas('playlist.beatmap')->getWithHasMore();
 
         $rooms->each->findAndSetCurrentPlaylistItem();
         $rooms->loadMissing('currentPlaylistItem.beatmap.beatmapset');


### PR DESCRIPTION
There have been occasional errors relating to this. I wonder if this should be in the `search` function itself...