### PR TITLE
Link daily challenge card on dashboard to daily challenge ranking page

### DIFF
--- a/resources/views/home/_user_beatmapset.blade.php
+++ b/resources/views/home/_user_beatmapset.blade.php
@@ -4,8 +4,13 @@
 --}}
 @php
     $user = Auth::user();
+    $href = $type === 'daily_challenge' && isset($dailyChallenge) 
+        ? route('daily-challenge.show', [
+            'daily_challenge' => \App\Libraries\DailyChallengeDateHelper::roomId($dailyChallenge)
+        ])
+        : route('beatmapsets.show', $beatmapset->beatmapset_id);
 @endphp
-<a class='user-home-beatmapset' href="{{route('beatmapsets.show', $beatmapset->beatmapset_id)}}">
+<a class='user-home-beatmapset' href="{{$href}}">
     @include('objects._beatmapset_cover', [
         'beatmapset' => $beatmapset,
         'modifiers' => 'home',


### PR DESCRIPTION
Daily challenge beatmaps on the dashboard now link to the daily challenge rankings page (e.g., /rankings/daily-challenge/2025-06-26) instead of the beatmapset.

Fixes #12226