### PR TITLE
Add migration to add `osu_file_version` column to `osu_beatmaps` table

### DIFF
--- a/app/Models/Beatmap.php
+++ b/app/Models/Beatmap.php
@@ -40,6 +40,7 @@ use Illuminate\Database\Eloquent\SoftDeletes;
  * @property \Carbon\Carbon $last_update
  * @property int $max_combo
  * @property mixed $mode
+ * @property int $osu_file_version
  * @property-read Collection<User> $owners
  * @property int $passcount
  * @property int $playcount

--- a/database/migrations/2025_06_27_071031_add_osu_file_version_to_beatmaps.php
+++ b/database/migrations/2025_06_27_071031_add_osu_file_version_to_beatmaps.php
@@ -1,0 +1,33 @@
+<?php
+
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('osu_beatmaps', function (Blueprint $table) {
+            $table->unsignedTinyInteger('osu_file_version')->default(14)->after('score_version');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('osu_beatmaps', function (Blueprint $table) {
+            $table->dropColumn('osu_file_version');
+        });
+    }
+};


### PR DESCRIPTION
See context in https://discord.com/channels/90072389919997952/1327149041511043134/1387774287909359629.

As I understand it this already exists in production, so production database will likely require some jiggling so that this migration doesn't attempt to run and utterly fail to do so next deploy.

- [ ] add `2025_06_27_071031_add_osu_file_version_to_beatmaps` to migrations