### PR TITLE
Show more data on daily challenge leaderboard

### DIFF
--- a/app/Http/Controllers/Ranking/DailyChallengeController.php
+++ b/app/Http/Controllers/Ranking/DailyChallengeController.php
@@ -41,7 +41,11 @@ class DailyChallengeController extends Controller
         } else {
             $playlist = $room->currentPlaylistItem;
 
-            $scores = $room->topScores()->paginate();
+            $scores = $playlist
+                ->highScores()
+                ->forRanking()
+                ->with(['score.user.team'])
+                ->paginate();
         }
 
         $currentUser = \Auth::user();
@@ -67,7 +71,7 @@ class DailyChallengeController extends Controller
                 ->get()
                 ->keyBy(fn ($agg) => $dateHelper::makeId(parse_db_time($agg->getAttribute('room_starts_at'))));
 
-            $userScore = $room?->topScores()->whereBelongsTo($currentUser)->first();
+            $userScore = $playlist?->highScores()->whereBelongsTo($currentUser)->first();
         }
 
         return ext_view('rankings.daily_challenge', compact(

--- a/resources/css/bem/ranking-page-table.less
+++ b/resources/css/bem/ranking-page-table.less
@@ -62,11 +62,25 @@
     }
   }
 
+  &__combo {
+    &--perfect {
+      color: hsl(@beatmap-score--hsl-perfect);
+    }
+  }
+
   &__heading {
     font-weight: normal;
     color: hsl(var(--hsl-f1));
-    padding: 5px 10px;
+    padding: 6px 5px;
     text-align: center;
+
+    &:first-child {
+      padding-left: 10px;
+    }
+
+    &:last-child {
+      padding-right: 10px;
+    }
 
     &--focused {
       color: hsl(var(--hsl-c1));

--- a/resources/css/bem/score-rank.less
+++ b/resources/css/bem/score-rank.less
@@ -29,6 +29,11 @@
   .all(~"D", "D");
   .all(~"F", "F");
 
+  &--daily-challenge {
+    display: inline-block;
+    font-size: 16px; // icon size
+  }
+
   &--full {
     .full-size();
   }

--- a/resources/views/rankings/_main_column.blade.php
+++ b/resources/views/rankings/_main_column.blade.php
@@ -44,6 +44,9 @@
         </span>
     </a>
 @elseif ($object instanceof App\Models\User)
+    @php
+        $country = app('countries')->byCode($object->country_acronym);
+    @endphp
     <div class="ranking-page-table-main">
         <span class="ranking-page-table-main__flag">
             <a
@@ -53,13 +56,13 @@
                     'sort' => $params['sort'],
                     'type' => $params['type'],
 
-                    'country' => $object->country->acronym,
+                    'country' => $country->acronym,
                     'filter' => $params['filter'],
                     'variant' => $params['variant'],
                 ]) }}"
             >
                 @include('objects._flag_country', [
-                    'country' => $object->country,
+                    'country' => $country,
                 ])
             </a>
         </span>

--- a/resources/views/rankings/daily_challenge.blade.php
+++ b/resources/views/rankings/daily_challenge.blade.php
@@ -152,6 +152,81 @@
         @include('rankings._beatmapsets', ['beatmapsets' => [$playlist->beatmap->beatmapset], 'modifiers' => 'daily-challenge'])
     @endsection
     @section('scores')
-        @include('multiplayer.rooms._rankings_table')
+        <table class="ranking-page-table">
+            <thead>
+                <tr>
+                    <th></th>
+                    <th class="ranking-page-table__heading ranking-page-table__heading--main"></th>
+                    <th class="ranking-page-table__heading">
+                        {{ osu_trans('beatmapsets.show.scoreboard.headers.combo') }}
+                    </th>
+                    <th class="ranking-page-table__heading">
+                        {{ osu_trans('rankings.stat.accuracy') }}
+                    </th>
+                    <th class="ranking-page-table__heading">
+                        {{ osu_trans('rankings.stat.play_count') }}
+                    </th>
+                    <th class="ranking-page-table__heading ranking-page-table__heading--focused">
+                        {{ osu_trans('rankings.stat.total_score') }}
+                    </th>
+                    <th class="ranking-page-table__heading">
+                        {{ osu_trans('beatmapsets.show.scoreboard.headers.rank') }}
+                    </th>
+                </tr>
+            </thead>
+            <tbody>
+                @php
+                    // -1 due to userScore being prepended
+                    $firstItem = $scores->firstItem() - 1;
+                @endphp
+                @foreach ([$userScore, ...$scores] as $index => $agg)
+                    @if ($agg === null)
+                        @continue
+                    @endif
+                    @php
+                        $score = $agg->score;
+                    @endphp
+                    @if ($score === null)
+                        @continue
+                    @endif
+                    <tr class="{{ class_with_modifiers('ranking-page-table__row', ['inactive' => !$score->user->isActive()]) }}">
+                        <td class="ranking-page-table__column">
+                            #{{ i18n_number_format($loop->first
+                                ? $score->userRank()
+                                : $firstItem + $index
+                            ) }}
+                        </td>
+                        <td class="ranking-page-table__column ranking-page-table__column--main">
+                            @include('rankings._main_column', ['object' => $score->user])
+                        </td>
+                        <td class="ranking-page-table__column ranking-page-table__column--dimmed">
+                            <span class="{{ class_with_modifiers(
+                                'ranking-page-table__combo',
+                                ['perfect' => $score->is_perfect_combo],
+                            ) }}">
+                                {{ i18n_number_format($score->max_combo) }}
+                            </span>
+                        </td>
+                        <td class="ranking-page-table__column ranking-page-table__column--dimmed">
+                            {{ format_percentage($score->accuracy) }}
+                        </td>
+                        <td class="ranking-page-table__column ranking-page-table__column--dimmed">
+                            {{ i18n_number_format($agg->attempts) }}
+                        </td>
+                        <td class="ranking-page-table__column">
+                            {!! i18n_number_format($score->total_score) !!}
+                        </td>
+                        <td class="ranking-page-table__column ranking-page-table__column--dimmed">
+                            <div class="score-rank score-rank--daily-challenge score-rank--{{ $score->rank }}"></div>
+                        </td>
+                    </tr>
+                    @if ($loop->first)
+                        <tr>
+                            <td colspan="7">&nbsp;</td>
+                        </tr>
+                    @endif
+                @endforeach
+            </tbody>
+        </table>
     @endsection
 @endif


### PR DESCRIPTION
This adds two more columns (combo/perfect and rank). There's still more that can be improved like more columns (mainly mods and ruleset-specific stats) and link to the score itself...

The first one requires either changing the table into react or porting the column generation back to php.

The second one I'd rather convert the table into grids instead of doing the link-per-column thing.