### PR TITLE
Fix pippi in supporter page being occasionally cropped

### DIFF
--- a/resources/css/bem/supporter-status.less
+++ b/resources/css/bem/supporter-status.less
@@ -46,11 +46,12 @@
 
   &__pippi {
     .at2x-simple("~@images/layout/supporter/header-pippi.png");
-    background-size: cover;
-    background-position: center;
+    background-size: contain;
+    background-position: center bottom;
+    background-repeat: no-repeat;
     height: 348px;
     width: 375px;
-    align-items: flex-end;
+    flex: none;
     max-width: 100%;
   }
 


### PR DESCRIPTION
Mainly when there's supporter tag purchases, the image container gets pushed to less than its specified width.

Also adjusted the background sizing itself so it should always be rendered in full.