### PR TITLE
Restore voted state on contest entry when navigating through history

### DIFF
--- a/resources/js/contest-voting/base-entry-list.coffee
+++ b/resources/js/contest-voting/base-entry-list.coffee
@@ -49,19 +49,14 @@ export class BaseEntryList extends React.Component
       contest: response.contest
       selected: response.userVotes
       waitingForResponse: false
-      callback
+      () =>
+        @saveState()
+        callback?()
 
 
   componentDidMount: ->
     $.subscribe "contest:vote:click.#{@eventId}", @handleVoteClick
     $.subscribe "contest:vote:done.#{@eventId}", @handleUpdate
-
-
-  componentDidUpdate: (_, prevState) ->
-    if !isEqual(prevState.selected, @state.selected) || prevState.showVotedOnly != @state.showVotedOnly
-      @props.container.dataset.state = JSON.stringify
-        selected: @state.selected
-        showVotedOnly: @state.showVotedOnly
 
 
   componentWillUnmount: ->
@@ -79,4 +74,13 @@ export class BaseEntryList extends React.Component
 
 
   onToggleShowVotedOnlyClick: =>
-    @setState showVotedOnly: !@state.showVotedOnly
+    @setState
+      showVotedOnly: !@state.showVotedOnly
+      @saveState
+
+
+  saveState: =>
+    @props.container.dataset.state = JSON.stringify
+      selected: @state.selected
+      showVotedOnly: @state.showVotedOnly
+

--- a/resources/js/contest-voting/base-entry-list.coffee
+++ b/resources/js/contest-voting/base-entry-list.coffee
@@ -10,7 +10,9 @@ export class BaseEntryList extends React.Component
     super props
 
     @eventId = "contests-show-voting-#{nextVal()}"
-    @state =
+    state = JSON.parse(@props.container.dataset.state) if @props.container.dataset.state?
+
+    @state = Object.assign
       waitingForResponse: false
       contest: @props.contest
       selected: @props.selected
@@ -18,7 +20,9 @@ export class BaseEntryList extends React.Component
       options:
         showPreview: @props.options.showPreview ? false
         showLink: @props.options.showLink ? false
-        linkIcon: @props.options.linkIcon ? false
+        linkIcon: @props.options.linkIcon ? false,
+      state ? {}
+
 
   handleVoteClick: (_e, {contest_id, entry_id, callback}) =>
     return unless contest_id == @state.contest.id
@@ -35,6 +39,7 @@ export class BaseEntryList extends React.Component
       waitingForResponse: true
       callback
 
+
   handleUpdate: (_e, {response, callback}) =>
     return unless response.contest.id == @state.contest.id
 
@@ -42,11 +47,16 @@ export class BaseEntryList extends React.Component
       contest: response.contest
       selected: response.userVotes
       waitingForResponse: false
-      callback
+      () =>
+        # TODO: combine with count in GalleryContestVoteProgress when converting to typescript
+        @props.container.dataset.state = JSON.stringify(@state)
+        callback?()
+
 
   componentDidMount: ->
     $.subscribe "contest:vote:click.#{@eventId}", @handleVoteClick
     $.subscribe "contest:vote:done.#{@eventId}", @handleUpdate
+
 
   componentWillUnmount: ->
     $.unsubscribe ".#{@eventId}"
@@ -63,4 +73,6 @@ export class BaseEntryList extends React.Component
 
 
   onToggleShowVotedOnlyClick: =>
-    @setState showVotedOnly: !@state.showVotedOnly
+    @setState
+      showVotedOnly: !@state.showVotedOnly
+      () => @props.container.dataset.state = JSON.stringify(@state)

--- a/resources/js/contest-voting/base-entry-list.coffee
+++ b/resources/js/contest-voting/base-entry-list.coffee
@@ -1,6 +1,7 @@
 # Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 # See the LICENCE file in the repository root for full licence text.
 
+import { isEqual } from 'lodash'
 import { button, span } from 'react-dom-factories'
 import { trans } from 'utils/lang'
 import { nextVal } from 'utils/seq'
@@ -10,6 +11,7 @@ export class BaseEntryList extends React.Component
     super props
 
     @eventId = "contests-show-voting-#{nextVal()}"
+    # TODO: combine with count in GalleryContestVoteProgress when converting to typescript
     state = JSON.parse(@props.container.dataset.state) if @props.container.dataset.state?
 
     @state = Object.assign
@@ -47,15 +49,19 @@ export class BaseEntryList extends React.Component
       contest: response.contest
       selected: response.userVotes
       waitingForResponse: false
-      () =>
-        # TODO: combine with count in GalleryContestVoteProgress when converting to typescript
-        @props.container.dataset.state = JSON.stringify(@state)
-        callback?()
+      callback
 
 
   componentDidMount: ->
     $.subscribe "contest:vote:click.#{@eventId}", @handleVoteClick
     $.subscribe "contest:vote:done.#{@eventId}", @handleUpdate
+
+
+  componentDidUpdate: (_, prevState) ->
+    if !isEqual(prevState.selected, @state.selected) || prevState.showVotedOnly != @state.showVotedOnly
+      @props.container.dataset.state = JSON.stringify
+        selected: @state.selected
+        showVotedOnly: @state.showVotedOnly
 
 
   componentWillUnmount: ->
@@ -73,6 +79,4 @@ export class BaseEntryList extends React.Component
 
 
   onToggleShowVotedOnlyClick: =>
-    @setState
-      showVotedOnly: !@state.showVotedOnly
-      () => @props.container.dataset.state = JSON.stringify(@state)
+    @setState showVotedOnly: !@state.showVotedOnly

--- a/resources/js/entrypoints/contest-voting.coffee
+++ b/resources/js/entrypoints/contest-voting.coffee
@@ -11,6 +11,7 @@ propsFunction = (container) ->
   data = parseJson container.dataset.src
 
   return {
+    container
     contest: data.contest
     selected: data.userVotes
     stdRange:


### PR DESCRIPTION
closes #11854
Also persists the show voted only flag.
Also discovered a bug if show voted only is enabled and removing a vote through the gallery view but that's not being fixed here.

~~Yes, it's saving more state than needed because it's easier than digging for the specific properties~~