### PR TITLE
Apply phpbb acl check to editing Topic title and posts

### DIFF
--- a/app/Singletons/OsuAuthorize.php
+++ b/app/Singletons/OsuAuthorize.php
@@ -1413,14 +1413,15 @@ class OsuAuthorize
     {
         $prefix = 'forum.post.edit.';
 
-        if ($this->doCheckUser($user, 'ForumModerate', $post->forum)->can()) {
+        $forum = $post->forum;
+        if ($this->doCheckUser($user, 'ForumModerate', $forum)->can()) {
             return 'ok';
         }
 
         $this->ensureLoggedIn($user);
         $this->ensureCleanRecord($user);
 
-        if (!$this->doCheckUser($user, 'ForumView', $post->forum)->can()) {
+        if (!$this->doCheckUser($user, 'ForumView', $forum)->can()) {
             return $prefix.'no_forum_access';
         }
 
@@ -1438,6 +1439,10 @@ class OsuAuthorize
 
         if ($post->post_edit_locked) {
             return $prefix.'locked';
+        }
+
+        if (!ForumAuthorize::aclCheck($user, 'f_post', $forum)) {
+            return 'forum.topic.edit.no_permission';
         }
 
         return 'ok';
@@ -1504,10 +1509,6 @@ class OsuAuthorize
         $postEditPermission = $this->doCheckUser($user, 'ForumPostEdit', $topic->firstPost);
         if (!$postEditPermission->can()) {
             return $postEditPermission->rawMessage();
-        }
-
-        if (!ForumAuthorize::aclCheck($user, 'f_post', $topic->forum)) {
-            return 'forum.topic.edit.no_permission';
         }
 
         return 'ok';

--- a/app/Singletons/OsuAuthorize.php
+++ b/app/Singletons/OsuAuthorize.php
@@ -1441,7 +1441,8 @@ class OsuAuthorize
             return $prefix.'locked';
         }
 
-        if (!ForumAuthorize::aclCheck($user, 'f_post', $forum)) {
+        $isFirstPost = $post->getKey() === $post->topic->topic_first_post_id;
+        if (!ForumAuthorize::aclCheck($user, $isFirstPost ? 'f_post' : 'f_reply', $forum)) {
             return $prefix.'no_permission';
         }
 
@@ -1502,16 +1503,7 @@ class OsuAuthorize
      */
     public function checkForumTopicEdit(?User $user, Topic $topic): string
     {
-        if ($this->doCheckUser($user, 'ForumModerate', $topic->forum)->can()) {
-            return 'ok';
-        }
-
-        $postEditPermission = $this->doCheckUser($user, 'ForumPostEdit', $topic->firstPost);
-        if (!$postEditPermission->can()) {
-            return $postEditPermission->rawMessage();
-        }
-
-        return 'ok';
+        return $this->checkForumPostEdit($user, $topic->firstPost);
     }
 
     /**

--- a/app/Singletons/OsuAuthorize.php
+++ b/app/Singletons/OsuAuthorize.php
@@ -1442,7 +1442,7 @@ class OsuAuthorize
         }
 
         if (!ForumAuthorize::aclCheck($user, 'f_post', $forum)) {
-            return 'forum.topic.edit.no_permission';
+            return $prefix.'no_permission';
         }
 
         return 'ok';

--- a/app/Singletons/OsuAuthorize.php
+++ b/app/Singletons/OsuAuthorize.php
@@ -1493,14 +1493,24 @@ class OsuAuthorize
     }
 
     /**
-     * @param User|null $user
-     * @param Topic $topic
-     * @return string
      * @throws AuthorizationCheckException
      */
     public function checkForumTopicEdit(?User $user, Topic $topic): string
     {
-        return $this->checkForumPostEdit($user, $topic->firstPost);
+        if ($this->doCheckUser($user, 'ForumModerate', $topic->forum)->can()) {
+            return 'ok';
+        }
+
+        $postEditPermission = $this->doCheckUser($user, 'ForumPostEdit', $topic->firstPost);
+        if (!$postEditPermission->can()) {
+            return $postEditPermission->rawMessage();
+        }
+
+        if (!ForumAuthorize::aclCheck($user, 'f_post', $topic->forum)) {
+            return 'forum.topic.edit.no_permission';
+        }
+
+        return 'ok';
     }
 
     /**

--- a/database/factories/Forum/ForumFactory.php
+++ b/database/factories/Forum/ForumFactory.php
@@ -7,6 +7,7 @@ declare(strict_types=1);
 
 namespace Database\Factories\Forum;
 
+use App\Models\Forum\Authorize;
 use App\Models\Forum\Forum;
 use Database\Factories\Factory;
 
@@ -28,5 +29,24 @@ class ForumFactory extends Factory
     public function closed(): static
     {
         return $this->state(['forum_type' => 0]);
+    }
+
+    public function moderatorGroups(array $groups): static
+    {
+        return $this->state([
+            'moderator_groups' => array_map(fn ($group) => app('groups')->byIdentifier($group)->getKey(), $groups),
+        ]);
+    }
+
+    public function withAuthorize(?string $type): static
+    {
+        return $type === null
+            ? $this
+            : $this->afterCreating(function (Forum $forum) use ($type) {
+                Authorize::factory()->$type()->create([
+                    'forum_id' => $forum,
+                    'group_id' => app('groups')->byIdentifier('default'),
+                ]);
+            });
     }
 }

--- a/database/factories/Forum/ForumFactory.php
+++ b/database/factories/Forum/ForumFactory.php
@@ -42,11 +42,9 @@ class ForumFactory extends Factory
     {
         return $type === null
             ? $this
-            : $this->afterCreating(function (Forum $forum) use ($type) {
-                Authorize::factory()->$type()->create([
-                    'forum_id' => $forum,
-                    'group_id' => app('groups')->byIdentifier('default'),
-                ]);
-            });
+            : $this->afterCreating(fn (Forum $forum) => Authorize::factory()->$type()->create([
+                'forum_id' => $forum,
+                'group_id' => app('groups')->byIdentifier('default'),
+            ]));
     }
 }

--- a/database/factories/Forum/TopicFactory.php
+++ b/database/factories/Forum/TopicFactory.php
@@ -61,13 +61,13 @@ class TopicFactory extends Factory
             );
     }
 
-    public function withPost(): static
+    public function withPost(array $attribs = []): static
     {
         return $this
             ->has(
                 Post::factory()
-                    ->state(function (array $_attr, Topic $topic) {
-                        $attributes = ['post_time' => $topic->topic_time];
+                    ->state(function (array $_attr, Topic $topic) use ($attribs) {
+                        $attributes = [...$attribs, 'post_time' => $topic->topic_time];
 
                         if ($topic->topic_poster !== null) {
                             $attributes['poster_id'] = $topic->topic_poster;

--- a/resources/lang/en/authorization.php
+++ b/resources/lang/en/authorization.php
@@ -113,6 +113,7 @@ return [
                 'deleted' => 'Can not edit deleted post.',
                 'locked' => 'The post is locked from editing.',
                 'no_forum_access' => 'Access to requested forum is required.',
+                'no_permission' => 'No permission to edit.',
                 'not_owner' => 'Only poster can edit the post.',
                 'topic_locked' => 'Can not edit post of a locked topic.',
             ],

--- a/tests/Controllers/Forum/PostsControllerTest.php
+++ b/tests/Controllers/Forum/PostsControllerTest.php
@@ -19,12 +19,23 @@ class PostsControllerTest extends TestCase
     public static function dataProviderForTestUpdate(): array
     {
         return [
-            [null, 'post', null, [], 422],
-            ['new text', 'post', null, [], 200],
-            ['new text', null, null, [], 403],
-            ['new text', null, 'loved', [], 403],
-            ['new text', null, 'loved', ['loved'], 200],
-            ['new text', null, 'gmt', [], 200],
+            [true, null, 'post', null, [], 422],
+            [true, null, 'reply', null, [], 403],
+            [true, 'new text', 'post', null, [], 200],
+            [true, 'new text', 'reply', null, [], 403],
+            [true, 'new text', null, null, [], 403],
+            [true, 'new text', null, 'loved', [], 403],
+            [true, 'new text', null, 'loved', ['loved'], 200],
+            [true, 'new text', null, 'gmt', [], 200],
+
+            [false, null, 'post', null, [], 403],
+            [false, null, 'reply', null, [], 422],
+            [false, 'new text', 'post', null, [], 403],
+            [false, 'new text', 'reply', null, [], 200],
+            [false, 'new text', null, null, [], 403],
+            [false, 'new text', null, 'loved', [], 403],
+            [false, 'new text', null, 'loved', ['loved'], 200],
+            [false, 'new text', null, 'gmt', [], 200],
         ];
     }
 
@@ -103,15 +114,15 @@ class PostsControllerTest extends TestCase
     }
 
     #[DataProvider('dataProviderForTestUpdate')]
-    public function testUpdate(?string $newText, ?string $authorize, ?string $group, array $forumGroups, int $statusCode): void
+    public function testUpdate(bool $first, ?string $newText, ?string $authorize, ?string $group, array $forumGroups, int $statusCode): void
     {
         $user = User::factory()->withGroup($group)->create();
-        $topic = Topic::factory()->withPost()->for(
+        $topic = Topic::factory()->withPost(['post_text' => 'text'])->for(
             Forum::factory()->withAuthorize($authorize)->moderatorGroups($forumGroups)
         )->create([
             'topic_poster' => $user,
         ]);
-        $post = Post::factory()->create([
+        $post = $first ? $topic->firstPost : Post::factory()->create([
             'topic_id' => $topic,
             'post_text' => 'text',
             'poster_id' => $user,

--- a/tests/Controllers/Forum/TopicsControllerTest.php
+++ b/tests/Controllers/Forum/TopicsControllerTest.php
@@ -7,40 +7,80 @@ declare(strict_types=1);
 
 namespace Tests\Controllers\Forum;
 
-use App\Models\Forum\Authorize;
 use App\Models\Forum\Forum;
 use App\Models\Forum\Post;
 use App\Models\Forum\Topic;
 use App\Models\Forum\TopicTrack;
+use App\Models\Log;
 use App\Models\User;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Tests\TestCase;
 
 class TopicsControllerTest extends TestCase
 {
-    public function testDestroy(): void
+    public static function dataProviderForModerationTests(): array
     {
-        $user = User::factory()->create();
-        $topic = Topic::factory()->withPost()->create(['topic_poster' => $user]);
-
-        $this->expectCountChange(fn () => Topic::count(), -1);
-
-        $this
-            ->actingAsVerified($user)
-            ->delete(route('forum.topics.destroy', $topic))
-            ->assertRedirect(route('forum.forums.show', $topic->forum_id));
+        return [
+            [null, [], false],
+            ['gmt', [], true],
+            ['loved', [], false],
+            ['loved', ['loved'], true],
+        ];
     }
 
-    public function testDestroyAsDifferentUser(): void
+    public static function dataProviderForTestDestroy(): array
     {
-        $user = User::factory()->create();
+        return [
+            [null, false],
+            ['gmt', true],
+        ];
+    }
+
+    public static function dataProviderForTestReply(): array
+    {
+        return [
+            [false, 'reply', false],
+            [true, 'reply', true],
+            [true, 'post', false],
+            [true, null, false],
+        ];
+    }
+
+    public static function dataProviderForTestStore(): array
+    {
+        return [
+            [false, 'post', false],
+            [true, 'post', true],
+            [true, 'reply', false],
+            [true, null, false],
+        ];
+    }
+
+    public static function dataProviderForTestUpdate(): array
+    {
+        return [
+            [null, 'post', null, [], 422],
+            ['new title', 'post', null, [], 204],
+            ['new title', null, null, [], 403],
+            ['new title', null, 'loved', [], 403],
+            ['new title', null, 'loved', ['loved'], 204],
+            ['new title', null, 'gmt', [], 204],
+        ];
+    }
+
+    #[DataProvider('dataProviderForTestDestroy')]
+    public function testDestroy(?string $group, bool $success): void
+    {
+        $user = User::factory()->withGroup($group)->create();
         $topic = Topic::factory()->withPost()->create();
 
-        $this->expectCountChange(fn () => Topic::count(), 0);
+        $this->expectCountChange(fn () => Topic::count(), $success ? -1 : 0);
+        $this->expectCountChange(fn () => Log::count(), $success ? 1 : 0);
 
         $this
             ->actingAsVerified($user)
             ->delete(route('forum.topics.destroy', $topic))
-            ->assertStatus(403);
+            ->assertStatus($success ? 200 : 403);
     }
 
     public function testDestroyAsGuest(): void
@@ -48,93 +88,107 @@ class TopicsControllerTest extends TestCase
         $topic = Topic::factory()->withPost()->create();
 
         $this->expectCountChange(fn () => Topic::count(), 0);
+        $this->expectCountChange(fn () => Log::count(), 0);
 
         $this
             ->delete(route('forum.topics.destroy', $topic))
             ->assertStatus(401);
     }
 
-    public function testDestroyAsModerator(): void
+    public function testDestroyAsSameUser(): void
     {
-        $topic = Topic::factory()->withPost()->create();
-        $user = User::factory()->withGroup('gmt')->create();
+        $user = User::factory()->create();
+        $topic = Topic::factory()->withPost()->create(['topic_poster' => $user]);
 
         $this->expectCountChange(fn () => Topic::count(), -1);
+        $this->expectCountChange(fn () => Log::count(), 0);
 
         $this
             ->actingAsVerified($user)
             ->delete(route('forum.topics.destroy', $topic))
-            ->assertSuccessful();
+            ->assertRedirect(route('forum.forums.show', $topic->forum_id));
     }
 
-    public function testPin(): void
+    #[DataProvider('dataProviderForModerationTests')]
+    public function testPin(?string $group, array $forumGroups, bool $success): void
     {
-        $moderator = User::factory()->withGroup('gmt')->create();
-        $topic = Topic::factory()->create();
+        $user = User::factory()->withGroup($group)->create();
+        $topic = Topic::factory()->for(Forum::factory()->moderatorGroups($forumGroups))->create();
         $typeInt = Topic::TYPES['sticky'];
 
-        $this
-            ->actingAsVerified($moderator)
-            ->post(route('forum.topics.pin', $topic), ['pin' => $typeInt])
-            ->assertSuccessful();
+        $this->expectCountChange(fn () => Log::count(), $success ? 1 : 0);
 
-        $this->assertSame($typeInt, $topic->fresh()->topic_type);
+        $response = $this
+            ->actingAsVerified($user)
+            ->post(route('forum.topics.pin', $topic), ['pin' => $typeInt]);
+
+        if ($success) {
+            $response->assertSuccessful();
+            $this->assertSame($typeInt, $topic->fresh()->topic_type);
+        } else {
+            $response->assertStatus(403);
+            $this->assertSame(Topic::TYPES['normal'], $topic->fresh()->topic_type);
+        }
     }
 
-    public function testReply(): void
+    #[DataProvider('dataProviderForModerationTests')]
+    public function testLock(?string $group, array $forumGroups, bool $success): void
     {
-        $topic = Topic::factory()->create();
-        $user = User::factory()->withPlays($GLOBALS['cfg']['osu']['forum']['minimum_plays'])->create();
-        Authorize::factory()->reply()->create([
-            'forum_id' => $topic->forum_id,
-            'group_id' => app('groups')->byIdentifier('default'),
-        ]);
+        $user = User::factory()->withGroup($group)->create();
+        $topic = Topic::factory()->for(Forum::factory()->moderatorGroups($forumGroups))->create();
 
-        $this->expectCountChange(fn () => Post::count(), 1);
+        $this->expectCountChange(fn () => Log::count(), $success ? 1 : 0);
+
+        $response = $this
+            ->actingAsVerified($user)
+            ->post(route('forum.topics.lock', $topic), ['lock' => true]);
+
+        if ($success) {
+            $response->assertSuccessful();
+            $this->assertTrue($topic->fresh()->isLocked());
+        } else {
+            $response->assertStatus(403);
+            $this->assertFalse($topic->fresh()->isLocked());
+        }
+    }
+
+    #[DataProvider('dataProviderForTestReply')]
+    public function testReply(bool $hasMinPlays, ?string $authorize, bool $success): void
+    {
+        $topic = Topic::factory()->for(Forum::factory()->withAuthorize($authorize))->create();
+        $user = User::factory()->withPlays($hasMinPlays ? $GLOBALS['cfg']['osu']['forum']['minimum_plays'] : 0)->create();
+
+        $this->expectCountChange(fn () => Post::count(), $success ? 1 : 0);
         $this->expectCountChange(fn () => Topic::count(), 0);
-        $this->expectCountChange(fn () => $topic->fresh()->postCount(), 1);
+        $this->expectCountChange(fn () => $topic->fresh()->postCount(), $success ? 1 : 0);
 
         $this
             ->actingAsVerified($user)
             ->post(route('forum.topics.reply', $topic), [
                 'body' => 'This is test reply',
             ])
-            ->assertSuccessful();
+            ->assertStatus($success ? 200 : 403);
     }
 
-    public function testReplyWithoutPlays(): void
+    #[DataProvider('dataProviderForModerationTests')]
+    public function testRestore(?string $group, array $forumGroups, bool $success): void
     {
-        $topic = Topic::factory()->create();
-        $user = User::factory()->create();
-        Authorize::factory()->reply()->create([
-            'forum_id' => $topic->forum_id,
-            'group_id' => app('groups')->byIdentifier('default'),
-        ]);
-
-        $this->expectCountChange(fn () => Post::count(), 0);
-        $this->expectCountChange(fn () => Topic::count(), 0);
-        $this->expectCountChange(fn () => $topic->fresh()->postCount(), 0);
-
-        $this
-            ->actingAsVerified($user)
-            ->post(route('forum.topics.reply', $topic), [
-                'body' => 'This is test reply',
-            ])
-            ->assertStatus(403);
-    }
-
-    public function testRestore(): void
-    {
-        $moderator = User::factory()->withGroup('gmt')->create();
-        $topic = Topic::factory()->withPost()->create();
+        $user = User::factory()->withGroup($group)->create();
+        $topic = Topic::factory()->withPost()->for(Forum::factory()->moderatorGroups($forumGroups))->create();
         $topic->delete();
 
-        $this->expectCountChange(fn () => Topic::count(), 1);
+        $this->expectCountChange(fn () => Topic::count(), $success ? 1 : 0);
+        $this->expectCountChange(fn () => Log::count(), $success ? 1 : 0);
 
-        $this
-            ->actingAsVerified($moderator)
-            ->post(route('forum.topics.restore', $topic))
-            ->assertSuccessful();
+        $response = $this
+            ->actingAsVerified($user)
+            ->post(route('forum.topics.restore', $topic));
+
+        if ($success) {
+            $response->assertSuccessful();
+        } else {
+            $response->assertStatus(403);
+        }
     }
 
     public function testShow(): void
@@ -201,61 +255,44 @@ class TopicsControllerTest extends TestCase
             ->assertSuccessful();
     }
 
-    public function testStore(): void
+    #[DataProvider('dataProviderForTestStore')]
+    public function testStore(bool $hasMinPlays, ?string $authorize, bool $success): void
     {
-        $forum = Forum::factory()->create();
-        $user = User::factory()->withPlays($GLOBALS['cfg']['osu']['forum']['minimum_plays'])->create();
-        Authorize::factory()->post()->create([
-            'forum_id' => $forum,
-            'group_id' => app('groups')->byIdentifier('default'),
-        ]);
+        $forum = Forum::factory()->withAuthorize($authorize)->create();
+        $user = User::factory()->withPlays($hasMinPlays ? $GLOBALS['cfg']['osu']['forum']['minimum_plays'] : 0)->create();
 
-        $this->expectCountChange(fn () => Post::count(), 1);
-        $this->expectCountChange(fn () => Topic::count(), 1);
-        $this->expectCountChange(fn () => TopicTrack::count(), 1);
+        $change = $success ? 1 : 0;
+        $this->expectCountChange(fn () => Post::count(), $change);
+        $this->expectCountChange(fn () => Topic::count(), $change);
+        $this->expectCountChange(fn () => TopicTrack::count(), $change);
 
-        $this
+        $response = $this
             ->actingAsVerified($user)
             ->post(route('forum.topics.store', ['forum_id' => $forum]), [
                 'title' => 'Test post',
                 'body' => 'This is test post',
-            ])
-            ->assertRedirect(route(
+            ]);
+
+        if ($success) {
+            $response->assertRedirect(route(
                 'forum.topics.show',
                 Topic::orderBy('topic_id', 'DESC')->first(),
             ));
+        } else {
+            $response->assertStatus(403);
+        }
     }
 
-    public function testStoreWithoutPlays(): void
+    #[DataProvider('dataProviderForTestUpdate')]
+    public function testUpdate(?string $newTitle, ?string $authorize, ?string $group, array $forumGroups, int $statusCode): void
     {
-        $forum = Forum::factory()->create();
-        $user = User::factory()->create();
-        Authorize::factory()->post()->create([
-            'forum_id' => $forum,
-            'group_id' => app('groups')->byIdentifier('default'),
-        ]);
-
-        $this->expectCountChange(fn () => Post::count(), 0);
-        $this->expectCountChange(fn () => Topic::count(), 0);
-        $this->expectCountChange(fn () => TopicTrack::count(), 0);
-
-        $this
-            ->actingAsVerified($user)
-            ->post(route('forum.topics.store', ['forum_id' => $forum]), [
-                'title' => 'Test post',
-                'body' => 'This is test post',
-            ])
-            ->assertStatus(403);
-    }
-
-    public function testUpdateTitle(): void
-    {
-        $user = User::factory()->create();
-        $topic = Topic::factory()->withPost()->create([
+        $user = User::factory()->withGroup($group)->create();
+        $topic = Topic::factory()->withPost()->for(
+            Forum::factory()->withAuthorize($authorize)->moderatorGroups($forumGroups)
+        )->create([
             'topic_poster' => $user,
             'topic_title' => 'Initial title',
         ]);
-        $newTitle = 'A different title';
 
         $this
             ->actingAsVerified($user)
@@ -264,26 +301,12 @@ class TopicsControllerTest extends TestCase
                     'topic_title' => $newTitle,
                 ],
             ])
-            ->assertSuccessful();
+            ->assertStatus($statusCode);
 
-        $this->assertSame($newTitle, $topic->fresh()->topic_title);
-    }
-
-    public function testUpdateTitleBlank(): void
-    {
-        $user = User::factory()->create();
-        $topic = Topic::factory()->withPost()->create(['topic_poster' => $user]);
-        $title = $topic->topic_title;
-
-        $this
-            ->actingAsVerified($user)
-            ->put(route('forum.topics.update', $topic), [
-                'forum_topic' => [
-                    'topic_title' => null,
-                ],
-            ])
-            ->assertStatus(422);
-
-        $this->assertSame($title, $topic->fresh()->topic_title);
+        if ($statusCode === 204) {
+            $this->assertSame($newTitle, $topic->fresh()->topic_title);
+        } else {
+            $this->assertSame('Initial title', $topic->fresh()->topic_title);
+        }
     }
 }


### PR DESCRIPTION
As discussed internally, you shouldn't be able to update the title of a forum topic if you can't post to it.

Also consolidate some tests and add a few more checks.