### PR TITLE
Force rooms with no end time to be the first

### DIFF
--- a/app/Libraries/DbCursorHelper.php
+++ b/app/Libraries/DbCursorHelper.php
@@ -35,7 +35,7 @@ class DbCursorHelper
         foreach ($this->sort as $sort) {
             $column = $sort['column'];
             $columnInput = $sort['columnInput'] ?? $sort['column'];
-            $ret[$columnInput] = $item->$column;
+            $ret[$columnInput] = $item->$column ?? $sort['nullPlaceholder'] ?? null;
         }
 
         return $ret;
@@ -63,13 +63,14 @@ class DbCursorHelper
             $columnInput = $sortItem['columnInput'] ?? $sortItem['column'];
             $column = $sortItem['column'];
             $order = $sortItem['order'];
+            $nullPlaceholder = $sortItem['nullPlaceholder'] ?? null;
             $value = get_param_value($cursor[$columnInput] ?? null, $sortItem['type'] ?? null);
 
             if ($value === null) {
                 return;
             }
 
-            $ret[] = compact('column', 'order', 'value');
+            $ret[] = compact('column', 'nullPlaceholder', 'order', 'value');
         }
 
         return $ret;

--- a/app/Models/Multiplayer/Room.php
+++ b/app/Models/Multiplayer/Room.php
@@ -57,7 +57,7 @@ class Room extends Model
 
     const SORTS = [
         'ended' => [
-            ['column' => 'ends_at', 'order' => 'DESC', 'type' => 'time'],
+            ['column' => 'ends_at', 'order' => 'DESC', 'type' => 'time', 'nullPlaceholder' => '9999-12-31 00:00:00'],
             ['column' => 'id', 'order' => 'DESC', 'type' => 'int'],
         ],
         'created' => [


### PR DESCRIPTION
Was reviewing something else and figured to play around with dealing with nulls in db.

I haven't done much testing on this (namely hitting other room listing endpoint) so stuff may break 🤷 (or just slow)

And there may be better way of fixing this...?

Resolves #12306. Drafting because I realized there's also problem when the cursor value itself is null... ಠ_ಠ It maybe better to just set the end time to be the silly date instead after all.