### PR TITLE
Add OAuth scope for pinning and locking topics

### DIFF
--- a/app/Models/OAuth/Client.php
+++ b/app/Models/OAuth/Client.php
@@ -10,6 +10,7 @@ use App\Models\User;
 use App\Traits\Validatable;
 use Carbon\Carbon;
 use DB;
+use Illuminate\Database\Eloquent\Collection;
 use Laravel\Passport\Client as PassportClient;
 use Laravel\Passport\RefreshToken;
 
@@ -21,10 +22,10 @@ use Laravel\Passport\RefreshToken;
  * @property bool $personal_access_client
  * @property string $provider
  * @property string $redirect
- * @property-read Collection<RefreshToken> refreshTokens
+ * @property-read Collection<RefreshToken> $refreshTokens
  * @property bool $revoked
  * @property string $secret
- * @property-read Collection<Token> tokens
+ * @property-read Collection<Token> $tokens
  * @property Carbon|null $updated_at
  * @property-read User|null $user
  * @property int|null $user_id

--- a/app/Models/OAuth/Token.php
+++ b/app/Models/OAuth/Token.php
@@ -20,7 +20,7 @@ class Token extends PassportToken implements SessionVerificationInterface
     // PassportToken doesn't have factory
     use HasFactory, FasterAttributes;
 
-    const SCOPES_REQUIRE_DELEGATION = ['chat.write', 'chat.write_manage', 'delegate'];
+    const SCOPES_REQUIRE_DELEGATION = ['chat.write', 'chat.write_manage', 'delegate', 'forum.write_manage', 'forum.write'];
 
     protected $casts = [
         'expires_at' => 'datetime',

--- a/app/Models/OAuth/Token.php
+++ b/app/Models/OAuth/Token.php
@@ -20,9 +20,9 @@ class Token extends PassportToken implements SessionVerificationInterface
     // PassportToken doesn't have factory
     use HasFactory, FasterAttributes;
 
-    const SCOPES_CLIENT_CREDENTIALS_ONLY = ['delegate', 'forum.write_manage'];
+    const SCOPES_CLIENT_CREDENTIALS_ONLY = ['delegate', 'forum.delegate', 'forum.write_manage'];
     const SCOPES_OWN_CLIENT = ['chat.read', 'chat.write', 'chat.write_manage'];
-    const SCOPES_REQUIRE_DELEGATION = ['chat.write', 'chat.write_manage', 'delegate', 'forum.write', 'forum.write_manage'];
+    const SCOPES_REQUIRE_DELEGATION = ['chat.write', 'chat.write_manage', 'delegate', 'forum.delegate', 'forum.write', 'forum.write_manage'];
 
     protected $casts = [
         'expires_at' => 'datetime',

--- a/app/Models/OAuth/Token.php
+++ b/app/Models/OAuth/Token.php
@@ -20,7 +20,7 @@ class Token extends PassportToken implements SessionVerificationInterface
     // PassportToken doesn't have factory
     use HasFactory, FasterAttributes;
 
-    const SCOPES_REQUIRE_DELEGATION = ['chat.write', 'chat.write_manage', 'delegate', 'forum.write_manage', 'forum.write'];
+    const SCOPES_REQUIRE_DELEGATION = ['chat.write', 'chat.write_manage', 'delegate', 'forum.write', 'forum.write_manage'];
 
     protected $casts = [
         'expires_at' => 'datetime',
@@ -180,7 +180,16 @@ class Token extends PassportToken implements SessionVerificationInterface
 
     public function validate(): void
     {
-        static $scopesRequireDelegation = new Set(static::SCOPES_REQUIRE_DELEGATION);
+        static $clientCredentialsRequireDelegateScopes = new Set(static::SCOPES_REQUIRE_DELEGATION);
+        // only clients owned by bots are allowed to act on behalf of another user.
+        // the user's own client can send messages as themselves for authorization code flows.
+        static $ownClientScopes = new Set([
+            'chat.read',
+            'chat.write',
+            'chat.write_manage',
+        ]);
+        static $clientCredentialsOnlyScopes = new Set(['delegate', 'forum.write_manage']);
+
 
         $scopes = $this->scopeSet();
         if ($scopes->isEmpty()) {
@@ -211,29 +220,21 @@ class Token extends PassportToken implements SessionVerificationInterface
                 throw new InvalidScopeException('delegate_bot_only');
             }
 
-            if (!$scopes->intersect($scopesRequireDelegation)->isEmpty()) {
+            if (!$scopes->intersect($clientCredentialsRequireDelegateScopes)->isEmpty()) {
                 if (!$this->delegatesOwner()) {
                     throw new InvalidScopeException('delegate_required');
                 }
 
                 // delegation is only allowed if scopes given allow delegation.
-                if (!$scopes->diff($scopesRequireDelegation)->isEmpty()) {
+                if (!$scopes->diff($clientCredentialsRequireDelegateScopes)->isEmpty()) {
                     throw new InvalidScopeException('delegate_invalid_combination');
                 }
             }
         } else {
-            // delegation is only available for client_credentials.
-            if ($this->delegatesOwner()) {
-                throw new InvalidScopeException('delegate_client_credentials_only');
+            if (!$scopes->intersect($clientCredentialsOnlyScopes)->isEmpty()) {
+                throw new InvalidScopeException('client_credentials_only');
             }
 
-            // only clients owned by bots are allowed to act on behalf of another user.
-            // the user's own client can send messages as themselves for authorization code flows.
-            static $ownClientScopes = new Set([
-                'chat.read',
-                'chat.write',
-                'chat.write_manage',
-            ]);
             if (!$scopes->intersect($ownClientScopes)->isEmpty() && !($this->isOwnToken() || $client->user->isBot())) {
                 throw new InvalidScopeException('bot_only');
             }

--- a/app/Models/OAuth/Token.php
+++ b/app/Models/OAuth/Token.php
@@ -20,6 +20,8 @@ class Token extends PassportToken implements SessionVerificationInterface
     // PassportToken doesn't have factory
     use HasFactory, FasterAttributes;
 
+    const SCOPES_CLIENT_CREDENTIALS_ONLY = ['delegate', 'forum.write_manage'];
+    const SCOPES_OWN_CLIENT = ['chat.read', 'chat.write', 'chat.write_manage'];
     const SCOPES_REQUIRE_DELEGATION = ['chat.write', 'chat.write_manage', 'delegate', 'forum.write', 'forum.write_manage'];
 
     protected $casts = [
@@ -183,13 +185,8 @@ class Token extends PassportToken implements SessionVerificationInterface
         static $clientCredentialsRequireDelegateScopes = new Set(static::SCOPES_REQUIRE_DELEGATION);
         // only clients owned by bots are allowed to act on behalf of another user.
         // the user's own client can send messages as themselves for authorization code flows.
-        static $ownClientScopes = new Set([
-            'chat.read',
-            'chat.write',
-            'chat.write_manage',
-        ]);
-        static $clientCredentialsOnlyScopes = new Set(['delegate', 'forum.write_manage']);
-
+        static $ownClientScopes = new Set(static::SCOPES_OWN_CLIENT);
+        static $clientCredentialsOnlyScopes = new Set(static::SCOPES_CLIENT_CREDENTIALS_ONLY);
 
         $scopes = $this->scopeSet();
         if ($scopes->isEmpty()) {

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -1045,10 +1045,13 @@ class User extends Model implements AfterCommit, AuthenticatableContract, HasLoc
         return $this->inGroupWithPlaymode('bng', $mode);
     }
 
+    /**
+     * Check if the User is explicitly assigned Forum permissions via moderator_groups.
+     *
+     * Permission set directly though moderator_groups are available through OAuth with the group_permissions scope.
+     */
     public function isForumModerator(Forum\Forum $forum): bool
     {
-        // permission set directly though moderator_groups should behave like checks
-        // using findUserGroup directly instead of isGroup and are available with OAuth.
         $token = $this->token();
 
         return ($token === null || $token->delegatesOwner() && $token->can('group_permissions'))

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -1042,6 +1042,13 @@ class User extends Model implements AfterCommit, AuthenticatableContract, HasLoc
         return $this->inGroupWithPlaymode('bng', $mode);
     }
 
+    public function isForumModerator(Forum\Forum $forum): bool
+    {
+        // permission set directly though moderator_groups should behave like checks
+        // using findUserGroup directly instead of isGroup and are available with OAuth.
+        return $forum->moderator_groups !== null && !empty(array_intersect($this->groupIds()['active'], $forum->moderator_groups));
+    }
+
     public function isLimitedBN(?string $mode = null)
     {
         return $this->inGroupWithPlaymode('bng_limited', $mode);

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -1051,9 +1051,9 @@ class User extends Model implements AfterCommit, AuthenticatableContract, HasLoc
         // using findUserGroup directly instead of isGroup and are available with OAuth.
         $token = $this->token();
 
-        return $token !== null && !($token->delegatesOwner() && $token->can('forum.delegate')) && !$token->isOwnToken()
-            ? false
-            : $forum->moderator_groups !== null && !empty(array_intersect($this->groupIds()['active'], $forum->moderator_groups));
+        return ($token === null || $token->delegatesOwner() && $token->can('group_permissions'))
+            && $forum->moderator_groups !== null && !empty(array_intersect($this->groupIds()['active'], $forum->moderator_groups));
+
     }
 
     public function isLimitedBN(?string $mode = null)

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -1053,7 +1053,6 @@ class User extends Model implements AfterCommit, AuthenticatableContract, HasLoc
 
         return ($token === null || $token->delegatesOwner() && $token->can('group_permissions'))
             && $forum->moderator_groups !== null && !empty(array_intersect($this->groupIds()['active'], $forum->moderator_groups));
-
     }
 
     public function isLimitedBN(?string $mode = null)

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -1024,7 +1024,10 @@ class User extends Model implements AfterCommit, AuthenticatableContract, HasLoc
 
     public function isChatAnnouncer()
     {
-        return $this->findUserGroup(app('groups')->byIdentifier('announce'), true) !== null;
+        $token = $this->token();
+        return $token !== null && !$token->delegatesOwner() && !$token->isOwnToken()
+            ? false
+            : $this->findUserGroup(app('groups')->byIdentifier('announce'), true) !== null;
     }
 
     public function isGMT()
@@ -1046,7 +1049,10 @@ class User extends Model implements AfterCommit, AuthenticatableContract, HasLoc
     {
         // permission set directly though moderator_groups should behave like checks
         // using findUserGroup directly instead of isGroup and are available with OAuth.
-        return $forum->moderator_groups !== null && !empty(array_intersect($this->groupIds()['active'], $forum->moderator_groups));
+        $token = $this->token();
+        return $token !== null && !$token->delegatesOwner() && !$token->isOwnToken()
+            ? false
+            : $forum->moderator_groups !== null && !empty(array_intersect($this->groupIds()['active'], $forum->moderator_groups));
     }
 
     public function isLimitedBN(?string $mode = null)

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -1050,7 +1050,8 @@ class User extends Model implements AfterCommit, AuthenticatableContract, HasLoc
         // permission set directly though moderator_groups should behave like checks
         // using findUserGroup directly instead of isGroup and are available with OAuth.
         $token = $this->token();
-        return $token !== null && !$token->delegatesOwner() && !$token->isOwnToken()
+
+        return $token !== null && !($token->delegatesOwner() && $token->can('forum.delegate')) && !$token->isOwnToken()
             ? false
             : $forum->moderator_groups !== null && !empty(array_intersect($this->groupIds()['active'], $forum->moderator_groups));
     }

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -68,6 +68,7 @@ class AuthServiceProvider extends ServiceProvider
         Passport::tokensCan([
             'delegate' => '',
             'forum.write' => osu_trans('api.scopes.forum.write'),
+            'forum.write_manage' => osu_trans('api.scopes.forum.write_manage'),
             'chat.read' => osu_trans('api.scopes.chat.read'),
             'chat.write' => osu_trans('api.scopes.chat.write'),
             'chat.write_manage' => osu_trans('api.scopes.chat.write_manage'),

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -67,6 +67,7 @@ class AuthServiceProvider extends ServiceProvider
 
         Passport::tokensCan([
             'delegate' => '',
+            'forum.delegate' => '',
             'forum.write' => osu_trans('api.scopes.forum.write'),
             'forum.write_manage' => osu_trans('api.scopes.forum.write_manage'),
             'chat.read' => osu_trans('api.scopes.chat.read'),

--- a/app/Providers/AuthServiceProvider.php
+++ b/app/Providers/AuthServiceProvider.php
@@ -67,13 +67,13 @@ class AuthServiceProvider extends ServiceProvider
 
         Passport::tokensCan([
             'delegate' => '',
-            'forum.delegate' => '',
             'forum.write' => osu_trans('api.scopes.forum.write'),
             'forum.write_manage' => osu_trans('api.scopes.forum.write_manage'),
             'chat.read' => osu_trans('api.scopes.chat.read'),
             'chat.write' => osu_trans('api.scopes.chat.write'),
             'chat.write_manage' => osu_trans('api.scopes.chat.write_manage'),
             'friends.read' => osu_trans('api.scopes.friends.read'),
+            'group_permissions' => '',
             'identify' => osu_trans('api.scopes.identify'),
             'public' => osu_trans('api.scopes.public'),
         ]);

--- a/app/Singletons/OsuAuthorize.php
+++ b/app/Singletons/OsuAuthorize.php
@@ -1341,11 +1341,7 @@ class OsuAuthorize
         $this->ensureLoggedIn($user);
         $this->ensureCleanRecord($user);
 
-        if ($user->isModerator()) {
-            return 'ok';
-        }
-
-        if ($forum->moderator_groups !== null && !empty(array_intersect($user->groupIds()['active'], $forum->moderator_groups))) {
+        if ($user->isModerator() || $user->isForumModerator($forum)) {
             return 'ok';
         }
 

--- a/database/factories/Forum/ForumFactory.php
+++ b/database/factories/Forum/ForumFactory.php
@@ -38,13 +38,13 @@ class ForumFactory extends Factory
         ]);
     }
 
-    public function withAuthorize(?string $type): static
+    public function withAuthorize(?string $type, ?string $group = null): static
     {
         return $type === null
             ? $this
             : $this->afterCreating(fn (Forum $forum) => Authorize::factory()->$type()->create([
                 'forum_id' => $forum,
-                'group_id' => app('groups')->byIdentifier('default'),
+                'group_id' => app('groups')->byIdentifier($group ?? 'default'),
             ]));
     }
 }

--- a/database/factories/UserFactory.php
+++ b/database/factories/UserFactory.php
@@ -140,6 +140,16 @@ class UserFactory extends Factory
             });
     }
 
+    public function withGroups(array $groupIdentifiers, ?array $playmodes = null)
+    {
+        $factory = $this;
+        foreach ($groupIdentifiers as $groupIdentifier) {
+            $factory = $factory->withGroup($groupIdentifier, $playmodes);
+        }
+
+        return $factory;
+    }
+
     public function withNote()
     {
         return $this->has(UserAccountHistory::factory(), 'accountHistories');

--- a/resources/lang/en/api.php
+++ b/resources/lang/en/api.php
@@ -24,6 +24,7 @@ return [
 
         'forum' => [
             'write' => 'Create and edit forum topics and posts on your behalf.',
+            'write_manage' => 'Manage forum topics and posts on your behalf.',
         ],
 
         'friends' => [

--- a/resources/lang/en/model_validation/token.php
+++ b/resources/lang/en/model_validation/token.php
@@ -10,7 +10,7 @@ return [
         'client_missing_owner' => 'The client is missing owner.',
         'client_unauthorized' => 'The client is not authorized.',
         'delegate_bot_only' => 'Delegation with Client Credentials is only available to chat bots.',
-        'delegate_client_credentials_only' => 'delegate scope is only valid for client_credentials tokens.',
+        'client_credentials_only' => 'This scope is only valid for client_credentials tokens.',
         'delegate_invalid_combination' => 'Delegation is not supported for this combination of scopes.',
         'delegate_required' => 'delegate scope is required.',
         'empty' => 'Tokens without scopes are not valid.',

--- a/resources/views/docs/auth.blade.php
+++ b/resources/views/docs/auth.blade.php
@@ -11,6 +11,7 @@
     $baseUrl = $GLOBALS['cfg']['app']['url'];
     $wikiUrl = wiki_url('Bot_account', null, false);
     $delegateScopes = new Set(Token::SCOPES_REQUIRE_DELEGATION);
+    $ownScopeBadges = array_map(fn ($scope) => ApidocRouteHelper::scopeBadge($scope), Token::SCOPES_OWN_CLIENT);
 
     $defaultHeaders = [
         'Accept' => 'application/json',
@@ -529,7 +530,7 @@ $scopeDescriptions = [
 </table>
 
 <p>
-    <code>identify</code> is the default scope for the <a href="#authorization-code-grant">Authorization Code Grant</a> and always implicitly provided. The <a href="#client-credentials-grant">Client Credentials Grant</a> does not currently have any default scopes.
+    {{ ApidocRouteHelper::scopeBadge('identify') }} is the default scope for the <a href="#authorization-code-grant">Authorization Code Grant</a> and always implicitly provided. The <a href="#client-credentials-grant">Client Credentials Grant</a> does not currently have any default scopes.
 </p>
 
 <p>
@@ -537,7 +538,7 @@ $scopeDescriptions = [
 </p>
 
 <p>
-    Using the {{ ApidocRouteHelper::scopeBadge('chat.write') }} scope requires either
+    Using any of the {!! implode(' ', $ownScopeBadges) !!} scopes requires either
     <ul>
         <li>a <a href="{{ $wikiUrl }}">Chat Bot</a> account to send messages on behalf of other users.
         <li>Authorization code grant where the user is the same as the client's owner (send as yourself).

--- a/resources/views/docs/auth.blade.php
+++ b/resources/views/docs/auth.blade.php
@@ -4,10 +4,13 @@
 --}}
 @php
     use App\Libraries\ApidocRouteHelper;
+    use App\Models\OAuth\Token;
+    use Ds\Set;
     use Knuckles\Camel\Output\OutputEndpointData;
 
     $baseUrl = $GLOBALS['cfg']['app']['url'];
     $wikiUrl = wiki_url('Bot_account', null, false);
+    $delegateScopes = new Set(Token::SCOPES_REQUIRE_DELEGATION);
 
     $defaultHeaders = [
         'Accept' => 'application/json',
@@ -479,21 +482,8 @@ fetch("{{ $GLOBALS['cfg']['app']['url'] }}/api/[version]/[endpoint]", {
 </p>
 
 <p>
-    The following scopes currently support delegation:
+    Refer to the list of <a href="#scopes">Scopes</a> for which scopes support delegation.
 </p>
-
-<table>
-    <thead>
-        <tr>
-            <th>Name</th>
-        </tr>
-    </thead>
-    <tbody>
-        <tr>
-            <td>{{ ApidocRouteHelper::scopeBadge('chat.write') }}</td>
-        </tr>
-    </tbody>
-</table>
 
 <h2>Scopes</h2>
 
@@ -520,6 +510,7 @@ $scopeDescriptions = [
         <tr>
             <th>Name</th>
             <th>Description</th>
+            <th><a href="#client-credentials-delegation">Can Delegate?</a></th>
         </tr>
     </thead>
     <tbody>
@@ -529,6 +520,7 @@ $scopeDescriptions = [
                     <a class="badge badge-scope badge-scope-{{ $scope }}" name="scope-{{ $scope }}">{{ $scope }}</a>
                 </td>
                 <td>{!! markdown_plain($description) !!}</td>
+                <td>{{ $delegateScopes->contains($scope) ? 'Yes' : 'No' }}</td>
             </tr>
         @endforeach
         <tr>

--- a/resources/views/docs/auth.blade.php
+++ b/resources/views/docs/auth.blade.php
@@ -508,6 +508,7 @@ $scopeDescriptions = [
     'chat.write_manage' => "Allows joining and leaving chat channels on a user's behalf.",
     'delegate' => "Allows acting as the owner of a client; only available for [Client Credentials Grant](#client-credentials-grant).",
     'forum.write' => "Allows creating and editing forum posts on a user's behalf.",
+    'forum.write_manage' => "Allows managing forum topics on a user's behalf.",
     'friends.read' => 'Allows reading of the user\'s friend list.',
     'identify' => 'Allows reading of the public profile of the user (`/me`).',
     'public' => 'Allows reading of publicly available data on behalf of the user.',

--- a/resources/views/docs/auth.blade.php
+++ b/resources/views/docs/auth.blade.php
@@ -501,7 +501,7 @@ $scopeDescriptions = [
     'forum.write' => "Allows creating and editing forum posts on a user's behalf.",
     'forum.write_manage' => "Allows managing forum topics on a user's behalf.",
     'friends.read' => 'Allows reading of the user\'s friend list.',
-    'group_permissions' => 'Allows `delegate` tokens to inherit the Resource Owner's group permissions in some cases.',
+    'group_permissions' => "Allows `delegate` tokens to inherit the Resource Owner's group permissions in some cases.",
     'identify' => 'Allows reading of the public profile of the user (`/me`).',
     'public' => 'Allows reading of publicly available data on behalf of the user.',
 ];

--- a/resources/views/docs/auth.blade.php
+++ b/resources/views/docs/auth.blade.php
@@ -498,10 +498,10 @@ $scopeDescriptions = [
     'chat.write' => "Allows sending chat messages on a user's behalf.",
     'chat.write_manage' => "Allows joining and leaving chat channels on a user's behalf.",
     'delegate' => "Allows acting as the owner of a client; only available for [Client Credentials Grant](#client-credentials-grant).",
-    'forum.delegate' => 'Allows `delegate` tokens to have forum group permissions.',
     'forum.write' => "Allows creating and editing forum posts on a user's behalf.",
     'forum.write_manage' => "Allows managing forum topics on a user's behalf.",
     'friends.read' => 'Allows reading of the user\'s friend list.',
+    'group_permissions' => 'Allows `delegate` tokens to inherit the Resource Owner's group permissions in some cases.',
     'identify' => 'Allows reading of the public profile of the user (`/me`).',
     'public' => 'Allows reading of publicly available data on behalf of the user.',
 ];

--- a/resources/views/docs/auth.blade.php
+++ b/resources/views/docs/auth.blade.php
@@ -498,6 +498,7 @@ $scopeDescriptions = [
     'chat.write' => "Allows sending chat messages on a user's behalf.",
     'chat.write_manage' => "Allows joining and leaving chat channels on a user's behalf.",
     'delegate' => "Allows acting as the owner of a client; only available for [Client Credentials Grant](#client-credentials-grant).",
+    'forum.delegate' => 'Allows `delegate` tokens to have forum group permissions.',
     'forum.write' => "Allows creating and editing forum posts on a user's behalf.",
     'forum.write_manage' => "Allows managing forum topics on a user's behalf.",
     'friends.read' => 'Allows reading of the user\'s friend list.',

--- a/routes/web.php
+++ b/routes/web.php
@@ -501,7 +501,13 @@ Route::group(['as' => 'api.', 'prefix' => 'api', 'middleware' => ['api', Throttl
 
         Route::group(['as' => 'forum.', 'namespace' => 'Forum'], function () {
             Route::group(['prefix' => 'forums'], function () {
-                Route::post('topics/{topic}/reply', 'TopicsController@reply')->name('topics.reply');
+                Route::group(['as' => 'topics.', 'prefix' => 'topics/{topic}'], function () {
+                    Route::post('lock', 'TopicsController@lock')->name('lock');
+                    Route::post('move', 'TopicsController@move')->name('move');
+                    Route::post('pin', 'TopicsController@pin')->name('pin');
+                    Route::post('reply', 'TopicsController@reply')->name('reply');
+                });
+
                 Route::resource('topics', 'TopicsController', ['only' => ['index', 'show', 'store', 'update']]);
                 Route::resource('posts', 'PostsController', ['only' => ['update']]);
             });

--- a/tests/Controllers/Forum/PostsControllerTest.php
+++ b/tests/Controllers/Forum/PostsControllerTest.php
@@ -18,24 +18,43 @@ class PostsControllerTest extends TestCase
 {
     public static function dataProviderForTestUpdate(): array
     {
+        // $first, $newText, $group, $forumGroups, $authorize, $aclGroup, $statusCode
         return [
-            [true, null, 'post', null, [], 422],
-            [true, null, 'reply', null, [], 403],
-            [true, 'new text', 'post', null, [], 200],
-            [true, 'new text', 'reply', null, [], 403],
-            [true, 'new text', null, null, [], 403],
-            [true, 'new text', null, 'loved', [], 403],
-            [true, 'new text', null, 'loved', ['loved'], 200],
-            [true, 'new text', null, 'gmt', [], 200],
+            // default acl post
+            [true, null, null, [], 'post', null, 422],
+            [true, null, null, [], 'reply', null, 403],
+            [true, 'new text', null, [], 'post', null, 200],
+            [true, 'new text', null, [], 'reply', null, 403],
+            [true, 'new text', null, [], null, null, 403],
+            [true, 'new text', 'loved', [], null, null, 403],
+            [true, 'new text', 'loved', ['loved'], null, null, 200],
+            [true, 'new text', 'gmt', [], null, null, 200],
 
-            [false, null, 'post', null, [], 403],
-            [false, null, 'reply', null, [], 422],
-            [false, 'new text', 'post', null, [], 403],
-            [false, 'new text', 'reply', null, [], 200],
-            [false, 'new text', null, null, [], 403],
-            [false, 'new text', null, 'loved', [], 403],
-            [false, 'new text', null, 'loved', ['loved'], 200],
-            [false, 'new text', null, 'gmt', [], 200],
+            // default acl reply
+            [false, null, null, [], 'post', null, 403],
+            [false, null, null, [], 'reply', null, 422],
+            [false, 'new text', null, [], 'post', null, 403],
+            [false, 'new text', null, [], 'reply', null, 200],
+            [false, 'new text', null, [], null, null, 403],
+            [false, 'new text', 'loved', [], null, null, 403],
+            [false, 'new text', 'loved', ['loved'], null, null, 200],
+            [false, 'new text', 'gmt', [], null, null, 200],
+
+            // specific group acl post
+            [true, 'new text', null, [], 'post', 'gmt', 403],
+            [true, 'new text', 'loved', [], 'post', 'loved', 200],
+            [true, 'new text', 'loved', [], 'post', 'gmt', 403],
+            [true, 'new text', null, [], 'reply', 'gmt', 403],
+            [true, 'new text', 'loved', [], 'reply', 'loved', 403],
+            [true, 'new text', 'loved', [], 'reply', 'gmt', 403],
+
+            // specific group acl reply
+            [false, 'new text', null, [], 'post', 'gmt', 403],
+            [false, 'new text', 'loved', [], 'post', 'loved', 403],
+            [false, 'new text', 'loved', [], 'post', 'gmt', 403],
+            [false, 'new text', null, [], 'reply', 'gmt', 403],
+            [false, 'new text', 'loved', [], 'reply', 'loved', 200],
+            [false, 'new text', 'loved', [], 'reply', 'gmt', 403],
         ];
     }
 
@@ -114,14 +133,22 @@ class PostsControllerTest extends TestCase
     }
 
     #[DataProvider('dataProviderForTestUpdate')]
-    public function testUpdate(bool $first, ?string $newText, ?string $authorize, ?string $group, array $forumGroups, int $statusCode): void
-    {
+    public function testUpdate(
+        bool $first,
+        ?string $newText,
+        ?string $group,
+        array $forumGroups,
+        ?string $authorize,
+        ?string $aclGroup,
+        int $statusCode
+    ): void {
         $user = User::factory()->withGroup($group)->create();
-        $topic = Topic::factory()->withPost(['post_text' => 'text'])->for(
-            Forum::factory()->withAuthorize($authorize)->moderatorGroups($forumGroups)
-        )->create([
-            'topic_poster' => $user,
-        ]);
+        $topic = Topic::factory()
+            ->for(Forum::factory()->withAuthorize($authorize, $aclGroup)->moderatorGroups($forumGroups))
+            ->withPost(['post_text' => 'text'])
+            ->create([
+                'topic_poster' => $user,
+            ]);
         $post = $first ? $topic->firstPost : Post::factory()->create([
             'topic_id' => $topic,
             'post_text' => 'text',

--- a/tests/Controllers/Forum/TopicsControllerTest.php
+++ b/tests/Controllers/Forum/TopicsControllerTest.php
@@ -8,7 +8,6 @@ declare(strict_types=1);
 namespace Tests\Controllers\Forum;
 
 use App\Exceptions\InvalidScopeException;
-use App\Models\Forum\Authorize;
 use App\Models\Forum\Forum;
 use App\Models\Forum\Post;
 use App\Models\Forum\Topic;
@@ -241,7 +240,8 @@ class TopicsControllerTest extends TestCase
 
         $this
             ->actAsScopedUser($user, ['forum.write_manage'], $client)
-            ->post(route('api.forum.topics.pin', $topic), ['pin' => Topic::TYPES['sticky']]);}
+            ->post(route('api.forum.topics.pin', $topic), ['pin' => Topic::TYPES['sticky']]);
+    }
 
     #[DataProvider('dataProviderForClientCredentialsGroupTests')]
     public function testPinClientCredentials(array $groups, array $forumGroups, bool $expectException, bool $success): void
@@ -265,7 +265,7 @@ class TopicsControllerTest extends TestCase
         }
     }
 
-   #[DataProvider('dataProviderForTestReply')]
+    #[DataProvider('dataProviderForTestReply')]
     public function testReply(bool $hasMinPlays, ?string $authorize, bool $success): void
     {
         $topic = Topic::factory()->for(Forum::factory()->withAuthorize($authorize))->create();

--- a/tests/Controllers/Forum/TopicsControllerTest.php
+++ b/tests/Controllers/Forum/TopicsControllerTest.php
@@ -522,8 +522,7 @@ class TopicsControllerTest extends TestCase
         ?string $authorize,
         ?string $aclGroup,
         int $statusCode
-    ): void
-    {
+    ): void {
         $user = User::factory()->withGroup($group)->create();
         $topic = Topic::factory()
             ->for(Forum::factory()->withAuthorize($authorize, $aclGroup)->moderatorGroups($forumGroups))

--- a/tests/Controllers/Forum/TopicsControllerTest.php
+++ b/tests/Controllers/Forum/TopicsControllerTest.php
@@ -7,7 +7,6 @@ declare(strict_types=1);
 
 namespace Tests\Controllers\Forum;
 
-use App\Exceptions\InvalidScopeException;
 use App\Models\Forum\Forum;
 use App\Models\Forum\Post;
 use App\Models\Forum\Topic;
@@ -22,26 +21,16 @@ class TopicsControllerTest extends TestCase
 {
     public static function dataProviderForClientCredentialsWithPermissionGroupTests(): array
     {
-        // $groups, $forumGroups, $expectException, $success
+        // $groups, $forumGroups, $success
         return [
-            [[], [], true, false],
-
-            // standalone group
-            [['bot'], [], false, false],
-            [['loved'], [], true, false],
-            [['loved'], ['loved'], true, false],
-            [['loved'], ['gmt'], true, false],
-            [['gmt'], [], true, false],
-            [['gmt'], ['loved'], true, false],
-            [['gmt'], ['gmt'], true, false],
-
             // factory uses last assigned group as group_id, so bot has to be last.
-            [['loved', 'bot'], [], false, false],
-            [['loved', 'bot'], ['loved'], false, true],
-            [['loved', 'bot'], ['gmt'], false, false],
-            [['gmt', 'bot'], [], false, false],
-            [['gmt', 'bot'], ['loved'], false, false],
-            [['gmt', 'bot'], ['gmt'], false, true],
+            [['bot'], [], false],
+            [['loved', 'bot'], [], false],
+            [['loved', 'bot'], ['loved'], true],
+            [['loved', 'bot'], ['gmt'], false],
+            [['gmt', 'bot'], [], false],
+            [['gmt', 'bot'], ['loved'], false],
+            [['gmt', 'bot'], ['gmt'], true],
         ];
     }
 
@@ -193,15 +182,11 @@ class TopicsControllerTest extends TestCase
     }
 
     #[DataProvider('dataProviderForClientCredentialsWithPermissionGroupTests')]
-    public function testLockClientCredentialsWithGroupPermission(array $groups, array $forumGroups, bool $expectException, bool $success): void
+    public function testLockClientCredentialsWithGroupPermission(array $groups, array $forumGroups, bool $success): void
     {
         $user = User::factory()->withGroups($groups)->create();
         $client = Client::factory()->create(['user_id' => $user]);
         $topic = Topic::factory()->for(Forum::factory()->moderatorGroups($forumGroups))->create();
-
-        if ($expectException) {
-            $this->expectException(InvalidScopeException::class);
-        }
 
         $response = $this
             ->actAsScopedUser(null, ['delegate', 'forum.write_manage', 'group_permissions'], $client)
@@ -250,15 +235,11 @@ class TopicsControllerTest extends TestCase
     }
 
     #[DataProvider('dataProviderForClientCredentialsWithPermissionGroupTests')]
-    public function testPinClientCredentialsWithGroupPermission(array $groups, array $forumGroups, bool $expectException, bool $success): void
+    public function testPinClientCredentialsWithGroupPermission(array $groups, array $forumGroups, bool $success): void
     {
         $user = User::factory()->withGroups($groups)->create();
         $client = Client::factory()->create(['user_id' => $user]);
         $topic = Topic::factory()->for(Forum::factory()->moderatorGroups($forumGroups))->create();
-
-        if ($expectException) {
-            $this->expectException(InvalidScopeException::class);
-        }
 
         $response = $this
             ->actAsScopedUser(null, ['delegate', 'forum.write_manage', 'group_permissions'], $client)
@@ -321,15 +302,11 @@ class TopicsControllerTest extends TestCase
     }
 
     #[DataProvider('dataProviderForClientCredentialsWithPermissionGroupTests')]
-    public function testReplyClientCredentialsWithGroupPermission(array $groups, array $forumGroups, bool $expectException, bool $success): void
+    public function testReplyClientCredentialsWithGroupPermission(array $groups, array $forumGroups, bool $success): void
     {
         $user = User::factory()->withGroups($groups)->create();
         $client = Client::factory()->create(['user_id' => $user]);
         $topic = Topic::factory()->for(Forum::factory()->moderatorGroups($forumGroups))->create();
-
-        if ($expectException) {
-            $this->expectException(InvalidScopeException::class);
-        }
 
         $countChange = $success ? 1 : 0;
 
@@ -503,15 +480,11 @@ class TopicsControllerTest extends TestCase
     }
 
     #[DataProvider('dataProviderForClientCredentialsWithPermissionGroupTests')]
-    public function testStoreClientCredentialsWithPermission(array $groups, array $forumGroups, bool $expectException, bool $success): void
+    public function testStoreClientCredentialsWithPermission(array $groups, array $forumGroups, bool $success): void
     {
         $user = User::factory()->withGroups($groups)->create();
         $client = Client::factory()->create(['user_id' => $user]);
         $forum = Forum::factory()->moderatorGroups($forumGroups)->create();
-
-        if ($expectException) {
-            $this->expectException(InvalidScopeException::class);
-        }
 
         $countChange = $success ? 1 : 0;
 
@@ -611,15 +584,11 @@ class TopicsControllerTest extends TestCase
     }
 
     #[DataProvider('dataProviderForClientCredentialsWithPermissionGroupTests')]
-    public function testUpdateClientCredentialsWithPermission(array $groups, array $forumGroups, bool $expectException, bool $success): void
+    public function testUpdateClientCredentialsWithPermission(array $groups, array $forumGroups, bool $success): void
     {
         $user = User::factory()->withGroups($groups)->create();
         $client = Client::factory()->create(['user_id' => $user]);
         $topic = Topic::factory()->for(Forum::factory()->moderatorGroups($forumGroups))->withPost()->create(['topic_poster' => $user]);
-
-        if ($expectException) {
-            $this->expectException(InvalidScopeException::class);
-        }
 
         $this->expectCountChange(fn () => Post::count(), 0);
         $this->expectCountChange(fn () => Topic::count(), 0);

--- a/tests/Controllers/Forum/TopicsControllerTest.php
+++ b/tests/Controllers/Forum/TopicsControllerTest.php
@@ -242,16 +242,12 @@ class TopicsControllerTest extends TestCase
         }
     }
 
-    #[DataProvider('dataProviderForClientCredentialsWithPermissionGroupTests')]
-    public function testLockClientCredentialsWithoutGroupPermission(array $groups, array $forumGroups, bool $expectException): void
+    #[DataProvider('dataProviderForClientCredentialsWithoutPermissionGroupTests')]
+    public function testLockClientCredentialsWithoutGroupPermission(array $groups, array $forumGroups): void
     {
         $user = User::factory()->withGroups($groups)->create();
         $client = Client::factory()->create(['user_id' => $user]);
         $topic = Topic::factory()->for(Forum::factory()->moderatorGroups($forumGroups))->create();
-
-        if ($expectException) {
-            $this->expectException(InvalidScopeException::class);
-        }
 
         $this
             ->actAsScopedUser(null, ['delegate', 'forum.write_manage'], $client)

--- a/tests/Controllers/Forum/TopicsControllerTest.php
+++ b/tests/Controllers/Forum/TopicsControllerTest.php
@@ -35,7 +35,7 @@ class TopicsControllerTest extends TestCase
             [['gmt'], ['loved'], true, false],
             [['gmt'], ['gmt'], true, false],
 
-            // with bot group, bot needs to be last for the factory.
+            // factory uses last assigned group as group_id, so bot has to be last.
             [['loved', 'bot'], [], false, false],
             [['loved', 'bot'], ['loved'], false, true],
             [['loved', 'bot'], ['gmt'], false, false],

--- a/tests/Controllers/Forum/TopicsControllerTest.php
+++ b/tests/Controllers/Forum/TopicsControllerTest.php
@@ -61,26 +61,16 @@ class TopicsControllerTest extends TestCase
 
     public static function dataProviderForClientCredentialsWithoutPermissionGroupTests(): array
     {
-        // $groups, $forumGroups, $expectException
+        // $groups, $forumGroups
         return [
-            [[], [], true, false],
-
-            // standalone group
-            [['bot'], [], false],
-            [['loved'], [], true],
-            [['loved'], ['loved'], true],
-            [['loved'], ['gmt'], true],
-            [['gmt'], [], true],
-            [['gmt'], ['loved'], true],
-            [['gmt'], ['gmt'], true],
-
-            // with bot group, bot needs to be last for the factory.
-            [['loved', 'bot'], [], false],
-            [['loved', 'bot'], ['loved'], false],
-            [['loved', 'bot'], ['gmt'], false],
-            [['gmt', 'bot'], [], false],
-            [['gmt', 'bot'], ['loved'], false],
-            [['gmt', 'bot'], ['gmt'], false],
+            // bot needs to be last for the factory.
+            [['bot'], []],
+            [['loved', 'bot'], []],
+            [['loved', 'bot'], ['loved']],
+            [['loved', 'bot'], ['gmt']],
+            [['gmt', 'bot'], []],
+            [['gmt', 'bot'], ['loved']],
+            [['gmt', 'bot'], ['gmt']],
         ];
     }
 
@@ -328,15 +318,11 @@ class TopicsControllerTest extends TestCase
     }
 
     #[DataProvider('dataProviderForClientCredentialsWithoutPermissionGroupTests')]
-    public function testPinClientCredentialsWithoutGroupPermission(array $groups, array $forumGroups, bool $expectException): void
+    public function testPinClientCredentialsWithoutGroupPermission(array $groups, array $forumGroups): void
     {
         $user = User::factory()->withGroups($groups)->create();
         $client = Client::factory()->create(['user_id' => $user]);
         $topic = Topic::factory()->for(Forum::factory()->moderatorGroups($forumGroups))->create();
-
-        if ($expectException) {
-            $this->expectException(InvalidScopeException::class);
-        }
 
         $this
             ->actAsScopedUser(null, ['delegate', 'forum.write_manage'], $client)
@@ -411,15 +397,11 @@ class TopicsControllerTest extends TestCase
     }
 
     #[DataProvider('dataProviderForClientCredentialsWithoutPermissionGroupTests')]
-    public function testReplyClientCredentialsWithoutGroupPermission(array $groups, array $forumGroups, bool $expectException): void
+    public function testReplyClientCredentialsWithoutGroupPermission(array $groups, array $forumGroups): void
     {
         $user = User::factory()->withGroups($groups)->create();
         $client = Client::factory()->create(['user_id' => $user]);
         $topic = Topic::factory()->for(Forum::factory()->moderatorGroups($forumGroups))->create();
-
-        if ($expectException) {
-            $this->expectException(InvalidScopeException::class);
-        }
 
         $this->expectCountChange(fn () => Post::count(), 0);
         $this->expectCountChange(fn () => Topic::count(), 0);
@@ -598,15 +580,11 @@ class TopicsControllerTest extends TestCase
     }
 
     #[DataProvider('dataProviderForClientCredentialsWithoutPermissionGroupTests')]
-    public function testStoreClientCredentialsWithoutPermission(array $groups, array $forumGroups, bool $expectException): void
+    public function testStoreClientCredentialsWithoutPermission(array $groups, array $forumGroups): void
     {
         $user = User::factory()->withGroups($groups)->create();
         $client = Client::factory()->create(['user_id' => $user]);
         $forum = Forum::factory()->moderatorGroups($forumGroups)->create();
-
-        if ($expectException) {
-            $this->expectException(InvalidScopeException::class);
-        }
 
         $this->expectCountChange(fn () => Post::count(), 0);
         $this->expectCountChange(fn () => Topic::count(), 0);
@@ -708,15 +686,11 @@ class TopicsControllerTest extends TestCase
     }
 
     #[DataProvider('dataProviderForClientCredentialsWithoutPermissionGroupTests')]
-    public function testUpdateClientCredentialsWithoutPermission(array $groups, array $forumGroups, bool $expectException): void
+    public function testUpdateClientCredentialsWithoutPermission(array $groups, array $forumGroups): void
     {
         $user = User::factory()->withGroups($groups)->create();
         $client = Client::factory()->create(['user_id' => $user]);
         $topic = Topic::factory()->for(Forum::factory()->moderatorGroups($forumGroups))->withPost()->create(['topic_poster' => $user]);
-
-        if ($expectException) {
-            $this->expectException(InvalidScopeException::class);
-        }
 
         $this->expectCountChange(fn () => Post::count(), 0);
         $this->expectCountChange(fn () => Topic::count(), 0);

--- a/tests/Controllers/Forum/TopicsControllerTest.php
+++ b/tests/Controllers/Forum/TopicsControllerTest.php
@@ -20,20 +20,6 @@ use Tests\TestCase;
 
 class TopicsControllerTest extends TestCase
 {
-    public static function dataProviderForAuthCodeDelegateOnlyGroupTests(): array
-    {
-        // $groups, $forumGroups
-        return [
-            [[], []],
-            [['loved'], []],
-            [['loved'], ['loved']],
-            [['loved'], ['gmt']],
-            [['gmt'], []],
-            [['gmt'], ['loved']],
-            [['gmt'], ['gmt']],
-        ];
-    }
-
     public static function dataProviderForClientCredentialsWithPermissionGroupTests(): array
     {
         // $groups, $forumGroups, $expectException, $success
@@ -206,20 +192,6 @@ class TopicsControllerTest extends TestCase
         }
     }
 
-    #[DataProvider('dataProviderForAuthCodeDelegateOnlyGroupTests')]
-    public function testLockAuthCode(array $groups, array $forumGroups): void
-    {
-        $user = User::factory()->withGroups($groups)->create();
-        $client = Client::factory()->create();
-        $topic = Topic::factory()->for(Forum::factory()->moderatorGroups($forumGroups))->create();
-
-        $this->expectInvalidScopeException('client_credentials_only');
-
-        $this
-            ->actAsScopedUser($user, ['forum.write_manage'], $client)
-            ->post(route('api.forum.topics.lock', $topic), ['lock' => true]);
-    }
-
     #[DataProvider('dataProviderForClientCredentialsWithPermissionGroupTests')]
     public function testLockClientCredentialsWithGroupPermission(array $groups, array $forumGroups, bool $expectException, bool $success): void
     {
@@ -275,20 +247,6 @@ class TopicsControllerTest extends TestCase
             $response->assertStatus(403);
             $this->assertSame(Topic::TYPES['normal'], $topic->fresh()->topic_type);
         }
-    }
-
-    #[DataProvider('dataProviderForAuthCodeDelegateOnlyGroupTests')]
-    public function testPinAuthCode(array $groups, array $forumGroups): void
-    {
-        $user = User::factory()->withGroups($groups)->create();
-        $client = Client::factory()->create();
-        $topic = Topic::factory()->for(Forum::factory()->moderatorGroups($forumGroups))->create();
-
-        $this->expectInvalidScopeException('client_credentials_only');
-
-        $this
-            ->actAsScopedUser($user, ['forum.write_manage'], $client)
-            ->post(route('api.forum.topics.pin', $topic), ['pin' => Topic::TYPES['sticky']]);
     }
 
     #[DataProvider('dataProviderForClientCredentialsWithPermissionGroupTests')]

--- a/tests/Controllers/Forum/TopicsControllerTest.php
+++ b/tests/Controllers/Forum/TopicsControllerTest.php
@@ -232,7 +232,7 @@ class TopicsControllerTest extends TestCase
         }
 
         $response = $this
-            ->actAsScopedUser(null, ['delegate', 'forum.delegate', 'forum.write_manage'], $client)
+            ->actAsScopedUser(null, ['delegate', 'forum.write_manage', 'group_permissions'], $client)
             ->post(route('api.forum.topics.lock', $topic), ['lock' => true]);
 
         if ($success) {
@@ -303,7 +303,7 @@ class TopicsControllerTest extends TestCase
         }
 
         $response = $this
-            ->actAsScopedUser(null, ['delegate', 'forum.delegate', 'forum.write_manage'], $client)
+            ->actAsScopedUser(null, ['delegate', 'forum.write_manage', 'group_permissions'], $client)
             ->post(route('api.forum.topics.pin', $topic), ['pin' => Topic::TYPES['sticky']]);
 
         if ($success) {
@@ -380,7 +380,7 @@ class TopicsControllerTest extends TestCase
         $this->expectCountChange(fn () => $topic->fresh()->postCount(), $countChange);
 
         $response = $this
-            ->actAsScopedUser(null, ['delegate', 'forum.delegate', 'forum.write'], $client)
+            ->actAsScopedUser(null, ['delegate', 'forum.write', 'group_permissions'], $client)
             ->post(route('api.forum.topics.reply', $topic), [
                 'body' => 'This is test reply',
             ]);
@@ -562,7 +562,7 @@ class TopicsControllerTest extends TestCase
         $this->expectCountChange(fn () => TopicTrack::count(), $countChange);
 
         $response = $this
-            ->actAsScopedUser(null, ['delegate', 'forum.delegate', 'forum.write'], $client)
+            ->actAsScopedUser(null, ['delegate', 'forum.write', 'group_permissions'], $client)
             ->post(route('api.forum.topics.store', ['forum_id' => $forum]), [
                 'title' => 'Test post',
                 'body' => 'This is test post',
@@ -667,7 +667,7 @@ class TopicsControllerTest extends TestCase
         $this->expectCountChange(fn () => Topic::count(), 0);
 
         $response = $this
-            ->actAsScopedUser(null, ['delegate', 'forum.delegate', 'forum.write'], $client)
+            ->actAsScopedUser(null, ['delegate', 'forum.write', 'group_permissions'], $client)
             ->put(route('api.forum.topics.update', $topic), [
                 'forum_topic' => [
                     'topic_title' => 'A different title',

--- a/tests/Models/OAuth/GroupPermissionTest.php
+++ b/tests/Models/OAuth/GroupPermissionTest.php
@@ -71,9 +71,12 @@ class GroupPermissionTest extends TestCase
     #[DataProvider('dataProviderForTestForumModerator')]
     public function testForumModeratorWithOAuth(string $group, array $forumGroups, bool $inGroup)
     {
+
         $user = User::factory()->withGroup($group)->create();
+        $client = Client::factory()->create(['user_id' => $user]);
         $forum = Forum::factory()->moderatorGroups($forumGroups)->create();
-        $this->actAsUser($user);
+        $token = $this->createToken($user, ['*'], $client);
+        $this->actAsUserWithToken($token);
 
         $this->assertSame($inGroup, \Auth::user()->isForumModerator($forum));
     }
@@ -82,10 +85,8 @@ class GroupPermissionTest extends TestCase
     public function testForumModeratorWithoutOAuth(string $group, array $forumGroups, bool $inGroup)
     {
         $user = User::factory()->withGroup($group)->create();
-        $client = Client::factory()->create(['user_id' => $user]);
         $forum = Forum::factory()->moderatorGroups($forumGroups)->create();
-        $token = $this->createToken($user, ['*'], $client);
-        $this->actAsUserWithToken($token);
+        $this->actAsUser($user);
 
         $this->assertSame($inGroup, \Auth::user()->isForumModerator($forum));
     }

--- a/tests/Models/OAuth/GroupPermissionTest.php
+++ b/tests/Models/OAuth/GroupPermissionTest.php
@@ -7,40 +7,11 @@ namespace Tests\Models\OAuth;
 
 use App\Models\OAuth\Client;
 use App\Models\User;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Tests\TestCase;
 
 class GroupPermissionTest extends TestCase
 {
-    /**
-     * TODO: maybe an exclusion list of when groups are allowed with token instead...
-     *
-     * @dataProvider groupsDataProvider
-     *
-     * @return void
-     */
-    public function testGroupWithOAuth(string $group, string $method, bool $inGroup)
-    {
-        $user = User::factory()->withGroup($group)->create();
-        $client = Client::factory()->create(['user_id' => $user]);
-        $token = $this->createToken($user, ['*'], $client);
-        $this->actAsUserWithToken($token);
-
-        $this->assertSame($inGroup, auth()->user()->$method());
-    }
-
-    /**
-     * @dataProvider groupsDataProvider
-     *
-     * @return void
-     */
-    public function testGroupWithoutOAuth(string $group, string $method)
-    {
-        $user = User::factory()->withGroup($group)->create();
-        $this->actAsUser($user);
-
-        $this->assertTrue(auth()->user()->$method());
-    }
-
     public static function groupsDataProvider()
     {
         return [
@@ -54,5 +25,28 @@ class GroupPermissionTest extends TestCase
             ['loved', 'isProjectLoved', false],
             ['nat', 'isNAT', false],
         ];
+    }
+
+    /**
+     * TODO: maybe an exclusion list of when groups are allowed with token instead...
+     */
+    #[DataProvider('groupsDataProvider')]
+    public function testGroupWithOAuth(string $group, string $method, bool $inGroup)
+    {
+        $user = User::factory()->withGroup($group)->create();
+        $client = Client::factory()->create(['user_id' => $user]);
+        $token = $this->createToken($user, ['*'], $client);
+        $this->actAsUserWithToken($token);
+
+        $this->assertSame($inGroup, auth()->user()->$method());
+    }
+
+    #[DataProvider('groupsDataProvider')]
+    public function testGroupWithoutOAuth(string $group, string $method)
+    {
+        $user = User::factory()->withGroup($group)->create();
+        $this->actAsUser($user);
+
+        $this->assertTrue(auth()->user()->$method());
     }
 }

--- a/tests/Models/OAuth/TokenTest.php
+++ b/tests/Models/OAuth/TokenTest.php
@@ -6,7 +6,6 @@
 namespace Tests\Models\OAuth;
 
 use App\Events\UserSessionEvent;
-use App\Exceptions\InvalidScopeException;
 use App\Models\OAuth\Client;
 use App\Models\OAuth\Token;
 use App\Models\User;
@@ -116,7 +115,7 @@ class TokenTest extends TestCase
         $user = User::factory()->withGroup('bot')->create();
         $client = Client::factory()->create(['user_id' => $user]);
 
-        $this->expectInvalidScopeException('delegate_client_credentials_only');
+        $this->expectInvalidScopeException('client_credentials_only');
         $this->createToken($user, ['chat.read', 'delegate'], $client);
     }
 
@@ -125,7 +124,7 @@ class TokenTest extends TestCase
         $user = User::factory()->create();
         $client = Client::factory()->create(['user_id' => $user]);
 
-        $this->expectInvalidScopeException('delegate_client_credentials_only');
+        $this->expectInvalidScopeException('client_credentials_only');
         $this->createToken($user, ['delegate'], $client);
     }
 
@@ -234,15 +233,5 @@ class TokenTest extends TestCase
         $this->assertTrue($refreshToken->fresh()->revoked);
         $this->assertTrue($token->fresh()->revoked);
         Event::assertDispatched(UserSessionEvent::class, fn (UserSessionEvent $event) => $event->action === 'logout');
-    }
-
-    private function expectInvalidScopeException(?string $key)
-    {
-        if ($key === null) {
-            $this->expectNotToPerformAssertions();
-        } else {
-            $this->expectException(InvalidScopeException::class);
-            $this->expectExceptionMessage(osu_trans("model_validation/token.invalid_scope.{$key}"));
-        }
     }
 }

--- a/tests/Models/OAuth/TokenTest.php
+++ b/tests/Models/OAuth/TokenTest.php
@@ -188,7 +188,6 @@ class TokenTest extends TestCase
     {
         $user = User::factory()->withGroup($group)->create();
         $client = Client::factory()->create(['user_id' => $user]);
-        $tokenUser = User::factory()->create();
 
         $this->expectInvalidScopeException($shouldThrow ? 'delegate_bot_only' : null);
 

--- a/tests/Models/OAuth/TokenTest.php
+++ b/tests/Models/OAuth/TokenTest.php
@@ -36,6 +36,11 @@ class TokenTest extends TestCase
         return $data;
     }
 
+    public static function dataProviderForTestClientCredentialsOnly()
+    {
+        return array_map(fn ($scope) => [$scope], Token::SCOPES_CLIENT_CREDENTIALS_ONLY);
+    }
+
     public static function dataProviderForTestDelegationNotAllowedScopes()
     {
         return array_reject_null(static::allPassportScopeIds()->map(fn ($scope) => match (true) {
@@ -119,13 +124,15 @@ class TokenTest extends TestCase
         $this->createToken($user, ['chat.read', 'delegate'], $client);
     }
 
-    public function testClientCredentialsRequiredForDelegation()
+
+    #[DataProvider('dataProviderForTestClientCredentialsOnly')]
+    public function testClientCredentialsOnly(string $scope)
     {
         $user = User::factory()->create();
         $client = Client::factory()->create(['user_id' => $user]);
 
         $this->expectInvalidScopeException('client_credentials_only');
-        $this->createToken($user, ['delegate'], $client);
+        $this->createToken($user, [$scope], $client);
     }
 
     public function testClientCredentialResourceOwnerBot()

--- a/tests/OAuthClientCredentialsRequestTest.php
+++ b/tests/OAuthClientCredentialsRequestTest.php
@@ -55,7 +55,7 @@ class OAuthClientCredentialsRequestTest extends TestCase
             'cannot request empty scope' => ['', 400],
             'delegate scope allows chat.write' => ['chat.write delegate ', 200],
             'chat.write cannot be requested by itself' => ['chat.write', 400],
-            'mixing scope delegation is not allowed' => ['chat.write delegate forum.write', 400],
+            'mixing scope delegation is not allowed' => ['chat.write delegate friends.read', 400],
             'public scope is allowed' => ['public', 200],
         ];
     }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -6,6 +6,7 @@
 namespace Tests;
 
 use App\Events\NewPrivateNotificationEvent;
+use App\Exceptions\InvalidScopeException;
 use App\Http\Middleware\AuthApi;
 use App\Jobs\Notifications\BroadcastNotificationBase;
 use App\Libraries\OAuth\EncodeToken;
@@ -138,6 +139,16 @@ class TestCase extends BaseTestCase
             'build_id' => 0,
             'ruleset_id' => $playlistItem->ruleset_id,
         ]);
+    }
+
+    protected function expectInvalidScopeException(?string $key)
+    {
+        if ($key === null) {
+            $this->expectNotToPerformAssertions();
+        } else {
+            $this->expectException(InvalidScopeException::class);
+            $this->expectExceptionMessage(osu_trans("model_validation/token.invalid_scope.{$key}"));
+        }
     }
 
     protected function setUp(): void

--- a/tests/api_routes.json
+++ b/tests/api_routes.json
@@ -722,6 +722,50 @@
         ]
     },
     {
+        "uri": "api/v2/forums/topics/{topic}/lock",
+        "methods": [
+            "POST"
+        ],
+        "controller": "App\\Http\\Controllers\\Forum\\TopicsController@lock",
+        "middlewares": [
+            "App\\Http\\Middleware\\ThrottleRequests:1200,1,api:",
+            "App\\Http\\Middleware\\RequireScopes",
+            "Illuminate\\Auth\\Middleware\\Authenticate",
+            "App\\Http\\Middleware\\RequireScopes:forum.write_manage"
+        ],
+        "scopes": [
+            "forum.write_manage"
+        ]
+    },
+    {
+        "uri": "api/v2/forums/topics/{topic}/move",
+        "methods": [
+            "POST"
+        ],
+        "controller": "App\\Http\\Controllers\\Forum\\TopicsController@move",
+        "middlewares": [
+            "App\\Http\\Middleware\\ThrottleRequests:1200,1,api:",
+            "App\\Http\\Middleware\\RequireScopes"
+        ],
+        "scopes": []
+    },
+    {
+        "uri": "api/v2/forums/topics/{topic}/pin",
+        "methods": [
+            "POST"
+        ],
+        "controller": "App\\Http\\Controllers\\Forum\\TopicsController@pin",
+        "middlewares": [
+            "App\\Http\\Middleware\\ThrottleRequests:1200,1,api:",
+            "App\\Http\\Middleware\\RequireScopes",
+            "Illuminate\\Auth\\Middleware\\Authenticate",
+            "App\\Http\\Middleware\\RequireScopes:forum.write_manage"
+        ],
+        "scopes": [
+            "forum.write_manage"
+        ]
+    },
+    {
         "uri": "api/v2/forums/topics/{topic}/reply",
         "methods": [
             "POST"


### PR DESCRIPTION
- `forum.write_manage` scope added; scope is `client_credentials` only, requires `delegate` and requires the bot account to be in the groups listed in the forum's `moderator_groups`.
- `forum.write` can now be `delegate`d to a bot account
- Added `group_permissions` (can use some name suggestion) scope for enabling forum moderation group permissions
- ~~The OAuth scopes documentation is out of date and still needs updating~~ just moved them here instead of a larger doc update
- ~~things that support group permissions with OAuth have been changed to apply receive the group permission if the token supports delegation or is an `ownToken`.~~ The `ownToken` thing should only be only for chat.

related #7441 but this doesn't include moving or deleting

- [x] #12300

I thought of making a separate bot group for this to separate the "chat bots" and bots used for other things, but decided to use the existing bot group for now.