### PR TITLE
Fix incorrect early number formatting

### DIFF
--- a/app/Http/Controllers/HomeController.php
+++ b/app/Http/Controllers/HomeController.php
@@ -260,7 +260,7 @@ class HomeController extends Controller
                 // gifted
                 'giftedDollars' => currency($giftedDollars, 2, false),
                 'giftedDuration' => $giftedDuration,
-                'giftedUsers' => i18n_number_format($giftedUsers),
+                'giftedUsers' => $giftedUsers,
             ];
 
             if ($current) {


### PR DESCRIPTION
It's rendered using choice translator which does its own formatting. It's fine up to three digit numeral and then explodes once the thousand separator is included.