### PR TITLE
Add default tooltip for favourites count on `beatmapset` page

### DIFF
--- a/resources/js/beatmapsets-show/header.tsx
+++ b/resources/js/beatmapsets-show/header.tsx
@@ -231,19 +231,11 @@ export default class Header extends React.Component<Props> {
 
   @action
   private readonly onEnterFavouriteIcon = () => {
-    if (this.filteredFavourites.length < 1) {
-      if (this.favouritePopupDisposer != null) {
-        this.favouritePopupDisposer();
-        $(this.favouriteIconRef.current ?? []).qtip('destroy', true);
-      }
-
-      return;
-    }
-
     this.favouritePopupDisposer ??= createTooltip(
       () => this.favouriteIconRef.current,
       () => ({
         count: this.controller.beatmapset.favourite_count,
+        title: this.filteredFavourites.length < 1 ? trans('beatmapsets.show.stats.no_favourites') : undefined,
         users: this.filteredFavourites,
       }),
       'right center',

--- a/resources/js/components/user-list-popup.tsx
+++ b/resources/js/components/user-list-popup.tsx
@@ -76,7 +76,7 @@ export default function UserListPopup(props: Props) {
           ))}
         </div>
       }
-      {props.count > props.users.length &&
+      {props.count > props.users.length && props.users.length > 0 &&
         <div className='user-list-popup__remainder-count'>
           {transChoice('common.count.plus_others', props.count - props.users.length)}
         </div>

--- a/resources/lang/en/beatmapsets.php
+++ b/resources/lang/en/beatmapsets.php
@@ -224,6 +224,7 @@ return [
             'rating-spread' => 'Rating Spread',
             'nominations' => 'Nominations',
             'playcount' => 'Playcount',
+            'no_favourites' => 'No favourites yet!',
         ],
 
         'status' => [


### PR DESCRIPTION
- closes https://github.com/ppy/osu-web/issues/12281

| master | pr |
|-|-|
| <img width="157" height="94" alt="image" src="https://github.com/user-attachments/assets/93c90340-0317-4075-be2b-f449a4eda11b" /> | <img width="192" height="56" alt="image" src="https://github.com/user-attachments/assets/1d948f9c-fa9e-4997-8a20-c1d60b068e08" /> |