### PR TITLE
Update class name for verification mail state

### DIFF
--- a/app/Libraries/SessionVerification/Helper.php
+++ b/app/Libraries/SessionVerification/Helper.php
@@ -31,7 +31,7 @@ class Helper
     public static function issue(SessionVerificationInterface $session, User $user, bool $initial = false): void
     {
         if ($initial) {
-            if (State::fromSession($session) === null) {
+            if (MailState::fromSession($session) === null) {
                 static::logAttempt('input', 'new');
             } else {
                 return;
@@ -42,10 +42,10 @@ class Helper
             return;
         }
 
-        $state = State::create($session);
+        $mailState = MailState::create($session);
         $keys = [
-            'link' => $state->linkKey,
-            'main' => $state->key,
+            'link' => $mailState->linkKey,
+            'main' => $mailState->key,
         ];
 
         $request = \Request::instance();
@@ -67,10 +67,10 @@ class Helper
         );
     }
 
-    public static function markVerified(SessionVerificationInterface $session, State $state)
+    public static function markVerified(SessionVerificationInterface $session, MailState $mailState)
     {
         $session->markVerified();
-        $state->delete();
+        $mailState->delete();
         UserSessionEvent::newVerified($session->userId(), $session->getKeyForEvent())->broadcast();
     }
 }

--- a/app/Libraries/SessionVerification/MailState.php
+++ b/app/Libraries/SessionVerification/MailState.php
@@ -12,7 +12,7 @@ use App\Interfaces\SessionVerificationInterface;
 use App\Libraries\SignedRandomString;
 use Carbon\CarbonImmutable;
 
-class State
+class MailState
 {
     private const KEY_VALID_DURATION = 600;
 

--- a/tests/Browser/SanityTest.php
+++ b/tests/Browser/SanityTest.php
@@ -333,7 +333,7 @@ class SanityTest extends DuskTestCase
 
         $session = Session\Store::findOrNew($sessionId);
 
-        return SessionVerification\State::fromSession($session)->key;
+        return SessionVerification\MailState::fromSession($session)->key;
     }
 
     public static function routesDataProvider()

--- a/tests/Libraries/SessionVerification/ControllerTest.php
+++ b/tests/Libraries/SessionVerification/ControllerTest.php
@@ -47,7 +47,7 @@ class ControllerTest extends TestCase
             ->withPersistentSession($session)
             ->get(route('account.edit'));
 
-        $state = SessionVerification\State::fromSession($session);
+        $state = SessionVerification\MailState::fromSession($session);
 
         $this
             ->withPersistentSession($session)
@@ -55,7 +55,7 @@ class ControllerTest extends TestCase
             ->assertSuccessful();
 
         \Mail::assertQueued(UserVerificationMail::class, 2);
-        $this->assertNotSame($state->key, SessionVerification\State::fromSession($session)->key);
+        $this->assertNotSame($state->key, SessionVerification\MailState::fromSession($session)->key);
     }
 
     public function testReissueOAuthVerified(): void
@@ -69,7 +69,7 @@ class ControllerTest extends TestCase
             ->assertStatus(422);
 
         \Mail::assertNotQueued(UserVerificationMail::class);
-        $this->assertNull(SessionVerification\State::fromSession($token));
+        $this->assertNull(SessionVerification\MailState::fromSession($token));
     }
 
     public function testReissueVerified(): void
@@ -86,7 +86,7 @@ class ControllerTest extends TestCase
             ->assertStatus(422);
 
         \Mail::assertNotQueued(UserVerificationMail::class);
-        $this->assertNull(SessionVerification\State::fromSession($session));
+        $this->assertNull(SessionVerification\MailState::fromSession($session));
     }
 
     public function testVerify(): void
@@ -101,7 +101,7 @@ class ControllerTest extends TestCase
             ->assertStatus(401)
             ->assertViewIs('users.verify');
 
-        $key = SessionVerification\State::fromSession($session)->key;
+        $key = SessionVerification\MailState::fromSession($session)->key;
 
         $this
             ->withPersistentSession($session)
@@ -112,7 +112,7 @@ class ControllerTest extends TestCase
 
         $this->assertFalse($record->containsUser($user, 'verify-mismatch:'));
         $this->assertTrue($session->isVerified());
-        $this->assertNull(SessionVerification\State::fromSession($session));
+        $this->assertNull(SessionVerification\MailState::fromSession($session));
     }
 
     public function testVerifyLink(): void
@@ -128,7 +128,7 @@ class ControllerTest extends TestCase
             ->assertStatus(401)
             ->assertViewIs('users.verify');
 
-        $linkKey = SessionVerification\State::fromSession($session)->linkKey;
+        $linkKey = SessionVerification\MailState::fromSession($session)->linkKey;
 
         $guestSession = SessionStore::findOrNew();
         $this
@@ -176,7 +176,7 @@ class ControllerTest extends TestCase
             ->get(route('api.me'))
             ->assertSuccessful();
 
-        $linkKey = SessionVerification\State::fromSession($token)->linkKey;
+        $linkKey = SessionVerification\MailState::fromSession($token)->linkKey;
 
         \Auth::logout();
         $this
@@ -228,7 +228,7 @@ class ControllerTest extends TestCase
             ->get(route('api.me'))
             ->assertSuccessful();
 
-        $key = SessionVerification\State::fromSession($token)->key;
+        $key = SessionVerification\MailState::fromSession($token)->key;
 
         $this
             ->actingWithToken($token)
@@ -251,7 +251,7 @@ class ControllerTest extends TestCase
             ->post(route('api.verify', ['verification_key' => 'invalid']))
             ->assertSuccessful();
 
-        $this->assertNull(SessionVerification\State::fromSession($token));
+        $this->assertNull(SessionVerification\MailState::fromSession($token));
         \Mail::assertNotQueued(UserVerificationMail::class);
     }
 
@@ -268,7 +268,7 @@ class ControllerTest extends TestCase
             ->post(route('account.verify'), ['verification_key' => 'invalid'])
             ->assertSuccessful();
 
-        $this->assertNull(SessionVerification\State::fromSession($session));
+        $this->assertNull(SessionVerification\MailState::fromSession($session));
         \Mail::assertNotQueued(UserVerificationMail::class);
     }
 }


### PR DESCRIPTION
Preparing for a different `State` class 😄 

Things may explode when php tries to deserialise existing class...? I guess I can create a blank class inheriting the new class name but not sure if worth it.