### PR TITLE
Remove remember login option

### DIFF
--- a/app/Http/Controllers/Controller.php
+++ b/app/Http/Controllers/Controller.php
@@ -33,7 +33,7 @@ abstract class Controller extends BaseController
         Log::log($params);
     }
 
-    protected function login($user, $remember = false)
+    protected function login($user)
     {
         cleanup_cookies();
 
@@ -41,7 +41,7 @@ abstract class Controller extends BaseController
         $session->flush();
         $session->regenerateToken();
         $session->put('requires_verification', VerifyUserAlways::isRequired($user));
-        Auth::login($user, $remember);
+        Auth::login($user, false);
         if ($GLOBALS['cfg']['osu']['user']['bypass_verification']) {
             $session->markVerified();
         }

--- a/app/Http/Controllers/SessionsController.php
+++ b/app/Http/Controllers/SessionsController.php
@@ -29,10 +29,9 @@ class SessionsController extends Controller
     {
         $request = request();
 
-        $params = get_params($request->all(), null, ['username:string', 'password:string', 'remember:bool', 'cf-turnstile-response:string']);
+        $params = get_params($request->all(), null, ['username:string', 'password:string', 'cf-turnstile-response:string']);
         $username = presence(trim($params['username'] ?? null));
         $password = presence($params['password'] ?? null);
-        $remember = $params['remember'] ?? false;
 
         if ($username === null) {
             DatadogLoginAttempt::log('missing_username');
@@ -101,7 +100,7 @@ class SessionsController extends Controller
             }
 
             DatadogLoginAttempt::log(null);
-            $this->login($user, $remember);
+            $this->login($user);
 
             return [
                 'csrf_token' => csrf_token(),


### PR DESCRIPTION
I don't think there's option for that on the frontend anymore? Or ever?

And actually enabling this option on login adds a 400 bytes of cookies thanks to how efficient laravel's cookies are.