### PR TITLE
Fix error on legacy score download with invalid ruleset

### DIFF
--- a/app/Http/Controllers/ScoresController.php
+++ b/app/Http/Controllers/ScoresController.php
@@ -65,7 +65,7 @@ class ScoresController extends Controller
             $soloScore = SoloScore::where([
                 'has_replay' => true,
                 'legacy_score_id' => $id,
-                'ruleset_id' => Beatmap::MODES[$rulesetOrSoloId],
+                'ruleset_id' => Beatmap::MODES[$rulesetOrSoloId] ?? abort(404, 'unknown ruleset name'),
             ])->firstOrFail();
         }
 

--- a/tests/Controllers/ScoresControllerTest.php
+++ b/tests/Controllers/ScoresControllerTest.php
@@ -200,6 +200,18 @@ class ScoresControllerTest extends TestCase
             ->assertRedirect(route('scores.show', $this->params()));
     }
 
+    public function testDownloadLegacyInvalidRuleset()
+    {
+        $this
+            ->actingAs($this->otherUser)
+            ->withHeaders(['HTTP_REFERER' => $GLOBALS['cfg']['app']['url'].'/'])
+            ->json(
+                'GET',
+                route('scores.download-legacy', [...$this->params(), 'rulesetOrScore' => 'nope'])
+            )
+            ->assertStatus(404);
+    }
+
     public function testDownloadNoReferer()
     {
         $this
@@ -209,17 +221,6 @@ class ScoresControllerTest extends TestCase
                 route('scores.download-legacy', $this->params())
             )
             ->assertRedirect(route('scores.show', $this->params()));
-    }
-
-    public function testDownloadInvalidRuleset()
-    {
-        $this
-            ->actingAs($this->user)
-            ->json(
-                'GET',
-                route('scores.download-legacy', ['rulesetOrScore' => 'nope', 'score' => $this->score->getKey()])
-            )
-            ->assertStatus(302);
     }
 
     protected function setUp(): void


### PR DESCRIPTION
The test was missing required header so it has been testing download with invalid referer instead.

I updated the name for this single one to DownloadLegacy but I wonder if I should've kept it the slightly wrong name since that's how the rest of the tests as well...