### PR TITLE
Add retry logic to the commonly failing dusk test

### DIFF
--- a/tests/Browser/LoginTest.php
+++ b/tests/Browser/LoginTest.php
@@ -6,6 +6,7 @@
 namespace Tests\Browser;
 
 use App\Models\User;
+use Facebook\WebDriver\Exception\TimeoutException;
 use Laravel\Dusk\Browser;
 use Tests\DuskTestCase;
 
@@ -34,25 +35,36 @@ class LoginTest extends DuskTestCase
         });
     }
 
-    /**
-     * Test sign out.
-     *
-     * @return void
-     */
-    public function testLogout()
+    public function testLogout(): void
     {
         $user = User::factory()->create();
 
-        $this->browse(function (Browser $browser) use ($user) {
-            $browser->loginAs($user)
-                ->visit('/')
-                ->click('.js-user-login--menu') // bring up user menu
-                ->waitFor('.js-user-header-popup .js-logout-link')
-                ->click('.js-user-header-popup .js-logout-link') // click the logout 'button'
-                ->acceptDialog()
-                ->waitFor('.landing-hero__bg-container')
-                ->assertPathIs('/')
-                ->assertVisible('.landing-hero');
-        });
+        $timedOut = false;
+        $attempts = 1;
+        while (true) {
+            $timedOut = false;
+            try {
+                $this->browse(function (Browser $browser) use ($user) {
+                    $browser->loginAs($user)
+                        ->visit('/')
+                        ->click('.js-user-login--menu') // bring up user menu
+                        ->waitFor('.js-user-header-popup .js-logout-link')
+                        ->click('.js-user-header-popup .js-logout-link') // click the logout 'button'
+                        ->acceptDialog()
+                        ->waitFor('.landing-hero__bg-container')
+                        ->assertPathIs('/')
+                        ->assertVisible('.landing-hero');
+                });
+            } catch (TimeoutException $e) {
+                $timedOut = true;
+                static::closeAll();
+                if ($attempts++ > 5) {
+                    throw $e;
+                }
+            }
+            if (!$timedOut) {
+                break;
+            }
+        }
     }
 }


### PR DESCRIPTION
I think this works...? Should probably extract it somewhere but I'm inlining it for now for testing purpose.

And maybe just doing the reset every time in the `setUp` could also work...? Instead of the current cookie reset.

<sub>wouldn't it be funny if the test fails right in this pr</sub>