### PR TITLE
Update dusk setup to match upstream closer

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,7 @@ env:
   APP_KEY: base64:q7U5qyAkedR1F6UhN0SQlUxBpAMDyfHy3NNFkqmiMqA=
   APP_URL: http://localhost:8000
   DB_HOST: 127.0.0.1
-  DUSK_WEBDRIVER_URL: http://127.0.0.1:9515
+  DUSK_DRIVER_URL: http://127.0.0.1:9515
   ES_SOLO_SCORES_HOST: http://localhost:9200
   GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
   NOTIFICATION_ENDPOINT: ws://localhost:2345

--- a/Dockerfile.development
+++ b/Dockerfile.development
@@ -38,8 +38,6 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get install -y \
 RUN npm install -g yarn
 
 RUN curl -L "https://getcomposer.org/download/latest-2.x/composer.phar" > /usr/local/bin/composer && chmod 755 /usr/local/bin/composer
-RUN mv /usr/bin/chromium /usr/bin/chromium.orig
-COPY chromium /usr/bin/
 
 WORKDIR /app
 

--- a/docker/development/chromium
+++ b/docker/development/chromium
@@ -1,3 +1,0 @@
-#!/bin/sh
-
-exec /usr/bin/chromium.orig --no-sandbox "$@"


### PR DESCRIPTION
Apparently it's a thing. The "old" headless is being deprecated or something ([reference](https://developer.chrome.com/docs/chromium/headless)).

And then there's problem with that mode; `--no-sandbox` needs to be specified ([reference](https://github.com/laravel/dusk/issues/1155#issuecomment-2614087776)).