### PR TITLE
Add pinned flag & description field to multiplayer rooms

### DIFF
--- a/app/Models/Multiplayer/Room.php
+++ b/app/Models/Multiplayer/Room.php
@@ -35,12 +35,14 @@ use Illuminate\Database\Eloquent\SoftDeletes;
  * @property int|null $channel_id
  * @property \Carbon\Carbon|null $created_at
  * @property \Carbon\Carbon|null $deleted_at
+ * @property string|null $description
  * @property \Carbon\Carbon $ends_at
  * @property User $host
  * @property int $id
  * @property int|null $max_attempts
  * @property string $name
  * @property int $participant_count
+ * @property bool $pinned
  * @property \Illuminate\Database\Eloquent\Collection $playlist PlaylistItem
  * @property \Illuminate\Database\Eloquent\Collection $scoreLinks ScoreLink
  * @property-read Season $season

--- a/app/Models/Multiplayer/Room.php
+++ b/app/Models/Multiplayer/Room.php
@@ -94,6 +94,7 @@ class Room extends Model
         'auto_skip' => 'boolean',
         'ends_at' => 'datetime',
         'password' => PresentString::class,
+        'pinned' => 'boolean',
         'starts_at' => 'datetime',
     ];
     protected array $macros = [

--- a/app/Models/Multiplayer/Room.php
+++ b/app/Models/Multiplayer/Room.php
@@ -63,6 +63,7 @@ class Room extends Model
             ['column' => 'id', 'order' => 'DESC', 'type' => 'int'],
         ],
         'created' => [
+            ['column' => 'pinned', 'order' => 'DESC', 'type' => 'bool'],
             ['column' => 'id', 'order' => 'DESC', 'type' => 'int'],
         ],
     ];

--- a/app/Transformers/Multiplayer/RoomTransformer.php
+++ b/app/Transformers/Multiplayer/RoomTransformer.php
@@ -48,6 +48,7 @@ class RoomTransformer extends TransformerAbstract
         return [
             'id' => $room->id,
             'name' => $room->name,
+            'description' => $room->description,
             'category' => $room->category,
             'status' => $room->status,
             'type' => $room->type,
@@ -61,6 +62,7 @@ class RoomTransformer extends TransformerAbstract
             'has_password' => $room->password !== null,
             'queue_mode' => $room->queue_mode,
             'auto_skip' => $room->auto_skip,
+            'pinned' => $room->pinned,
         ];
     }
 

--- a/database/migrations/2025_08_21_103748_add_pinned_description_to_multiplayer_rooms.php
+++ b/database/migrations/2025_08_21_103748_add_pinned_description_to_multiplayer_rooms.php
@@ -19,6 +19,7 @@ return new class extends Migration
         Schema::table('multiplayer_rooms', function (Blueprint $table) {
             $table->boolean('pinned')->default(false);
             $table->string('description')->nullable();
+            $table->index('pinned');
         });
     }
 
@@ -28,6 +29,7 @@ return new class extends Migration
     public function down(): void
     {
         Schema::table('multiplayer_rooms', function (Blueprint $table) {
+            $table->dropIndex(['pinned']);
             $table->dropColumn(['pinned', 'description']);
         });
     }

--- a/database/migrations/2025_08_21_103748_add_pinned_description_to_multiplayer_rooms.php
+++ b/database/migrations/2025_08_21_103748_add_pinned_description_to_multiplayer_rooms.php
@@ -1,0 +1,34 @@
+<?php
+
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('multiplayer_rooms', function (Blueprint $table) {
+            $table->boolean('pinned')->default(false);
+            $table->string('description')->nullable();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('multiplayer_rooms', function (Blueprint $table) {
+            $table->dropColumn(['pinned', 'description']);
+        });
+    }
+};

--- a/database/migrations/2025_08_21_103748_add_pinned_description_to_multiplayer_rooms.php
+++ b/database/migrations/2025_08_21_103748_add_pinned_description_to_multiplayer_rooms.php
@@ -19,7 +19,14 @@ return new class extends Migration
         Schema::table('multiplayer_rooms', function (Blueprint $table) {
             $table->boolean('pinned')->default(false);
             $table->string('description')->nullable();
+
             $table->index('pinned');
+
+            $table->index(['user_id', 'pinned']);
+            $table->dropIndex(['user_id']);
+
+            $table->index(['category', 'user_id', 'pinned']);
+            $table->dropIndex(['category', 'user_id']);
         });
     }
 
@@ -30,6 +37,13 @@ return new class extends Migration
     {
         Schema::table('multiplayer_rooms', function (Blueprint $table) {
             $table->dropIndex(['pinned']);
+
+            $table->index(['user_id']);
+            $table->dropIndex(['user_id', 'pinned']);
+
+            $table->index(['category', 'user_id']);
+            $table->dropIndex(['category', 'user_id', 'pinned']);
+
             $table->dropColumn(['pinned', 'description']);
         });
     }

--- a/database/migrations/2025_08_21_103748_add_pinned_description_to_multiplayer_rooms.php
+++ b/database/migrations/2025_08_21_103748_add_pinned_description_to_multiplayer_rooms.php
@@ -25,8 +25,21 @@ return new class extends Migration
             $table->index(['user_id', 'pinned']);
             $table->dropIndex(['user_id']);
 
+            $table->index(['category', 'ends_at', 'pinned']);
+            $table->dropIndex(['category', 'ends_at']);
+
             $table->index(['category', 'user_id', 'pinned']);
             $table->dropIndex(['category', 'user_id']);
+
+            $table->index(['ends_at', 'pinned']);
+            $table->dropIndex(['ends_at']);
+
+            $table->index(['type', 'category', 'ends_at', 'pinned']);
+            $table->dropIndex(['type', 'category', 'ends_at']);
+        });
+
+        Schema::table('multiplayer_rooms_high', function (Blueprint $table) {
+            $table->index(['room_id', 'in_room', 'user_id', 'updated_at']);
         });
     }
 
@@ -35,14 +48,27 @@ return new class extends Migration
      */
     public function down(): void
     {
+        Schema::table('multiplayer_rooms_high', function (Blueprint $table) {
+            $table->dropIndex(['room_id', 'in_room', 'user_id', 'updated_at']);
+        });
+
         Schema::table('multiplayer_rooms', function (Blueprint $table) {
             $table->dropIndex(['pinned']);
 
             $table->index(['user_id']);
             $table->dropIndex(['user_id', 'pinned']);
 
+            $table->index(['category', 'ends_at']);
+            $table->dropIndex(['category', 'ends_at', 'pinned']);
+
             $table->index(['category', 'user_id']);
             $table->dropIndex(['category', 'user_id', 'pinned']);
+
+            $table->index(['ends_at']);
+            $table->dropIndex(['ends_at', 'pinned']);
+
+            $table->index(['type', 'category', 'ends_at']);
+            $table->dropIndex(['type', 'category', 'ends_at', 'pinned']);
 
             $table->dropColumn(['pinned', 'description']);
         });


### PR DESCRIPTION
- `pinned` is specifically for https://github.com/ppy/osu/issues/34537.
  - I went for the flag rather than a new category of room because categories have stuff like filtering attached to them that I think doesn't make sense if a separate "pinned" room category was to be created.
  - I expect that going forward all spotlights / FA rooms should also specify `pinned = true`. This would affect / require updating ASS automation (cc @peppy).
  - Pinned rooms will be prioritised order-wise when listing rooms using the default `created` sort. This affects both the room listing endpoint (`GET /api/v2/rooms`), as well as the website's user playlist listing (`/users/{user_id}/playlists`). The second is arguable and could be considered as a side effect but I think it's probably fine and not worth creating a separate sort mode for.
- `description` is for currently-unspecified further use.

  @Hiviexd previously asked for it [in terms of daily challenge to describe the 'theme' of the challenge](https://discord.com/channels/90072389919997952/1237133068116955308/1364531588255449108) but I don't know that themed challenges are still a thing. Maybe it could be used for the special pinned rooms.

  I'm reluctant to make this available to the general game populace because as I've learned over time, the general game populace cannot be trusted with a freeform textbox.