### PR TITLE
Updated Beatmap search query parsing

### DIFF
--- a/app/Libraries/Elasticsearch/QueryHelper.php
+++ b/app/Libraries/Elasticsearch/QueryHelper.php
@@ -40,9 +40,8 @@ class QueryHelper
             $mode = str_starts_with($token, '-') ? 'exclude' : 'include';
             $word = ltrim($token, '-');
             if (str_starts_with($word, '"')) {
-                $phraseStart = ltrim($word, '"');
                 $token = strtok('"');
-                $parts[$mode][] = $phraseStart.' '.$token;
+                $parts[$mode][] = $word.' '.$token.'"';
             } else {
                 $parts[$mode][] = $word;
             }

--- a/app/Libraries/Elasticsearch/QueryHelper.php
+++ b/app/Libraries/Elasticsearch/QueryHelper.php
@@ -27,6 +27,32 @@ class QueryHelper
         throw new Exception('$clause should be associative array or Queryable.');
     }
 
+    public static function tokenize(string $query): array
+    {
+        $parts = [
+            'exclude' => [],
+            'include' => [],
+        ];
+
+        $mode = 'include';
+        $token = strtok($query, ' ');
+        while ($token !== false) {
+            $mode = str_starts_with($token, '-') ? 'exclude' : 'include';
+            $word = ltrim($token, '-');
+            if (str_starts_with($word, '"')) {
+                $phraseStart = ltrim($word, '"');
+                $token = strtok('"');
+                $parts[$mode][] = $phraseStart.' '.$token;
+            } else {
+                $parts[$mode][] = $word;
+            }
+
+            $token = strtok(' ');
+        }
+
+        return $parts;
+    }
+
     /**
      * Helper method that creates the simple_query_string query.
      *

--- a/app/Libraries/Elasticsearch/QueryHelper.php
+++ b/app/Libraries/Elasticsearch/QueryHelper.php
@@ -27,26 +27,58 @@ class QueryHelper
         throw new Exception('$clause should be associative array or Queryable.');
     }
 
-    public static function tokenize(string $query): array
+    /**
+     * Tokenises and parses a search query into include and exclude portions.
+     * Multiple whitespaces are not preserved and treated as a single whitespace.
+     */
+    public static function tokenise(string $query): array
     {
+        $query = preg_replace('/[\s\pZ\pC]+/u', ' ', $query);
         $parts = [
             'exclude' => [],
             'include' => [],
         ];
 
         $mode = 'include';
+        $phrase = '';
+        $quoteOpened = false;
+        $quoteClosed = false;
+
         $token = strtok($query, ' ');
         while ($token !== false) {
-            $mode = str_starts_with($token, '-') ? 'exclude' : 'include';
-            $word = ltrim($token, '-');
-            if (str_starts_with($word, '"')) {
-                $token = strtok('"');
-                $parts[$mode][] = $word.' '.$token.'"';
-            } else {
-                $parts[$mode][] = $word;
+            $word = $token;
+            if ($phrase === '') {
+                $mode = str_starts_with($token, '-') ? 'exclude' : 'include';
+                $word = ltrim($token, '-');
+            }
+
+            if ($quoteOpened) {
+                $phrase .= ' ';
+            }
+
+            $phrase .= $word;
+
+            if (!$quoteOpened) {
+                $quoteOpened = str_starts_with($word, '"');
+            }
+            if ($quoteOpened) {
+                $quoteClosed = $phrase !== '"' && str_ends_with($word, '"');
+            }
+
+            // don't push if still looking for closing quote
+            if (!($quoteOpened && !$quoteClosed)) {
+                $parts[$mode][] = $phrase;
+                $phrase = '';
+                $quoteOpened = false;
+                $quoteClosed = false;
             }
 
             $token = strtok(' ');
+        }
+
+        // push remainder if missing closing quote.
+        if ($phrase !== '') {
+            $parts[$mode][] = $phrase;
         }
 
         return $parts;

--- a/app/Libraries/Search/BeatmapsetSearch.php
+++ b/app/Libraries/Search/BeatmapsetSearch.php
@@ -35,7 +35,7 @@ class BeatmapsetSearch extends RecordSearch
             Beatmapset::class
         );
 
-        $this->tokens = QueryHelper::tokenize($params->queryString ?? '');
+        $this->tokens = QueryHelper::tokenise($params->queryString ?? '');
     }
 
     /**

--- a/app/Libraries/Search/BeatmapsetSearch.php
+++ b/app/Libraries/Search/BeatmapsetSearch.php
@@ -63,20 +63,30 @@ class BeatmapsetSearch extends RecordSearch
         $query = new BoolQuery();
 
         if (!empty($this->tokens['include'])) {
+            $implodedInclude = implode(' ', $this->tokens['include']);
             // the subscoping is not necessary but prevents unintentional accidents when combining other matchers
             $boolQuery = new BoolQuery()
-                // results must contain at least one of the terms and boosted by containing all of them,
-                // or match the id of the beatmapset.
+                // results boosted by containing all terms, or match the id of the beatmapset.
                 ->shouldMatch(1)
-                ->should(['term' => ['_id' => ['value' => implode(' ', $this->tokens['include']), 'boost' => 100]]]);
+                ->should(['term' => ['_id' => ['value' => $implodedInclude, 'boost' => 100]]])
+                ->should([
+                    'multi_match' => [
+                        'fields' => $fullMatchFields,
+                        'type' => 'phrase',
+                        'query' => $implodedInclude,
+                    ],
+                ]);
 
+            // Look for maybe relevant results.
+            // "Something like this but I'm not exactly sure" kind of search.
             foreach ($this->tokens['include'] as $include) {
                 $isQuoted = static::isQuoted($include);
                 $boolQuery
                     ->should([
                         'multi_match' => [
+                            'boost' => $isQuoted ? 1 : 1 / count($this->tokens['include']),
                             'fields' => $isQuoted ? $fullMatchFields : $partialMatchFields,
-                            'type' => $isQuoted ? 'phrase' : 'most_fields',
+                            'type' => $isQuoted ? 'phrase' : 'cross_fields',
                             'query' => $include,
                         ],
                     ]);

--- a/app/Libraries/Search/BeatmapsetSearch.php
+++ b/app/Libraries/Search/BeatmapsetSearch.php
@@ -20,6 +20,8 @@ use Ds\Set;
 
 class BeatmapsetSearch extends RecordSearch
 {
+    private array $tokens;
+
     public function __construct(?BeatmapsetSearchParams $params = null)
     {
         parent::__construct(
@@ -27,6 +29,8 @@ class BeatmapsetSearch extends RecordSearch
             $params ?? new BeatmapsetSearchParams(),
             Beatmapset::class
         );
+
+        $this->tokens = QueryHelper::tokenize($params->queryString ?? '');
     }
 
     /**
@@ -34,34 +38,51 @@ class BeatmapsetSearch extends RecordSearch
      */
     public function getQuery()
     {
-        static $partialMatchFields = [
+        static $fullMatchFields = [
             'artist',
-            'artist.*',
             'artist_unicode',
-            'artist_unicode.*',
             'creator',
             'title',
-            'title.*',
             'title_unicode',
+        ];
+
+        static $partialMatchFields = [
+            ...$fullMatchFields,
+            'artist.*',
+            'artist_unicode.*',
+            'title.*',
             'title_unicode.*',
             'tags^0.5',
         ];
 
         $query = new BoolQuery();
 
-        if (present($this->params->queryString)) {
-            $terms = explode(' ', $this->params->queryString);
+        if (!empty($this->tokens['include'])) {
+            $includeString = implode(' ', $this->tokens['include']);
 
             // the subscoping is not necessary but prevents unintentional accidents when combining other matchers
-            $query->must(
-                (new BoolQuery())
-                    // results must contain at least one of the terms and boosted by containing all of them,
-                    // or match the id of the beatmapset.
-                    ->shouldMatch(1)
-                    ->should(['term' => ['_id' => ['value' => $this->params->queryString, 'boost' => 100]]])
-                    ->should(QueryHelper::queryString($this->params->queryString, $partialMatchFields, 'or', 1 / count($terms)))
-                    ->should(QueryHelper::queryString($this->params->queryString, [], 'and'))
-            );
+            $query->must(new BoolQuery()
+                // results must contain at least one of the terms and boosted by containing all of them,
+                // or match the id of the beatmapset.
+                ->shouldMatch(1)
+                ->should(['term' => ['_id' => ['value' => $includeString, 'boost' => 100]]])
+                ->should([
+                    'multi_match' => [
+                        'fields' => $partialMatchFields,
+                        'type' => 'most_fields',
+                        'query' => $includeString,
+                    ],
+                ]));
+        }
+
+        // exclusion should be full matches only, and only on the main beatmapset fields.
+        if (!empty($this->tokens['exclude'])) {
+            $query->mustNot([
+                'multi_match' => [
+                    'fields' => $fullMatchFields,
+                    'query' => implode(' ', $this->tokens['exclude']),
+                ],
+            ]);
         }
 
         $this->addBlockedUsersFilter($query);

--- a/app/Libraries/Search/BeatmapsetSearch.php
+++ b/app/Libraries/Search/BeatmapsetSearch.php
@@ -142,6 +142,18 @@ class BeatmapsetSearch extends RecordSearch
             ],
         ]);
 
+        if (!empty($this->tokens['exclude'])) {
+            $query = [
+                'boosting' => [
+                    'positive' => $query->toArray(),
+                    'negative' => [
+                        'match' => ['tags' => implode(' ', $this->tokens['exclude'])],
+                    ],
+                    'negative_boost' => 0.5,
+                ],
+            ];
+        }
+
         if (present($this->params->queryString)) {
             $query = (new FunctionScore($query))
                 ->applyFunction([

--- a/app/Libraries/Search/BeatmapsetSearch.php
+++ b/app/Libraries/Search/BeatmapsetSearch.php
@@ -22,6 +22,11 @@ class BeatmapsetSearch extends RecordSearch
 {
     private array $tokens;
 
+    private static function isQuoted(string $value): bool
+    {
+        return str_starts_with($value, '"') && str_ends_with($value, '"');
+    }
+
     public function __construct(?BeatmapsetSearchParams $params = null)
     {
         parent::__construct(
@@ -169,7 +174,7 @@ class BeatmapsetSearch extends RecordSearch
     private function addDifficultyFilter(BoolQuery $nested)
     {
         if ($this->params->difficulty !== null) {
-            $nested->must(QueryHelper::queryString($this->params->difficulty, ['beatmaps.version'], 'and'));
+            $nested->must(['match' => ['beatmaps.version' => ['query' => $this->params->difficulty, 'operator' => 'and']]]);
         }
     }
 
@@ -435,7 +440,14 @@ class BeatmapsetSearch extends RecordSearch
             $subQuery->should(['term' => ["{$field}.raw" => ['value' => $value, 'boost' => 100]]]);
         }
 
-        $subQuery->should(QueryHelper::queryString($value, $searchFields, 'and'));
+        $subQuery->should([
+            'multi_match' => [
+                'fields' => $searchFields,
+                'query' => $value,
+                'operator' => 'and',
+                'type' => static::isQuoted($value) ? 'phrase' : 'most_fields',
+            ],
+        ]);
 
         $query->must($subQuery);
     }
@@ -464,7 +476,7 @@ class BeatmapsetSearch extends RecordSearch
         }
 
         foreach (array_values($tagMap) as $tag) {
-            $query->filter(QueryHelper::queryString($tag, ['beatmaps.top_tags'], 'and'));
+            $query->filter(['match' => ['beatmaps.top_tags' => ['query' => $tags, 'operator' => 'and']]]);
         }
     }
 

--- a/app/Libraries/Search/BeatmapsetSearch.php
+++ b/app/Libraries/Search/BeatmapsetSearch.php
@@ -470,6 +470,7 @@ class BeatmapsetSearch extends RecordSearch
             $subQuery->should(['term' => ["{$field}.raw" => ['value' => $value, 'boost' => 100]]]);
         }
 
+        // TODO: change matching logic to match query string keywords?
         $subQuery->should([
             'multi_match' => [
                 'fields' => $searchFields,

--- a/app/Libraries/Search/BeatmapsetSearch.php
+++ b/app/Libraries/Search/BeatmapsetSearch.php
@@ -63,31 +63,39 @@ class BeatmapsetSearch extends RecordSearch
         $query = new BoolQuery();
 
         if (!empty($this->tokens['include'])) {
-            $includeString = implode(' ', $this->tokens['include']);
-
             // the subscoping is not necessary but prevents unintentional accidents when combining other matchers
-            $query->must(new BoolQuery()
+            $boolQuery = new BoolQuery()
                 // results must contain at least one of the terms and boosted by containing all of them,
                 // or match the id of the beatmapset.
                 ->shouldMatch(1)
-                ->should(['term' => ['_id' => ['value' => $includeString, 'boost' => 100]]])
-                ->should([
-                    'multi_match' => [
-                        'fields' => $partialMatchFields,
-                        'type' => 'most_fields',
-                        'query' => $includeString,
-                    ],
-                ]));
+                ->should(['term' => ['_id' => ['value' => implode(' ', $this->tokens['include']), 'boost' => 100]]]);
+
+            foreach ($this->tokens['include'] as $include) {
+                $isQuoted = static::isQuoted($include);
+                $boolQuery
+                    ->should([
+                        'multi_match' => [
+                            'fields' => $isQuoted ? $fullMatchFields : $partialMatchFields,
+                            'type' => $isQuoted ? 'phrase' : 'most_fields',
+                            'query' => $include,
+                        ],
+                    ]);
+            }
+
+            $query->must($boolQuery);
         }
 
         // exclusion should be full matches only, and only on the main beatmapset fields.
         if (!empty($this->tokens['exclude'])) {
-            $query->mustNot([
-                'multi_match' => [
-                    'fields' => $fullMatchFields,
-                    'query' => implode(' ', $this->tokens['exclude']),
-                ],
-            ]);
+            foreach ($this->tokens['exclude'] as $exclude) {
+                $query->mustNot([
+                    'multi_match' => [
+                        'fields' => $fullMatchFields,
+                        'type' => static::isQuoted($exclude) ? 'phrase' : 'most_fields',
+                        'query' => $exclude,
+                    ],
+                ]);
+            }
         }
 
         $this->addBlockedUsersFilter($query);

--- a/database/factories/BeatmapsetFactory.php
+++ b/database/factories/BeatmapsetFactory.php
@@ -52,6 +52,20 @@ class BeatmapsetFactory extends Factory
         return $this->state(['deleted_at' => now()]);
     }
 
+    // Sets search scorable fields to the same value.
+    // The relevancy score between different runs will still be different.
+    public function fixedStrings(): static
+    {
+        return $this->state([
+            'artist' => 'test',
+            'creator' => 'test',
+            'source' => 'test',
+            'tags' => 'test',
+            'title' => 'test',
+            'favourite_count' => 0,
+        ]);
+    }
+
     public function inactive()
     {
         return $this->state(['active' => 0]);

--- a/database/factories/BeatmapsetFactory.php
+++ b/database/factories/BeatmapsetFactory.php
@@ -47,12 +47,6 @@ class BeatmapsetFactory extends Factory
         ];
     }
 
-    // Set values that can affect search scoring to a consistent value.
-    public function consistent()
-    {
-        return $this->state(['favourite_count' => 0]);
-    }
-
     public function deleted()
     {
         return $this->state(['deleted_at' => now()]);

--- a/database/factories/BeatmapsetFactory.php
+++ b/database/factories/BeatmapsetFactory.php
@@ -47,6 +47,12 @@ class BeatmapsetFactory extends Factory
         ];
     }
 
+    // Set values that can affect search scoring to a consistent value.
+    public function consistent()
+    {
+        return $this->state(['favourite_count' => 0]);
+    }
+
     public function deleted()
     {
         return $this->state(['deleted_at' => now()]);

--- a/tests/Libraries/Search/BeatmapsetSearch/ConvertsFilterTest.php
+++ b/tests/Libraries/Search/BeatmapsetSearch/ConvertsFilterTest.php
@@ -15,13 +15,13 @@ class ConvertsFilterTest extends TestCase
     public static function dataProvider(): array
     {
         return [
-            [['q' => 'cs=4'], [1, 2]],
+            [['q' => 'cs=4'], [2, 1]],
             [['m' => 0, 'q' => 'cs=4'], [1]],
             [['m' => 3, 'q' => 'cs=4'], [2]],
 
-            [['c' => 'converts', 'q' => 'cs=4',], [0, 1, 2]],
+            [['c' => 'converts', 'q' => 'cs=4',], [2, 1, 0]],
             [['c' => 'converts', 'm' => 0, 'q' => 'cs=4',], [1]],
-            [['c' => 'converts', 'm' => 3, 'q' => 'cs=4'], [0, 2]],
+            [['c' => 'converts', 'm' => 3, 'q' => 'cs=4'], [2, 0]],
         ];
     }
 

--- a/tests/Libraries/Search/BeatmapsetSearch/CreatorFilterTest.php
+++ b/tests/Libraries/Search/BeatmapsetSearch/CreatorFilterTest.php
@@ -12,10 +12,12 @@ use App\Models\User;
 
 class CreatorFilterTest extends TestCase
 {
+    protected array $defaultExpectedSort = ['_score', 'id'];
+
     public static function dataProvider(): array
     {
         return [
-            'include lookup user' => [['q' => 'creator=mapper'], [0, 1]],
+            'include lookup user' => [['q' => 'creator=mapper'], [1, 0]],
             'include non-lookup user' => [['q' => 'creator=someone'], [0, 3]],
         ];
     }
@@ -23,12 +25,12 @@ class CreatorFilterTest extends TestCase
     public static function setUpBeforeClass(): void
     {
         static::withDbAccess(function () {
-            $factory = Beatmapset::factory()->withBeatmaps()->ranked();
+            $factory = Beatmapset::factory()->fixedStrings()->withBeatmaps(beatmapState: ['version' => 'test'])->ranked();
             $mapper1 = User::factory()->create(['username' => 'mapper']);
             $mapper2 = User::factory()->create(['username' => 'another_mapper']);
 
             static::$beatmapsets = [
-                $factory->withBeatmaps(guestMapper: $mapper1)->create(['creator' => 'someone']),
+                $factory->withBeatmaps(guestMapper: $mapper1, beatmapState: ['version' => 'test2'])->create(['creator' => 'someone']),
                 $factory->create(['user_id' => $mapper1]),
                 $factory->create(['user_id' => $mapper2]),
                 $factory->create(['creator' => 'someone_else']),

--- a/tests/Libraries/Search/BeatmapsetSearch/DateFilterTest.php
+++ b/tests/Libraries/Search/BeatmapsetSearch/DateFilterTest.php
@@ -22,16 +22,16 @@ class DateFilterTest extends TestCase
             // BeatmapsetQueryParserTest will test the other date formats are equivalent.
             $year = 2023 + $index;
 
-            $data[] = [['q' => "{$key}={$year}"], [2, 3, 4]];
-            $data[] = [['q' => "{$key}={$year}-02"], [2, 3]];
+            $data[] = [['q' => "{$key}={$year}"], [4, 3, 2]];
+            $data[] = [['q' => "{$key}={$year}-02"], [3, 2]];
             $data[] = [['q' => "{$key}={$year}-02-28"], [3]];
-            $data[] = [['q' => "{$key}={$year}"], [2, 3, 4]];
+            $data[] = [['q' => "{$key}={$year}"], [4, 3, 2]];
 
             $year = 2022 + $index;
-            $data[] = [['q' => "{$key}>{$year}"], [2, 3, 4]];
-            $data[] = [['q' => "{$key}>={$year}"], [1, 2, 3, 4]];
+            $data[] = [['q' => "{$key}>{$year}"], [4, 3, 2]];
+            $data[] = [['q' => "{$key}>={$year}"], [4, 3, 2, 1]];
             $data[] = [['q' => "{$key}<{$year}"], [0]];
-            $data[] = [['q' => "{$key}<={$year}"], [0, 1]];
+            $data[] = [['q' => "{$key}<={$year}"], [1, 0]];
         }
 
         return $data;

--- a/tests/Libraries/Search/BeatmapsetSearch/DifficultyFilterTest.php
+++ b/tests/Libraries/Search/BeatmapsetSearch/DifficultyFilterTest.php
@@ -15,7 +15,7 @@ class DifficultyFilterTest extends TestCase
     public static function dataProvider(): array
     {
         return [
-            [['q' => 'difficulty=hard'], [1, 2]],
+            [['q' => 'difficulty=hard'], [2, 1]],
             [['q' => 'difficulty="very mapper"'], [2]],
             [['q' => 'difficulty="very hard"'], []],
             [['q' => 'difficulty=""very easy""'], [0]],

--- a/tests/Libraries/Search/BeatmapsetSearch/FeaturedArtistFilterTest.php
+++ b/tests/Libraries/Search/BeatmapsetSearch/FeaturedArtistFilterTest.php
@@ -17,8 +17,8 @@ class FeaturedArtistFilterTest extends TestCase
     public static function dataProvider(): array
     {
         return [
-            [['q' => 'featured_artist=1'], [0, 2, 4]],
-            [['c' => 'featured_artists'], [0, 1, 2, 3, 4, 5]],
+            [['q' => 'featured_artist=1'], [4, 2, 0]],
+            [['c' => 'featured_artists'], [5, 4, 3, 2, 1, 0]],
         ];
     }
 

--- a/tests/Libraries/Search/BeatmapsetSearch/ManiaKeysFilterTest.php
+++ b/tests/Libraries/Search/BeatmapsetSearch/ManiaKeysFilterTest.php
@@ -14,7 +14,7 @@ class ManiaKeysFilterTest extends TestCase
     public static function dataProvider(): array
     {
         return [
-            [['q' => 'keys=7'], [1, 3]],
+            [['q' => 'keys=7'], [3, 1]],
         ];
     }
 

--- a/tests/Libraries/Search/BeatmapsetSearch/NegativeBoostTest.php
+++ b/tests/Libraries/Search/BeatmapsetSearch/NegativeBoostTest.php
@@ -7,13 +7,12 @@ declare(strict_types=1);
 
 namespace Tests\Libraries\Search\BeatmapsetSearch;
 
-use App\Libraries\Search\BeatmapsetSearch;
-use App\Libraries\Search\BeatmapsetSearchRequestParams;
 use App\Models\Beatmapset;
-use PHPUnit\Framework\Attributes\DataProvider;
 
 class NegativeBoostTest extends TestCase
 {
+    protected array $defaultExpectedSort = ['_score', 'id'];
+
     public static function dataProvider(): array
     {
         return [
@@ -26,8 +25,7 @@ class NegativeBoostTest extends TestCase
     public static function setUpBeforeClass(): void
     {
         static::withDbAccess(function () {
-            // use something besides empty string so it doesn't match empty string.
-            $factory = Beatmapset::factory()->state(['artist' => 'a', 'creator' => 'a', 'favourite_count' => 0])->ranked()->withBeatmaps();
+            $factory = Beatmapset::factory()->fixedStrings()->ranked()->withBeatmaps(beatmapState: ['version' => 'test']);
             static::$beatmapsets = [
                 $factory->create(['tags' => 'too hoos', 'title' => 'Good Apple']),
                 $factory->create(['tags' => 'fruit cake', 'title' => 'Apple']),
@@ -36,14 +34,5 @@ class NegativeBoostTest extends TestCase
             ];
         });
         parent::setUpBeforeClass();
-    }
-
-    #[DataProvider('dataProvider')]
-    public function testSearch(array $params, array $expected): void
-    {
-        $this->assertEquals(
-            array_map(fn (int $index) => static::$beatmapsets[$index]->getKey(), $expected),
-            new BeatmapsetSearch(new BeatmapsetSearchRequestParams($params))->response()->ids()
-        );
     }
 }

--- a/tests/Libraries/Search/BeatmapsetSearch/NegativeBoostTest.php
+++ b/tests/Libraries/Search/BeatmapsetSearch/NegativeBoostTest.php
@@ -1,0 +1,37 @@
+<?php
+
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
+declare(strict_types=1);
+
+namespace Tests\Libraries\Search\BeatmapsetSearch;
+
+use App\Models\Beatmapset;
+
+class NegativeBoostTest extends TestCase
+{
+    public static function dataProvider(): array
+    {
+        return [
+            [['q' => 'apple'], [2, 1, 0], true],
+            [['q' => 'apple -too'], [1, 2, 0], true],
+            [['q' => '-too'], [3, 2, 1, 0], true], // no effect because all the scores are 0
+        ];
+    }
+
+    public static function setUpBeforeClass(): void
+    {
+        static::withDbAccess(function () {
+            // use something besides empty string so it doesn't match empty string.
+            $factory = Beatmapset::factory()->consistent()->state(['artist' => 'a', 'creator' => 'a'])->ranked()->withBeatmaps();
+            static::$beatmapsets = [
+                $factory->create(['tags' => 'too hoos', 'title' => 'Good Apple']),
+                $factory->create(['tags' => 'fruit cake', 'title' => 'Apple']),
+                $factory->create(['tags' => 'too hoos', 'title' => 'Apple']),
+                $factory->create(['tags' => 'hoo', 'title' => 'Orange']),
+            ];
+        });
+        parent::setUpBeforeClass();
+    }
+}

--- a/tests/Libraries/Search/BeatmapsetSearch/NegativeBoostTest.php
+++ b/tests/Libraries/Search/BeatmapsetSearch/NegativeBoostTest.php
@@ -7,16 +7,19 @@ declare(strict_types=1);
 
 namespace Tests\Libraries\Search\BeatmapsetSearch;
 
+use App\Libraries\Search\BeatmapsetSearch;
+use App\Libraries\Search\BeatmapsetSearchRequestParams;
 use App\Models\Beatmapset;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class NegativeBoostTest extends TestCase
 {
     public static function dataProvider(): array
     {
         return [
-            [['q' => 'apple'], [2, 1, 0], true],
-            [['q' => 'apple -too'], [1, 2, 0], true],
-            [['q' => '-too'], [3, 2, 1, 0], true], // no effect because all the scores are 0
+            [['q' => 'apple'], [2, 1, 0]],
+            [['q' => 'apple -too'], [1, 2, 0]],
+            [['q' => '-too'], [3, 2, 1, 0]], // no effect because all the scores are 0
         ];
     }
 
@@ -24,7 +27,7 @@ class NegativeBoostTest extends TestCase
     {
         static::withDbAccess(function () {
             // use something besides empty string so it doesn't match empty string.
-            $factory = Beatmapset::factory()->consistent()->state(['artist' => 'a', 'creator' => 'a'])->ranked()->withBeatmaps();
+            $factory = Beatmapset::factory()->state(['artist' => 'a', 'creator' => 'a', 'favourite_count' => 0])->ranked()->withBeatmaps();
             static::$beatmapsets = [
                 $factory->create(['tags' => 'too hoos', 'title' => 'Good Apple']),
                 $factory->create(['tags' => 'fruit cake', 'title' => 'Apple']),
@@ -33,5 +36,14 @@ class NegativeBoostTest extends TestCase
             ];
         });
         parent::setUpBeforeClass();
+    }
+
+    #[DataProvider('dataProvider')]
+    public function testSearch(array $params, array $expected): void
+    {
+        $this->assertEquals(
+            array_map(fn (int $index) => static::$beatmapsets[$index]->getKey(), $expected),
+            new BeatmapsetSearch(new BeatmapsetSearchRequestParams($params))->response()->ids()
+        );
     }
 }

--- a/tests/Libraries/Search/BeatmapsetSearch/QueryStringTest.php
+++ b/tests/Libraries/Search/BeatmapsetSearch/QueryStringTest.php
@@ -11,11 +11,12 @@ use App\Models\Beatmapset;
 
 class QueryStringTest extends TestCase
 {
+    protected array $defaultExpectedSort = ['_score', 'id'];
+
     public static function dataProvider(): array
     {
-        // TODO: support scoring order in tests.
         return [
-            [['q' => ''], [0, 1, 2, 3]],
+            [['q' => ''], [3, 2, 1, 0], ['approved_date', 'id']],
             [['q' => '2'], [1]], // id only search.
             [['q' => '2 3'], []], // putting more than one id becomes a normal string search.
             [['q' => 'triangles'], [0, 1, 3]],
@@ -26,7 +27,7 @@ class QueryStringTest extends TestCase
             [['q' => 'tri'], [0, 1, 3]],
             [['q' => 'tri -circ'], [0, 1, 3]],
             [['q' => 'tri -circle'], [0, 1, 3]],
-            [['q' => '-tri'], [0, 1, 2, 3]],
+            [['q' => '-tri'], [3, 2, 1, 0]],
         ];
     }
 
@@ -34,7 +35,7 @@ class QueryStringTest extends TestCase
     {
         static::withDbAccess(function () {
             // use something besides empty string so it doesn't match empty string.
-            $factory = Beatmapset::factory()->state(['artist' => 'a', 'creator' => 'a'])->ranked()->withBeatmaps();
+            $factory = Beatmapset::factory()->state(['artist' => 'a', 'creator' => 'a', 'favourite_count' => 0])->ranked()->withBeatmaps();
             static::$beatmapsets = [
                 $factory->create(['title' => 'Triangles']),
                 $factory->create(['title' => 'Triangles Revival']),

--- a/tests/Libraries/Search/BeatmapsetSearch/QueryStringTest.php
+++ b/tests/Libraries/Search/BeatmapsetSearch/QueryStringTest.php
@@ -13,17 +13,16 @@ class QueryStringTest extends TestCase
 {
     public static function dataProvider(): array
     {
-        // TODO: support scoring order in tests.
         return [
             [['q' => ''], [0, 1, 2, 3]],
             [['q' => '2'], [1]], // id only search.
             [['q' => '2 3'], []], // putting more than one id becomes a normal string search.
-            [['q' => 'triangles'], [0, 1, 3]],
+            [['q' => 'triangles'], [0, 1, 3], true],
             [['q' => '-triangles'], [2]],
-            [['q' => 'triangles -revival'], [0, 3]],
+            [['q' => 'triangles -revival'], [0, 3], true],
             [['q' => 'cross circle'], [2, 3]],
             [['q' => 'cross -circle'], []], // exclusion shouldn't add new matches.
-            [['q' => 'tri'], [0, 1, 3]],
+            [['q' => 'tri'], [0, 1, 3], true],
             [['q' => 'tri -circ'], [0, 1, 3]],
             [['q' => 'tri -circle'], [0, 1, 3]],
             [['q' => '-tri'], [0, 1, 2, 3]],
@@ -34,7 +33,7 @@ class QueryStringTest extends TestCase
     {
         static::withDbAccess(function () {
             // use something besides empty string so it doesn't match empty string.
-            $factory = Beatmapset::factory()->state(['artist' => 'a', 'creator' => 'a'])->ranked()->withBeatmaps();
+            $factory = Beatmapset::factory()->consistent()->state(['artist' => 'a', 'creator' => 'a'])->ranked()->withBeatmaps();
             static::$beatmapsets = [
                 $factory->create(['title' => 'Triangles']),
                 $factory->create(['title' => 'Triangles Revival']),

--- a/tests/Libraries/Search/BeatmapsetSearch/QueryStringTest.php
+++ b/tests/Libraries/Search/BeatmapsetSearch/QueryStringTest.php
@@ -13,16 +13,17 @@ class QueryStringTest extends TestCase
 {
     public static function dataProvider(): array
     {
+        // TODO: support scoring order in tests.
         return [
             [['q' => ''], [0, 1, 2, 3]],
             [['q' => '2'], [1]], // id only search.
             [['q' => '2 3'], []], // putting more than one id becomes a normal string search.
-            [['q' => 'triangles'], [0, 1, 3], true],
+            [['q' => 'triangles'], [0, 1, 3]],
             [['q' => '-triangles'], [2]],
-            [['q' => 'triangles -revival'], [0, 3], true],
+            [['q' => 'triangles -revival'], [0, 3]],
             [['q' => 'cross circle'], [2, 3]],
             [['q' => 'cross -circle'], []], // exclusion shouldn't add new matches.
-            [['q' => 'tri'], [0, 1, 3], true],
+            [['q' => 'tri'], [0, 1, 3]],
             [['q' => 'tri -circ'], [0, 1, 3]],
             [['q' => 'tri -circle'], [0, 1, 3]],
             [['q' => '-tri'], [0, 1, 2, 3]],
@@ -33,7 +34,7 @@ class QueryStringTest extends TestCase
     {
         static::withDbAccess(function () {
             // use something besides empty string so it doesn't match empty string.
-            $factory = Beatmapset::factory()->consistent()->state(['artist' => 'a', 'creator' => 'a'])->ranked()->withBeatmaps();
+            $factory = Beatmapset::factory()->state(['artist' => 'a', 'creator' => 'a'])->ranked()->withBeatmaps();
             static::$beatmapsets = [
                 $factory->create(['title' => 'Triangles']),
                 $factory->create(['title' => 'Triangles Revival']),

--- a/tests/Libraries/Search/BeatmapsetSearch/QueryStringTest.php
+++ b/tests/Libraries/Search/BeatmapsetSearch/QueryStringTest.php
@@ -1,0 +1,47 @@
+<?php
+
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
+declare(strict_types=1);
+
+namespace Tests\Libraries\Search\BeatmapsetSearch;
+
+use App\Models\Beatmapset;
+
+class QueryStringTest extends TestCase
+{
+    public static function dataProvider(): array
+    {
+        // TODO: support scoring order in tests.
+        return [
+            [['q' => ''], [0, 1, 2, 3]],
+            [['q' => '2'], [1]], // id only search.
+            [['q' => '2 3'], []], // putting more than one id becomes a normal string search.
+            [['q' => 'triangles'], [0, 1, 3]],
+            [['q' => '-triangles'], [2]],
+            [['q' => 'triangles -revival'], [0, 3]],
+            [['q' => 'cross circle'], [2, 3]],
+            [['q' => 'cross -circle'], []], // exclusion shouldn't add new matches.
+            [['q' => 'tri'], [0, 1, 3]],
+            [['q' => 'tri -circ'], [0, 1, 3]],
+            [['q' => 'tri -circle'], [0, 1, 3]],
+            [['q' => '-tri'], [0, 1, 2, 3]],
+        ];
+    }
+
+    public static function setUpBeforeClass(): void
+    {
+        static::withDbAccess(function () {
+            // use something besides empty string so it doesn't match empty string.
+            $factory = Beatmapset::factory()->state(['artist' => 'a', 'creator' => 'a'])->ranked()->withBeatmaps();
+            static::$beatmapsets = [
+                $factory->create(['title' => 'Triangles']),
+                $factory->create(['title' => 'Triangles Revival']),
+                $factory->create(['title' => 'Circle overload']),
+                $factory->create(['title' => 'Triangles circles squares']),
+            ];
+        });
+        parent::setUpBeforeClass();
+    }
+}

--- a/tests/Libraries/Search/BeatmapsetSearch/SimpleFilterTest.php
+++ b/tests/Libraries/Search/BeatmapsetSearch/SimpleFilterTest.php
@@ -13,6 +13,8 @@ use Illuminate\Database\Eloquent\Factories\Sequence;
 
 class SimpleFilterTest extends TestCase
 {
+    protected array $defaultExpectedSort = ['approved_date', 'id'];
+
     // Date tests in DateFilterTest
     private const KEYS = [
         'ar' => 'diff_approach',
@@ -31,23 +33,23 @@ class SimpleFilterTest extends TestCase
         $data = [];
         foreach (array_keys(static::KEYS) as $offset => $key) {
             $value = $offset + 2;
-            $data[] = [['q' => "{$key}={$value}"], [0, 1]];
-            $data[] = [['q' => "{$key}>{$value}"], [1, 2]];
-            $data[] = [['q' => "{$key}>={$value}"], [0, 1, 2]];
+            $data[] = [['q' => "{$key}={$value}"], [1, 0]];
+            $data[] = [['q' => "{$key}>{$value}"], [2, 1]];
+            $data[] = [['q' => "{$key}>={$value}"], [2, 1, 0]];
             $data[] = [['q' => "{$key}<{$value}"], [0]];
-            $data[] = [['q' => "{$key}<={$value}"], [0, 1]];
+            $data[] = [['q' => "{$key}<={$value}"], [1, 0]];
         }
 
         $data[] = [['q' => 'od>9 ar<3'], []];
 
         $data[] = [['q' => 'favourites=150'], []]; // if you really want an exact number of favourites...
         $data[] = [['q' => 'favourites>200'], [2]];
-        $data[] = [['q' => 'favourites>=200'], [1, 2]];
+        $data[] = [['q' => 'favourites>=200'], [2, 1]];
         $data[] = [['q' => 'favourites<200'], [0]];
-        $data[] = [['q' => 'favourites<=200'], [0, 1]];
+        $data[] = [['q' => 'favourites<=200'], [1, 0]];
 
-        $data[] = [['q' => 'od>7'], [0, 1, 2]];
-        $data[] = [['q' => 'od>7 favourites>123'], [1, 2]];
+        $data[] = [['q' => 'od>7'], [2, 1, 0]];
+        $data[] = [['q' => 'od>7 favourites>123'], [2, 1]];
 
         // no matches because there is no beatmap that matches both conditions
         // even though the beatmapset has both in different beatmaps.

--- a/tests/Libraries/Search/BeatmapsetSearch/StatusRangeFilterTest.php
+++ b/tests/Libraries/Search/BeatmapsetSearch/StatusRangeFilterTest.php
@@ -32,8 +32,8 @@ class StatusRangeFilterTest extends TestCase
             [['s' => 'any', 'q' => 'status=loved'], [6]],
 
             // weird, but still...
-            [['q' => 'status>ranked'], [4, 6]],
-            [['s' => 'qualified', 'q' => 'status>ranked'], [5]],
+            [['q' => 'status>ranked'], [6, 4]],
+            [['s' => 'qualified', 'q' => 'status>ranked'], [5], ['queued_at', 'approved_date', 'id']],
             [['s' => 'ranked', 'q' => 'status>ranked'], [4]],
         ];
     }

--- a/tests/Libraries/Search/BeatmapsetSearch/TestCase.php
+++ b/tests/Libraries/Search/BeatmapsetSearch/TestCase.php
@@ -74,12 +74,11 @@ abstract class TestCase extends BaseTestCase
     }
 
     #[DataProvider('dataProvider')]
-    public function testSearch(array $params, array $expected): void
+    public function testSearch(array $params, array $expected, ?bool $order = null): void
     {
-        $this->assertEqualsCanonicalizing(
-            array_map(fn (int $index) => static::$beatmapsets[$index]->getKey(), $expected),
-            new BeatmapsetSearch(new BeatmapsetSearchRequestParams($params))->response()->ids()
-        );
+        $ids = new BeatmapsetSearch(new BeatmapsetSearchRequestParams($params))->response()->ids();
+        $method = $order ?? false ? 'assertEquals' : 'assertEqualsCanonicalizing';
+        $this->$method(array_map(fn (int $index) => static::$beatmapsets[$index]->getKey(), $expected), $ids);
     }
 
     protected function setUp(): void

--- a/tests/Libraries/Search/BeatmapsetSearch/TestCase.php
+++ b/tests/Libraries/Search/BeatmapsetSearch/TestCase.php
@@ -56,7 +56,10 @@ abstract class TestCase extends BaseTestCase
             throw new \Exception('No beatmapsets added to test setup.');
         }
 
-        Es::getClient()->indices()->refresh();
+        $indexParams = ['index' => Beatmapset::esIndexName()];
+        Es::getClient()->indices()->close($indexParams);
+        Es::getClient()->indices()->open($indexParams);
+
         $params = new BeatmapsetSearchParams();
         $params->status = 'any';
 

--- a/tests/Libraries/Search/BeatmapsetSearch/TitleFilterTest.php
+++ b/tests/Libraries/Search/BeatmapsetSearch/TitleFilterTest.php
@@ -11,20 +11,34 @@ use App\Models\Beatmapset;
 
 class TitleFilterTest extends TestCase
 {
+    protected array $defaultExpectedSort = ['_score', 'id'];
+
     public static function dataProvider(): array
     {
         return [
-            [['q' => 'best'], [0, 1, 2, 3, 4]],
-            [['q' => 'best beatmap'], [0, 1, 2, 3, 4]],
-            [['q' => '"best beatmap"'], [1, 2, 3]],
+            // TODO: find a working solution to relevancy ordering; the problem is scores are not consistent between test runs
+            // depending on elasticsearch term frequency statistic updates.
+            // _scores of test #0 when TitleFilterTest run alone
+            // [[1.2779001,0],[0.8136996,4],[0.33432162,3],[0.28844222,2],[0.27818984,1]]
+            // [[1.2878734,0],[0.8301021,4],[0.32621458,3],[0.28144777,2],[0.271444,1]]
+            // [[1.2516384,0],[0.7690376,4],[0.35742703,3],[0.30837688,2],[0.2974159,1]]
+            //
+            // when tests are run together
+            // [[4.0467224,0],[3.039711,4],[2.9713743,3],[2.7553484,2],[2.6568809,1]]
+            // [[4.9247246,0],[3.8785365,3],[3.8699822,4],[3.6045477,2],[3.4773993,1]]
+            // [[4.9854345,0],[3.9834518,4],[3.8591044,3],[3.580671,2],[3.4518704,1]]
+
+            [['q' => 'best'], [0, 4, 3, 2, 1]],
+            [['q' => 'best beatmap'], [3, 2, 1, 0, 4]],
+            [['q' => '"best beatmap"'], [3, 2, 1]],
             [['q' => '-best'], []],
             [['q' => '-best -beatmap'], []],
-            [['q' => '-"best beatmap"'], [0, 4]],
+            [['q' => '-"best beatmap"'], [4, 0]],
 
-            [['q' => 'title=best'], [0, 1, 2, 3]],
-            [['q' => 'title="best beatmap"'], [1, 2, 3]],
+            [['q' => 'title=best'], [0, 3, 2, 1]],
+            [['q' => 'title="best beatmap"'], [3, 2, 1]],
             [['q' => 'title="the beatmap"'], [1, 2]],
-            [['q' => 'title=""best beatmap""'], [1, 2, 3]],
+            [['q' => 'title=""best beatmap""'], [3, 2, 1]],
             [['q' => 'title=""the beatmap""'], []],
         ];
     }
@@ -32,7 +46,7 @@ class TitleFilterTest extends TestCase
     public static function setUpBeforeClass(): void
     {
         static::withDbAccess(function () {
-            $factory = Beatmapset::factory()->ranked()->withBeatmaps();
+            $factory = Beatmapset::factory()->fixedStrings()->ranked()->withBeatmaps(beatmapState: ['version' => 'test']);
             static::$beatmapsets = [
                 $factory->create(['title' => 'best']),
                 $factory->create(['title' => 'the best beatmap']),

--- a/tests/Libraries/Search/BeatmapsetSearch/TitleFilterTest.php
+++ b/tests/Libraries/Search/BeatmapsetSearch/TitleFilterTest.php
@@ -14,17 +14,17 @@ class TitleFilterTest extends TestCase
     public static function dataProvider(): array
     {
         return [
-            [['q' => 'best'], [0, 1, 2, 3, 4]],
-            [['q' => 'best beatmap'], [3, 2, 1, 0, 4], true],
-            [['q' => '"best beatmap"'], [3, 2, 1], true],
+            [['q' => 'best'], [0, 4, 1, 3, 2], true],
+            [['q' => 'best beatmap'], [1, 3, 2, 0, 4], true],
+            [['q' => '"best beatmap"'], [1, 3, 2], true],
             [['q' => '-best'], []],
             [['q' => '-best -beatmap'], []],
-            [['q' => '-"best beatmap"'], [0, 4]],
+            [['q' => '-"best beatmap"'], [4, 0], true],
 
-            [['q' => 'title=best'], [0, 1, 2, 3]],
-            [['q' => 'title="best beatmap"'], [1, 2, 3]],
-            [['q' => 'title="the beatmap"'], [1, 2], true],
-            [['q' => 'title=""best beatmap""'], [3, 2, 1], true],
+            [['q' => 'title=best'], [0, 1, 3, 2], true],
+            [['q' => 'title="best beatmap"'], [1, 3, 2], true],
+            [['q' => 'title="the beatmap"'], [2, 3], true],
+            [['q' => 'title=""best beatmap""'], [1, 3, 2], true],
             [['q' => 'title=""the beatmap""'], []],
         ];
     }
@@ -35,9 +35,10 @@ class TitleFilterTest extends TestCase
             $factory = Beatmapset::factory()->consistent()->ranked()->withBeatmaps();
             static::$beatmapsets = [
                 $factory->create(['title' => 'best']),
+                $factory->create(['title' => 'best beatmap']),
                 $factory->create(['title' => 'the best beatmap']),
                 $factory->create(['title' => 'the best beatmap', 'title_unicode' => 'ダ best beatmap']), // scores slightly better in prefix matching.
-                $factory->create(['title' => 'best beatmap']),
+                // this will score better in the 'best' test due to the term having lower frequency in the artist field.
                 $factory->create(['artist' => 'the best artist']),
             ];
         });

--- a/tests/Libraries/Search/BeatmapsetSearch/TitleFilterTest.php
+++ b/tests/Libraries/Search/BeatmapsetSearch/TitleFilterTest.php
@@ -14,17 +14,17 @@ class TitleFilterTest extends TestCase
     public static function dataProvider(): array
     {
         return [
-            [['q' => 'best'], [0, 4, 1, 3, 2], true],
-            [['q' => 'best beatmap'], [1, 3, 2, 0, 4], true],
-            [['q' => '"best beatmap"'], [1, 3, 2], true],
+            [['q' => 'best'], [0, 1, 2, 3, 4]],
+            [['q' => 'best beatmap'], [0, 1, 2, 3, 4]],
+            [['q' => '"best beatmap"'], [1, 2, 3]],
             [['q' => '-best'], []],
             [['q' => '-best -beatmap'], []],
-            [['q' => '-"best beatmap"'], [4, 0], true],
+            [['q' => '-"best beatmap"'], [0, 4]],
 
-            [['q' => 'title=best'], [0, 1, 3, 2], true],
-            [['q' => 'title="best beatmap"'], [1, 3, 2], true],
-            [['q' => 'title="the beatmap"'], [2, 3], true],
-            [['q' => 'title=""best beatmap""'], [1, 3, 2], true],
+            [['q' => 'title=best'], [0, 1, 2, 3]],
+            [['q' => 'title="best beatmap"'], [1, 2, 3]],
+            [['q' => 'title="the beatmap"'], [1, 2]],
+            [['q' => 'title=""best beatmap""'], [1, 2, 3]],
             [['q' => 'title=""the beatmap""'], []],
         ];
     }
@@ -32,13 +32,12 @@ class TitleFilterTest extends TestCase
     public static function setUpBeforeClass(): void
     {
         static::withDbAccess(function () {
-            $factory = Beatmapset::factory()->consistent()->ranked()->withBeatmaps();
+            $factory = Beatmapset::factory()->ranked()->withBeatmaps();
             static::$beatmapsets = [
                 $factory->create(['title' => 'best']),
-                $factory->create(['title' => 'best beatmap']),
                 $factory->create(['title' => 'the best beatmap']),
-                $factory->create(['title' => 'the best beatmap', 'title_unicode' => 'ダ best beatmap']), // scores slightly better in prefix matching.
-                // this will score better in the 'best' test due to the term having lower frequency in the artist field.
+                $factory->create(['title' => 'the best beatmap', 'title_unicode' => 'ダ best beatmap']),
+                $factory->create(['title' => 'best beatmap']),
                 $factory->create(['artist' => 'the best artist']),
             ];
         });

--- a/tests/Libraries/Search/BeatmapsetSearch/TitleFilterTest.php
+++ b/tests/Libraries/Search/BeatmapsetSearch/TitleFilterTest.php
@@ -14,17 +14,17 @@ class TitleFilterTest extends TestCase
     public static function dataProvider(): array
     {
         return [
-            [['q' => 'best'], [0, 1, 2, 3]],
-            [['q' => 'best beatmap'], [0, 1, 2, 3]],
-            [['q' => '"best beatmap"'], [1, 2]],
+            [['q' => 'best'], [0, 1, 2, 3, 4]],
+            [['q' => 'best beatmap'], [3, 1, 2, 0, 4], true],
+            [['q' => '"best beatmap"'], [3, 1, 2], true],
             [['q' => '-best'], []],
             [['q' => '-best -beatmap'], []],
-            [['q' => '-"best beatmap"'], [0, 3]],
+            [['q' => '-"best beatmap"'], [0, 4]],
 
-            [['q' => 'title=best'], [0, 1, 2]],
-            [['q' => 'title="best beatmap"'], [1, 2]],
-            [['q' => 'title="the beatmap"'], [1, 2]],
-            [['q' => 'title=""best beatmap""'], [1, 2]],
+            [['q' => 'title=best'], [0, 1, 2, 3]],
+            [['q' => 'title="best beatmap"'], [1, 2, 3]],
+            [['q' => 'title="the beatmap"'], [2, 1], true],
+            [['q' => 'title=""best beatmap""'], [3, 2, 1], true],
             [['q' => 'title=""the beatmap""'], []],
         ];
     }
@@ -32,11 +32,12 @@ class TitleFilterTest extends TestCase
     public static function setUpBeforeClass(): void
     {
         static::withDbAccess(function () {
-            $factory = Beatmapset::factory()->ranked()->withBeatmaps();
+            $factory = Beatmapset::factory()->consistent()->ranked()->withBeatmaps();
             static::$beatmapsets = [
                 $factory->create(['title' => 'best']),
                 $factory->create(['title' => 'the best beatmap']),
-                $factory->create(['title_unicode' => 'the best beatmapよ']),
+                $factory->create(['title_unicode' => 'the best beatmapよ']), // this sets title as well, giving it higher field relevancy scoring.
+                $factory->create(['title' => 'best beatmap']),
                 $factory->create(['artist' => 'the best artist']),
             ];
         });

--- a/tests/Libraries/Search/BeatmapsetSearch/TitleFilterTest.php
+++ b/tests/Libraries/Search/BeatmapsetSearch/TitleFilterTest.php
@@ -15,15 +15,15 @@ class TitleFilterTest extends TestCase
     {
         return [
             [['q' => 'best'], [0, 1, 2, 3, 4]],
-            [['q' => 'best beatmap'], [3, 1, 2, 0, 4], true],
-            [['q' => '"best beatmap"'], [3, 1, 2], true],
+            [['q' => 'best beatmap'], [3, 2, 1, 0, 4], true],
+            [['q' => '"best beatmap"'], [3, 2, 1], true],
             [['q' => '-best'], []],
             [['q' => '-best -beatmap'], []],
             [['q' => '-"best beatmap"'], [0, 4]],
 
             [['q' => 'title=best'], [0, 1, 2, 3]],
             [['q' => 'title="best beatmap"'], [1, 2, 3]],
-            [['q' => 'title="the beatmap"'], [2, 1], true],
+            [['q' => 'title="the beatmap"'], [1, 2], true],
             [['q' => 'title=""best beatmap""'], [3, 2, 1], true],
             [['q' => 'title=""the beatmap""'], []],
         ];
@@ -36,7 +36,7 @@ class TitleFilterTest extends TestCase
             static::$beatmapsets = [
                 $factory->create(['title' => 'best']),
                 $factory->create(['title' => 'the best beatmap']),
-                $factory->create(['title_unicode' => 'the best beatmapよ']), // this sets title as well, giving it higher field relevancy scoring.
+                $factory->create(['title' => 'the best beatmap', 'title_unicode' => 'ダ best beatmap']), // scores slightly better in prefix matching.
                 $factory->create(['title' => 'best beatmap']),
                 $factory->create(['artist' => 'the best artist']),
             ];

--- a/tests/Libraries/Search/BeatmapsetSearch/TitleFilterTest.php
+++ b/tests/Libraries/Search/BeatmapsetSearch/TitleFilterTest.php
@@ -14,6 +14,13 @@ class TitleFilterTest extends TestCase
     public static function dataProvider(): array
     {
         return [
+            [['q' => 'best'], [0, 1, 2, 3]],
+            [['q' => 'best beatmap'], [0, 1, 2, 3]],
+            [['q' => '"best beatmap"'], [1, 2]],
+            [['q' => '-best'], []],
+            [['q' => '-best -beatmap'], []],
+            [['q' => '-"best beatmap"'], [0, 3]],
+
             [['q' => 'title=best'], [0, 1, 2]],
             [['q' => 'title="best beatmap"'], [1, 2]],
             [['q' => 'title="the beatmap"'], [1, 2]],

--- a/tests/Libraries/Search/QueryTokeniserTest.php
+++ b/tests/Libraries/Search/QueryTokeniserTest.php
@@ -1,0 +1,51 @@
+<?php
+
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
+declare(strict_types=1);
+
+namespace Tests\Libraries\Search;
+
+use App\Libraries\Elasticsearch\QueryHelper;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Tests\TestCase;
+
+class QueryTokeniserTest extends TestCase
+{
+    public static function dataProvider()
+    {
+        return [
+            ['', [], []],
+            ['foo bar', ['foo', 'bar'], []],
+            ['"foo bar"', ['"foo bar"'], []],
+            ['llama "foo bar"', ['llama', '"foo bar"'], []],
+            ['llama "foo bar" whee', ['llama', '"foo bar"', 'whee'], []],
+            ['"foo bar" whee', ['"foo bar"', 'whee'], []],
+            ['"foo" "bar" whee', ['"foo"', '"bar"', 'whee'], []],
+            ['"foo" bar" whee', ['"foo"', 'bar"', 'whee'], []],
+            ['"foo bar""', ['"foo bar""'], []],
+            ['""foo bar""', ['""foo bar""'], []],
+            ['"foo bar" "', ['"foo bar"', '"'], []],
+            ['"foo bar -llamas', ['"foo bar -llamas'], []],
+
+            ['" " " "" -"', ['" "', '" ""'], ['"']],
+
+            ['-foo bar', ['bar'], ['foo']],
+            ['foo -bar', ['foo'], ['bar']],
+            ['-"foo bar"', [], ['"foo bar"']],
+            ['llama -"foo bar"', ['llama'], ['"foo bar"']],
+            ['more -"foo bar" llamas', ['more', 'llamas'], ['"foo bar"']],
+            ['more -"foo bar" -bar llamas', ['more', 'llamas'], ['"foo bar"', 'bar']],
+            ['-"foo -bar"', [], ['"foo -bar"']],
+        ];
+    }
+
+    #[DataProvider('dataProvider')]
+    public function testParse(?string $query, array $include, array $exclude)
+    {
+        $tokens = QueryHelper::tokenise($query);
+        $this->assertSame(json_encode($include), json_encode($tokens['include']));
+        $this->assertSame(json_encode($exclude), json_encode($tokens['exclude']));
+    }
+}


### PR DESCRIPTION
Beatmap search query string parsing portion of #12148
Removes all usages of `QueryHelper::queryString`/`simple_query_string` in `BeatmapsetSearch` which isn't suitable for our supported syntax without more contortions and parsing to make it fit, at which point we might as well just parse it ourselves.

- [x] `tokenise` test
- [x] depends on #12345