### PR TITLE
Add matchmaking room type and stats table

### DIFF
--- a/app/Models/Multiplayer/Room.php
+++ b/app/Models/Multiplayer/Room.php
@@ -428,6 +428,11 @@ class Room extends Model
         return $realtimeTypes->contains($this->type);
     }
 
+    public function isMatchmaking()
+    {
+        return $this->type === static::MATCHMAKING_TYPE;
+    }
+
     public function isScoreSubmissionStillAllowed()
     {
         // TODO: move grace period to config or use the beatmap's duration
@@ -667,14 +672,17 @@ class Room extends Model
 
         $playlistItemsCount = count($playlistItems);
 
-        if ($this->isRealtime() && $playlistItemsCount !== 1) {
-            if ($this->type !== static::MATCHMAKING_TYPE) {
-                throw new InvariantException('realtime room must have exactly one playlist item');
-            }
-        }
-
         if ($playlistItemsCount < 1) {
             throw new InvariantException('room must have at least one playlist item');
+        }
+
+        if ($this->isMatchmaking()) {
+            $banchoBotId = $GLOBALS['cfg']['osu']['legacy']['bancho_bot_user_id'];
+            foreach ($playlistItems as $item) {
+                $item->owner_id = $banchoBotId;
+            }
+        } elseif ($this->isRealtime() && $playlistItemsCount !== 1) {
+            throw new InvariantException('realtime room must have exactly one playlist item');
         }
 
         if (mb_strlen($this->name) > 100) {
@@ -763,9 +771,18 @@ class Room extends Model
 
     private function assertHostRoomAllowance()
     {
+        $banchoBotId = $GLOBALS['cfg']['osu']['legacy']['bancho_bot_user_id'];
+
+        if ($this->host->getKey() == $banchoBotId) {
+            // BanchoBot can always create rooms.
+            return;
+        }
+
         $query = static::active()->startedBy($this->host);
 
-        if ($this->isRealtime()) {
+        if ($this->isMatchmaking()) {
+            throw new InvariantException('matchmaking rooms cannot be created');
+        } else if ($this->isRealtime()) {
             $query->whereIn('type', static::REALTIME_TYPES);
             $max = 1;
         } else {

--- a/app/Models/Multiplayer/Room.php
+++ b/app/Models/Multiplayer/Room.php
@@ -74,6 +74,7 @@ class Room extends Model
     ];
 
     const PLAYLIST_TYPE = 'playlists';
+    const MATCHMAKING_TYPE = 'matchmaking';
     const REALTIME_DEFAULT_TYPE = 'head_to_head';
     const REALTIME_TYPES = ['head_to_head', 'team_versus', 'matchmaking'];
 
@@ -667,7 +668,9 @@ class Room extends Model
         $playlistItemsCount = count($playlistItems);
 
         if ($this->isRealtime() && $playlistItemsCount !== 1) {
-            throw new InvariantException('realtime room must have exactly one playlist item');
+            if ($this->type !== static::MATCHMAKING_TYPE) {
+                throw new InvariantException('realtime room must have exactly one playlist item');
+            }
         }
 
         if ($playlistItemsCount < 1) {

--- a/app/Models/Multiplayer/Room.php
+++ b/app/Models/Multiplayer/Room.php
@@ -75,7 +75,7 @@ class Room extends Model
 
     const PLAYLIST_TYPE = 'playlists';
     const REALTIME_DEFAULT_TYPE = 'head_to_head';
-    const REALTIME_TYPES = ['head_to_head', 'team_versus'];
+    const REALTIME_TYPES = ['head_to_head', 'team_versus', 'matchmaking'];
 
     const PLAYLIST_QUEUE_MODE = 'host_only';
     const REALTIME_DEFAULT_QUEUE_MODE = 'host_only';

--- a/database/migrations/2025_08_01_000000_add_matchmaking_room_type.php
+++ b/database/migrations/2025_08_01_000000_add_matchmaking_room_type.php
@@ -1,0 +1,33 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        DB::statement("ALTER TABLE `multiplayer_rooms` MODIFY `type` ENUM(
+            'playlists',
+            'head_to_head',
+            'team_versus',
+            'matchmaking'
+        ) NOT NULL");
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        DB::statement("ALTER TABLE `multiplayer_rooms` MODIFY `type` ENUM(
+            'playlists',
+            'head_to_head',
+            'team_versus'
+        ) NOT NULL");
+    }
+};

--- a/database/migrations/2025_08_26_000000_create_matchmaking_stats_table.php
+++ b/database/migrations/2025_08_26_000000_create_matchmaking_stats_table.php
@@ -1,0 +1,29 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::create('matchmaking_stats', function (Blueprint $table) {
+            $table->unsignedMediumInteger('user_id')->nullable(false);
+            $table->unsignedMediumInteger('first_placements')->default(0);
+
+            $table->primary('user_id');
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::dropIfExists('matchmaking_stats');
+    }
+};

--- a/tests/Controllers/Multiplayer/RoomsControllerTest.php
+++ b/tests/Controllers/Multiplayer/RoomsControllerTest.php
@@ -176,7 +176,7 @@ class RoomsControllerTest extends TestCase
     public function testStoreRealtime()
     {
         $token = Token::factory()->create(['scopes' => ['*']]);
-        $type = array_rand_val(Room::REALTIME_TYPES);
+        $type = array_rand_val(array_except(Room::REALTIME_TYPES, Room::MATCHMAKING_TYPE));
 
         $roomsCountInitial = Room::count();
         $playlistItemsCountInitial = PlaylistItem::count();
@@ -205,7 +205,7 @@ class RoomsControllerTest extends TestCase
     public function testStoreRealtimeByType()
     {
         $token = Token::factory()->create(['scopes' => ['*']]);
-        $type = array_rand_val(Room::REALTIME_TYPES);
+        $type = array_rand_val(array_except(Room::REALTIME_TYPES, Room::MATCHMAKING_TYPE));
 
         $response = $this
             ->actingWithToken($token)
@@ -273,7 +273,7 @@ class RoomsControllerTest extends TestCase
                 $this->createBasicStoreParams(),
                 [
                     'password' => $password,
-                    'type' => array_rand_val(Room::REALTIME_TYPES),
+                    'type' => array_rand_val(array_except(Room::REALTIME_TYPES, Room::MATCHMAKING_TYPE)),
                 ],
             ))->assertSuccessful();
 
@@ -295,7 +295,7 @@ class RoomsControllerTest extends TestCase
             'beatmap_id' => $beatmap->getKey(),
             'ruleset_id' => $beatmap->playmode,
         ];
-        $params['type'] = array_rand_val(Room::REALTIME_TYPES);
+        $params['type'] = array_rand_val(array_except(Room::REALTIME_TYPES, Room::MATCHMAKING_TYPE));
 
         $this
             ->actingWithToken($token)
@@ -364,7 +364,7 @@ class RoomsControllerTest extends TestCase
             ->actingWithToken($token)
             ->post(route('api.rooms.store'), array_merge(
                 $this->createBasicStoreParams(),
-                ['type' => array_rand_val(Room::REALTIME_TYPES)],
+                ['type' => array_rand_val(array_except(Room::REALTIME_TYPES, Room::MATCHMAKING_TYPE))],
             ))->assertStatus(422);
 
         $this->assertSame($roomsCountInitial, Room::count());
@@ -388,7 +388,7 @@ class RoomsControllerTest extends TestCase
             ->actingWithToken($token)
             ->post(route('api.rooms.store'), array_merge(
                 $this->createBasicStoreParams(),
-                ['type' => array_rand_val(Room::REALTIME_TYPES)],
+                ['type' => array_rand_val(array_except(Room::REALTIME_TYPES, Room::MATCHMAKING_TYPE))],
             ))->assertSuccessful();
 
         $this->assertSame($roomsCountInitial + 1, Room::count());
@@ -520,7 +520,7 @@ class RoomsControllerTest extends TestCase
     public static function dataProviderForTestStoreWithInvalidPlayableMods(): array
     {
         $ret = [];
-        foreach ([Arr::random(Room::REALTIME_TYPES), Room::PLAYLIST_TYPE] as $type) {
+        foreach ([Arr::random(array_except(Room::REALTIME_TYPES, Room::MATCHMAKING_TYPE)), Room::PLAYLIST_TYPE] as $type) {
             foreach (['allowed', 'required'] as $modType) {
                 $ret[] = [$type, $modType];
             }
@@ -532,7 +532,7 @@ class RoomsControllerTest extends TestCase
     public static function dataProviderForTestStoreWithInvalidRealtimeAllowedMods(): array
     {
         return [
-            [Arr::random(Room::REALTIME_TYPES), false],
+            [Arr::random(array_except(Room::REALTIME_TYPES, Room::MATCHMAKING_TYPE)), false],
             [Room::PLAYLIST_TYPE, true],
         ];
     }
@@ -540,7 +540,7 @@ class RoomsControllerTest extends TestCase
     public static function dataProviderForTestStoreWithInvalidRealtimeMods(): array
     {
         return [
-            [Arr::random(Room::REALTIME_TYPES), false],
+            [Arr::random(array_except(Room::REALTIME_TYPES, Room::MATCHMAKING_TYPE)), false],
             [Room::PLAYLIST_TYPE, true],
         ];
     }


### PR DESCRIPTION
- Only BanchoBot should be able to create these rooms.
- These rooms start off with a large (50+) number of items in their playlist. osu-server-spectator will likely clean these up when the room is closed.
- The stats table is very low-effort. Will need more tables here when ELO is in place.