### PR TITLE
Fix Beatmap search played filter sometimes not working

### DIFF
--- a/app/Libraries/Search/BeatmapsetSearch.php
+++ b/app/Libraries/Search/BeatmapsetSearch.php
@@ -234,17 +234,34 @@ class BeatmapsetSearch extends RecordSearch
 
     private function addPlayedFilter($query, $nested)
     {
+        if ($this->params->playedFilter === null) {
+            return;
+        }
+
+        $ids = $this->getPlayedBeatmapIds();
+        $chunks = array_chunk($ids, 10000);
+
         if ($this->params->playedFilter === 'played') {
-            $nested->filter(['terms' => ['beatmaps.beatmap_id' => $this->getPlayedBeatmapIds()]]);
+            if (count($ids) === 0) { // avoids the should empty list matching everything case.
+                return $query->filter(['match_none' => (object) []]);
+            }
+
+            $boolQuery = new BoolQuery();
+            foreach ($chunks as $chunk) {
+                $boolQuery->should(['terms' => ['beatmaps.beatmap_id' => $chunk]]);
+            }
+            $nested->filter($boolQuery);
         } elseif ($this->params->playedFilter === 'unplayed') {
             // The inverse of nested:filter/must is must_not:nested, not nested:must_not
             // https://github.com/elastic/elasticsearch/issues/26264#issuecomment-323668358
-            $query->mustNot([
-                'nested' => [
-                    'path' => 'beatmaps',
-                    'query' => ['terms' => ['beatmaps.beatmap_id' => $this->getPlayedBeatmapIds()]],
-                ],
-            ]);
+            foreach ($chunks as $chunk) {
+                $query->mustNot([
+                    'nested' => [
+                        'path' => 'beatmaps',
+                        'query' => ['terms' => ['beatmaps.beatmap_id' => $chunk]],
+                    ],
+                ]);
+            }
         }
     }
 
@@ -254,7 +271,17 @@ class BeatmapsetSearch extends RecordSearch
             return;
         }
 
-        $query->filter(['terms' => ['beatmaps.beatmap_id' => $this->getPlayedBeatmapIds($this->params->rank)]]);
+        $ids = $this->getPlayedBeatmapIds($this->params->rank);
+        if (count($ids) === 0) { // avoids the should empty list matching everything case.
+            return $query->filter(['match_none' => (object) []]);
+        }
+
+        $chunks = array_chunk($ids, 10000);
+        $boolQuery = new BoolQuery();
+        foreach ($chunks as $chunk) {
+            $boolQuery->should(['terms' => ['beatmaps.beatmap_id' => $chunk]]);
+        }
+        $query->filter($boolQuery);
     }
 
     private function addRecommendedFilter($query)
@@ -450,7 +477,7 @@ class BeatmapsetSearch extends RecordSearch
         }
 
         if ($rank === null) {
-            return $query->distinct('beatmap_id')->pluck('beatmap_id');
+            return $query->distinct('beatmap_id')->pluck('beatmap_id')->all();
         }
 
         $topScores = [];


### PR DESCRIPTION
Works around the per query term limit of `65536`. The other option is to increase `max_terms_count` on the index