### PR TITLE
Use relevance score as default sort for title filter

### DIFF
--- a/app/Libraries/Search/BeatmapsetSearchRequestParams.php
+++ b/app/Libraries/Search/BeatmapsetSearchRequestParams.php
@@ -189,7 +189,7 @@ class BeatmapsetSearchRequestParams extends BeatmapsetSearchParams
 
     private function getDefaultSortField(): string
     {
-        if (present($this->queryString) || present($this->artist) || present($this->creator)) {
+        if (present($this->queryString) || present($this->artist) || present($this->creator) || present($this->title)) {
             return 'relevance';
         }
 


### PR DESCRIPTION
It's based on a text scoring search so it doesn't make sense it doesn't default to relevance score like the other filters using text search...

(The web side default display for the filters input via querystring are still wrong, though)