### PR TITLE
Ignore tag for topic title length check

### DIFF
--- a/database/migrations/2025_09_01_140349_adjust_topic_title_length.php
+++ b/database/migrations/2025_09_01_140349_adjust_topic_title_length.php
@@ -1,0 +1,27 @@
+<?php
+
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('phpbb_topics', function (Blueprint $table) {
+            $table->string('topic_title')->default('')->change();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('phpbb_topics', function (Blueprint $table) {
+            $table->string('topic_title', 100)->default('')->change();
+        });
+    }
+};


### PR DESCRIPTION
Resolves #12353

- [ ] fix table charset on prod (not adding this to migration)
  - `alter table phpbb_topics charset=utf8mb4 collate=utf8mb4_0900_ai_ci;`
  - I think most of other tables' collation has different (older) one but this one is the latest mysql default 