### PR TITLE
Add strict to migration files and create better default

### DIFF
--- a/database/migrations/2015_01_01_133337_base_tables.php
+++ b/database/migrations/2015_01_01_133337_base_tables.php
@@ -2,6 +2,9 @@
 
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
+
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 

--- a/database/migrations/2015_01_01_133337_chat_base_tables.php
+++ b/database/migrations/2015_01_01_133337_chat_base_tables.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 

--- a/database/migrations/2015_01_01_133337_multiplayer_base_tables.php
+++ b/database/migrations/2015_01_01_133337_multiplayer_base_tables.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 

--- a/database/migrations/2015_01_01_133337_store_base_tables.php
+++ b/database/migrations/2015_01_01_133337_store_base_tables.php
@@ -2,6 +2,9 @@
 
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
+
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 

--- a/database/migrations/2015_01_01_133337_updates_base_tables.php
+++ b/database/migrations/2015_01_01_133337_updates_base_tables.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 
 class UpdatesBaseTables extends Migration

--- a/database/migrations/2015_01_01_133338_create_beatmap_failtimes_table.php
+++ b/database/migrations/2015_01_01_133338_create_beatmap_failtimes_table.php
@@ -2,6 +2,9 @@
 
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
+
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 

--- a/database/migrations/2015_01_23_114030_extend_products_table.php
+++ b/database/migrations/2015_01_23_114030_extend_products_table.php
@@ -2,6 +2,9 @@
 
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
+
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 
 class ExtendProductsTable extends Migration

--- a/database/migrations/2015_01_29_013313_add_last_order_tracking_state.php
+++ b/database/migrations/2015_01_29_013313_add_last_order_tracking_state.php
@@ -2,6 +2,9 @@
 
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
+
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 
 class AddLastOrderTrackingState extends Migration

--- a/database/migrations/2015_02_03_051509_record_cost_and_shipping_in_order.php
+++ b/database/migrations/2015_02_03_051509_record_cost_and_shipping_in_order.php
@@ -2,6 +2,9 @@
 
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
+
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 
 class RecordCostAndShippingInOrder extends Migration

--- a/database/migrations/2015_02_04_165733_record_cost_and_shipping_in_order_populate.php
+++ b/database/migrations/2015_02_04_165733_record_cost_and_shipping_in_order_populate.php
@@ -2,6 +2,9 @@
 
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
+
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 
 class RecordCostAndShippingInOrderPopulate extends Migration

--- a/database/migrations/2015_05_01_013313_add_item_family.php
+++ b/database/migrations/2015_05_01_013313_add_item_family.php
@@ -2,6 +2,9 @@
 
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
+
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 
 class AddItemFamily extends Migration

--- a/database/migrations/2015_06_04_083548_infinite_stock_products.php
+++ b/database/migrations/2015_06_04_083548_infinite_stock_products.php
@@ -2,6 +2,9 @@
 
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
+
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 
 class InfiniteStockProducts extends Migration

--- a/database/migrations/2015_06_04_093340_custom_product_implementations.php
+++ b/database/migrations/2015_06_04_093340_custom_product_implementations.php
@@ -2,6 +2,9 @@
 
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
+
+declare(strict_types=1);
+
 use App\Models\Store;
 use Illuminate\Database\Migrations\Migration;
 

--- a/database/migrations/2015_06_18_022845_order_transaction_id.php
+++ b/database/migrations/2015_06_18_022845_order_transaction_id.php
@@ -2,6 +2,9 @@
 
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
+
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 
 class OrderTransactionId extends Migration

--- a/database/migrations/2015_06_19_050528_add_order_paid_at_column.php
+++ b/database/migrations/2015_06_19_050528_add_order_paid_at_column.php
@@ -2,6 +2,9 @@
 
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
+
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 
 class AddOrderPaidAtColumn extends Migration

--- a/database/migrations/2015_07_08_042238_create_tournaments_tables.php
+++ b/database/migrations/2015_07_08_042238_create_tournaments_tables.php
@@ -2,6 +2,9 @@
 
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
+
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 

--- a/database/migrations/2015_07_09_084235_create_user_profile_customizations_table.php
+++ b/database/migrations/2015_07_09_084235_create_user_profile_customizations_table.php
@@ -2,6 +2,9 @@
 
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
+
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 

--- a/database/migrations/2015_07_09_091745_add_tournament_description_text.php
+++ b/database/migrations/2015_07_09_091745_add_tournament_description_text.php
@@ -2,6 +2,9 @@
 
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
+
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 
 class AddTournamentDescriptionText extends Migration

--- a/database/migrations/2015_07_09_105144_create_tournaments_registrations_table.php
+++ b/database/migrations/2015_07_09_105144_create_tournaments_registrations_table.php
@@ -2,6 +2,9 @@
 
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
+
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 

--- a/database/migrations/2015_08_10_083016_add_slug_to_achievements.php
+++ b/database/migrations/2015_08_10_083016_add_slug_to_achievements.php
@@ -2,6 +2,9 @@
 
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
+
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 
 class AddSlugToAchievements extends Migration

--- a/database/migrations/2015_11_16_065319_create_topic_covers_table.php
+++ b/database/migrations/2015_11_16_065319_create_topic_covers_table.php
@@ -2,6 +2,9 @@
 
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
+
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 

--- a/database/migrations/2015_11_20_122003_add_unique_index_to_forum_topic_covers_forum_id.php
+++ b/database/migrations/2015_11_20_122003_add_unique_index_to_forum_topic_covers_forum_id.php
@@ -2,6 +2,9 @@
 
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
+
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 
 class AddUniqueIndexToForumTopicCoversForumId extends Migration

--- a/database/migrations/2015_12_07_061307_create_forum_covers_table.php
+++ b/database/migrations/2015_12_07_061307_create_forum_covers_table.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 

--- a/database/migrations/2016_01_12_074035_unique_user_customization_user_id.php
+++ b/database/migrations/2016_01_12_074035_unique_user_customization_user_id.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 
 class UniqueUserCustomizationUserId extends Migration

--- a/database/migrations/2016_01_26_194005_disable_products.php
+++ b/database/migrations/2016_01_26_194005_disable_products.php
@@ -2,6 +2,9 @@
 
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
+
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 
 class DisableProducts extends Migration

--- a/database/migrations/2016_01_29_090810_add_description_to_achievements.php
+++ b/database/migrations/2016_01_29_090810_add_description_to_achievements.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 
 class AddDescriptionToAchievements extends Migration

--- a/database/migrations/2016_02_11_155642_add_extras_order_on_user_profile_customization.php
+++ b/database/migrations/2016_02_11_155642_add_extras_order_on_user_profile_customization.php
@@ -2,6 +2,9 @@
 
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
+
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 
 class AddExtrasOrderOnUserProfileCustomization extends Migration

--- a/database/migrations/2016_02_23_094326_create_jobs_table.php
+++ b/database/migrations/2016_02_23_094326_create_jobs_table.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 

--- a/database/migrations/2016_02_25_072543_add_cover_updated_at_to_beatmapsets.php
+++ b/database/migrations/2016_02_25_072543_add_cover_updated_at_to_beatmapsets.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 

--- a/database/migrations/2016_02_25_080550_create_failed_jobs_table.php
+++ b/database/migrations/2016_02_25_080550_create_failed_jobs_table.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 

--- a/database/migrations/2016_02_27_103851_create_osu_slack_users_table.php
+++ b/database/migrations/2016_02_27_103851_create_osu_slack_users_table.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 

--- a/database/migrations/2016_02_29_052133_create_beatmapset_discussions.php
+++ b/database/migrations/2016_02_29_052133_create_beatmapset_discussions.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 

--- a/database/migrations/2016_02_29_060025_create_beatmap_discussions.php
+++ b/database/migrations/2016_02_29_060025_create_beatmap_discussions.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 

--- a/database/migrations/2016_02_29_081309_create_beatmap_discussion_posts.php
+++ b/database/migrations/2016_02_29_081309_create_beatmap_discussion_posts.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 

--- a/database/migrations/2016_03_02_214730_change_primary_key_on_slack_users.php
+++ b/database/migrations/2016_03_02_214730_change_primary_key_on_slack_users.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 
 return new class extends Migration

--- a/database/migrations/2016_03_03_223651_osu_slack_user_make_slack_id_nullable.php
+++ b/database/migrations/2016_03_03_223651_osu_slack_user_make_slack_id_nullable.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 
 return new class extends Migration

--- a/database/migrations/2016_03_09_083112_add_index_on_slack_id.php
+++ b/database/migrations/2016_03_09_083112_add_index_on_slack_id.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 
 return new class extends Migration

--- a/database/migrations/2016_03_15_080726_add_default_topic_cover_to_forum_covers.php
+++ b/database/migrations/2016_03_15_080726_add_default_topic_cover_to_forum_covers.php
@@ -2,6 +2,9 @@
 
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
+
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 
 class AddDefaultTopicCoverToForumCovers extends Migration

--- a/database/migrations/2016_03_18_170000_create_oauth_scopes_table.php
+++ b/database/migrations/2016_03_18_170000_create_oauth_scopes_table.php
@@ -9,6 +9,8 @@
  * file that was distributed with this source code.
  */
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2016_03_18_170001_create_oauth_grants_table.php
+++ b/database/migrations/2016_03_18_170001_create_oauth_grants_table.php
@@ -9,6 +9,8 @@
  * file that was distributed with this source code.
  */
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2016_03_18_170002_create_oauth_grant_scopes_table.php
+++ b/database/migrations/2016_03_18_170002_create_oauth_grant_scopes_table.php
@@ -9,6 +9,8 @@
  * file that was distributed with this source code.
  */
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2016_03_18_170003_create_oauth_clients_table.php
+++ b/database/migrations/2016_03_18_170003_create_oauth_clients_table.php
@@ -9,6 +9,8 @@
  * file that was distributed with this source code.
  */
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2016_03_18_170004_create_oauth_client_endpoints_table.php
+++ b/database/migrations/2016_03_18_170004_create_oauth_client_endpoints_table.php
@@ -9,6 +9,8 @@
  * file that was distributed with this source code.
  */
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2016_03_18_170005_create_oauth_client_scopes_table.php
+++ b/database/migrations/2016_03_18_170005_create_oauth_client_scopes_table.php
@@ -9,6 +9,8 @@
  * file that was distributed with this source code.
  */
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2016_03_18_170006_create_oauth_client_grants_table.php
+++ b/database/migrations/2016_03_18_170006_create_oauth_client_grants_table.php
@@ -9,6 +9,8 @@
  * file that was distributed with this source code.
  */
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2016_03_18_170007_create_oauth_sessions_table.php
+++ b/database/migrations/2016_03_18_170007_create_oauth_sessions_table.php
@@ -9,6 +9,8 @@
  * file that was distributed with this source code.
  */
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2016_03_18_170008_create_oauth_session_scopes_table.php
+++ b/database/migrations/2016_03_18_170008_create_oauth_session_scopes_table.php
@@ -9,6 +9,8 @@
  * file that was distributed with this source code.
  */
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2016_03_18_170009_create_oauth_auth_codes_table.php
+++ b/database/migrations/2016_03_18_170009_create_oauth_auth_codes_table.php
@@ -9,6 +9,8 @@
  * file that was distributed with this source code.
  */
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2016_03_18_170010_create_oauth_auth_code_scopes_table.php
+++ b/database/migrations/2016_03_18_170010_create_oauth_auth_code_scopes_table.php
@@ -9,6 +9,8 @@
  * file that was distributed with this source code.
  */
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2016_03_18_170011_create_oauth_access_tokens_table.php
+++ b/database/migrations/2016_03_18_170011_create_oauth_access_tokens_table.php
@@ -9,6 +9,8 @@
  * file that was distributed with this source code.
  */
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2016_03_18_170012_create_oauth_access_token_scopes_table.php
+++ b/database/migrations/2016_03_18_170012_create_oauth_access_token_scopes_table.php
@@ -9,6 +9,8 @@
  * file that was distributed with this source code.
  */
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2016_03_18_170013_create_oauth_refresh_tokens_table.php
+++ b/database/migrations/2016_03_18_170013_create_oauth_refresh_tokens_table.php
@@ -9,6 +9,8 @@
  * file that was distributed with this source code.
  */
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2016_03_22_054843_create_beatmap_discussion_votes.php
+++ b/database/migrations/2016_03_22_054843_create_beatmap_discussion_votes.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 

--- a/database/migrations/2016_04_11_071007_use_user_id_for_resolving_issue.php
+++ b/database/migrations/2016_04_11_071007_use_user_id_for_resolving_issue.php
@@ -2,6 +2,9 @@
 
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
+
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 
 class UseUserIdForResolvingIssue extends Migration

--- a/database/migrations/2016_04_12_111756_add_last_editor_id_to_beatmap_discussion_posts.php
+++ b/database/migrations/2016_04_12_111756_add_last_editor_id_to_beatmap_discussion_posts.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 
 class AddLastEditorIdToBeatmapDiscussionPosts extends Migration

--- a/database/migrations/2016_04_13_054710_add_system_to_beatmap_discussion_posts.php
+++ b/database/migrations/2016_04_13_054710_add_system_to_beatmap_discussion_posts.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 
 class AddSystemToBeatmapDiscussionPosts extends Migration

--- a/database/migrations/2016_04_13_185417_add_moderated_flag_to_channel.php
+++ b/database/migrations/2016_04_13_185417_add_moderated_flag_to_channel.php
@@ -2,6 +2,9 @@
 
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
+
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 
 class AddModeratedFlagToChannel extends Migration

--- a/database/migrations/2016_04_14_061643_create_user_zebras_table.php
+++ b/database/migrations/2016_04_14_061643_create_user_zebras_table.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 

--- a/database/migrations/2016_04_19_112407_create_store_notification_requests_table.php
+++ b/database/migrations/2016_04_19_112407_create_store_notification_requests_table.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 

--- a/database/migrations/2016_05_10_080557_update_achievements_table.php
+++ b/database/migrations/2016_05_10_080557_update_achievements_table.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 
 class UpdateAchievementsTable extends Migration

--- a/database/migrations/2016_06_17_081023_create_beatmapset_events.php
+++ b/database/migrations/2016_06_17_081023_create_beatmapset_events.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 

--- a/database/migrations/2016_06_21_054206_create_poll_votes_table.php
+++ b/database/migrations/2016_06_21_054206_create_poll_votes_table.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 
 class CreatePollVotesTable extends Migration

--- a/database/migrations/2016_06_21_055139_create_poll_options_table.php
+++ b/database/migrations/2016_06_21_055139_create_poll_options_table.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 
 class CreatePollOptionsTable extends Migration

--- a/database/migrations/2016_06_21_134532_create_banchostats_table.php
+++ b/database/migrations/2016_06_21_134532_create_banchostats_table.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 

--- a/database/migrations/2016_07_21_072328_create_artist_tables.php
+++ b/database/migrations/2016_07_21_072328_create_artist_tables.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 

--- a/database/migrations/2016_07_29_024320_create_contest_tables.php
+++ b/database/migrations/2016_07_29_024320_create_contest_tables.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 

--- a/database/migrations/2016_08_04_100929_add_length_to_artist_tracks.php
+++ b/database/migrations/2016_08_04_100929_add_length_to_artist_tracks.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 

--- a/database/migrations/2016_08_16_101048_create_sessions_table.php
+++ b/database/migrations/2016_08_16_101048_create_sessions_table.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 
 class CreateSessionsTable extends Migration

--- a/database/migrations/2016_08_25_031518_add_show_votes_to_contests.php
+++ b/database/migrations/2016_08_25_031518_add_show_votes_to_contests.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 

--- a/database/migrations/2016_08_25_055700_create_contest_vote_aggregates_view.php
+++ b/database/migrations/2016_08_25_055700_create_contest_vote_aggregates_view.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 
 return new class extends Migration

--- a/database/migrations/2016_08_31_062640_add_visible_to_artists_table.php
+++ b/database/migrations/2016_08_31_062640_add_visible_to_artists_table.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 

--- a/database/migrations/2016_08_31_103716_add_exclusive_to_artist_tracks.php
+++ b/database/migrations/2016_08_31_103716_add_exclusive_to_artist_tracks.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 

--- a/database/migrations/2016_09_06_124728_add_soft_deletes_to_posts_topics_tables.php
+++ b/database/migrations/2016_09_06_124728_add_soft_deletes_to_posts_topics_tables.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 

--- a/database/migrations/2016_09_07_105853_add_visible_to_contests.php
+++ b/database/migrations/2016_09_07_105853_add_visible_to_contests.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 

--- a/database/migrations/2016_09_20_203638_contest_submissions.php
+++ b/database/migrations/2016_09_20_203638_contest_submissions.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 

--- a/database/migrations/2016_09_30_064049_create_user_contest_entries_table.php
+++ b/database/migrations/2016_09_30_064049_create_user_contest_entries_table.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 

--- a/database/migrations/2016_10_05_061323_add_max_entries_to_contests.php
+++ b/database/migrations/2016_10_05_061323_add_max_entries_to_contests.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 

--- a/database/migrations/2016_10_24_062803_update_jobs_table.php
+++ b/database/migrations/2016_10_24_062803_update_jobs_table.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2016_10_28_000000_update_oauth_tables.php
+++ b/database/migrations/2016_10_28_000000_update_oauth_tables.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 
 class UpdateOauthTables extends Migration

--- a/database/migrations/2016_10_28_000001_create_passport_oauth_auth_codes_table.php
+++ b/database/migrations/2016_10_28_000001_create_passport_oauth_auth_codes_table.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2016_10_28_000002_create_passport_oauth_access_tokens_table.php
+++ b/database/migrations/2016_10_28_000002_create_passport_oauth_access_tokens_table.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2016_10_28_000003_create_passport_oauth_refresh_tokens_table.php
+++ b/database/migrations/2016_10_28_000003_create_passport_oauth_refresh_tokens_table.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2016_10_28_000004_create_passport_oauth_clients_table.php
+++ b/database/migrations/2016_10_28_000004_create_passport_oauth_clients_table.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2016_10_28_000005_create_passport_oauth_personal_access_clients_table.php
+++ b/database/migrations/2016_10_28_000005_create_passport_oauth_personal_access_clients_table.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2016_11_02_063649_add_user_id_to_contest_entries.php
+++ b/database/migrations/2016_11_02_063649_add_user_id_to_contest_entries.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2016_11_04_022225_add_extra_options_to_contests.php
+++ b/database/migrations/2016_11_04_022225_add_extra_options_to_contests.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2016_12_01_090638_add_soft_delete_to_beatmap_discussion_posts.php
+++ b/database/migrations/2016_12_01_090638_add_soft_delete_to_beatmap_discussion_posts.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Support\Facades\Schema;
 

--- a/database/migrations/2016_12_01_114033_add_additional_links_to_artists.php
+++ b/database/migrations/2016_12_01_114033_add_additional_links_to_artists.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2016_12_02_092104_add_soft_delete_to_beatmap_discussions.php
+++ b/database/migrations/2016_12_02_092104_add_soft_delete_to_beatmap_discussions.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Support\Facades\Schema;
 

--- a/database/migrations/2016_12_07_063316_create_artist_albums_table.php
+++ b/database/migrations/2016_12_07_063316_create_artist_albums_table.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2016_12_07_065315_add_album_id_to_artist_tracks.php
+++ b/database/migrations/2016_12_07_065315_add_album_id_to_artist_tracks.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2016_12_09_052957_add_more_fields_to_artist_tracks.php
+++ b/database/migrations/2016_12_09_052957_add_more_fields_to_artist_tracks.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2016_12_16_080558_update_kudos_exchange.php
+++ b/database/migrations/2016_12_16_080558_update_kudos_exchange.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 
 class UpdateKudosExchange extends Migration

--- a/database/migrations/2016_12_19_124550_add_kudosu_block_to_beatmap_discussions.php
+++ b/database/migrations/2016_12_19_124550_add_kudosu_block_to_beatmap_discussions.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Support\Facades\Schema;
 

--- a/database/migrations/2016_12_19_132350_add_kudosu_refresh_votes_to_beatmap_discussions.php
+++ b/database/migrations/2016_12_19_132350_add_kudosu_refresh_votes_to_beatmap_discussions.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Support\Facades\Schema;
 

--- a/database/migrations/2017_01_13_062704_nullable_entry_url_on_contest_entries.php
+++ b/database/migrations/2017_01_13_062704_nullable_entry_url_on_contest_entries.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2017_02_01_105338_drop_slack_users.php
+++ b/database/migrations/2017_02_01_105338_drop_slack_users.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Support\Facades\Schema;
 

--- a/database/migrations/2017_02_06_083745_nullable_cover_json_on_user_profile_customizations.php
+++ b/database/migrations/2017_02_06_083745_nullable_cover_json_on_user_profile_customizations.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Support\Facades\Schema;
 

--- a/database/migrations/2017_02_10_030227_contest_votes_change_weighting_to_float.php
+++ b/database/migrations/2017_02_10_030227_contest_votes_change_weighting_to_float.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2017_02_13_013536_delete_contest_vote_aggregates_view.php
+++ b/database/migrations/2017_02_13_013536_delete_contest_vote_aggregates_view.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 
 class DeleteContestVoteAggregatesView extends Migration

--- a/database/migrations/2017_02_20_141012_allow_nulls_on_user_contest_entries.php
+++ b/database/migrations/2017_02_20_141012_allow_nulls_on_user_contest_entries.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Support\Facades\Schema;
 

--- a/database/migrations/2017_02_21_084403_mb4_forum_last_topic.php
+++ b/database/migrations/2017_02_21_084403_mb4_forum_last_topic.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 
 class Mb4ForumLastTopic extends Migration

--- a/database/migrations/2017_02_22_061910_nullables_on_forum_covers.php
+++ b/database/migrations/2017_02_22_061910_nullables_on_forum_covers.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Support\Facades\Schema;
 

--- a/database/migrations/2017_03_10_080135_add_index_to_user_donations.php
+++ b/database/migrations/2017_03_10_080135_add_index_to_user_donations.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Support\Facades\Schema;
 

--- a/database/migrations/2017_05_04_070936_add_index_on_osu_builds.php
+++ b/database/migrations/2017_05_04_070936_add_index_on_osu_builds.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Support\Facades\Schema;
 

--- a/database/migrations/2017_05_12_111922_add_build_propagation_history_table.php
+++ b/database/migrations/2017_05_12_111922_add_build_propagation_history_table.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Support\Facades\Schema;
 

--- a/database/migrations/2017_05_22_061803_add_allow_multiple_to_products.php
+++ b/database/migrations/2017_05_22_061803_add_allow_multiple_to_products.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2017_05_22_073156_drop_order_id_product_id_from_order_items.php
+++ b/database/migrations/2017_05_22_073156_drop_order_id_product_id_from_order_items.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2017_05_26_101854_add_extra_data_to_order_items_table.php
+++ b/database/migrations/2017_05_26_101854_add_extra_data_to_order_items_table.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2017_05_31_042932_add_supporter_tag_to_products.php
+++ b/database/migrations/2017_05_31_042932_add_supporter_tag_to_products.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use App\Models\Store\Product;
 use Illuminate\Database\Migrations\Migration;
 

--- a/database/migrations/2017_06_02_040908_CreateCountryStatisticsTables.php
+++ b/database/migrations/2017_06_02_040908_CreateCountryStatisticsTables.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2017_07_14_040809_add_action_field_to_chat_tables.php
+++ b/database/migrations/2017_07_14_040809_add_action_field_to_chat_tables.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Support\Facades\Schema;
 

--- a/database/migrations/2017_07_20_013337_create_osu_beatmappacks_table.php
+++ b/database/migrations/2017_07_20_013337_create_osu_beatmappacks_table.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2017_07_20_013338_create_osu_beatmappacks_items_table.php
+++ b/database/migrations/2017_07_20_013338_create_osu_beatmappacks_items_table.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2017_07_20_094844_add_playmode_to_osu_beatmappacks.php
+++ b/database/migrations/2017_07_20_094844_add_playmode_to_osu_beatmappacks.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2017_07_26_093948_add_more_type_to_beatmapset_events.php
+++ b/database/migrations/2017_07_26_093948_add_more_type_to_beatmapset_events.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 
 class AddMoreTypeToBeatmapsetEvents extends Migration

--- a/database/migrations/2017_08_03_064207_unresolve_non_issue_beatmap_discussions.php
+++ b/database/migrations/2017_08_03_064207_unresolve_non_issue_beatmap_discussions.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 
 class UnresolveNonIssueBeatmapDiscussions extends Migration

--- a/database/migrations/2017_08_04_104549_make_all_beatmap_discussion_general_as_suggestion.php
+++ b/database/migrations/2017_08_04_104549_make_all_beatmap_discussion_general_as_suggestion.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 
 class MakeAllBeatmapDiscussionGeneralAsSuggestion extends Migration

--- a/database/migrations/2017_08_28_075817_add_discussion_enabled_to_beatmapsets.php
+++ b/database/migrations/2017_08_28_075817_add_discussion_enabled_to_beatmapsets.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Support\Facades\Schema;
 

--- a/database/migrations/2017_08_28_080125_add_deleted_at_to_beatmapsets.php
+++ b/database/migrations/2017_08_28_080125_add_deleted_at_to_beatmapsets.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Support\Facades\Schema;
 

--- a/database/migrations/2017_08_28_090801_directly_use_beatmapset_id_for_beatmap_discussions.php
+++ b/database/migrations/2017_08_28_090801_directly_use_beatmapset_id_for_beatmap_discussions.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Support\Facades\Schema;
 

--- a/database/migrations/2017_08_28_110634_drop_beatmapset_discussions.php
+++ b/database/migrations/2017_08_28_110634_drop_beatmapset_discussions.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 
 class DropBeatmapsetDiscussions extends Migration

--- a/database/migrations/2017_09_01_101541_create_osu_profile_banners.php
+++ b/database/migrations/2017_09_01_101541_create_osu_profile_banners.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2017_09_04_064001_add_deleted_at_to_beatmaps.php
+++ b/database/migrations/2017_09_04_064001_add_deleted_at_to_beatmaps.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Support\Facades\Schema;
 

--- a/database/migrations/2017_09_06_050956_add_youtube_to_artists.php
+++ b/database/migrations/2017_09_06_050956_add_youtube_to_artists.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2017_09_07_084729_better_forum_posts_index.php
+++ b/database/migrations/2017_09_07_084729_better_forum_posts_index.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Support\Facades\Schema;
 

--- a/database/migrations/2017_09_08_110651_simplify_forum_posts_index.php
+++ b/database/migrations/2017_09_08_110651_simplify_forum_posts_index.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Support\Facades\Schema;
 

--- a/database/migrations/2017_09_12_065003_fix_logs_table_encoding.php
+++ b/database/migrations/2017_09_12_065003_fix_logs_table_encoding.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 
 class FixLogsTableEncoding extends Migration

--- a/database/migrations/2017_09_13_102556_create_user_channels_table.php
+++ b/database/migrations/2017_09_13_102556_create_user_channels_table.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2017_09_20_055045_create_payments_table.php
+++ b/database/migrations/2017_09_20_055045_create_payments_table.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2017_10_10_082642_add_ip_bans.php
+++ b/database/migrations/2017_10_10_082642_add_ip_bans.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Support\Facades\Schema;
 

--- a/database/migrations/2017_10_20_133251_add_beatmapset_watches.php
+++ b/database/migrations/2017_10_20_133251_add_beatmapset_watches.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Support\Facades\Schema;
 

--- a/database/migrations/2017_10_25_054504_add_banner_to_tournaments.php
+++ b/database/migrations/2017_10_25_054504_add_banner_to_tournaments.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2017_11_17_074755_add_index_to_payments_transaction_id.php
+++ b/database/migrations/2017_11_17_074755_add_index_to_payments_transaction_id.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Support\Facades\Schema;
 

--- a/database/migrations/2017_11_22_070257_update_discussion_type_by_mapper.php
+++ b/database/migrations/2017_11_22_070257_update_discussion_type_by_mapper.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 
 class UpdateDiscussionTypeByMapper extends Migration

--- a/database/migrations/2017_11_22_081837_remove_kudosu_refresh_votes_from_beatmap_discussions.php
+++ b/database/migrations/2017_11_22_081837_remove_kudosu_refresh_votes_from_beatmap_discussions.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 
 class RemoveKudosuRefreshVotesFromBeatmapDiscussions extends Migration

--- a/database/migrations/2017_11_22_114135_add_even_more_type_to_beatmapset_events.php
+++ b/database/migrations/2017_11_22_114135_add_even_more_type_to_beatmapset_events.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 
 class AddEvenMoreTypeToBeatmapsetEvents extends Migration

--- a/database/migrations/2017_11_23_102444_add_index_to_kudosu_histories_kudosuable.php
+++ b/database/migrations/2017_11_23_102444_add_index_to_kudosu_histories_kudosuable.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Support\Facades\Schema;
 

--- a/database/migrations/2017_11_27_064736_fix_user_sig_encoding.php
+++ b/database/migrations/2017_11_27_064736_fix_user_sig_encoding.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 
 class FixUserSigEncoding extends Migration

--- a/database/migrations/2017_11_29_033957_add_nomination_reset_type_to_beatmapset_events.php
+++ b/database/migrations/2017_11_29_033957_add_nomination_reset_type_to_beatmapset_events.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 
 class AddNominationResetTypeToBeatmapsetEvents extends Migration

--- a/database/migrations/2017_12_13_083252_change_costs_to_decimal.php
+++ b/database/migrations/2017_12_13_083252_change_costs_to_decimal.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 
 class ChangeCostsToDecimal extends Migration

--- a/database/migrations/2017_12_20_090905_add_new_rank_cache_columns.php
+++ b/database/migrations/2017_12_20_090905_add_new_rank_cache_columns.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 
 class AddNewRankCacheColumns extends Migration

--- a/database/migrations/2018_01_03_082931_add_hype_to_beatmapsets.php
+++ b/database/migrations/2018_01_03_082931_add_hype_to_beatmapsets.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Support\Facades\Schema;
 

--- a/database/migrations/2018_01_09_063809_add_processing_type_to_order_status.php
+++ b/database/migrations/2018_01_09_063809_add_processing_type_to_order_status.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 
 class AddProcessingTypeToOrderStatus extends Migration

--- a/database/migrations/2018_01_11_060632_add_nominations_to_beatmapsets.php
+++ b/database/migrations/2018_01_11_060632_add_nominations_to_beatmapsets.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Support\Facades\Schema;
 

--- a/database/migrations/2018_03_06_114525_add_mail_to_topic_watches.php
+++ b/database/migrations/2018_03_06_114525_add_mail_to_topic_watches.php
@@ -2,6 +2,9 @@
 
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
+
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Support\Facades\Schema;
 

--- a/database/migrations/2018_04_06_081112_unique_beatmapset_discussion_votes.php
+++ b/database/migrations/2018_04_06_081112_unique_beatmapset_discussion_votes.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Support\Facades\Schema;
 

--- a/database/migrations/2018_04_12_080404_add_index_to_achievements_name.php
+++ b/database/migrations/2018_04_12_080404_add_index_to_achievements_name.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Support\Facades\Schema;
 

--- a/database/migrations/2018_04_12_085114_add_spotify_and_osu_profile_to_artists.php
+++ b/database/migrations/2018_04_12_085114_add_spotify_and_osu_profile_to_artists.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Support\Facades\Schema;
 

--- a/database/migrations/2018_04_20_100654_add_queue_time_to_beatmapsets.php
+++ b/database/migrations/2018_04_20_100654_add_queue_time_to_beatmapsets.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Support\Facades\Schema;
 

--- a/database/migrations/2018_05_09_083801_add_wiki_and_store_link_to_tournaments.php
+++ b/database/migrations/2018_05_09_083801_add_wiki_and_store_link_to_tournaments.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Support\Facades\Schema;
 

--- a/database/migrations/2018_05_22_024629_create_changelogs.php
+++ b/database/migrations/2018_05_22_024629_create_changelogs.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2018_06_06_091751_link_streams_to_changelog_entries.php
+++ b/database/migrations/2018_06_06_091751_link_streams_to_changelog_entries.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Support\Facades\Schema;
 

--- a/database/migrations/2018_06_22_132317_link_streams_to_repositories.php
+++ b/database/migrations/2018_06_22_132317_link_streams_to_repositories.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Support\Facades\Schema;
 

--- a/database/migrations/2018_06_25_072709_update_beatmapset_datetimes_datatype.php
+++ b/database/migrations/2018_06_25_072709_update_beatmapset_datetimes_datatype.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 
 class UpdateBeatmapsetDatetimesDatatype extends Migration

--- a/database/migrations/2018_07_03_101029_add_default_category_to_repositories.php
+++ b/database/migrations/2018_07_03_101029_add_default_category_to_repositories.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Support\Facades\Schema;
 

--- a/database/migrations/2018_07_03_103002_update_repositories_nullable_stream_id.php
+++ b/database/migrations/2018_07_03_103002_update_repositories_nullable_stream_id.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Support\Facades\Schema;
 

--- a/database/migrations/2018_07_03_114909_link_changelog_entries_to_repositories.php
+++ b/database/migrations/2018_07_03_114909_link_changelog_entries_to_repositories.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Support\Facades\Schema;
 

--- a/database/migrations/2018_07_03_115128_set_changelog_entries_repository_id.php
+++ b/database/migrations/2018_07_03_115128_set_changelog_entries_repository_id.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 
 class SetChangelogEntriesRepositoryId extends Migration

--- a/database/migrations/2018_07_03_115621_drop_repository_from_changelog_entries.php
+++ b/database/migrations/2018_07_03_115621_drop_repository_from_changelog_entries.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Support\Facades\Schema;
 

--- a/database/migrations/2018_07_12_110501_add_build_on_tag_to_repositories.php
+++ b/database/migrations/2018_07_12_110501_add_build_on_tag_to_repositories.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Support\Facades\Schema;
 

--- a/database/migrations/2018_07_13_073008_add_chat_channel_types.php
+++ b/database/migrations/2018_07_13_073008_add_chat_channel_types.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 
 class AddChatChannelTypes extends Migration

--- a/database/migrations/2018_07_26_110501_add_love_type_to_beatmapset_events.php
+++ b/database/migrations/2018_07_26_110501_add_love_type_to_beatmapset_events.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 
 class AddLoveTypeToBeatmapsetEvents extends Migration

--- a/database/migrations/2018_07_26_211352_add_moderating_groups_to_forums.php
+++ b/database/migrations/2018_07_26_211352_add_moderating_groups_to_forums.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2018_07_31_073629_create_comments.php
+++ b/database/migrations/2018_07_31_073629_create_comments.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2018_07_31_101323_create_news_posts.php
+++ b/database/migrations/2018_07_31_101323_create_news_posts.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2018_08_02_073727_drop_comments_from_builds.php
+++ b/database/migrations/2018_08_02_073727_drop_comments_from_builds.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2018_08_03_102238_add_reserved_to_order_items.php
+++ b/database/migrations/2018_08_03_102238_add_reserved_to_order_items.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Support\Facades\Schema;
 

--- a/database/migrations/2018_08_27_053717_add_country_code_to_payments.php
+++ b/database/migrations/2018_08_27_053717_add_country_code_to_payments.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2018_09_26_082418_add_soft_delete_to_user_contest_entries.php
+++ b/database/migrations/2018_09_26_082418_add_soft_delete_to_user_contest_entries.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2018_10_12_045503_add_index_to_orders_updated_at.php
+++ b/database/migrations/2018_10_12_045503_add_index_to_orders_updated_at.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2018_10_15_102603_create_comment_votes.php
+++ b/database/migrations/2018_10_15_102603_create_comment_votes.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2018_10_16_012859_add_votes_count_to_comments.php
+++ b/database/migrations/2018_10_16_012859_add_votes_count_to_comments.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2018_11_29_050923_create_rooms.php
+++ b/database/migrations/2018_11_29_050923_create_rooms.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2018_11_29_081727_create_playlist_items.php
+++ b/database/migrations/2018_11_29_081727_create_playlist_items.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2018_12_06_094847_add_ruleset_id_to_multiplayer_playlist_items.php
+++ b/database/migrations/2018_12_06_094847_add_ruleset_id_to_multiplayer_playlist_items.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2018_12_13_072418_create_multiplayer_scores.php
+++ b/database/migrations/2018_12_13_072418_create_multiplayer_scores.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2018_12_13_121903_add_reportable_type_to_user_reports.php
+++ b/database/migrations/2018_12_13_121903_add_reportable_type_to_user_reports.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2018_12_14_100020_add_chat_channel_id_to_multiplayer_room.php
+++ b/database/migrations/2018_12_14_100020_add_chat_channel_id_to_multiplayer_room.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2018_12_21_101924_create_multiplayer_scores_high.php
+++ b/database/migrations/2018_12_21_101924_create_multiplayer_scores_high.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2018_12_21_101935_create_multiplayer_rooms_high.php
+++ b/database/migrations/2018_12_21_101935_create_multiplayer_rooms_high.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2018_12_25_090628_add_participation_index_to_multiplayer_scores.php
+++ b/database/migrations/2018_12_25_090628_add_participation_index_to_multiplayer_scores.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2018_12_26_114102_add_participation_count_to_multiplayer_rooms.php
+++ b/database/migrations/2018_12_26_114102_add_participation_count_to_multiplayer_rooms.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2018_12_26_120639_change_multiplayer_scores_rank_to_enum.php
+++ b/database/migrations/2018_12_26_120639_change_multiplayer_scores_rank_to_enum.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 
 class ChangeMultiplayerScoresRankToEnum extends Migration

--- a/database/migrations/2019_01_17_051612_add_available_until_to_products.php
+++ b/database/migrations/2019_01_17_051612_add_available_until_to_products.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2019_01_17_065444_add_notifications.php
+++ b/database/migrations/2019_01_17_065444_add_notifications.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2019_01_23_031727_add_user_notifications.php
+++ b/database/migrations/2019_01_23_031727_add_user_notifications.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2019_02_15_062607_add_shopify_id_to_products.php
+++ b/database/migrations/2019_02_15_062607_add_shopify_id_to_products.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2019_04_01_202237_add_poll_hide_results_to_topics.php
+++ b/database/migrations/2019_04_01_202237_add_poll_hide_results_to_topics.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2019_04_09_053403_add_allow_topic_covers_to_forums.php
+++ b/database/migrations/2019_04_09_053403_add_allow_topic_covers_to_forums.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2019_04_17_103403_add_discussion_locked_to_beatmapsets.php
+++ b/database/migrations/2019_04_17_103403_add_discussion_locked_to_beatmapsets.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2019_04_23_051152_add_discussion_locked_to_beatmapset_events.php
+++ b/database/migrations/2019_04_23_051152_add_discussion_locked_to_beatmapset_events.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 
 class AddDiscussionLockedToBeatmapsetEvents extends Migration

--- a/database/migrations/2019_05_22_041713_add_hidden_to_user_channels.php
+++ b/database/migrations/2019_05_22_041713_add_hidden_to_user_channels.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Support\Facades\Schema;
 

--- a/database/migrations/2019_05_28_024814_create_follows.php
+++ b/database/migrations/2019_05_28_024814_create_follows.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2019_06_25_083703_add_options_to_user_profile_customizations.php
+++ b/database/migrations/2019_06_25_083703_add_options_to_user_profile_customizations.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2019_07_23_034016_add_score_process_queue.php
+++ b/database/migrations/2019_07_23_034016_add_score_process_queue.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2019_07_25_082550_add_url_to_badges.php
+++ b/database/migrations/2019_07_25_082550_add_url_to_badges.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2019_08_07_070216_add_last_post_at_to_beatmap_discussions.php
+++ b/database/migrations/2019_08_07_070216_add_last_post_at_to_beatmap_discussions.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2019_08_07_103120_add_index_to_beatmap_discussion.php
+++ b/database/migrations/2019_08_07_103120_add_index_to_beatmap_discussion.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2019_08_21_104727_add_index_to_beatmapset_events.php
+++ b/database/migrations/2019_08_21_104727_add_index_to_beatmapset_events.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2019_08_26_053354_add_expires_at_index_to_oauth_tables.php
+++ b/database/migrations/2019_08_26_053354_add_expires_at_index_to_oauth_tables.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2019_08_27_094035_add_client_id_index_to_oauth_access_tokens.php
+++ b/database/migrations/2019_08_27_094035_add_client_id_index_to_oauth_access_tokens.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2019_09_11_135102_add_beatmap_discussion_post_to_report_types.php
+++ b/database/migrations/2019_09_11_135102_add_beatmap_discussion_post_to_report_types.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 
 class AddBeatmapDiscussionPostToReportTypes extends Migration

--- a/database/migrations/2019_09_18_074659_update_beatmapset_discussion_polymorphic_name.php
+++ b/database/migrations/2019_09_18_074659_update_beatmapset_discussion_polymorphic_name.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 
 class UpdateBeatmapsetDiscussionPolymorphicName extends Migration

--- a/database/migrations/2019_10_21_075612_add_pinned_field_to_comments.php
+++ b/database/migrations/2019_10_21_075612_add_pinned_field_to_comments.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2019_10_23_023102_add_hidden_to_beatmapset_packs.php
+++ b/database/migrations/2019_10_23_023102_add_hidden_to_beatmapset_packs.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2019_10_23_100514_create_user_notification_options.php
+++ b/database/migrations/2019_10_23_100514_create_user_notification_options.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2019_11_07_095402_add_parent_id_to_beatmap_discussions.php
+++ b/database/migrations/2019_11_07_095402_add_parent_id_to_beatmap_discussions.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2019_11_14_032004_add_new_index_to_scores_high.php
+++ b/database/migrations/2019_11_14_032004_add_new_index_to_scores_high.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2019_11_27_084154_add_bpm_to_beatmaps.php
+++ b/database/migrations/2019_11_27_084154_add_bpm_to_beatmaps.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2019_12_04_015903_add_extra_columns_to_groups.php
+++ b/database/migrations/2019_12_04_015903_add_extra_columns_to_groups.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2019_12_11_045755_add_show_in_client_to_user_contest_entries.php
+++ b/database/migrations/2019_12_11_045755_add_show_in_client_to_user_contest_entries.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2020_01_17_080543_update_multiplayer_mods.php
+++ b/database/migrations/2020_01_17_080543_update_multiplayer_mods.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 
 class UpdateMultiplayerMods extends Migration

--- a/database/migrations/2020_01_20_031913_json_news_post_page.php
+++ b/database/migrations/2020_01_20_031913_json_news_post_page.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 
 class JsonNewsPostPage extends Migration

--- a/database/migrations/2020_01_23_083342_nullable_groups_display_order.php
+++ b/database/migrations/2020_01_23_083342_nullable_groups_display_order.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2020_02_13_080406_add_country_acronym_to_scores_high.php
+++ b/database/migrations/2020_02_13_080406_add_country_acronym_to_scores_high.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2020_03_09_095216_add_channel_type_index_to_channels.php
+++ b/database/migrations/2020_03_09_095216_add_channel_type_index_to_channels.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2020_03_09_100459_remove_multiplayer_rooms_high_accuracy_precision.php
+++ b/database/migrations/2020_03_09_100459_remove_multiplayer_rooms_high_accuracy_precision.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2020_04_12_101236_add_genre_and_language_edit_to_beatmapset_events.php
+++ b/database/migrations/2020_04_12_101236_add_genre_and_language_edit_to_beatmapset_events.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 
 class AddGenreAndLanguageEditToBeatmapsetEvents extends Migration

--- a/database/migrations/2020_05_15_083037_sync_structure.php
+++ b/database/migrations/2020_05_15_083037_sync_structure.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2020_05_28_072624_add_multiplayer_scores_high_top_scores_index.php
+++ b/database/migrations/2020_05_28_072624_add_multiplayer_scores_high_top_scores_index.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2020_06_09_041029_add_user_stats_mania_4k7k.php
+++ b/database/migrations/2020_06_09_041029_add_user_stats_mania_4k7k.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2020_06_12_112517_add_delivery_to_user_notifications.php
+++ b/database/migrations/2020_06_12_112517_add_delivery_to_user_notifications.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2020_06_12_112518_set_last_mail_notification_id_sent.php
+++ b/database/migrations/2020_06_12_112518_set_last_mail_notification_id_sent.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use App\Models\Count;
 //use App\Models\UserNotification;
 use Illuminate\Database\Migrations\Migration;

--- a/database/migrations/2020_07_08_042634_add_category_to_multiplayer_rooms.php
+++ b/database/migrations/2020_07_08_042634_add_category_to_multiplayer_rooms.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2020_07_10_105258_add_ends_at_index_to_multiplayer_rooms.php
+++ b/database/migrations/2020_07_10_105258_add_ends_at_index_to_multiplayer_rooms.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2020_07_13_055413_add_last_score_id_to_multiplayer_rooms_high.php
+++ b/database/migrations/2020_07_13_055413_add_last_score_id_to_multiplayer_rooms_high.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2020_07_17_021430_add_play_mode_variant_to_tournaments.php
+++ b/database/migrations/2020_07_17_021430_add_play_mode_variant_to_tournaments.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2020_07_22_045416_add_timestamp_index_to_user_account_history.php
+++ b/database/migrations/2020_07_22_045416_add_timestamp_index_to_user_account_history.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2020_07_22_054643_add_user_read_index_to_user_notifications.php
+++ b/database/migrations/2020_07_22_054643_add_user_read_index_to_user_notifications.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2020_08_27_202640_add_nsfw_flag_to_beatmapsets.php
+++ b/database/migrations/2020_08_27_202640_add_nsfw_flag_to_beatmapsets.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2020_09_09_042555_update_comments_index.php
+++ b/database/migrations/2020_09_09_042555_update_comments_index.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2020_09_13_081046_create_user_group_events.php
+++ b/database/migrations/2020_09_13_081046_create_user_group_events.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2020_09_25_092826_create_phpbb_banlist.php
+++ b/database/migrations/2020_09_25_092826_create_phpbb_banlist.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2020_10_01_060127_add_has_playmodes_to_phpbb_groups.php
+++ b/database/migrations/2020_10_01_060127_add_has_playmodes_to_phpbb_groups.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2020_10_01_065459_add_playmodes_to_phpbb_user_group.php
+++ b/database/migrations/2020_10_01_065459_add_playmodes_to_phpbb_user_group.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2020_10_06_010117_add_url_to_ranks.php
+++ b/database/migrations/2020_10_06_010117_add_url_to_ranks.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2020_10_13_064901_add_provider_reference_to_orders.php
+++ b/database/migrations/2020_10_13_064901_add_provider_reference_to_orders.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2020_10_14_030317_add_remove_from_loved_type_to_beatmapset_events.php
+++ b/database/migrations/2020_10_14_030317_add_remove_from_loved_type_to_beatmapset_events.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 
 class AddRemoveFromLovedTypeToBeatmapsetEvents extends Migration

--- a/database/migrations/2020_11_04_144136_add_index_to_user_id_on_comments.php
+++ b/database/migrations/2020_11_04_144136_add_index_to_user_id_on_comments.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2020_11_13_025024_add_no_diff_reduction_to_beatmap_packs.php
+++ b/database/migrations/2020_11_13_025024_add_no_diff_reduction_to_beatmap_packs.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2020_11_19_071006_add_forum_post_to_report_types.php
+++ b/database/migrations/2020_11_19_071006_add_forum_post_to_report_types.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 
 class AddForumPostToReportTypes extends Migration

--- a/database/migrations/2020_11_26_055928_add_modding_and_user_to_follows.php
+++ b/database/migrations/2020_11_26_055928_add_modding_and_user_to_follows.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 
 class AddModdingAndUserToFollows extends Migration

--- a/database/migrations/2020_12_03_075220_add_realtime_to_multiplayer_rooms.php
+++ b/database/migrations/2020_12_03_075220_add_realtime_to_multiplayer_rooms.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 
 class AddRealtimeToMultiplayerRooms extends Migration

--- a/database/migrations/2020_12_09_052337_add_mapping_to_follows.php
+++ b/database/migrations/2020_12_09_052337_add_mapping_to_follows.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 
 class AddMappingToFollows extends Migration

--- a/database/migrations/2021_01_15_092749_add_nsfw_toggle_to_beatmapset_events.php
+++ b/database/migrations/2021_01_15_092749_add_nsfw_toggle_to_beatmapset_events.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 
 class AddNsfwToggleToBeatmapsetEvents extends Migration

--- a/database/migrations/2021_01_25_050834_add_count_last_mail_user_notification_id_sent.php
+++ b/database/migrations/2021_01_25_050834_add_count_last_mail_user_notification_id_sent.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use App\Models\Count;
 use App\Models\UserNotification;
 use Illuminate\Database\Migrations\Migration;

--- a/database/migrations/2021_01_25_092927_create_beatmap_mode_stats.php
+++ b/database/migrations/2021_01_25_092927_create_beatmap_mode_stats.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Support\Facades\Schema;
 

--- a/database/migrations/2021_02_02_073616_add_last_message_id_to_channels.php
+++ b/database/migrations/2021_02_02_073616_add_last_message_id_to_channels.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2021_02_03_120003_add_max_attempts_to_playlist_items.php
+++ b/database/migrations/2021_02_03_120003_add_max_attempts_to_playlist_items.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2021_02_16_090310_add_provider_to_oauth_clients.php
+++ b/database/migrations/2021_02_16_090310_add_provider_to_oauth_clients.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2021_02_17_073637_add-expired-column-to-playlist-items.php
+++ b/database/migrations/2021_02_17_073637_add-expired-column-to-playlist-items.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2021_03_19_065458_add_external_contest_type.php
+++ b/database/migrations/2021_03_19_065458_add_external_contest_type.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 
 class AddExternalContestType extends Migration

--- a/database/migrations/2021_03_24_130818_create_solo_scores.php
+++ b/database/migrations/2021_03_24_130818_create_solo_scores.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2021_04_15_075328_add_thumbnail_url_to_contest_entries.php
+++ b/database/migrations/2021_04_15_075328_add_thumbnail_url_to_contest_entries.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2021_04_16_083901_rename_contest_shape_extra_option.php
+++ b/database/migrations/2021_04_16_083901_rename_contest_shape_extra_option.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use App\Models\Contest;
 use Illuminate\Database\Migrations\Migration;
 

--- a/database/migrations/2021_04_26_075454_add_beatmap_owner_change_to_beatmapset_events.php
+++ b/database/migrations/2021_04_26_075454_add_beatmap_owner_change_to_beatmapset_events.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 
 class AddBeatmapOwnerChangeToBeatmapsetEvents extends Migration

--- a/database/migrations/2021_06_03_115603_create_chat_filters_table.php
+++ b/database/migrations/2021_06_03_115603_create_chat_filters_table.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2021_06_12_145807_add_multi_accounting_report.php
+++ b/database/migrations/2021_06_12_145807_add_multi_accounting_report.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 
 class AddMultiAccountingReport extends Migration

--- a/database/migrations/2021_06_28_084610_create_solo_score_tokens.php
+++ b/database/migrations/2021_06_28_084610_create_solo_score_tokens.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2021_07_01_091316_add_in_room_to_multiplayer_rooms_high.php
+++ b/database/migrations/2021_07_01_091316_add_in_room_to_multiplayer_rooms_high.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2021_07_07_065618_add_password_to_multiplayer_rooms.php
+++ b/database/migrations/2021_07_07_065618_add_password_to_multiplayer_rooms.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2021_07_07_073634_create_beatmapset_nominations.php
+++ b/database/migrations/2021_07_07_073634_create_beatmapset_nominations.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2021_07_19_084446_add_nomination_reset_received_to_beatmapset_events.php
+++ b/database/migrations/2021_07_19_084446_add_nomination_reset_received_to_beatmapset_events.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 
 class AddNominationResetReceivedToBeatmapsetEvents extends Migration

--- a/database/migrations/2021_08_03_090146_add_type_to_multiplayer_rooms.php
+++ b/database/migrations/2021_08_03_090146_add_type_to_multiplayer_rooms.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2021_08_17_194701_add_beatmapset_to_report_types.php
+++ b/database/migrations/2021_08_17_194701_add_beatmapset_to_report_types.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 
 class AddBeatmapsetToReportTypes extends Migration

--- a/database/migrations/2021_08_30_153214_add_track_id_to_beatmapsets.php
+++ b/database/migrations/2021_08_30_153214_add_track_id_to_beatmapsets.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2021_09_15_065842_create_new_score_tables.php
+++ b/database/migrations/2021_09_15_065842_create_new_score_tables.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2021_10_05_064929_create_solo_scores_performance.php
+++ b/database/migrations/2021_10_05_064929_create_solo_scores_performance.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2021_10_14_094706_add_build_id_to_solo_score_tokens.php
+++ b/database/migrations/2021_10_14_094706_add_build_id_to_solo_score_tokens.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2021_11_01_194418_add_post_id_to_phpbb_log.php
+++ b/database/migrations/2021_11_01_194418_add_post_id_to_phpbb_log.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2021_11_17_073841_add_queue_mode_to_multiplayer_rooms.php
+++ b/database/migrations/2021_11_17_073841_add_queue_mode_to_multiplayer_rooms.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2021_11_17_074221_add_owner_id_to_multiplayer_playlist_items.php
+++ b/database/migrations/2021_11_17_074221_add_owner_id_to_multiplayer_playlist_items.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2021_12_03_102651_add_played_at_to_playlist_items.php
+++ b/database/migrations/2021_12_03_102651_add_played_at_to_playlist_items.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2022_01_17_104933_update_default_beatmaps_bpm.php
+++ b/database/migrations/2022_01_17_104933_update_default_beatmaps_bpm.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2022_01_22_110033_create_score_pins.php
+++ b/database/migrations/2022_01_22_110033_create_score_pins.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2022_01_26_210000_add_announce_type_to_channels.php
+++ b/database/migrations/2022_01_26_210000_add_announce_type_to_channels.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 
 class AddAnnounceTypeToChannels extends Migration

--- a/database/migrations/2022_01_28_180000_add_playmode_changes_to_user_group_events.php
+++ b/database/migrations/2022_01_28_180000_add_playmode_changes_to_user_group_events.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 
 class AddPlaymodeChangesToUserGroupEvents extends Migration

--- a/database/migrations/2022_03_18_125356_add_auto_start_duration_to_multiplayer_rooms.php
+++ b/database/migrations/2022_03_18_125356_add_auto_start_duration_to_multiplayer_rooms.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2022_04_12_142434_add_offset_edit_to_beatmapset_events.php
+++ b/database/migrations/2022_04_12_142434_add_offset_edit_to_beatmapset_events.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 
 return new class extends Migration

--- a/database/migrations/2022_04_30_152502_add_spotlight_to_beatmapsets.php
+++ b/database/migrations/2022_04_30_152502_add_spotlight_to_beatmapsets.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2022_05_16_114745_update_beatmapsets_approvedby_id_type.php
+++ b/database/migrations/2022_05_16_114745_update_beatmapsets_approvedby_id_type.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2022_05_23_052743_add_unique_index_to_groups_identifier.php
+++ b/database/migrations/2022_05_23_052743_add_unique_index_to_groups_identifier.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2022_05_23_072546_rename_builds_build_on_release.php
+++ b/database/migrations/2022_05_23_072546_rename_builds_build_on_release.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2022_05_25_081221_add_ruleset_id_to_score_pins.php
+++ b/database/migrations/2022_05_25_081221_add_ruleset_id_to_score_pins.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2022_05_27_094956_add_featured_artist_to_multiplayer_rooms_category.php
+++ b/database/migrations/2022_05_27_094956_add_featured_artist_to_multiplayer_rooms_category.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 
 return new class extends Migration

--- a/database/migrations/2022_06_08_065812_add_comment_locked_to_beatmapsets.php
+++ b/database/migrations/2022_06_08_065812_add_comment_locked_to_beatmapsets.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2022_06_27_073817_create_solo_scores_legacy_id_map.php
+++ b/database/migrations/2022_06_27_073817_create_solo_scores_legacy_id_map.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2022_07_07_070707_add_solo_score_to_score_pins_score_type.php
+++ b/database/migrations/2022_07_07_070707_add_solo_score_to_score_pins_score_type.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 
 return new class extends Migration

--- a/database/migrations/2022_07_08_085310_add_allow_performance_to_osu_builds.php
+++ b/database/migrations/2022_07_08_085310_add_allow_performance_to_osu_builds.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2022_07_19_060203_set_compressed_row_format_on_solo_scores.php
+++ b/database/migrations/2022_07_19_060203_set_compressed_row_format_on_solo_scores.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 
 class SetCompressedRowFormatOnSoloScores extends Migration

--- a/database/migrations/2022_08_04_220851_create_bss_process_queue.php
+++ b/database/migrations/2022_08_04_220851_create_bss_process_queue.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2022_08_08_083336_add_solo_score_to_report_types.php
+++ b/database/migrations/2022_08_08_083336_add_solo_score_to_report_types.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 
 return new class extends Migration

--- a/database/migrations/2022_08_15_074123_index_beatmap_id_on_solo_scores.php
+++ b/database/migrations/2022_08_15_074123_index_beatmap_id_on_solo_scores.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2022_08_15_081810_index_user_ruleset_id_on_solo_scores.php
+++ b/database/migrations/2022_08_15_081810_index_user_ruleset_id_on_solo_scores.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2022_08_16_195413_add_permanent_to_user_account_history.php
+++ b/database/migrations/2022_08_16_195413_add_permanent_to_user_account_history.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2022_08_31_102024_add_auto_skip_to_multiplayer_rooms.php
+++ b/database/migrations/2022_08_31_102024_add_auto_skip_to_multiplayer_rooms.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2022_09_09_011035_upgrade_legacy_scoreids_to_bigint.php
+++ b/database/migrations/2022_09_09_011035_upgrade_legacy_scoreids_to_bigint.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2022_09_09_080211_create_osu_beatmap_performance_blacklist.php
+++ b/database/migrations/2022_09_09_080211_create_osu_beatmap_performance_blacklist.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2022_09_21_052117_create_osu_difficulty_attribs.php
+++ b/database/migrations/2022_09_21_052117_create_osu_difficulty_attribs.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2022_10_18_103120_create_osu_user_performance_rank_highest.php
+++ b/database/migrations/2022_10_18_103120_create_osu_user_performance_rank_highest.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\DB;

--- a/database/migrations/2022_11_12_103015_index_user_id_on_beatmapset_nominations.php
+++ b/database/migrations/2022_11_12_103015_index_user_id_on_beatmapset_nominations.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2023_01_05_022852_require_user_group_events_details_and_type.php
+++ b/database/migrations/2023_01_05_022852_require_user_group_events_details_and_type.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use App\Models\UserGroupEvent;
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;

--- a/database/migrations/2023_03_13_100000_add_tags_edit_to_beatmapset_events.php
+++ b/database/migrations/2023_03_13_100000_add_tags_edit_to_beatmapset_events.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 
 return new class extends Migration

--- a/database/migrations/2023_03_22_000000_add_chat_message_to_report_types.php
+++ b/database/migrations/2023_03_22_000000_add_chat_message_to_report_types.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 
 return new class extends Migration

--- a/database/migrations/2023_11_27_173516_add_video_url_on_artists.php
+++ b/database/migrations/2023_11_27_173516_add_video_url_on_artists.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2024_11_19_130731_create_beatmap_versioning_tables.php
+++ b/database/migrations/2024_11_19_130731_create_beatmap_versioning_tables.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 

--- a/database/migrations/2024_12_03_102822_add_synthetic_pk_to_beatmapset_version_files.php
+++ b/database/migrations/2024_12_03_102822_add_synthetic_pk_to_beatmapset_version_files.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2025_09_04_000000_add_matchmaking_room_type.php
+++ b/database/migrations/2025_09_04_000000_add_matchmaking_room_type.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 
 return new class extends Migration

--- a/database/migrations/2025_09_04_000001_create_matchmaking_user_stats_table.php
+++ b/database/migrations/2025_09_04_000001_create_matchmaking_user_stats_table.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2025_09_04_000002_create_matchmaking_pools_table.php
+++ b/database/migrations/2025_09_04_000002_create_matchmaking_pools_table.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2025_09_04_000003_create_matchmaking_pool_beatmaps_table.php
+++ b/database/migrations/2025_09_04_000003_create_matchmaking_pool_beatmaps_table.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2025_09_04_000004_adjust_matchmaking_tables.php
+++ b/database/migrations/2025_09_04_000004_adjust_matchmaking_tables.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/database/migrations/2025_09_05_000000_remove_matchmaking_pool_beatmaps_pk.php
+++ b/database/migrations/2025_09_05_000000_remove_matchmaking_pool_beatmaps_pk.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 use Illuminate\Database\Migrations\Migration;
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Support\Facades\Schema;

--- a/phpcs.xml
+++ b/phpcs.xml
@@ -78,6 +78,15 @@
     <rule ref="SlevomatCodingStandard.PHP.ShortList"/>
     <rule ref="SlevomatCodingStandard.PHP.UselessParentheses"/>
     <rule ref="SlevomatCodingStandard.PHP.UselessSemicolon"/>
+    <rule ref="SlevomatCodingStandard.TypeHints.DeclareStrictTypes">
+        <include-pattern>database/migrations/*</include-pattern>
+        <properties>
+            <property name="declareOnFirstLine" type="boolean" value="false"/>
+            <property name="linesCountBeforeDeclare" value="1"/>
+            <property name="linesCountAfterDeclare" value="1"/>
+            <property name="spacesCountAroundEqualsSign" value="0"/>
+        </properties>
+    </rule>
     <rule ref="SlevomatCodingStandard.TypeHints.LongTypeHints"/>
     <rule ref="SlevomatCodingStandard.TypeHints.NullableTypeForNullDefaultValue"/>
     <rule ref="SlevomatCodingStandard.TypeHints.ParameterTypeHintSpacing"/>

--- a/stubs/migration.create.stub
+++ b/stubs/migration.create.stub
@@ -1,0 +1,26 @@
+<?php
+
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('{{ table }}', function (Blueprint $table) {
+            $table->id();
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('{{ table }}');
+    }
+};

--- a/stubs/migration.stub
+++ b/stubs/migration.stub
@@ -1,0 +1,23 @@
+<?php
+
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        //
+    }
+
+    public function down(): void
+    {
+        //
+    }
+};

--- a/stubs/migration.update.stub
+++ b/stubs/migration.update.stub
@@ -1,0 +1,27 @@
+<?php
+
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('{{ table }}', function (Blueprint $table) {
+            //
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('{{ table }}', function (Blueprint $table) {
+            //
+        });
+    }
+};


### PR DESCRIPTION
Initially just creating the better defaults but then figured might as well update all the migrations while at it.

<del>Moved it to before licence because that's what the linter supports 🤔</del> Back to the original place. I don't suppose we want to use it blindly.

Alternatively maybe change the licence to docblock comment instead?