### PR TITLE
Update the description under the customization section in supporter perks page

### DIFF
--- a/resources/lang/en/community.php
+++ b/resources/lang/en/community.php
@@ -81,7 +81,7 @@ return [
 
             'customisation' => [
                 'title' => 'Customisation',
-                'description' => "Stand out by uploading a custom cover image or by creating a fully customizable 'me!' section within your user profile.",
+                'description' => "Stand out by uploading a custom cover image, creating a fully customizable 'me!' section, or even change the colour to any of your liking within your user profile.",
             ],
 
             'beatmap_filters' => [


### PR DESCRIPTION
- fixes #12385 

Brought back this commit (https://github.com/ppy/osu-web/commit/686ef4066e12b8f0eab028bdbe16646cb46eaaf6), so now the mentioned page will also mention customizable profile colours. Still not sure about updating the image, so that's why this PR only changes the text, related to it.

Comparison:

|[`master`](https://github.com/ppy/osu-web)|[`this PR`](https://github.com/tadatomix/osu-web/tree/supporter_profile_text)|
|---|---|
|<img width="381" height="242" alt="изображение" src="https://github.com/user-attachments/assets/300751f2-90b5-4038-8382-9dccdeffb0f1" />|<img width="370" height="222" alt="изображение" src="https://github.com/user-attachments/assets/1a38b7d7-ea66-49dd-8af3-f11e64694d2e" />|


