### PR TITLE
Improve team short name generator

### DIFF
--- a/database/factories/TeamFactory.php
+++ b/database/factories/TeamFactory.php
@@ -14,11 +14,21 @@ class TeamFactory extends Factory
 {
     protected $model = Team::class;
 
+    private static function generateShortName(): string
+    {
+        static $chars = [...range('!', '~'), ''];
+
+        return implode(array_map(
+            fn (): string => array_rand_val($chars),
+            array_fill(0, 4, ''),
+        ));
+    }
+
     public function definition(): array
     {
         return [
             'name' => fn () => strtr($this->faker->unique()->userName(), '.', ' '),
-            'short_name' => fn () => substr(strtr($this->faker->unique()->userName(), '.', ' '), 0, 4),
+            'short_name' => static::generateShortName(...),
             'leader_id' => User::factory(),
         ];
     }


### PR DESCRIPTION
Good for at least 5000 unique names. Resolves #12224.

There's a shorter version with `implode($this->faker->randomElements(range('!', '~'), 4))` which doesn't allow repeating character and always has length of 4 but eh 🤷 