### PR TITLE
Wrap long mods list in score detail

### DIFF
--- a/resources/css/bem/play-detail.less
+++ b/resources/css/bem/play-detail.less
@@ -141,7 +141,6 @@
   &__mods {
     display: flex;
     margin-top: 10px;
-    padding-right: 0;
     flex-wrap: wrap;
 
     @media @desktop {
@@ -154,9 +153,10 @@
     }
   }
 
-  &__mods_pp {
+  &__mods-pp {
     display: flex;
     justify-content: space-between;
+    gap: 5px;
 
     @media @desktop {
       display: contents;

--- a/resources/js/profile-page/play-detail.tsx
+++ b/resources/js/profile-page/play-detail.tsx
@@ -111,7 +111,7 @@ export default class PlayDetail extends React.PureComponent<Props, State> {
             </div>
           </div>
 
-          <div className={`${bn}__mods_pp`}>
+          <div className={`${bn}__mods-pp`}>
             <div className={`${bn}__mods`}>
               {score.mods.map((mod) => <Mod key={mod.acronym} mod={mod} />)}
             </div>


### PR DESCRIPTION
fixes #12348

Adds a wrapper than (ab)uses `display: contents` to wrap the mods which keeping the rest of the layout.
The other option was to render another copy of pp in the mods list...