### PR TITLE
Fix placeholder shown in quick search when no results

### DIFF
--- a/resources/js/quick-search/main.tsx
+++ b/resources/js/quick-search/main.tsx
@@ -211,7 +211,7 @@ interface Props {
     let text: string;
 
     if (count === 0) {
-      text = trans(`${keyPrefix}.empty_for._`, { modes: trans(`quick_search.result.no_results.${mode}`) });
+      text = trans(`${keyPrefix}.empty_for._`, { mode: trans(`quick_search.result.no_results.${mode}`) });
     } else {
       const key = `${keyPrefix}.${otherModes.includes(mode) ? 'title' : 'more'}`;
       text = trans(key, { mode: trans(`quick_search.mode.${mode}`) });

--- a/resources/js/quick-search/main.tsx
+++ b/resources/js/quick-search/main.tsx
@@ -211,7 +211,7 @@ interface Props {
     let text: string;
 
     if (count === 0) {
-      text = trans(`${keyPrefix}.empty_for._`, { modes: trans(`quick_search.result.empty_for.${mode}`) });
+      text = trans(`${keyPrefix}.empty_for._`, { modes: trans(`quick_search.result.no_results.${mode}`) });
     } else {
       const key = `${keyPrefix}.${otherModes.includes(mode) ? 'title' : 'more'}`;
       text = trans(key, { mode: trans(`quick_search.mode.${mode}`) });

--- a/resources/lang/en/quick_search.php
+++ b/resources/lang/en/quick_search.php
@@ -19,7 +19,7 @@ return [
         'title' => ':mode Search Results',
 
         'no_results' => [
-            '_' => 'No results for :modes',
+            '_' => 'No results for :mode',
 
             'artist_track' => 'Featured Artist Tracks',
             'beatmapset' => 'Beatmaps',

--- a/resources/lang/en/quick_search.php
+++ b/resources/lang/en/quick_search.php
@@ -18,7 +18,7 @@ return [
         'more' => 'More :mode Search Results',
         'title' => ':mode Search Results',
 
-        'empty_for' => [
+        'no_results' => [
             '_' => 'No results for :modes',
 
             'artist_track' => 'Featured Artist Tracks',


### PR DESCRIPTION
Change the key, otherwise un-updated localisations show the `:modes` placeholder instead. #12395

Noticed while checking #12412