### PR TITLE
Reduce chance of model factory collision

### DIFF
--- a/database/factories/BeatmapsetFileFactory.php
+++ b/database/factories/BeatmapsetFileFactory.php
@@ -28,7 +28,7 @@ class BeatmapsetFileFactory extends Factory
     public function definition(): array
     {
         return [
-            'file_size' => rand(10, 100),
+            'file_size' => rand(10, 100000),
             'sha2_hash' => fn (array $attrs): string => hash(
                 'sha256',
                 static::generateContent($attrs['file_size']),


### PR DESCRIPTION
I tried some fancier ideas (generating actual random bytes) but it just doesn't work quite right without creating the file ahead of time (or storing the data in the model itself but that'd instead mean having test-specific things in the model).

Maybe I'll do it if this pr ends up not being sufficient.