### PR TITLE
Add [right] alignment tag to forum BBCode and fix [centre] for new HTML guidelines

### DIFF
--- a/app/Libraries/BBCodeForDB.php
+++ b/app/Libraries/BBCodeForDB.php
@@ -9,404 +9,404 @@ use App\Models\User;
 
 class BBCodeForDB
 {
-    const EXTRA_ESCAPES = [
-        '[' => '&#91;',
-        ']' => '&#93;',
-        '.' => '&#46;',
-        ':' => '&#58;',
-        "\n" => '&#10;',
-        '@' => '&#64;',
-    ];
-
-    public $text;
-    public $uid;
-
-    // "11111111111111111111111111111"
-    // encoded with: https://www.phpbb.com/support/docs/en/3.0/kb/article/how-to-template-bitfield-and-bbcodes/
-    // number of 1s are arbitrary
-    public $bitfield = '////+A==';
-
-    public function extraEscapes($text)
-    {
-        return strtr($text, static::EXTRA_ESCAPES);
-    }
-
-    public static function extraUnescape(string $text): string
-    {
-        static $mapping;
-        $mapping ??= array_flip(static::EXTRA_ESCAPES);
-
-        return strtr($text, $mapping);
-    }
-
-    public function __construct($text = '')
-    {
-        $this->text = $text;
-        $this->uid = $GLOBALS['cfg']['osu']['bbcode']['uid'];
-    }
-
-    public function parseAudio($text)
-    {
-        preg_match_all('#\[audio\](?<url>.*?)\[/audio\]#', $text, $audio, PREG_SET_ORDER);
-
-        foreach ($audio as $a) {
-            $escapedUrl = $this->extraEscapes($a['url']);
-
-            $audioTag = "[audio:{$this->uid}]{$escapedUrl}[/audio:{$this->uid}]";
-            $text = str_replace($a[0], $audioTag, $text);
-        }
-
-        return $text;
-    }
-
-    /**
-     * Handles:
-     * - Centre (centre).
-     */
-    public function parseBlockSimple($text)
-    {
-    foreach (['centre', 'right'] as $tag) {
-        $text = preg_replace(
-            "#\[{$tag}](.*?)\[/{$tag}\]#s",
-            "[{$tag}:{$this->uid}]\\1[/{$tag}:{$this->uid}]",
-            $text
-        );
-    }
-
-    return $text;
-    }
-
-    public function parseBox($text)
-    {
-        $text = preg_replace('#\[box=((\\\[\[\]]|[^][]|\[(\\\[\[\]]|[^][]|(?R))*\])*?)\]#s', "[box=\\1:{$this->uid}]", $text);
-
-        return strtr($text, [
-            '[/box]' => "[/box:{$this->uid}]",
-            '[spoilerbox]' => "[spoilerbox:{$this->uid}]",
-            '[/spoilerbox]' => "[/spoilerbox:{$this->uid}]",
-        ]);
-    }
-
-    public function parseCode($text)
-    {
-        return preg_replace_callback(
-            "#\[code\](?<prespaces>\n*)(?<code>.+?)(?<postspaces>\n*)\[/code\]#s",
-            function ($m) {
-                $escapedCode = $this->extraEscapes($m['code']);
-
-                return "[code:{$this->uid}]{$m['prespaces']}{$escapedCode}{$m['postspaces']}[/code:{$this->uid}]";
-            },
-            $text
-        );
-    }
-
-    public function parseColour($text)
-    {
-        return preg_replace(
-            ',\[(color=(?:#[[:xdigit:]]{6}|[[:alpha:]]+))\](.*?)\[(/color)\],s',
-            "[\\1:{$this->uid}]\\2[\\3:{$this->uid}]",
-            $text
-        );
-    }
-
-    public function parseEmail($text)
-    {
-        $emailPattern = '[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z-]+';
-
-        $text = preg_replace_callback(
-            "#\[email\]({$emailPattern})\[/email\]#",
-            fn (array $m): string => "[email:{$this->uid}]{$this->extraEscapes($m[1])}[/email:{$this->uid}]",
-            $text
-        );
-        $text = preg_replace_callback(
-            "#\[email=({$emailPattern})\](.+?)\[/email\]#",
-            fn (array $m): string => "[email={$this->extraEscapes($m[1])}:{$this->uid}]{$this->extraEscapes($m[2])}[/email:{$this->uid}]",
-            $text
-        );
-
-        return $text;
-    }
-
-    public function parseImage($text)
-    {
-        preg_match_all('#\[img\](?<url>[^[]+)\[/img\]#', $text, $images, PREG_SET_ORDER);
-
-        foreach ($images as $i) {
-            $escapedUrl = $this->extraEscapes($i['url']);
-
-            $imageTag = "[img:{$this->uid}]{$escapedUrl}[/img:{$this->uid}]";
-            $text = str_replace($i[0], $imageTag, $text);
-        }
-
-        return $text;
-    }
-
-    public function parseImagemap($text)
-    {
-        return preg_replace_callback(
-            '#\[imagemap\](.+?)\[/imagemap\]#s',
-            function ($m) {
-                $escapedMap = $this->extraEscapes($m[1]);
-
-                return "[imagemap]{$escapedMap}[/imagemap]";
-            },
-            $text
-        );
-    }
-
-    /**
-     * Handles:
-     * - Code (c)
-     * - Heading (heading)
-     */
-    public function parseInlineSimple(string $text): string
-    {
-        foreach (['c', 'heading'] as $tag) {
-            $text = preg_replace(
-                "#\[{$tag}](.*?)\[/{$tag}\]#",
-                "[{$tag}:{$this->uid}]\\1[/{$tag}:{$this->uid}]",
-                $text
-            );
-        }
-
-        return $text;
-    }
-
-    public function parseLinks($text)
-    {
-        $spaces = ['(^|\[.+?\]|\s(?:&lt;|[.:([])*)', "((?:\[.+?\]|&gt;|[.:)\]])*(?:$|\s|\n|\r))"];
-        $internalUrl = rtrim(preg_quote($GLOBALS['cfg']['app']['url'], '#'), '/');
-
-        // internal url
-        $text = preg_replace(
-            "#{$spaces[0]}({$internalUrl}/([^\s]+?))(?={$spaces[1]})#",
-            "\\1<!-- m --><a href='\\2' rel='nofollow'>\\3</a><!-- m -->",
-            $text
-        );
-
-        // plain http/https/ftp
-        $text = preg_replace(
-            "#{$spaces[0]}((?:https?|ftp)://[^\s]+?)(?={$spaces[1]})#",
-            "\\1<!-- m --><a href='\\2' rel='nofollow'>\\2</a><!-- m -->",
-            $text
-        );
-
-        // www
-        $text = preg_replace(
-            "#{$spaces[0]}(www\.[^\s]+)(?={$spaces[1]})#",
-            "\\1<!-- w --><a href='http://\\2' rel='nofollow'>\\2</a><!-- w -->",
-            $text
-        );
-
-        // emails
-        $text = preg_replace(
-            "#{$spaces[0]}([A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z-]+)(?={$spaces[1]})#",
-            "\\1<!-- e --><a href='mailto:\\2' rel='nofollow'>\\2</a><!-- e -->",
-            $text
-        );
-
-        return $text;
-    }
-
-    // the implementation here is completely different and incompatible
-    // with phpBB original implementation.
-
-    public function parseList($text)
-    {
-        $patterns = ['/\[(list(?:=.+?)?)\]/', '[/list]'];
-        $counts = [preg_match_all($patterns[0], $text), substr_count($text, $patterns[1])];
-        $limit = min($counts);
-
-        $text = str_replace('[*]', "[*:{$this->uid}]", $text);
-        $text = str_replace('[/*]', '', $text);
-
-        $text = preg_replace($patterns[0], "[\\1:{$this->uid}]", $text, $limit);
-        $text = preg_replace('/'.preg_quote($patterns[1], '/').'/', "[/list:o:{$this->uid}]", $text, $limit);
-
-        return $text;
-    }
-
-    /**
-     * Handles:
-     * - Bold (b)
-     * - Italic (i)
-     * - Strike (strike, s)
-     * - Underline (u)
-     * - Spoiler (spoiler)
-     */
-    public function parseMultilineSimple($text)
-    {
-        foreach (['b', 'i', 'strike', 's', 'u', 'spoiler'] as $tag) {
-            $text = preg_replace(
-                "#\[{$tag}](.*?)\[/{$tag}\]#s",
-                "[{$tag}:{$this->uid}]\\1[/{$tag}:{$this->uid}]",
-                $text
-            );
-        }
-
-        return $text;
-    }
-
-    public function parseNotice($text)
-    {
-        return preg_replace(
-            "#\[(notice)\](.*?)\[/\\1\]#s",
-            "[\\1:{$this->uid}]\\2[/\\1:{$this->uid}]",
-            $text
-        );
-    }
-
-    public function parseProfile($text)
-    {
-        preg_match_all('#\[profile(?:=(?<id>[0-9]+))?\](?<name>.+?)\[/profile\]#', $text, $tags);
-
-        $count = count($tags[0]);
-
-        if ($count > 0) {
-            $users = User
-                ::whereIn('user_id', $tags['id'])
-                ->orWhereIn('username', $tags['name'])
-                ->orWhereIn('username_clean', $tags['name'])
-                ->get();
-
-            $usersBy = [];
-
-            foreach ($users as $user) {
-                foreach (['user_id', 'username', 'username_clean'] as $key) {
-                    $usersBy[$key][mb_strtolower($user->$key)] = $user;
-                }
-            }
-
-            for ($i = 0; $i < $count; $i++) {
-                $tag = presence($tags[0][$i]);
-                $name = $tags['name'][$i];
-                $nameNormalized = mb_strtolower($name);
-                $id = presence($tags['id'][$i]);
-
-                $user = $usersBy['user_id'][$id] ?? $usersBy['username'][$nameNormalized] ?? $usersBy['username_clean'][$nameNormalized] ?? null;
-
-                if ($user === null || !$user->hasProfileVisible()) {
-                    $idText = '';
-                } else {
-                    $idText = "={$user->getKey()}";
-                    $name = $user->username;
-                }
-
-                $name = $this->extraEscapes($name);
-
-                $text = str_replace($tag, "[profile{$idText}:{$this->uid}]{$name}[/profile:{$this->uid}]", $text);
-            }
-        }
-
-        return $text;
-    }
-
-    // this is quite different and much more dumb than the one in phpbb
-
-    public function parseQuote($text)
-    {
-        $patterns = ['/\[(quote(?:=&quot;.+?&quot;)?)\]/', '[/quote]'];
-        $counts = [preg_match_all($patterns[0], $text), substr_count($text, $patterns[1])];
-        $limit = min($counts);
-
-        $text = preg_replace($patterns[0], "[\\1:{$this->uid}]", $text, $limit);
-        $text = preg_replace('/'.preg_quote($patterns[1], '/').'/', "[/quote:{$this->uid}]", $text, $limit);
-
-        return $text;
-    }
-
-    public function parseSize($text)
-    {
-        return preg_replace(
-            '#\[(size=(?:\d+))\](.*?)\[(/size)\]#s',
-            "[\\1:{$this->uid}]\\2[\\3:{$this->uid}]",
-            $text
-        );
-    }
-
-    public function parseSmiley($text)
-    {
-        $replacer = app('smilies')->replacer();
-
-        if (count($replacer['patterns']) > 0) {
-            // Make sure the delimiter # is added in front and at the end of every element within $match
-            $text = trim(preg_replace($replacer['patterns'], $replacer['replacements'], $text));
-        }
-
-        return $text;
-    }
-
-    public function parseUrl($text)
-    {
-        $urlPattern = '(?:https?|ftp)://.+?';
-
-        $text = preg_replace_callback(
-            "#\[url\]({$urlPattern})\[/url\]#",
-            function ($m) {
-                $url = $this->extraEscapes($m[1]);
-
-                return "[url:{$this->uid}]{$url}[/url:{$this->uid}]";
-            },
-            $text
-        );
-        $text = preg_replace_callback(
-            "#\[url=({$urlPattern})\](.+?)\[/url\]#",
-            function ($m) {
-                $url = $this->extraEscapes($m[1]);
-
-                return "[url={$url}:{$this->uid}]{$m[2]}[/url:{$this->uid}]";
-            },
-            $text
-        );
-
-        return $text;
-    }
-
-    public function parseYoutube($text)
-    {
-        return preg_replace_callback(
-            '#\[youtube\](?:https?://(?:youtu\.be/|(?:m\.|www\.|)youtube\.com/(?:embed/|shorts/|watch\?v=))|)(.+?)\[/youtube\]#',
-            function ($m) {
-                $videoId = preg_replace('/\?.*/', '', $this->extraEscapes($m[1]));
-
-                return "[youtube:{$this->uid}]{$videoId}[/youtube:{$this->uid}]";
-            },
-            $text
-        );
-    }
-
-    public function generate()
-    {
-        $text = htmlentities($this->text, ENT_QUOTES, 'UTF-8', true);
-
-        $text = $this->unifyNewline($text);
-        $text = $this->parseImagemap($text);
-        $text = $this->parseCode($text);
-        $text = $this->parseNotice($text);
-        $text = $this->parseBox($text);
-        $text = $this->parseQuote($text);
-        $text = $this->parseList($text);
-
-        $text = $this->parseBlockSimple($text);
-        $text = $this->parseProfile($text);
-        $text = $this->parseImage($text);
-        $text = $this->parseMultilineSimple($text);
-        $text = $this->parseInlineSimple($text);
-        $text = $this->parseAudio($text);
-        $text = $this->parseEmail($text);
-        $text = $this->parseUrl($text);
-        $text = $this->parseSize($text);
-        $text = $this->parseColour($text);
-        $text = $this->parseYoutube($text);
-
-        $text = $this->parseSmiley($text);
-        $text = $this->parseLinks($text);
-
-        return $text;
-    }
-
-    public function unifyNewline($text)
-    {
-        return str_replace(["\r\n", "\r"], ["\n", "\n"], $text);
-    }
+	const EXTRA_ESCAPES = [
+		'[' => '&#91;',
+		']' => '&#93;',
+		'.' => '&#46;',
+		':' => '&#58;',
+		"\n" => '&#10;',
+		'@' => '&#64;',
+	];
+
+	public $text;
+	public $uid;
+
+	// "11111111111111111111111111111"
+	// encoded with: https://www.phpbb.com/support/docs/en/3.0/kb/article/how-to-template-bitfield-and-bbcodes/
+	// number of 1s are arbitrary
+	public $bitfield = '////+A==';
+
+	public function extraEscapes($text)
+	{
+		return strtr($text, static::EXTRA_ESCAPES);
+	}
+
+	public static function extraUnescape(string $text): string
+	{
+		static $mapping;
+		$mapping ??= array_flip(static::EXTRA_ESCAPES);
+
+		return strtr($text, $mapping);
+	}
+
+	public function __construct($text = '')
+	{
+		$this->text = $text;
+		$this->uid = $GLOBALS['cfg']['osu']['bbcode']['uid'];
+	}
+
+	public function parseAudio($text)
+	{
+		preg_match_all('#\[audio\](?<url>.*?)\[/audio\]#', $text, $audio, PREG_SET_ORDER);
+
+		foreach ($audio as $a) {
+			$escapedUrl = $this->extraEscapes($a['url']);
+
+			$audioTag = "[audio:{$this->uid}]{$escapedUrl}[/audio:{$this->uid}]";
+			$text = str_replace($a[0], $audioTag, $text);
+		}
+
+		return $text;
+	}
+
+	/**
+	 * Handles:
+	 * - Centre (centre).
+	 */
+	public function parseBlockSimple($text)
+	{
+		foreach (['centre', 'right'] as $tag) {
+			$text = preg_replace(
+				"#\[{$tag}](.*?)\[/{$tag}\]#s",
+				"[{$tag}:{$this->uid}]\\1[/{$tag}:{$this->uid}]",
+				$text
+			);
+		}
+
+		return $text;
+	}
+
+	public function parseBox($text)
+	{
+		$text = preg_replace('#\[box=((\\\[\[\]]|[^][]|\[(\\\[\[\]]|[^][]|(?R))*\])*?)\]#s', "[box=\\1:{$this->uid}]", $text);
+
+		return strtr($text, [
+			'[/box]' => "[/box:{$this->uid}]",
+			'[spoilerbox]' => "[spoilerbox:{$this->uid}]",
+			'[/spoilerbox]' => "[/spoilerbox:{$this->uid}]",
+		]);
+	}
+
+	public function parseCode($text)
+	{
+		return preg_replace_callback(
+			"#\[code\](?<prespaces>\n*)(?<code>.+?)(?<postspaces>\n*)\[/code\]#s",
+			function ($m) {
+				$escapedCode = $this->extraEscapes($m['code']);
+
+				return "[code:{$this->uid}]{$m['prespaces']}{$escapedCode}{$m['postspaces']}[/code:{$this->uid}]";
+			},
+			$text
+		);
+	}
+
+	public function parseColour($text)
+	{
+		return preg_replace(
+			',\[(color=(?:#[[:xdigit:]]{6}|[[:alpha:]]+))\](.*?)\[(/color)\],s',
+			"[\\1:{$this->uid}]\\2[\\3:{$this->uid}]",
+			$text
+		);
+	}
+
+	public function parseEmail($text)
+	{
+		$emailPattern = '[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z-]+';
+
+		$text = preg_replace_callback(
+			"#\[email\]({$emailPattern})\[/email\]#",
+			fn (array $m): string => "[email:{$this->uid}]{$this->extraEscapes($m[1])}[/email:{$this->uid}]",
+			$text
+		);
+		$text = preg_replace_callback(
+			"#\[email=({$emailPattern})\](.+?)\[/email\]#",
+			fn (array $m): string => "[email={$this->extraEscapes($m[1])}:{$this->uid}]{$this->extraEscapes($m[2])}[/email:{$this->uid}]",
+			$text
+		);
+
+		return $text;
+	}
+
+	public function parseImage($text)
+	{
+		preg_match_all('#\[img\](?<url>[^[]+)\[/img\]#', $text, $images, PREG_SET_ORDER);
+
+		foreach ($images as $i) {
+			$escapedUrl = $this->extraEscapes($i['url']);
+
+			$imageTag = "[img:{$this->uid}]{$escapedUrl}[/img:{$this->uid}]";
+			$text = str_replace($i[0], $imageTag, $text);
+		}
+
+		return $text;
+	}
+
+	public function parseImagemap($text)
+	{
+		return preg_replace_callback(
+			'#\[imagemap\](.+?)\[/imagemap\]#s',
+			function ($m) {
+				$escapedMap = $this->extraEscapes($m[1]);
+
+				return "[imagemap]{$escapedMap}[/imagemap]";
+			},
+			$text
+		);
+	}
+
+	/**
+	 * Handles:
+	 * - Code (c)
+	 * - Heading (heading)
+	 */
+	public function parseInlineSimple(string $text): string
+	{
+		foreach (['c', 'heading'] as $tag) {
+			$text = preg_replace(
+				"#\[{$tag}](.*?)\[/{$tag}\]#",
+				"[{$tag}:{$this->uid}]\\1[/{$tag}:{$this->uid}]",
+				$text
+			);
+		}
+
+		return $text;
+	}
+
+	public function parseLinks($text)
+	{
+		$spaces = ['(^|\[.+?\]|\s(?:&lt;|[.:([])*)', "((?:\[.+?\]|&gt;|[.:)\]])*(?:$|\s|\n|\r))"];
+		$internalUrl = rtrim(preg_quote($GLOBALS['cfg']['app']['url'], '#'), '/');
+
+		// internal url
+		$text = preg_replace(
+			"#{$spaces[0]}({$internalUrl}/([^\s]+?))(?={$spaces[1]})#",
+			"\\1<!-- m --><a href='\\2' rel='nofollow'>\\3</a><!-- m -->",
+			$text
+		);
+
+		// plain http/https/ftp
+		$text = preg_replace(
+			"#{$spaces[0]}((?:https?|ftp)://[^\s]+?)(?={$spaces[1]})#",
+			"\\1<!-- m --><a href='\\2' rel='nofollow'>\\2</a><!-- m -->",
+			$text
+		);
+
+		// www
+		$text = preg_replace(
+			"#{$spaces[0]}(www\.[^\s]+)(?={$spaces[1]})#",
+			"\\1<!-- w --><a href='http://\\2' rel='nofollow'>\\2</a><!-- w -->",
+			$text
+		);
+
+		// emails
+		$text = preg_replace(
+			"#{$spaces[0]}([A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Za-z-]+)(?={$spaces[1]})#",
+			"\\1<!-- e --><a href='mailto:\\2' rel='nofollow'>\\2</a><!-- e -->",
+			$text
+		);
+
+		return $text;
+	}
+
+	// the implementation here is completely different and incompatible
+	// with phpBB original implementation.
+
+	public function parseList($text)
+	{
+		$patterns = ['/\[(list(?:=.+?)?)\]/', '[/list]'];
+		$counts = [preg_match_all($patterns[0], $text), substr_count($text, $patterns[1])];
+		$limit = min($counts);
+
+		$text = str_replace('[*]', "[*:{$this->uid}]", $text);
+		$text = str_replace('[/*]', '', $text);
+
+		$text = preg_replace($patterns[0], "[\\1:{$this->uid}]", $text, $limit);
+		$text = preg_replace('/'.preg_quote($patterns[1], '/').'/', "[/list:o:{$this->uid}]", $text, $limit);
+
+		return $text;
+	}
+
+	/**
+	 * Handles:
+	 * - Bold (b)
+	 * - Italic (i)
+	 * - Strike (strike, s)
+	 * - Underline (u)
+	 * - Spoiler (spoiler)
+	 */
+	public function parseMultilineSimple($text)
+	{
+		foreach (['b', 'i', 'strike', 's', 'u', 'spoiler'] as $tag) {
+			$text = preg_replace(
+				"#\[{$tag}](.*?)\[/{$tag}\]#s",
+				"[{$tag}:{$this->uid}]\\1[/{$tag}:{$this->uid}]",
+				$text
+			);
+		}
+
+		return $text;
+	}
+
+	public function parseNotice($text)
+	{
+		return preg_replace(
+			"#\[(notice)\](.*?)\[/\\1\]#s",
+			"[\\1:{$this->uid}]\\2[/\\1:{$this->uid}]",
+			$text
+		);
+	}
+
+	public function parseProfile($text)
+	{
+		preg_match_all('#\[profile(?:=(?<id>[0-9]+))?\](?<name>.+?)\[/profile\]#', $text, $tags);
+
+		$count = count($tags[0]);
+
+		if ($count > 0) {
+			$users = User
+				::whereIn('user_id', $tags['id'])
+				->orWhereIn('username', $tags['name'])
+				->orWhereIn('username_clean', $tags['name'])
+				->get();
+
+			$usersBy = [];
+
+			foreach ($users as $user) {
+				foreach (['user_id', 'username', 'username_clean'] as $key) {
+					$usersBy[$key][mb_strtolower($user->$key)] = $user;
+				}
+			}
+
+			for ($i = 0; $i < $count; $i++) {
+				$tag = presence($tags[0][$i]);
+				$name = $tags['name'][$i];
+				$nameNormalized = mb_strtolower($name);
+				$id = presence($tags['id'][$i]);
+
+				$user = $usersBy['user_id'][$id] ?? $usersBy['username'][$nameNormalized] ?? $usersBy['username_clean'][$nameNormalized] ?? null;
+
+				if ($user === null || !$user->hasProfileVisible()) {
+					$idText = '';
+				} else {
+					$idText = "={$user->getKey()}";
+					$name = $user->username;
+				}
+
+				$name = $this->extraEscapes($name);
+
+				$text = str_replace($tag, "[profile{$idText}:{$this->uid}]{$name}[/profile:{$this->uid}]", $text);
+			}
+		}
+
+		return $text;
+	}
+
+	// this is quite different and much more dumb than the one in phpbb
+
+	public function parseQuote($text)
+	{
+		$patterns = ['/\[(quote(?:=&quot;.+?&quot;)?)\]/', '[/quote]'];
+		$counts = [preg_match_all($patterns[0], $text), substr_count($text, $patterns[1])];
+		$limit = min($counts);
+
+		$text = preg_replace($patterns[0], "[\\1:{$this->uid}]", $text, $limit);
+		$text = preg_replace('/'.preg_quote($patterns[1], '/').'/', "[/quote:{$this->uid}]", $text, $limit);
+
+		return $text;
+	}
+
+	public function parseSize($text)
+	{
+		return preg_replace(
+			'#\[(size=(?:\d+))\](.*?)\[(/size)\]#s',
+			"[\\1:{$this->uid}]\\2[\\3:{$this->uid}]",
+			$text
+		);
+	}
+
+	public function parseSmiley($text)
+	{
+		$replacer = app('smilies')->replacer();
+
+		if (count($replacer['patterns']) > 0) {
+			// Make sure the delimiter # is added in front and at the end of every element within $match
+			$text = trim(preg_replace($replacer['patterns'], $replacer['replacements'], $text));
+		}
+
+		return $text;
+	}
+
+	public function parseUrl($text)
+	{
+		$urlPattern = '(?:https?|ftp)://.+?';
+
+		$text = preg_replace_callback(
+			"#\[url\]({$urlPattern})\[/url\]#",
+			function ($m) {
+				$url = $this->extraEscapes($m[1]);
+
+				return "[url:{$this->uid}]{$url}[/url:{$this->uid}]";
+			},
+			$text
+		);
+		$text = preg_replace_callback(
+			"#\[url=({$urlPattern})\](.+?)\[/url\]#",
+			function ($m) {
+				$url = $this->extraEscapes($m[1]);
+
+				return "[url={$url}:{$this->uid}]{$m[2]}[/url:{$this->uid}]";
+			},
+			$text
+		);
+
+		return $text;
+	}
+
+	public function parseYoutube($text)
+	{
+		return preg_replace_callback(
+			'#\[youtube\](?:https?://(?:youtu\.be/|(?:m\.|www\.|)youtube\.com/(?:embed/|shorts/|watch\?v=))|)(.+?)\[/youtube\]#',
+			function ($m) {
+				$videoId = preg_replace('/\?.*/', '', $this->extraEscapes($m[1]));
+
+				return "[youtube:{$this->uid}]{$videoId}[/youtube:{$this->uid}]";
+			},
+			$text
+		);
+	}
+
+	public function generate()
+	{
+		$text = htmlentities($this->text, ENT_QUOTES, 'UTF-8', true);
+
+		$text = $this->unifyNewline($text);
+		$text = $this->parseImagemap($text);
+		$text = $this->parseCode($text);
+		$text = $this->parseNotice($text);
+		$text = $this->parseBox($text);
+		$text = $this->parseQuote($text);
+		$text = $this->parseList($text);
+
+		$text = $this->parseBlockSimple($text);
+		$text = $this->parseProfile($text);
+		$text = $this->parseImage($text);
+		$text = $this->parseMultilineSimple($text);
+		$text = $this->parseInlineSimple($text);
+		$text = $this->parseAudio($text);
+		$text = $this->parseEmail($text);
+		$text = $this->parseUrl($text);
+		$text = $this->parseSize($text);
+		$text = $this->parseColour($text);
+		$text = $this->parseYoutube($text);
+
+		$text = $this->parseSmiley($text);
+		$text = $this->parseLinks($text);
+
+		return $text;
+	}
+
+	public function unifyNewline($text)
+	{
+		return str_replace(["\r\n", "\r"], ["\n", "\n"], $text);
+	}
 }

--- a/app/Libraries/BBCodeForDB.php
+++ b/app/Libraries/BBCodeForDB.php
@@ -65,15 +65,15 @@ class BBCodeForDB
      */
     public function parseBlockSimple($text)
     {
-        foreach (['centre'] as $tag) {
-            $text = preg_replace(
-                "#\[{$tag}](.*?)\[/{$tag}\]#s",
-                "[{$tag}:{$this->uid}]\\1[/{$tag}:{$this->uid}]",
-                $text
-            );
-        }
+    foreach (['centre', 'right'] as $tag) {
+        $text = preg_replace(
+            "#\[{$tag}](.*?)\[/{$tag}\]#s",
+            "[{$tag}:{$this->uid}]\\1[/{$tag}:{$this->uid}]",
+            $text
+        );
+    }
 
-        return $text;
+    return $text;
     }
 
     public function parseBox($text)

--- a/app/Libraries/BBCodeFromDB.php
+++ b/app/Libraries/BBCodeFromDB.php
@@ -85,7 +85,7 @@ class BBCodeFromDB
 
     public function parseCentre($text)
     {
-        $text = str_replace("[centre:{$this->uid}]", "<div style='text-align:center;'>", $text);
+        $text = str_replace("[centre:{$this->uid}]", "<div class='bbcode--centre'>", $text);
         $text = str_replace("[/centre:{$this->uid}]", '</div>', $text);
 
         return $text;
@@ -93,7 +93,7 @@ class BBCodeFromDB
     
     public function parseRight($text)
     {
-        $text = str_replace("[right:{$this->uid}]", "<div style='text-align:right;'>", $text);
+        $text = str_replace("[right:{$this->uid}]", "<div class='bbcode--right'>", $text);
         $text = str_replace("[/right:{$this->uid}]", '</div>', $text);
 
     return $text;

--- a/app/Libraries/BBCodeFromDB.php
+++ b/app/Libraries/BBCodeFromDB.php
@@ -13,462 +13,462 @@ namespace App\Libraries;
 */
 class BBCodeFromDB
 {
-    public $text;
-    public $uid;
-    public $refId;
-    public $withGallery;
-
-    private array $options;
-
-    public function __construct($text, $uid = '', $options = [])
-    {
-        $defaultOptions = [
-            'withGallery' => false,
-            'ignoreLineHeight' => false,
-            'extraClasses' => '',
-            'modifiers' => [],
-        ];
-
-        $this->text = $text;
-        $this->uid = presence($uid) ?? $GLOBALS['cfg']['osu']['bbcode']['uid'];
-        $this->options = array_merge($defaultOptions, $options);
-
-        if ($this->options['withGallery']) {
-            $this->refId = rand();
-        }
-    }
-
-    public function parseAudio($text)
-    {
-        preg_match_all("#\[audio:{$this->uid}\](?<url>[^[]+)\[/audio:{$this->uid}\]#", $text, $matches, PREG_SET_ORDER);
-
-        foreach ($matches as $match) {
-            $proxiedSrc = proxy_media(html_entity_decode_better($match['url']));
-            $tag = '<audio controls="controls" preload="none" src="'.$proxiedSrc.'"></audio>';
-
-            $text = str_replace($match[0], $tag, $text);
-        }
-
-        return $text;
-    }
-
-    public function parseBold($text)
-    {
-        $text = str_replace("[b:{$this->uid}]", '<strong>', $text);
-        $text = str_replace("[/b:{$this->uid}]", '</strong>', $text);
-
-        return $text;
-    }
-
-    public function parseBox($text)
-    {
-        $text = preg_replace("#\[box=((\\\[\[\]]|[^][]|\[(\\\[\[\]]|[^][]|(?R))*\])*?):{$this->uid}\]\n*#s", $this->parseBoxHelperPrefix('\\1'), $text);
-        $text = preg_replace("#\n*\[/box:{$this->uid}]\n?#s", $this->parseBoxHelperSuffix(), $text);
-
-        $text = preg_replace("#\[spoilerbox:{$this->uid}\]\n*#s", $this->parseBoxHelperPrefix(), $text);
-        $text = preg_replace("#\n*\[/spoilerbox:{$this->uid}]\n?#s", $this->parseBoxHelperSuffix(), $text);
-
-        return $text;
-    }
-
-    public function parseBoxHelperPrefix($linkText = null)
-    {
-        $linkText = presence($linkText) ?? 'SPOILER';
-
-        return "<div class='js-spoilerbox bbcode-spoilerbox'><a class='js-spoilerbox__link bbcode-spoilerbox__link' href='#'><span class='bbcode-spoilerbox__link-icon'></span>{$linkText}</a><div class='js-spoilerbox__body bbcode-spoilerbox__body'>";
-    }
-
-    public function parseBoxHelperSuffix()
-    {
-        return '</div></div>';
-    }
-
-    public function parseCentre($text)
-    {
-        $text = str_replace("[centre:{$this->uid}]", "<div class='bbcode--centre'>", $text);
-        $text = str_replace("[/centre:{$this->uid}]", '</div>', $text);
-
-        return $text;
-    }
-    
-    public function parseRight($text)
-    {
-        $text = str_replace("[right:{$this->uid}]", "<div class='bbcode--right'>", $text);
-        $text = str_replace("[/right:{$this->uid}]", '</div>', $text);
-
-    return $text;
-    }
-
-    public function parseCode($text)
-    {
-        return preg_replace(
-            "#\[code:{$this->uid}\]\n*(.*?)\n*\[/code:{$this->uid}\]\n?#s",
-            '<pre>\\1</pre>',
-            $text
-        );
-    }
-
-    public function parseColour($text)
-    {
-        $text = preg_replace("#\[color=([^:]+):{$this->uid}\]#", "<span style='color:\\1'>", $text);
-        $text = str_replace("[/color:{$this->uid}]", '</span>', $text);
-
-        return $text;
-    }
-
-    public function parseEmail($text)
-    {
-        $text = preg_replace(
-            "#\[email:{$this->uid}\](.+?)\[/email:{$this->uid}\]#",
-            "<a rel='nofollow' href='mailto:\\1'>\\1</a>",
-            $text
-        );
-        $text = preg_replace("#\[email=([^\]]+):{$this->uid}\]#", "<a rel='nofollow' href='mailto:\\1'>", $text);
-        $text = str_replace("[/email:{$this->uid}]", '</a>', $text);
-
-        return $text;
-    }
-
-    public function parseHeading($text)
-    {
-        $text = str_replace("[heading:{$this->uid}]", '<h2>', $text);
-        $text = preg_replace("#\[/heading:{$this->uid}\]\n?#", '</h2>', $text);
-
-        return $text;
-    }
-
-    public function parseImagemap($text)
-    {
-        return preg_replace_callback(
-            '#(\[imagemap\].+?\[/imagemap\]\n?)#',
-            function ($m) {
-                $unescaped = html_entity_decode_better(BBCodeForDB::extraUnescape($m[1]));
-                $parsed = preg_replace_callback(
-                    '#\[imagemap\]\n(?<imageUrl>https?://.+)\n(?<links>(?:(?:[0-9.]+ ){4}(?:\#|https?://[^\s]+|mailto:[^\s]+)(?: .*)?\n)+)\[/imagemap\]\n?#',
-                    function ($map) {
-                        $links = array_map(
-                            fn ($rawLink) => explode(' ', $rawLink, 6),
-                            explode("\n", $map['links']),
-                        );
-                        array_pop($links); // remove the empty string from last newline
-
-                        $linksHtml = implode('', array_map(
-                            fn ($link) => tag($link[4] === '#' ? 'span' : 'a', [
-                                'class' => 'imagemap__link',
-                                'href' => $link[4],
-                                'style' => implode(';', [
-                                    "left: {$link[0]}%",
-                                    "top: {$link[1]}%",
-                                    "width: {$link[2]}%",
-                                    "height: {$link[3]}%",
-                                ]),
-                                'title' => $link[5] ?? '',
-                            ]),
-                            $links,
-                        ));
-
-                        $imageUrl = proxy_media($map['imageUrl']);
-                        $imageAttributes = [
-                            'class' => 'imagemap__image',
-                            'loading' => 'lazy',
-                            'src' => $imageUrl,
-                        ];
-                        $imageSize = fast_imagesize($imageUrl);
-                        if ($imageSize !== null) {
-                            $imageAttributes['width'] = $imageSize[0];
-                            $imageAttributes['height'] = $imageSize[1];
-                        }
-                        $imageHtml = tag('img', $imageAttributes);
-
-                        return tag('div', ['class' => 'imagemap'], $imageHtml.$linksHtml);
-                    },
-                    $unescaped,
-                );
-
-                return $parsed === $unescaped ? $m[1] : $parsed;
-            },
-            $text,
-        );
-    }
-
-    public function parseItalic($text)
-    {
-        $text = str_replace("[i:{$this->uid}]", '<em>', $text);
-        $text = str_replace("[/i:{$this->uid}]", '</em>', $text);
-
-        return $text;
-    }
-
-    public function parseImage($text)
-    {
-        preg_match_all("#\[img:{$this->uid}\](?<url>[^[]+)\[/img:{$this->uid}\]#", $text, $images, PREG_SET_ORDER);
-
-        $index = 0;
-        $replacements = [];
-
-        foreach ($images as $i) {
-            $proxiedSrc = proxy_media(html_entity_decode_better($i['url']));
-
-            $attributes = [
-                'alt' => '',
-                'src' => $proxiedSrc,
-                'loading' => 'lazy',
-            ];
-
-            $imageSize = fast_imagesize($proxiedSrc);
-            if ($imageSize !== null && $imageSize[1] !== 0) {
-                $aspectRatio = round($imageSize[0] / $imageSize[1], 4);
-
-                $attributes['style'] = "aspect-ratio: {$aspectRatio}; width: {$imageSize[0]}px;";
-
-                if ($this->options['withGallery']) {
-                    $attributes = [
-                        ...$attributes,
-                        'class' => 'js-gallery',
-                        'data-width' => $imageSize[0],
-                        'data-height' => $imageSize[1],
-                        'data-index' => $index,
-                        'data-gallery-id' => $this->refId,
-                        'data-src' => $proxiedSrc,
-                    ];
-                }
-
-                $index += 1;
-            }
-
-            $replacements[$i[0]] = tag('img', $attributes);
-        }
-
-        return strtr($text, $replacements);
-    }
-
-    public function parseInlineCode(string $text): string
-    {
-        return strtr($text, [
-            "[c:{$this->uid}]" => '<code>',
-            "[/c:{$this->uid}]" => '</code>',
-        ]);
-    }
-
-    public function parseList($text)
-    {
-        // basic list.
-        $text = preg_replace("#\[list=[^]]+:{$this->uid}\]\s*\[\*:{$this->uid}\]#", '<ol><li>', $text);
-        $text = preg_replace("#\[list:{$this->uid}\]\s*\[\*:{$this->uid}\]#", '<ol class="unordered"><li>', $text);
-
-        // convert list items.
-        $text = preg_replace("#\[/\*(:m)?:{$this->uid}\]\n?\n?#", '</li>', $text);
-        $text = preg_replace("#\s*\[\*:{$this->uid}\]#", '<li>', $text);
-
-        // close list tags.
-        $text = preg_replace("#\s*\[/list:(o|u):{$this->uid}\]\n?\n?#", '</ol>', $text);
-
-        // list with "title", with it being just a list without style.
-        $text = preg_replace("#\[list=[^]]+:{$this->uid}\](.+?)(<li>|</ol>)#s", '<ul class="bbcode__list-title"><li>$1</li></ul><ol>$2', $text);
-        $text = preg_replace("#\[list:{$this->uid}\](.+?)(<li>|</ol>)#s", '<ul class="bbcode__list-title"><li>$1</li></ul><ol class="unordered">$2', $text);
-
-        return $text;
-    }
-
-    public function parseNotice($text)
-    {
-        return preg_replace(
-            "#\[notice:{$this->uid}\]\n*(.*?)\n*\[/notice:{$this->uid}\]\n?#s",
-            "<div class='well'>\\1</div>",
-            $text
-        );
-    }
-
-    public function parseProfile($text)
-    {
-        preg_match_all("#\[profile(?:=(?<id>[0-9]+))?:{$this->uid}\](?<name>.*?)\[/profile:{$this->uid}\]#", $text, $users, PREG_SET_ORDER);
-
-        foreach ($users as $user) {
-            $username = html_entity_decode_better($user['name']);
-            $userId = presence($user['id']) ?? "@{$username}";
-            $userLink = link_to_user($userId, $username, null);
-            $text = str_replace($user[0], $userLink, $text);
-        }
-
-        return $text;
-    }
-
-    public function parseQuote($text)
-    {
-        $text = preg_replace("#\[quote=&quot;([^:]+)&quot;:{$this->uid}\]\s*#", '<blockquote><h4>\\1 wrote:</h4>', $text);
-        $text = preg_replace("#\[quote:{$this->uid}\]\s*#", '<blockquote>', $text);
-        $text = preg_replace("#\s*\[/quote:{$this->uid}\]\n?\n?#", '</blockquote>', $text);
-
-        return $text;
-    }
-
-    // stolen from: www/forum/includes/functions.php:2845
-    public function parseSmilies($text)
-    {
-        return preg_replace('#<!\-\- s(.*?) \-\-><img src="\{SMILIES_PATH\}\/(.*?) \/><!\-\- s\1 \-\->#', '<img class="smiley" src="'.osu_url('smilies').'/\2 />', $text);
-    }
-
-    public function parseStrike($text)
-    {
-        $text = str_replace("[s:{$this->uid}]", '<del>', $text);
-        $text = str_replace("[/s:{$this->uid}]", '</del>', $text);
-        $text = str_replace("[strike:{$this->uid}]", '<del>', $text);
-        $text = str_replace("[/strike:{$this->uid}]", '</del>', $text);
-
-        return $text;
-    }
-
-    public function parseUnderline($text)
-    {
-        $text = str_replace("[u:{$this->uid}]", '<u>', $text);
-        $text = str_replace("[/u:{$this->uid}]", '</u>', $text);
-
-        return $text;
-    }
-
-    public function parseSpoiler($text)
-    {
-        $text = str_replace("[spoiler:{$this->uid}]", "<span class='spoiler'>", $text);
-        $text = str_replace("[/spoiler:{$this->uid}]", '</span>', $text);
-
-        return $text;
-    }
-
-    public function parseSize($text)
-    {
-        $text = preg_replace_callback(
-            "#\[size=(\d+):{$this->uid}\]#",
-            fn ($m) => '<span style="font-size:'.\Number::clamp((int) $m[1], 30, 200).'%;">',
-            $text,
-        );
-        $text = strtr($text, ["[/size:{$this->uid}]" => '</span>']);
-
-        return $text;
-    }
-
-    public function parseUrl($text)
-    {
-        $text = preg_replace("#\[url:{$this->uid}\](.+?)\[/url:{$this->uid}\]#", "<a rel='nofollow' href='\\1'>\\1</a>", $text);
-        $text = preg_replace("#\[url=([^\]]+):{$this->uid}\]#", "<a rel='nofollow' href='\\1'>", $text);
-        $text = str_replace("[/url:{$this->uid}]", '</a>', $text);
-
-        return $text;
-    }
-
-    public function parseYoutube(string $text): string
-    {
-        return strtr($text, [
-            "[youtube:{$this->uid}]" => "<iframe class='u-embed-wide u-embed-wide--bbcode' src='https://www.youtube.com/embed/",
-            "[/youtube:{$this->uid}]" => "?rel=0' allowfullscreen></iframe>",
-        ]);
-    }
-
-    public function toHTML()
-    {
-        $text = $this->text;
-
-        // block
-        $text = $this->parseImagemap($text);
-        $text = $this->parseBox($text);
-        $text = $this->parseCode($text);
-        $text = $this->parseList($text);
-        $text = $this->parseNotice($text);
-        $text = $this->parseQuote($text);
-        $text = $this->parseHeading($text);
-
-        // inline
-        $text = $this->parseAudio($text);
-        $text = $this->parseBold($text);
-        $text = $this->parseCentre($text);
-        $text = $this->parseRight($text);
-        $text = $this->parseInlineCode($text);
-        $text = $this->parseColour($text);
-        $text = $this->parseEmail($text);
-        $text = $this->parseImage($text);
-        $text = $this->parseItalic($text);
-        $text = $this->parseSize($text);
-        $text = $this->parseSmilies($text);
-        $text = $this->parseSpoiler($text);
-        $text = $this->parseStrike($text);
-        $text = $this->parseUnderline($text);
-        $text = $this->parseUrl($text);
-        $text = $this->parseYoutube($text);
-        $text = $this->parseProfile($text);
-
-        $text = str_replace("\n", '<br />', $text);
-        $text = app('clean-html')->purify($text);
-
-        $className = class_with_modifiers('bbcode', $this->options['modifiers']);
-
-        if (present($this->options['extraClasses'])) {
-            $className .= " {$this->options['extraClasses']}";
-        }
-
-        if ($this->options['ignoreLineHeight']) {
-            $className .= ' bbcode--normal-line-height';
-        }
-
-        return "<div class='{$className}'>{$text}</div>";
-    }
-
-    public function toEditor()
-    {
-        $text = $this->text;
-
-        // remove list item closing tags
-        $text = str_replace("[/*:m:{$this->uid}]", '', $text);
-
-        // remove list item type marker at closing tags
-        $text = preg_replace("#\[/list:[ou]:{$this->uid}\]#", '[/list]', $text);
-
-        // strip uids
-        $text = str_replace(":{$this->uid}]", ']', $text);
-
-        // strip url
-        $text = preg_replace('#<!-- ([mw]) --><a.*?href=[\'"]([^"\']+)[\'"].*?>.*?</a><!-- \\1 -->#', '\\2', $text);
-        $text = preg_replace('#<!-- e --><a.*?href=[\'"]mailto:([^"\']+)[\'"].*?>.*?</a><!-- e -->#', '\\1', $text);
-
-        // strip relative url
-        $text = preg_replace('#<!-- l --><a.*?href="(.*?)".*?>.*?</a><!-- l -->#', '\\1', $text);
-
-        // strip smilies
-        $text = preg_replace('#<!-- (s(.*?)) -->.*?<!-- \\1 -->#', '\\2', $text);
-
-        return html_entity_decode_better($text);
-    }
-
-    public static function removeBBCodeTags($text)
-    {
-        // Don't care if too many characters are stripped;
-        // just don't want tags to go into index because they mess up the highlighting.
-
-        static $pattern = '#\[/?(\*|\*:m|audio|b|box|color|spoilerbox|centre|right|code|email|heading|i|img|list|list:o|list:u|notice|profile|quote|s|strike|u|spoiler|size|url|youtube)(=.*?(?=:))?(:[a-zA-Z0-9]{1,5})?\]#';
-
-        return preg_replace($pattern, '', $text);
-    }
-
-    public static function removeBlockQuotes($text)
-    {
-        static $pattern = '#(?<start>\[quote(=.*?(?=:))?(:[a-zA-Z0-9]{1,5})?\])|(?<end>\[/quote(:[a-zA-Z0-9]{1,5})?\])#';
-
-        $matchCount = preg_match_all($pattern, $text);
-        $quotePositions = [];
-
-        for ($_ = 0; $_ < $matchCount; $_++) {
-            $offset = $quotePositions[count($quotePositions) - 1][1] ?? 0;
-            preg_match($pattern, $text, $match, PREG_OFFSET_CAPTURE, $offset);
-
-            if (present($match['start'][0])) {
-                $quotePositions[] = [
-                    $match['start'][1],
-                    $match['start'][1] + strlen($match['start'][0]),
-                ];
-            } elseif (!empty($quotePositions)) {
-                $quoteEnd = $match['end'][1] + strlen($match['end'][0]);
-                $text = substr($text, 0, array_pop($quotePositions)[0]).substr($text, $quoteEnd);
-            }
-        }
-
-        return $text;
-    }
+	public $text;
+	public $uid;
+	public $refId;
+	public $withGallery;
+
+	private array $options;
+
+	public function __construct($text, $uid = '', $options = [])
+	{
+		$defaultOptions = [
+			'withGallery' => false,
+			'ignoreLineHeight' => false,
+			'extraClasses' => '',
+			'modifiers' => [],
+		];
+
+		$this->text = $text;
+		$this->uid = presence($uid) ?? $GLOBALS['cfg']['osu']['bbcode']['uid'];
+		$this->options = array_merge($defaultOptions, $options);
+
+		if ($this->options['withGallery']) {
+			$this->refId = rand();
+		}
+	}
+
+	public function parseAudio($text)
+	{
+		preg_match_all("#\[audio:{$this->uid}\](?<url>[^[]+)\[/audio:{$this->uid}\]#", $text, $matches, PREG_SET_ORDER);
+
+		foreach ($matches as $match) {
+			$proxiedSrc = proxy_media(html_entity_decode_better($match['url']));
+			$tag = '<audio controls="controls" preload="none" src="'.$proxiedSrc.'"></audio>';
+
+			$text = str_replace($match[0], $tag, $text);
+		}
+
+		return $text;
+	}
+
+	public function parseBold($text)
+	{
+		$text = str_replace("[b:{$this->uid}]", '<strong>', $text);
+		$text = str_replace("[/b:{$this->uid}]", '</strong>', $text);
+
+		return $text;
+	}
+
+	public function parseBox($text)
+	{
+		$text = preg_replace("#\[box=((\\\[\[\]]|[^][]|\[(\\\[\[\]]|[^][]|(?R))*\])*?):{$this->uid}\]\n*#s", $this->parseBoxHelperPrefix('\\1'), $text);
+		$text = preg_replace("#\n*\[/box:{$this->uid}]\n?#s", $this->parseBoxHelperSuffix(), $text);
+
+		$text = preg_replace("#\[spoilerbox:{$this->uid}\]\n*#s", $this->parseBoxHelperPrefix(), $text);
+		$text = preg_replace("#\n*\[/spoilerbox:{$this->uid}]\n?#s", $this->parseBoxHelperSuffix(), $text);
+
+		return $text;
+	}
+
+	public function parseBoxHelperPrefix($linkText = null)
+	{
+		$linkText = presence($linkText) ?? 'SPOILER';
+
+		return "<div class='js-spoilerbox bbcode-spoilerbox'><a class='js-spoilerbox__link bbcode-spoilerbox__link' href='#'><span class='bbcode-spoilerbox__link-icon'></span>{$linkText}</a><div class='js-spoilerbox__body bbcode-spoilerbox__body'>";
+	}
+
+	public function parseBoxHelperSuffix()
+	{
+		return '</div></div>';
+	}
+
+	public function parseCentre($text)
+	{
+		$text = str_replace("[centre:{$this->uid}]", "<div class='bbcode--centre'>", $text);
+		$text = str_replace("[/centre:{$this->uid}]", '</div>', $text);
+
+		return $text;
+	}
+
+	public function parseRight($text)
+	{
+		$text = str_replace("[right:{$this->uid}]", "<div class='bbcode--right'>", $text);
+		$text = str_replace("[/right:{$this->uid}]", '</div>', $text);
+
+	return $text;
+	}
+
+	public function parseCode($text)
+	{
+		return preg_replace(
+			"#\[code:{$this->uid}\]\n*(.*?)\n*\[/code:{$this->uid}\]\n?#s",
+			'<pre>\\1</pre>',
+			$text
+		);
+	}
+
+	public function parseColour($text)
+	{
+		$text = preg_replace("#\[color=([^:]+):{$this->uid}\]#", "<span style='color:\\1'>", $text);
+		$text = str_replace("[/color:{$this->uid}]", '</span>', $text);
+
+		return $text;
+	}
+
+	public function parseEmail($text)
+	{
+		$text = preg_replace(
+			"#\[email:{$this->uid}\](.+?)\[/email:{$this->uid}\]#",
+			"<a rel='nofollow' href='mailto:\\1'>\\1</a>",
+			$text
+		);
+		$text = preg_replace("#\[email=([^\]]+):{$this->uid}\]#", "<a rel='nofollow' href='mailto:\\1'>", $text);
+		$text = str_replace("[/email:{$this->uid}]", '</a>', $text);
+
+		return $text;
+	}
+
+	public function parseHeading($text)
+	{
+		$text = str_replace("[heading:{$this->uid}]", '<h2>', $text);
+		$text = preg_replace("#\[/heading:{$this->uid}\]\n?#", '</h2>', $text);
+
+		return $text;
+	}
+
+	public function parseImagemap($text)
+	{
+		return preg_replace_callback(
+			'#(\[imagemap\].+?\[/imagemap\]\n?)#',
+			function ($m) {
+				$unescaped = html_entity_decode_better(BBCodeForDB::extraUnescape($m[1]));
+				$parsed = preg_replace_callback(
+					'#\[imagemap\]\n(?<imageUrl>https?://.+)\n(?<links>(?:(?:[0-9.]+ ){4}(?:\#|https?://[^\s]+|mailto:[^\s]+)(?: .*)?\n)+)\[/imagemap\]\n?#',
+					function ($map) {
+						$links = array_map(
+							fn ($rawLink) => explode(' ', $rawLink, 6),
+							explode("\n", $map['links']),
+						);
+						array_pop($links); // remove the empty string from last newline
+
+						$linksHtml = implode('', array_map(
+							fn ($link) => tag($link[4] === '#' ? 'span' : 'a', [
+								'class' => 'imagemap__link',
+								'href' => $link[4],
+								'style' => implode(';', [
+									"left: {$link[0]}%",
+									"top: {$link[1]}%",
+									"width: {$link[2]}%",
+									"height: {$link[3]}%",
+								]),
+								'title' => $link[5] ?? '',
+							]),
+							$links,
+						));
+
+						$imageUrl = proxy_media($map['imageUrl']);
+						$imageAttributes = [
+							'class' => 'imagemap__image',
+							'loading' => 'lazy',
+							'src' => $imageUrl,
+						];
+						$imageSize = fast_imagesize($imageUrl);
+						if ($imageSize !== null) {
+							$imageAttributes['width'] = $imageSize[0];
+							$imageAttributes['height'] = $imageSize[1];
+						}
+						$imageHtml = tag('img', $imageAttributes);
+
+						return tag('div', ['class' => 'imagemap'], $imageHtml.$linksHtml);
+					},
+					$unescaped,
+				);
+
+				return $parsed === $unescaped ? $m[1] : $parsed;
+			},
+			$text,
+		);
+	}
+
+	public function parseItalic($text)
+	{
+		$text = str_replace("[i:{$this->uid}]", '<em>', $text);
+		$text = str_replace("[/i:{$this->uid}]", '</em>', $text);
+
+		return $text;
+	}
+
+	public function parseImage($text)
+	{
+		preg_match_all("#\[img:{$this->uid}\](?<url>[^[]+)\[/img:{$this->uid}\]#", $text, $images, PREG_SET_ORDER);
+
+		$index = 0;
+		$replacements = [];
+
+		foreach ($images as $i) {
+			$proxiedSrc = proxy_media(html_entity_decode_better($i['url']));
+
+			$attributes = [
+				'alt' => '',
+				'src' => $proxiedSrc,
+				'loading' => 'lazy',
+			];
+
+			$imageSize = fast_imagesize($proxiedSrc);
+			if ($imageSize !== null && $imageSize[1] !== 0) {
+				$aspectRatio = round($imageSize[0] / $imageSize[1], 4);
+
+				$attributes['style'] = "aspect-ratio: {$aspectRatio}; width: {$imageSize[0]}px;";
+
+				if ($this->options['withGallery']) {
+					$attributes = [
+						...$attributes,
+						'class' => 'js-gallery',
+						'data-width' => $imageSize[0],
+						'data-height' => $imageSize[1],
+						'data-index' => $index,
+						'data-gallery-id' => $this->refId,
+						'data-src' => $proxiedSrc,
+					];
+				}
+
+				$index += 1;
+			}
+
+			$replacements[$i[0]] = tag('img', $attributes);
+		}
+
+		return strtr($text, $replacements);
+	}
+
+	public function parseInlineCode(string $text): string
+	{
+		return strtr($text, [
+			"[c:{$this->uid}]" => '<code>',
+			"[/c:{$this->uid}]" => '</code>',
+		]);
+	}
+
+	public function parseList($text)
+	{
+		// basic list.
+		$text = preg_replace("#\[list=[^]]+:{$this->uid}\]\s*\[\*:{$this->uid}\]#", '<ol><li>', $text);
+		$text = preg_replace("#\[list:{$this->uid}\]\s*\[\*:{$this->uid}\]#", '<ol class="unordered"><li>', $text);
+
+		// convert list items.
+		$text = preg_replace("#\[/\*(:m)?:{$this->uid}\]\n?\n?#", '</li>', $text);
+		$text = preg_replace("#\s*\[\*:{$this->uid}\]#", '<li>', $text);
+
+		// close list tags.
+		$text = preg_replace("#\s*\[/list:(o|u):{$this->uid}\]\n?\n?#", '</ol>', $text);
+
+		// list with "title", with it being just a list without style.
+		$text = preg_replace("#\[list=[^]]+:{$this->uid}\](.+?)(<li>|</ol>)#s", '<ul class="bbcode__list-title"><li>$1</li></ul><ol>$2', $text);
+		$text = preg_replace("#\[list:{$this->uid}\](.+?)(<li>|</ol>)#s", '<ul class="bbcode__list-title"><li>$1</li></ul><ol class="unordered">$2', $text);
+
+		return $text;
+	}
+
+	public function parseNotice($text)
+	{
+		return preg_replace(
+			"#\[notice:{$this->uid}\]\n*(.*?)\n*\[/notice:{$this->uid}\]\n?#s",
+			"<div class='well'>\\1</div>",
+			$text
+		);
+	}
+
+	public function parseProfile($text)
+	{
+		preg_match_all("#\[profile(?:=(?<id>[0-9]+))?:{$this->uid}\](?<name>.*?)\[/profile:{$this->uid}\]#", $text, $users, PREG_SET_ORDER);
+
+		foreach ($users as $user) {
+			$username = html_entity_decode_better($user['name']);
+			$userId = presence($user['id']) ?? "@{$username}";
+			$userLink = link_to_user($userId, $username, null);
+			$text = str_replace($user[0], $userLink, $text);
+		}
+
+		return $text;
+	}
+
+	public function parseQuote($text)
+	{
+		$text = preg_replace("#\[quote=&quot;([^:]+)&quot;:{$this->uid}\]\s*#", '<blockquote><h4>\\1 wrote:</h4>', $text);
+		$text = preg_replace("#\[quote:{$this->uid}\]\s*#", '<blockquote>', $text);
+		$text = preg_replace("#\s*\[/quote:{$this->uid}\]\n?\n?#", '</blockquote>', $text);
+
+		return $text;
+	}
+
+	// stolen from: www/forum/includes/functions.php:2845
+	public function parseSmilies($text)
+	{
+		return preg_replace('#<!\-\- s(.*?) \-\-><img src="\{SMILIES_PATH\}\/(.*?) \/><!\-\- s\1 \-\->#', '<img class="smiley" src="'.osu_url('smilies').'/\2 />', $text);
+	}
+
+	public function parseStrike($text)
+	{
+		$text = str_replace("[s:{$this->uid}]", '<del>', $text);
+		$text = str_replace("[/s:{$this->uid}]", '</del>', $text);
+		$text = str_replace("[strike:{$this->uid}]", '<del>', $text);
+		$text = str_replace("[/strike:{$this->uid}]", '</del>', $text);
+
+		return $text;
+	}
+
+	public function parseUnderline($text)
+	{
+		$text = str_replace("[u:{$this->uid}]", '<u>', $text);
+		$text = str_replace("[/u:{$this->uid}]", '</u>', $text);
+
+		return $text;
+	}
+
+	public function parseSpoiler($text)
+	{
+		$text = str_replace("[spoiler:{$this->uid}]", "<span class='spoiler'>", $text);
+		$text = str_replace("[/spoiler:{$this->uid}]", '</span>', $text);
+
+		return $text;
+	}
+
+	public function parseSize($text)
+	{
+		$text = preg_replace_callback(
+			"#\[size=(\d+):{$this->uid}\]#",
+			fn ($m) => '<span style="font-size:'.\Number::clamp((int) $m[1], 30, 200).'%;">',
+			$text,
+		);
+		$text = strtr($text, ["[/size:{$this->uid}]" => '</span>']);
+
+		return $text;
+	}
+
+	public function parseUrl($text)
+	{
+		$text = preg_replace("#\[url:{$this->uid}\](.+?)\[/url:{$this->uid}\]#", "<a rel='nofollow' href='\\1'>\\1</a>", $text);
+		$text = preg_replace("#\[url=([^\]]+):{$this->uid}\]#", "<a rel='nofollow' href='\\1'>", $text);
+		$text = str_replace("[/url:{$this->uid}]", '</a>', $text);
+
+		return $text;
+	}
+
+	public function parseYoutube(string $text): string
+	{
+		return strtr($text, [
+			"[youtube:{$this->uid}]" => "<iframe class='u-embed-wide u-embed-wide--bbcode' src='https://www.youtube.com/embed/",
+			"[/youtube:{$this->uid}]" => "?rel=0' allowfullscreen></iframe>",
+		]);
+	}
+
+	public function toHTML()
+	{
+		$text = $this->text;
+
+		// block
+		$text = $this->parseImagemap($text);
+		$text = $this->parseBox($text);
+		$text = $this->parseCode($text);
+		$text = $this->parseList($text);
+		$text = $this->parseNotice($text);
+		$text = $this->parseQuote($text);
+		$text = $this->parseHeading($text);
+
+		// inline
+		$text = $this->parseAudio($text);
+		$text = $this->parseBold($text);
+		$text = $this->parseCentre($text);
+		$text = $this->parseRight($text);
+		$text = $this->parseInlineCode($text);
+		$text = $this->parseColour($text);
+		$text = $this->parseEmail($text);
+		$text = $this->parseImage($text);
+		$text = $this->parseItalic($text);
+		$text = $this->parseSize($text);
+		$text = $this->parseSmilies($text);
+		$text = $this->parseSpoiler($text);
+		$text = $this->parseStrike($text);
+		$text = $this->parseUnderline($text);
+		$text = $this->parseUrl($text);
+		$text = $this->parseYoutube($text);
+		$text = $this->parseProfile($text);
+
+		$text = str_replace("\n", '<br />', $text);
+		$text = app('clean-html')->purify($text);
+
+		$className = class_with_modifiers('bbcode', $this->options['modifiers']);
+
+		if (present($this->options['extraClasses'])) {
+			$className .= " {$this->options['extraClasses']}";
+		}
+
+		if ($this->options['ignoreLineHeight']) {
+			$className .= ' bbcode--normal-line-height';
+		}
+
+		return "<div class='{$className}'>{$text}</div>";
+	}
+
+	public function toEditor()
+	{
+		$text = $this->text;
+
+		// remove list item closing tags
+		$text = str_replace("[/*:m:{$this->uid}]", '', $text);
+
+		// remove list item type marker at closing tags
+		$text = preg_replace("#\[/list:[ou]:{$this->uid}\]#", '[/list]', $text);
+
+		// strip uids
+		$text = str_replace(":{$this->uid}]", ']', $text);
+
+		// strip url
+		$text = preg_replace('#<!-- ([mw]) --><a.*?href=[\'"]([^"\']+)[\'"].*?>.*?</a><!-- \\1 -->#', '\\2', $text);
+		$text = preg_replace('#<!-- e --><a.*?href=[\'"]mailto:([^"\']+)[\'"].*?>.*?</a><!-- e -->#', '\\1', $text);
+
+		// strip relative url
+		$text = preg_replace('#<!-- l --><a.*?href="(.*?)".*?>.*?</a><!-- l -->#', '\\1', $text);
+
+		// strip smilies
+		$text = preg_replace('#<!-- (s(.*?)) -->.*?<!-- \\1 -->#', '\\2', $text);
+
+		return html_entity_decode_better($text);
+	}
+
+	public static function removeBBCodeTags($text)
+	{
+		// Don't care if too many characters are stripped;
+		// just don't want tags to go into index because they mess up the highlighting.
+
+		static $pattern = '#\[/?(\*|\*:m|audio|b|box|color|spoilerbox|centre|right|code|email|heading|i|img|list|list:o|list:u|notice|profile|quote|s|strike|u|spoiler|size|url|youtube)(=.*?(?=:))?(:[a-zA-Z0-9]{1,5})?\]#';
+
+		return preg_replace($pattern, '', $text);
+	}
+
+	public static function removeBlockQuotes($text)
+	{
+		static $pattern = '#(?<start>\[quote(=.*?(?=:))?(:[a-zA-Z0-9]{1,5})?\])|(?<end>\[/quote(:[a-zA-Z0-9]{1,5})?\])#';
+
+		$matchCount = preg_match_all($pattern, $text);
+		$quotePositions = [];
+
+		for ($_ = 0; $_ < $matchCount; $_++) {
+			$offset = $quotePositions[count($quotePositions) - 1][1] ?? 0;
+			preg_match($pattern, $text, $match, PREG_OFFSET_CAPTURE, $offset);
+
+			if (present($match['start'][0])) {
+				$quotePositions[] = [
+					$match['start'][1],
+					$match['start'][1] + strlen($match['start'][0]),
+				];
+			} elseif (!empty($quotePositions)) {
+				$quoteEnd = $match['end'][1] + strlen($match['end'][0]);
+				$text = substr($text, 0, array_pop($quotePositions)[0]).substr($text, $quoteEnd);
+			}
+		}
+
+		return $text;
+	}
 }

--- a/app/Libraries/BBCodeFromDB.php
+++ b/app/Libraries/BBCodeFromDB.php
@@ -85,10 +85,18 @@ class BBCodeFromDB
 
     public function parseCentre($text)
     {
-        $text = str_replace("[centre:{$this->uid}]", '<center>', $text);
-        $text = str_replace("[/centre:{$this->uid}]", '</center>', $text);
+        $text = str_replace("[centre:{$this->uid}]", '<div style='text-align:center;'>', $text);
+        $text = str_replace("[/centre:{$this->uid}]", '</div>', $text);
 
         return $text;
+    }
+    
+    public function parseRight($text)
+    {
+        $text = str_replace("[right:{$this->uid}]", "<div style='text-align:right;'>", $text);
+        $text = str_replace("[/right:{$this->uid}]", '</div>', $text);
+
+    return $text;
     }
 
     public function parseCode($text)
@@ -372,6 +380,7 @@ class BBCodeFromDB
         $text = $this->parseAudio($text);
         $text = $this->parseBold($text);
         $text = $this->parseCentre($text);
+        $text = $this->parseRight($text);
         $text = $this->parseInlineCode($text);
         $text = $this->parseColour($text);
         $text = $this->parseEmail($text);
@@ -433,7 +442,7 @@ class BBCodeFromDB
         // Don't care if too many characters are stripped;
         // just don't want tags to go into index because they mess up the highlighting.
 
-        static $pattern = '#\[/?(\*|\*:m|audio|b|box|color|spoilerbox|centre|code|email|heading|i|img|list|list:o|list:u|notice|profile|quote|s|strike|u|spoiler|size|url|youtube)(=.*?(?=:))?(:[a-zA-Z0-9]{1,5})?\]#';
+        static $pattern = '#\[/?(\*|\*:m|audio|b|box|color|spoilerbox|centre|right|code|email|heading|i|img|list|list:o|list:u|notice|profile|quote|s|strike|u|spoiler|size|url|youtube)(=.*?(?=:))?(:[a-zA-Z0-9]{1,5})?\]#';
 
         return preg_replace($pattern, '', $text);
     }

--- a/app/Libraries/BBCodeFromDB.php
+++ b/app/Libraries/BBCodeFromDB.php
@@ -85,7 +85,7 @@ class BBCodeFromDB
 
 	public function parseCentre($text)
 	{
-		$text = str_replace("[centre:{$this->uid}]", "<div class='bbcode--centre'>", $text);
+		$text = str_replace("[centre:{$this->uid}]", "<div data-align='center'>", $text);
 		$text = str_replace("[/centre:{$this->uid}]", '</div>', $text);
 
 		return $text;
@@ -93,7 +93,7 @@ class BBCodeFromDB
 
 	public function parseRight($text)
 	{
-		$text = str_replace("[right:{$this->uid}]", "<div class='bbcode--right'>", $text);
+		$text = str_replace("[right:{$this->uid}]", "<div data-align='right'>", $text);
 		$text = str_replace("[/right:{$this->uid}]", '</div>', $text);
 
 	return $text;

--- a/app/Libraries/BBCodeFromDB.php
+++ b/app/Libraries/BBCodeFromDB.php
@@ -85,7 +85,7 @@ class BBCodeFromDB
 
     public function parseCentre($text)
     {
-        $text = str_replace("[centre:{$this->uid}]", '<div style='text-align:center;'>', $text);
+        $text = str_replace("[centre:{$this->uid}]", "<div style='text-align:center;'>", $text);
         $text = str_replace("[/centre:{$this->uid}]", '</div>', $text);
 
         return $text;

--- a/resources/css/bbcode.less
+++ b/resources/css/bbcode.less
@@ -20,6 +20,41 @@
     font-style: normal;
     font-weight: bold;
   }
+// centre, right blocks
+  &--centre {
+    text-align: center;
+  }
+
+  &--right {
+    text-align: right;
+  }
+
+  // same as below
+  &--centre img,
+  &--centre iframe,
+  &--centre .imagemap,
+  &--centre .js-spoilerbox,
+  &--centre .bbcode-spoilerbox {
+    display: block;
+    margin-left: auto;
+    margin-right: auto;
+  }
+
+  // this seems unnecessary , but is a good precaution
+  &--right img,
+  &--right iframe,
+  &--right .imagemap,
+  &--right .js-spoilerbox,
+  &--right .bbcode-spoilerbox {
+    display: block;
+    margin-left: auto;
+    margin-right: 0;
+  }
+  &--centre .imagemap,
+  &--right .imagemap {
+    width: fit-content;
+    max-width: 100%;
+  }
 
   // heading tag
   h2 {

--- a/resources/css/bbcode.less
+++ b/resources/css/bbcode.less
@@ -20,40 +20,41 @@
     font-style: normal;
     font-weight: bold;
   }
-// centre, right blocks
-  &--centre {
+
+  &[data-align="center"] {
     text-align: center;
+
+    img,
+    iframe,
+    audio,
+    video,
+    .imagemap,
+    .js-spoilerbox,
+    .bbcode-spoilerbox {
+      display: block;
+      margin-left: auto;
+      margin-right: auto;
+      max-width: 100%;
+      width: fit-content;
+    }
   }
 
-  &--right {
+  &[data-align="right"] {
     text-align: right;
-  }
 
-  // same as below
-  &--centre img,
-  &--centre iframe,
-  &--centre .imagemap,
-  &--centre .js-spoilerbox,
-  &--centre .bbcode-spoilerbox {
-    display: block;
-    margin-left: auto;
-    margin-right: auto;
-  }
-
-  // this seems unnecessary , but is a good precaution
-  &--right img,
-  &--right iframe,
-  &--right .imagemap,
-  &--right .js-spoilerbox,
-  &--right .bbcode-spoilerbox {
-    display: block;
-    margin-left: auto;
-    margin-right: 0;
-  }
-  &--centre .imagemap,
-  &--right .imagemap {
-    width: fit-content;
-    max-width: 100%;
+    img,
+    iframe,
+    audio,
+    video,
+    .imagemap,
+    .js-spoilerbox,
+    .bbcode-spoilerbox {
+      display: block;
+      margin-left: auto;
+      margin-right: 0;
+      max-width: 100%;
+      width: fit-content;
+    }
   }
 
   // heading tag
@@ -108,7 +109,10 @@
     }
   }
 
-  img {
+  img,
+  iframe,
+  audio,
+  video {
     max-width: 100%;
   }
 


### PR DESCRIPTION
Needs to be tested, but should fix #12356

https://osu.ppy.sh/community/forums/topics/2117241?n=1

This also adresses the [centre] to fit new HTML guidelines: 
From Mozilla Developer:
> Deprecated: This feature is no longer recommended. Though some browsers might still support it, it may have already been removed from the relevant web standards, may be in the process of being dropped, or may only be kept for compatibility purposes. Avoid using it, and update existing code if possible; see the compatibility table at the bottom of this page to guide your decision. Be aware that this feature may cease to work at any time.