### PR TITLE
Add documentation to /matches active param

### DIFF
--- a/app/Http/Controllers/LegacyMatchesController.php
+++ b/app/Http/Controllers/LegacyMatchesController.php
@@ -36,10 +36,12 @@ class LegacyMatchesController extends Controller
      * matches       | [Match](#match)[]             | |
      * params.limit  | integer                       | |
      * params.sort   | string                        | |
+     * params.active | boolean                       | |
      *
      * @usesCursor
      * @queryParam limit integer Maximum number of matches (50 default, 1 minimum, 50 maximum). No-example
      * @queryParam sort string `id_desc` for newest first; `id_asc` for oldest first. Defaults to `id_desc`. No-example
+     * @queryParam active boolean `true` for active matches only; `false` for inactive matches only. Defaults to not specified, returning both. No-example
      * @response {
      *     "matches": [
      *         {
@@ -52,7 +54,8 @@ class LegacyMatchesController extends Controller
      *     ],
      *     "params": {
      *         "limit": 50,
-     *         "sort": "id_desc"
+     *         "sort": "id_desc",
+     *         "active": null
      *     },
      *     "cursor": {
      *         "match_id": 114428685


### PR DESCRIPTION
Added documentation on the active parameter for the /matches endpoint to cover changes in #12418 .

Incorporates nanaya's comment on "while passing string null works, it's not the correct value for the parameter. It should be either blank or not specified".  Line 44 is exceeding120 chars phpcs psr-2 standard but I hope that is ok. Thank you.