### PR TITLE
Add length limit to team description field

### DIFF
--- a/app/Models/Team.php
+++ b/app/Models/Team.php
@@ -26,6 +26,7 @@ class Team extends Model implements AfterCommit, Indexable, Traits\ReportableInt
     const FLAG_MAX_DIMENSIONS = [512, 256];
 
     const MAX_FIELD_LENGTHS = [
+        'description' => 63000,
         'name' => 100,
         'short_name' => 4,
         'url' => 255,


### PR DESCRIPTION
It's not really supposed to be that long...

(there are some teams close to this length)