### PR TITLE
Set correct limit for team description

### DIFF
--- a/app/Models/Team.php
+++ b/app/Models/Team.php
@@ -26,7 +26,7 @@ class Team extends Model implements AfterCommit, Indexable, Traits\ReportableInt
     const FLAG_MAX_DIMENSIONS = [512, 256];
 
     const MAX_FIELD_LENGTHS = [
-        'description' => 63000,
+        'description' => 64000,
         'name' => 100,
         'short_name' => 4,
         'url' => 255,


### PR DESCRIPTION
Apparently I never ended up committing the correct number for some reason ಠ_ಠ

(the longest is a bit over 63k)