### PR TITLE
Fix download filename of beatmap version file

### DIFF
--- a/app/Http/Controllers/BeatmapsetVersionFilesController.php
+++ b/app/Http/Controllers/BeatmapsetVersionFilesController.php
@@ -29,7 +29,8 @@ class BeatmapsetVersionFilesController extends Controller
             function () use ($file) {
                 echo $file->content();
             },
-            $versionFile->filename,
+            // filename column includes path so it needs to be stripped out
+            basename($versionFile->filename),
             ['Content-Type' => 'application/octet-stream'],
         );
     }


### PR DESCRIPTION
Well 🤷 

(`\` isn't allowed for download filename either but it shouldn't be a thing here...?)