### PR TITLE
Adjust qr code colour

### DIFF
--- a/resources/css/bem/qr-svg.less
+++ b/resources/css/bem/qr-svg.less
@@ -7,13 +7,9 @@
     width: 100%;
     height: auto;
     aspect-ratio: 1;
+  }
 
-    path {
-      fill: hsl(var(--hsl-c1));
-    }
-
-    rect {
-      fill: hsl(var(--hsl-b5));
-    }
+  &--user-totp {
+    margin-bottom: 10px;
   }
 }

--- a/resources/views/user_totp/create.blade.php
+++ b/resources/views/user_totp/create.blade.php
@@ -29,7 +29,7 @@
                 data-skip-ajax-error-popup="1"
             >
                 <div class="password-reset__input-group">
-                    <div class="qr-svg">
+                    <div class="qr-svg qr-svg--user-totp">
                         {!! qr_svg($uri) !!}
                     </div>
                     <p>


### PR DESCRIPTION
Or more like unadjust. Microsoft authenticator apparently is not capable of reading inverted code. And it's not recommended to invert in the first place?

As reported in #12445