### PR TITLE
Fix default sort for source filter beatmap search

### DIFF
--- a/app/Libraries/Search/BeatmapsetSearchRequestParams.php
+++ b/app/Libraries/Search/BeatmapsetSearchRequestParams.php
@@ -189,7 +189,7 @@ class BeatmapsetSearchRequestParams extends BeatmapsetSearchParams
 
     private function getDefaultSortField(): string
     {
-        if (present($this->queryString) || present($this->artist) || present($this->creator) || present($this->title)) {
+        if (present($this->queryString) || present($this->artist) || present($this->creator) || present($this->title) || present($this->source)) {
             return 'relevance';
         }
 


### PR DESCRIPTION
Another one that should have relevance order by default but currently not (the filter was added together with `title=` which was also missing until recently).