### PR TITLE
Add 'id', 'rating' and 'selection_count' to 'matchmaking_pool_beatmaps`

### DIFF
--- a/database/migrations/2025_10_08_133052_add_id_rating_selection_count_to_matchmaking_pool_beatmaps.php
+++ b/database/migrations/2025_10_08_133052_add_id_rating_selection_count_to_matchmaking_pool_beatmaps.php
@@ -1,0 +1,31 @@
+<?php
+
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('matchmaking_pool_beatmaps', function (Blueprint $table) {
+            $table->increments('id')->first();
+            $table->integer('rating')->after('mods')->default(1500);
+            $table->integer('selection_count')->after('rating')->default(0);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('matchmaking_pool_beatmaps', function (Blueprint $table) {
+            $table->dropColumn('id');
+            $table->dropColumn('rating');
+            $table->dropColumn('selection_count');
+        });
+    }
+};


### PR DESCRIPTION
- Added `id` so beatmaps can be identified, especially in the case that there's multiple { beatmap, mod } combinations with the same beatmap.
- Added `rating` which is an approximate rating at which this beatmap is intended to be played.
- Added `selection_count` which will be incremented by osu-server-spectator, tracking the number of times this particular beatmap was selected for the pool.

@peppy According to the proposal in https://github.com/ppy/osu/issues/34245#issuecomment-3373468105, I propose:

```sql
UPDATE matchmaking_pool_beatmaps p
SET rating = 800 + 150 * (SELECT difficultyrating FROM osu_beatmaps b WHERE b.beatmap_id = p.beatmap_id)
WHERE 1;
```

It spaces the beatmaps out a little more than the proposal, but my original value before the proposal was `200 * sr`.