### PR TITLE
Fix Beatmapset Discusisons reviews editor crashing when clicking on a timestamp

### DIFF
--- a/resources/js/beatmap-discussions/editor-toolbar.tsx
+++ b/resources/js/beatmap-discussions/editor-toolbar.tsx
@@ -34,7 +34,9 @@ export class EditorToolbar extends React.Component {
     }
 
     const domSelection = window.getSelection();
-    return domSelection?.getRangeAt(0);
+    return domSelection != null && domSelection.rangeCount > 0
+      ? domSelection.getRangeAt(0)
+      : null;
   }
 
   get visible() {


### PR DESCRIPTION
Came across this while looking into #12465 and #12469

Turns out it's possible to have a selection with 0 ranges ( ﾟ ヮﾟ)

reproducing:
triple click (to trigger word selection) on a timestamp in the selection area before the cursor enters any editor areas.
<img width="201" height="127" alt="image" src="https://github.com/user-attachments/assets/096b8b2a-9b54-4654-bd3d-1b99a0789b6d" />
