### PR TITLE
Make audio player invisible when hidden

### DIFF
--- a/resources/css/bem/audio-player.less
+++ b/resources/css/bem/audio-player.less
@@ -25,10 +25,14 @@
   &--main {
     margin-left: auto;
     bottom: -@_height;
-    transition: bottom 120ms;
+    transition:
+      bottom 120ms,
+      opacity 120ms;
+    opacity: 0;
 
     &[data-audio-visible="1"] {
       bottom: 0;
+      opacity: 1;
     }
   }
 


### PR DESCRIPTION
Otherwise it's visible when taking full page screenshot (at least in firefox. also when printing page on chrome).