### PR TITLE
Fill help forum template with lazer build if exists

### DIFF
--- a/app/Libraries/NewForumTopic.php
+++ b/app/Libraries/NewForumTopic.php
@@ -33,8 +33,9 @@ class NewForumTopic
         if ($this->forum->isHelpForum()) {
             $buildName = '';
 
-            $build = $this->user->clients()->last('timestamp')?->build
-                ?? $this->user->soloScores()->whereNotNull('build_id')->last()?->build;
+            $build = $this->user->soloScores()->last()?->build
+                // the build above will be null if the user last played on stable
+                ?? $this->user->clients()->last('timestamp')?->build;
             $stream = $build?->parent()?->updateStream;
 
             if ($stream !== null) {

--- a/app/Libraries/NewForumTopic.php
+++ b/app/Libraries/NewForumTopic.php
@@ -31,15 +31,15 @@ class NewForumTopic
         $body = null;
 
         if ($this->forum->isHelpForum()) {
-            $client = $this->user->clients()->last('timestamp');
-
             $buildName = '';
 
-            if ($client !== null && $client->build !== null && $client->build->updateStream !== null) {
-                $build = $client->build;
-                $stream = $build->updateStream;
-                $buildName = $stream->pretty_name.' '.$build->displayVersion();
-                if ($client->isLatest()) {
+            $build = $this->user->clients()->last('timestamp')?->build
+                ?? $this->user->soloScores()->whereNotNull('build_id')->last()?->build;
+            $stream = $build?->parent()?->updateStream;
+
+            if ($stream !== null) {
+                $buildName = $stream->pretty_name.' '.$build->version;
+                if ($build->isLatest()) {
                     $buildName .= ' (latest)';
                 }
             }

--- a/app/Models/Solo/Score.php
+++ b/app/Models/Solo/Score.php
@@ -14,6 +14,7 @@ use App\Libraries\Score\ScoringMode;
 use App\Libraries\Score\UserRank;
 use App\Libraries\Search\ScoreSearchParams;
 use App\Models\Beatmap;
+use App\Models\Build;
 use App\Models\Model;
 use App\Models\Multiplayer\ScoreLink as MultiplayerScoreLink;
 use App\Models\Score as LegacyScore;
@@ -154,6 +155,11 @@ class Score extends Model implements Traits\ReportableInterface
         return $this->belongsTo(Beatmap::class, 'beatmap_id');
     }
 
+    public function build()
+    {
+        return $this->belongsTo(Build::class, 'build_id');
+    }
+
     public function user()
     {
         return $this->belongsTo(User::class, 'user_id');
@@ -269,6 +275,7 @@ class Score extends Model implements Traits\ReportableInterface
             'legacy_perfect' => $this->isPerfectLegacyCombo(),
 
             'beatmap',
+            'build',
             'performance',
             'processHistory',
             'reportedIn',

--- a/app/Models/UserClient.php
+++ b/app/Models/UserClient.php
@@ -89,19 +89,4 @@ class UserClient extends Model
     {
         return $this->belongsTo(Build::class, 'osu_md5', 'hash');
     }
-
-    public function isLatest()
-    {
-        if ($this->build === null) {
-            return false;
-        }
-
-        $latestBuild = Build::select('build_id')
-            ->where([
-                'test_build' => false,
-                'stream_id' => $this->build->stream_id,
-            ])->last();
-
-        return $this->build->getKey() === optional($latestBuild)->getKey();
-    }
 }


### PR DESCRIPTION
Resolves #11701.

I changed the build version rendering so it shows the full version string which includes platform for lazer as it could be useful? The stream name ends up being a bit redundant though.

```
osu! version: Lazer 2025.424.0-lazer-windows (latest)
```

So lazer builds don't have the corresponding `stream_id` hence the `Build#parent()` function...


```
+--------------------------+----------+-----------+
| version                  | build_id | stream_id |
+--------------------------+----------+-----------+
| 2025.424.0-lazer-ios     |     6000 |      NULL |
| 2025.424.0               |     6001 |         8 |
| 2025.424.0               |     6002 |         7 |
| 2025.424.0-lazer-android |     6003 |      NULL |
| 2025.424.0-lazer-windows |     6004 |      NULL |
| 2025.424.0-lazer-macos   |     6005 |      NULL |
| 2025.424.0-lazer-macos   |     6006 |      NULL |
| 2025.424.0-lazer-linux   |     6007 |      NULL |
+--------------------------+----------+-----------+
```