### PR TITLE
Clean up source beatmap image file after processing

### DIFF
--- a/app/Models/Beatmapset.php
+++ b/app/Models/Beatmapset.php
@@ -481,6 +481,11 @@ class Beatmapset extends Model implements AfterCommit, Commentable, Indexable, T
         return '//b.ppy.sh/preview/'.$this->beatmapset_id.'.mp3';
     }
 
+    public function removeCover($targetFilename): void
+    {
+        \Storage::delete($this->coverPath().$targetFilename);
+    }
+
     public function removeCovers()
     {
         try {
@@ -574,7 +579,10 @@ class Beatmapset extends Model implements AfterCommit, Commentable, Indexable, T
                     return false;
                 }
                 throw $e;
+            } finally {
+                $this->removeCover('raw.jpg');
             }
+
             $this->storeCover('fullsize.jpg', get_stream_filename($optimized));
 
             // use thumbnailer to generate (and then upload) all our variants

--- a/resources/views/admin/beatmapsets/cover.blade.php
+++ b/resources/views/admin/beatmapsets/cover.blade.php
@@ -32,11 +32,14 @@
                 <i class="fas fa-fw fa-trash"></i>
                 {{osu_trans('admin.beatmapsets.covers.remove')}}
             </button>
-            @foreach (array_merge(['raw', 'fullsize'], $beatmapset->coverSizes()) as $size)
-                <h3>{{$size}}</h3>
-                <a href="{{$beatmapset->coverURL($size)}}">
-                    <div>{{$beatmapset->coverURL($size)}}</div>
-                    <img class="beatmapset-cover-admin__img" src="{{$beatmapset->coverURL($size)}}">
+            @foreach (['fullsize', ...$beatmapset->coverSizes()] as $size)
+                @php
+                    $url = $beatmapset->coverURL($size);
+                @endphp
+                <h3>{{ $size }}</h3>
+                <a href="{{ $url }}">
+                    <div>{{ $url }}</div>
+                    <img class="beatmapset-cover-admin__img" src="{{ $url }}">
                 </a>
             @endforeach
         </div>

--- a/resources/views/beatmapsets/show.blade.php
+++ b/resources/views/beatmapsets/show.blade.php
@@ -31,7 +31,7 @@
                         </span>
                     </a>
                 @endif
-                <a class="admin-menu-item" href="{{ $beatmapset->coverURL('raw') }}" target="_blank">
+                <a class="admin-menu-item" href="{{ $beatmapset->coverURL('fullsize') }}" target="_blank">
                     <span class="admin-menu-item__content">
                         <span class="admin-menu-item__label admin-menu-item__label--icon">
                             <span class="fas fa-image"></span>


### PR DESCRIPTION
The fullsize one is still being used for moderation. It was originally the original file but using optimised one should be fine...?