### PR TITLE
Prevent achievement transformer error on invalid user count

### DIFF
--- a/app/Transformers/AchievementTransformer.php
+++ b/app/Transformers/AchievementTransformer.php
@@ -16,7 +16,7 @@ class AchievementTransformer extends TransformerAbstract
         $userCount = app('user-count-by-ruleset')->get($rulesetName);
         $achievedPercent = $userCount === null
             ? null
-            : min(1, $achievement->achieved_count / $userCount);
+            : min(1, $achievement->achieved_count / max(1, $userCount));
 
         return [
             'achieved_percent' => $achievedPercent,


### PR DESCRIPTION
This shouldn't happen except on weirdly broken database...