### PR TITLE
Add tiered colour for global rank

### DIFF
--- a/app/Models/UserStatistics/Model.php
+++ b/app/Models/UserStatistics/Model.php
@@ -191,6 +191,19 @@ abstract class Model extends BaseModel
         return $value === 0 || $this->rank_score === 0.0 ? null : $value;
     }
 
+    public function globalRankPercent(): ?float
+    {
+        $rank = $this->globalRank();
+
+        if ($rank === null) {
+            return null;
+        }
+
+        $count = app('user-count-by-ruleset')->get(true, $this->getMode());
+
+        return $count === null ? null : $rank / max(1, $count);
+    }
+
     public function isRanked()
     {
         return $this->globalRank() !== null;

--- a/app/Transformers/AchievementTransformer.php
+++ b/app/Transformers/AchievementTransformer.php
@@ -13,7 +13,7 @@ class AchievementTransformer extends TransformerAbstract
     {
         $rulesetName = $achievement->mode;
 
-        $userCount = app('user-count-by-ruleset')->get($rulesetName);
+        $userCount = app('user-count-by-ruleset')->get(false, $rulesetName);
         $achievedCount = $achievement->achieved_count;
         $achievedPercent = $userCount === null
             ? null

--- a/app/Transformers/UserStatisticsTransformer.php
+++ b/app/Transformers/UserStatisticsTransformer.php
@@ -39,6 +39,7 @@ class UserStatisticsTransformer extends TransformerAbstract
                 'progress' => $stats->currentLevelProgressPercent(),
             ],
             'global_rank' => $stats->globalRank(),
+            'global_rank_percent' => $stats->globalRankPercent(),
             'global_rank_exp' => null,
             'pp' => $stats->rank_score,
             'pp_exp' => 0,
@@ -63,9 +64,7 @@ class UserStatisticsTransformer extends TransformerAbstract
 
     public function includeCountryRank(?UserStatistics\Model $stats = null)
     {
-        if ($stats !== null) {
-            return $this->primitive($stats->countryRank());
-        }
+        return $this->primitive($stats?->countryRank());
     }
 
     // TODO: remove this after country_rank is deployed

--- a/resources/css/bem-index.less
+++ b/resources/css/bem-index.less
@@ -332,6 +332,7 @@
 @import "bem/quick-search-input";
 @import "bem/quick-search-items";
 @import "bem/quick-search-result";
+@import "bem/rank-value";
 @import "bem/ranking-filter";
 @import "bem/ranking-page";
 @import "bem/ranking-page-table";

--- a/resources/css/bem/rank-value.less
+++ b/resources/css/bem/rank-value.less
@@ -3,6 +3,15 @@
 
 .rank-value {
   --colour: hsl(var(--hsl-c2)), hsl(var(--hsl-c2));
+  --font-weight: bold;
   .fancy-text(var(--colour));
-  font-weight: 400;
+  font-weight: var(--font-weight);
+
+  &--base {
+    --font-weight: 400;
+  }
+
+  &--iron {
+    --font-weight: 400;
+  }
 }

--- a/resources/css/bem/rank-value.less
+++ b/resources/css/bem/rank-value.less
@@ -1,0 +1,8 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
+.rank-value {
+  --colour: hsl(var(--hsl-c2)), hsl(var(--hsl-c2));
+  .fancy-text(var(--colour));
+  font-weight: 400;
+}

--- a/resources/js/interfaces/user-statistics-json.ts
+++ b/resources/js/interfaces/user-statistics-json.ts
@@ -44,12 +44,14 @@ interface UserStatisticsBaseJson {
 export interface UserStatisticsRankedJson extends UserStatisticsBaseJson {
   country_rank?: number;
   global_rank: number;
+  global_rank_percent: number;
   is_ranked: true;
 }
 
 interface UserStatisticsUnrankedJson extends UserStatisticsBaseJson {
   country_rank?: null;
   global_rank: null;
+  global_rank_percent: null;
   is_ranked: false;
 }
 

--- a/resources/js/profile-page/rank.tsx
+++ b/resources/js/profile-page/rank.tsx
@@ -6,6 +6,7 @@ import RankHighestJson from 'interfaces/rank-highest-json';
 import UserStatisticsJson, { RankType } from 'interfaces/user-statistics-json';
 import * as moment from 'moment';
 import * as React from 'react';
+import { classWithModifiers } from 'utils/css';
 import { formatNumber } from 'utils/html';
 import { trans } from 'utils/lang';
 
@@ -77,7 +78,7 @@ export default function Rank({ highest, stats, type }: Props) {
       modifiers='rank'
       value={
         <div
-          className='rank-value'
+          className={classWithModifiers('rank-value', tier ?? 'base')}
           data-html-title={tooltip.join('')}
           data-tooltip-position='bottom left'
           style={{

--- a/resources/js/profile-page/rank.tsx
+++ b/resources/js/profile-page/rank.tsx
@@ -15,6 +15,35 @@ interface Props {
   type: RankType;
 }
 
+function globalTier(stats: UserStatisticsJson) {
+  const rank = stats.global_rank;
+  const percent = stats.global_rank_percent;
+
+  if (rank == null || percent == null) {
+    return null;
+  }
+
+  if (rank <= 100) {
+    return 'lustrous';
+  }
+
+  return percent < 0.0005
+    ? 'radiant'
+    : percent < 0.0025
+      ? 'rhodium'
+      : percent < 0.005
+        ? 'platinum'
+        : percent < 0.025
+          ? 'gold'
+          : percent < 0.05
+            ? 'silver'
+            : percent < 0.25
+              ? 'bronze'
+              : percent < 0.5
+                ? 'iron'
+                : null;
+}
+
 export default function Rank({ highest, stats, type }: Props) {
   const key = `${type}_rank` as const;
   const rank = stats[key];
@@ -39,14 +68,21 @@ export default function Rank({ highest, stats, type }: Props) {
     tooltip.push(`<div>${text}</div>`);
   }
 
+  const tier = type === 'global' ? globalTier(stats) : null;
+  const tierVar = tier == null ? '' : `var(--level-tier-${tier})`;
+
   return (
     <ValueDisplay
       label={trans(`users.show.rank.${type}_simple`)}
       modifiers='rank'
       value={
         <div
+          className='rank-value'
           data-html-title={tooltip.join('')}
           data-tooltip-position='bottom left'
+          style={{
+            '--colour': tierVar,
+          } as React.CSSProperties}
           title=''
         >
           {rank != null ? (


### PR DESCRIPTION
Also changed the font weight to be more/slightly bolder based on the tier (also for country rank because shared style)

![](https://s.kohaku.love/2025/10/firefox_2025-10-20_09-49-49.png)

![](https://s.kohaku.love/2025/10/firefox_2025-10-20_09-50-16.png)

![](https://s.kohaku.love/2025/10/firefox_2025-10-20_09-51-04.png)

| tier | top n
| --- | ---
| iron | 50%
| bronze | 25%
| silver | 5%
| gold | 2.5%
| platinum | 0.5%
| rhodium | 0.25%
| radiant | 0.05%
| lustrous | rank 100 or higher
