### PR TITLE
Adjust global rank colour tiers

### DIFF
--- a/resources/js/profile-page/rank.tsx
+++ b/resources/js/profile-page/rank.tsx
@@ -30,15 +30,15 @@ function globalTier(stats: UserStatisticsJson) {
 
   return percent < 0.0005
     ? 'radiant'
-    : percent < 0.0025
+    : percent < 0.0015
       ? 'rhodium'
       : percent < 0.005
         ? 'platinum'
-        : percent < 0.025
+        : percent < 0.015
           ? 'gold'
           : percent < 0.05
             ? 'silver'
-            : percent < 0.25
+            : percent < 0.15
               ? 'bronze'
               : percent < 0.5
                 ? 'iron'


### PR DESCRIPTION
A more consistent ratio of 3 and 3.33 instead 2 and 5 between the tiers.

As suggested in https://github.com/ppy/osu-web/pull/12483#issuecomment-3491162791