### PR TITLE
Enforce typing of interop parameters

### DIFF
--- a/app/Http/Middleware/LegacyInterOpAuth.php
+++ b/app/Http/Middleware/LegacyInterOpAuth.php
@@ -8,9 +8,35 @@ namespace App\Http\Middleware;
 use App\Singletons\OsuAuthorize;
 use Carbon\Carbon;
 use Closure;
+use Illuminate\Http\Request;
 
 class LegacyInterOpAuth
 {
+    private static function validateSignature(Request $request, string $fullUrl): ?string
+    {
+        $timestamp = get_int($request->query('timestamp'));
+        if ($timestamp === null) {
+            return 'missing_timestamp';
+        }
+
+        $diff = Carbon::createFromTimestamp($timestamp)->diffInSeconds(absolute: true);
+        if ($diff > 300) {
+            return 'expired_signature';
+        }
+
+        $signature = get_string($request->header('X-LIO-Signature'));
+        if (!present($signature)) {
+            return 'missing_signature';
+        }
+
+        $expected = hash_hmac('sha1', $fullUrl, $GLOBALS['cfg']['osu']['legacy']['shared_interop_secret']);
+        if (!hash_equals($expected, $signature)) {
+            return 'invalid_signature';
+        }
+
+        return null;
+    }
+
     /**
      * Handle an incoming request.
      *
@@ -18,27 +44,17 @@ class LegacyInterOpAuth
      * @param  \Closure  $next
      * @return mixed
      */
-    public function handle($request, Closure $next)
+    public function handle(Request $request, Closure $next)
     {
-        $timestamp = $request->query('timestamp');
-        $diff = Carbon::createFromTimestamp($timestamp)->diffInSeconds(absolute: true);
-        $signature = $request->header('X-LIO-Signature');
         // don't use $request->fullUrl() because it returns normalised url.
         $fullUrl = $request->getSchemeAndHttpHost().$request->getRequestUri();
-        $expected = hash_hmac('sha1', $fullUrl, $GLOBALS['cfg']['osu']['legacy']['shared_interop_secret']);
 
-        if (!present($signature) || !present($timestamp) || $diff > 300 || !hash_equals($expected, $signature)) {
-            $reason = match (true) {
-                !present($signature) => 'missing_signature',
-                !present($timestamp) => 'missing_timestamp',
-                $diff > 300 => 'expired_signature',
-                !hash_equals($expected, $signature) => 'invalid_signature',
-            };
-
-            abort(403, "{$reason} ({$fullUrl})");
+        $err = static::validateSignature($request, $fullUrl);
+        if ($err !== null) {
+            abort(403, "{$err} ({$fullUrl})");
         }
 
-        request()->attributes->set(OsuAuthorize::REQUEST_IS_INTEROP_KEY, true);
+        $request->attributes->set(OsuAuthorize::REQUEST_IS_INTEROP_KEY, true);
 
         return $next($request);
     }


### PR DESCRIPTION
The missing timestamp error message isn't even actually reachable because the createFromTimestamp will already throw error due to null timestamp.

Reworked handling of the error to fail early and not repeat the check on failure.

Mainly just to reduce noise in sentry. An outright block on external access would probably be useful as well?