### PR TITLE
Adjust bottom padding to prevent text cutoff

### DIFF
--- a/resources/css/bem/rank-value.less
+++ b/resources/css/bem/rank-value.less
@@ -6,6 +6,9 @@
   --font-weight: bold;
   .fancy-text(var(--colour));
   font-weight: var(--font-weight);
+  // allow the fancy text to fill the characters overflowing to descender part
+  padding-bottom: 0.2em;
+  margin-bottom: -$padding-bottom;
 
   &--base {
     --font-weight: 400;


### PR DESCRIPTION
The background doesn't go over the box but the text itself may due to the comma going below the baseline. The end result is the descender part is not filled in by the background for the gradient effect.

Adjusting line-height could also work (or even not doing the negative margin part) but this one doesn't change the layout ┐(･_･)┌

As reported in https://github.com/ppy/osu-web/pull/12483#issuecomment-3498746947