### PR TITLE
Set default dev locale env

### DIFF
--- a/docker/development/run.sh
+++ b/docker/development/run.sh
@@ -2,6 +2,8 @@
 
 export CHROME_BIN=/usr/bin/chromium
 export DUSK_WEBDRIVER_BIN=/usr/bin/chromedriver
+export LANG="C.UTF-8"
+export LC_ALL="C.UTF-8"
 
 command=octane
 if [ "$#" -gt 0 ]; then


### PR DESCRIPTION
Being able to see the actual unicode value is useful. Mainly for viewing non-ascii unicode value in tinker.

Not sure if being able to pass own value would be useful because the container only have three locales installed (C, C.utf8, and POSIX) and no one should be using the other two anymore...

```sh
# overridable version for my own reference
export LANG=${LANG:-"C.UTF-8"}
export LC_ALL=${LC_ALL:-"C.UTF-8"}
```