### PR TITLE
Reduce number checks when mounting react component

### DIFF
--- a/resources/js/components/user-card-tooltip.tsx
+++ b/resources/js/components/user-card-tooltip.tsx
@@ -85,8 +85,9 @@ function createTooltip(element: HTMLElement) {
   // React should override the existing content after mounting.
   // Casting because cloneNode returns Node by default.
   const card = blankCard().cloneNode(true) as HTMLElement;
-  card.classList.remove('js-react--user-card');
-  card.classList.add('js-react--user-card-tooltip');
+  card.classList.add('js-user-card-tooltip');
+  card.classList.add('js-react');
+  card.dataset.react = 'user-card-tooltip';
   card.dataset.lookup = userId;
   for (const [key, value] of Object.entries(element.dataset)) {
     card.dataset[key] = value;
@@ -143,7 +144,7 @@ function onMouseOver(event: JQuery.TriggeredEvent<Document, unknown, HTMLElement
     if (qtip != null) {
       const tooltipElement = qtip.tooltip;
       if (tooltipElement != null) {
-        const container = tooltipElement.find('.js-react--user-card-tooltip')[0];
+        const container = tooltipElement.find('.js-user-card-tooltip')[0];
         if (container != null) {
           unmountComponentAtNode(container);
         }
@@ -174,7 +175,7 @@ function onRemoveUserCard(_event: unknown, element: HTMLElement | null) {
 
   const qtip = $(tooltipElement).qtip('api');
   if (qtip != null) {
-    const container = tooltipElement.querySelector('.js-react--user-card-tooltip');
+    const container = tooltipElement.querySelector('.js-user-card-tooltip');
     if (container != null) {
       unmountComponentAtNode(container);
     }
@@ -203,8 +204,8 @@ function shouldShow(event: JQuery.Event, api: any) {
 
 export function startListening() {
   $(document).on('mouseover', '.js-usercard', onMouseOver);
-  $(document).on('mouseenter', '.js-react--user-card-tooltip', onMouseEnter);
-  $(document).on('mouseleave', '.js-react--user-card-tooltip', onMouseLeave);
+  $(document).on('mouseenter', '.js-user-card-tooltip', onMouseEnter);
+  $(document).on('mouseleave', '.js-user-card-tooltip', onMouseLeave);
   $(document).on('turbo:before-cache', onBeforeCache);
   $.subscribe('user-card:remove.tooltip', onRemoveUserCard);
 }

--- a/resources/js/core/react-turbolinks.ts
+++ b/resources/js/core/react-turbolinks.ts
@@ -30,19 +30,21 @@ export default class ReactTurbolinks {
   boot = () => {
     if (!this.pageReady || window.newBody == null) return;
 
-    for (const [name, elementFn] of this.components.entries()) {
-      const containers = window.newBody.querySelectorAll(`.js-react--${name}`);
+    for (const container of window.newBody.querySelectorAll('.js-react')) {
+      if (!(container instanceof HTMLElement)) {
+        continue;
+      }
+      const name = container.dataset.react ?? '';
+      const elementFn = this.components.get(name);
 
-      for (const container of containers) {
-        if (!(container instanceof HTMLElement) || this.renderedContainers.has(container)) {
-          continue;
+      if (elementFn != null) {
+        if (!this.renderedContainers.has(container)) {
+          this.renderedContainers.add(container);
+
+          runInAction(() => {
+            ReactDOM.render(elementFn(container), container);
+          });
         }
-
-        this.renderedContainers.add(container);
-
-        runInAction(() => {
-          ReactDOM.render(elementFn(container), container);
-        });
       }
     }
   };

--- a/resources/js/core/react-turbolinks.ts
+++ b/resources/js/core/react-turbolinks.ts
@@ -13,7 +13,7 @@ import { currentUrl } from 'utils/turbolinks';
 type ElementFn = (container: HTMLElement) => React.ReactElement;
 
 export default class ReactTurbolinks {
-  private readonly components = new Map<string, ElementFn>();
+  private readonly components: Partial<Record<string, ElementFn>> = {};
   private newVisit = true;
   private pageReady = false;
   private readonly renderedContainers = new Set<HTMLElement>();
@@ -35,7 +35,7 @@ export default class ReactTurbolinks {
         continue;
       }
       const name = container.dataset.react ?? '';
-      const elementFn = this.components.get(name);
+      const elementFn = this.components[name];
 
       if (elementFn != null) {
         if (!this.renderedContainers.has(container)) {
@@ -50,9 +50,9 @@ export default class ReactTurbolinks {
   };
 
   register(name: string, elementFn: ElementFn) {
-    if (this.components.has(name)) return;
+    if (this.components[name] != null) return;
 
-    this.components.set(name, elementFn);
+    this.components[name] = elementFn;
 
     this.boot();
   }

--- a/resources/views/accounts/_edit_github_user.blade.php
+++ b/resources/views/accounts/_edit_github_user.blade.php
@@ -11,7 +11,8 @@
 
     <div class="account-edit__input-groups">
         <div
-            class="account-edit__input-group js-react--github-user"
+            class="account-edit__input-group js-react"
+            data-react="github-user"
             data-user="{{ json_encode($githubUser) }}"
         ></div>
     </div>

--- a/resources/views/accounts/_edit_legacy_api.blade.php
+++ b/resources/views/accounts/_edit_legacy_api.blade.php
@@ -15,7 +15,8 @@
                 <div class="account-edit-entry__label account-edit-entry__label--top-pinned">{{ osu_trans('accounts.edit.legacy_api.api') }}</div>
                 <div class="account-edit-entry__group">
                     <div
-                        class="js-react--legacy-api-key"
+                        class="js-react"
+                        data-react="legacy-api-key"
                         data-state="{{ json_encode(['legacy_api_key' => $legacyApiKeyJson]) }}"
                     ></div>
                 </div>
@@ -27,7 +28,8 @@
                 <div class="account-edit-entry__label account-edit-entry__label--top-pinned">{{ osu_trans('accounts.edit.legacy_api.irc') }}</div>
                 <div class="account-edit-entry__group">
                     <div
-                        class="js-react--legacy-irc-key"
+                        class="js-react"
+                        data-react="legacy-irc-key"
                         data-state="{{ json_encode(['legacy_irc_key' => $legacyIrcKeyJson]) }}"
                     ></div>
                 </div>

--- a/resources/views/accounts/_edit_oauth.blade.php
+++ b/resources/views/accounts/_edit_oauth.blade.php
@@ -14,7 +14,7 @@
             <div class="account-edit-entry">
                 <div class="account-edit-entry__label account-edit-entry__label--top-pinned">{{ osu_trans('accounts.oauth.authorized_clients') }}</div>
                 <div class="account-edit-entry__group">
-                    <div class="js-react--authorized-clients"></div>
+                    <div class="js-react" data-react="authorized-clients"></div>
                 </div>
             </div>
         </div>
@@ -23,7 +23,7 @@
             <div class="account-edit-entry">
                 <div class="account-edit-entry__label account-edit-entry__label--top-pinned">{{ osu_trans('accounts.oauth.own_clients') }}</div>
                 <div class="account-edit-entry__group">
-                    <div class="js-react--own-clients"></div>
+                    <div class="js-react" data-react="own-clients"></div>
                 </div>
             </div>
         </div>

--- a/resources/views/accounts/_edit_privacy.blade.php
+++ b/resources/views/accounts/_edit_privacy.blade.php
@@ -68,7 +68,7 @@
                             @foreach ($blocks as $block)
                                 <div class="block-list-item">
                                     <a class="block-list-item__link" href='{{route('users.show', $block->user_id)}}'>{{ $block->username }}</a>
-                                    <div class="js-react--blockButton" data-target="{{$block->user_id}}"></div>
+                                    <div class="js-react" data-react="blockButton" data-target="{{$block->user_id}}"></div>
                                 </div>
                             @endforeach
                         </div>

--- a/resources/views/admin/contests/show.blade.php
+++ b/resources/views/admin/contests/show.blade.php
@@ -110,7 +110,7 @@
                 </div>
             @endif
 
-            <div class="js-react--admin-contest-user-entry-list"></div>
+            <div class="js-react" data-react="admin-contest-user-entry-list"></div>
         </div>
     </div>
 @endsection

--- a/resources/views/artist_tracks/index.blade.php
+++ b/resources/views/artist_tracks/index.blade.php
@@ -8,8 +8,9 @@
 
 @section('content')
     <div
-        class="js-react--artist-tracks-index"
+        class="js-react"
         data-data="{{ json_encode(compact('availableGenres', 'index')) }}"
+        data-react="artist-tracks-index"
     ></div>
 
     @include('layout._react_js', ['src' => 'js/artist-tracks-index.js'])

--- a/resources/views/artists/show.blade.php
+++ b/resources/views/artists/show.blade.php
@@ -67,7 +67,12 @@
                                         </span>
                                     @endif
                                 </div>
-                                <div class="js-react--artistTracklist" data-artist-src="{{ $artistJsonId }}" data-src="album-json-{{$album['id']}}"></div>
+                                <div
+                                    class="js-react"
+                                    data-artist-src="{{ $artistJsonId }}"
+                                    data-react="artistTracklist"
+                                    data-src="album-json-{{$album['id']}}"
+                                ></div>
                                 <script id="album-json-{{$album['id']}}" type="application/json">
                                     {!! json_encode($album['tracks']) !!}
                                 </script>
@@ -81,7 +86,12 @@
                             <div class="artist-album__header-overlay" style="background-image: url('{{ $images['header_url'] }}');"></div>
                             <span class="artist-album__title">{{osu_trans('artist.songs._')}}</span>
                         </div>
-                        <div class="js-react--artistTracklist" data-artist-src="{{ $artistJsonId }}" data-src="singles-json-{{$artist->id}}"></div>
+                        <div
+                            class="js-react"
+                            data-artist-src="{{ $artistJsonId }}"
+                            data-react="artistTracklist"
+                            data-src="singles-json-{{$artist->id}}"
+                        ></div>
                         <script id="singles-json-{{$artist->id}}" type="application/json">
                             {!! json_encode($json['tracks']) !!}
                         </script>

--- a/resources/views/beatmap_discussions/index.blade.php
+++ b/resources/views/beatmap_discussions/index.blade.php
@@ -142,7 +142,7 @@
                 </div>
             </form>
 
-            <div class="js-react--beatmap-discussions-history">
+            <div class="js-react" data-react="beatmap-discussions-history">
                 <div class="beatmapset-activities__spinner">{!! spinner() !!}</div>
             </div>
 

--- a/resources/views/beatmapset_events/index.blade.php
+++ b/resources/views/beatmapset_events/index.blade.php
@@ -107,7 +107,7 @@
                 </div>
             </form>
 
-            <div class="js-react--beatmap-discussion-events" id="events"></div>
+            <div class="js-react" data-react="beatmap-discussion-events" id="events"></div>
             @include('objects._pagination_v2', ['object' => $paginator->fragment('events')])
         </div>
     </div>

--- a/resources/views/beatmapsets/discussion.blade.php
+++ b/resources/views/beatmapsets/discussion.blade.php
@@ -10,7 +10,7 @@
 ])
 
 @section('content')
-    <div class="js-react--beatmap-discussions u-contents"></div>
+    <div class="js-react u-contents" data-react="beatmap-discussions"></div>
 @endsection
 
 @section ("script")

--- a/resources/views/beatmapsets/index.blade.php
+++ b/resources/views/beatmapsets/index.blade.php
@@ -7,7 +7,7 @@
 ])
 
 @section('content')
-  <div class="js-react--beatmaps" data-advanced-search="{{ (int) $canAdvancedSearch }}"></div>
+  <div class="js-react" data-react="beatmaps" data-advanced-search="{{ (int) $canAdvancedSearch }}"></div>
   {{--
     this should content a server side react.js render which doesn't exist in hhvm
     because the only library for it, which is experimental, requires PHP extension

--- a/resources/views/beatmapsets/show.blade.php
+++ b/resources/views/beatmapsets/show.blade.php
@@ -10,7 +10,7 @@
 ])
 
 @section('content')
-    <div class="js-react--beatmapset-page u-contents"></div>
+    <div class="js-react u-contents" data-react="beatmapset-page"></div>
     @if ($currentUser?->isModerator() || $currentUser?->isAdmin())
         <div class="admin-menu">
             <button class="admin-menu__button js-menu" data-menu-target="admin-beatmapset" type="button">

--- a/resources/views/changelog/build.blade.php
+++ b/resources/views/changelog/build.blade.php
@@ -7,7 +7,7 @@
 ])
 
 @section('content')
-    <div class="js-react--changelog-build u-contents"></div>
+    <div class="js-react u-contents" data-react="changelog-build"></div>
 
     <script id="json-build" type="application/json">
         {!! json_encode($buildJson) !!}

--- a/resources/views/changelog/index.blade.php
+++ b/resources/views/changelog/index.blade.php
@@ -24,7 +24,7 @@
 @extends('master', compact('titlePrepend'))
 
 @section('content')
-    <div class="js-react--changelog-index u-contents"></div>
+    <div class="js-react u-contents" data-react="changelog-index"></div>
 
     <script id="json-index" type="application/json">
         {!! json_encode($indexJson) !!}

--- a/resources/views/chat/index.blade.php
+++ b/resources/views/chat/index.blade.php
@@ -7,7 +7,7 @@
 ])
 
 @section("content")
-    <div class="js-react--chat u-contents"></div>
+    <div class="js-react u-contents" data-react="chat"></div>
 @endsection
 
 @section("script")

--- a/resources/views/comments/index.blade.php
+++ b/resources/views/comments/index.blade.php
@@ -34,7 +34,7 @@
         'theme' => 'comments',
     ]])
     <div class="osu-page osu-page--comments">
-        <div class="js-react--comments-index u-contents"></div>
+        <div class="js-react u-contents" data-react="comments-index"></div>
 
         @include('objects._pagination_v2', ['object' => $commentPagination])
     </div>

--- a/resources/views/comments/show.blade.php
+++ b/resources/views/comments/show.blade.php
@@ -26,7 +26,7 @@
     ]])
 
     <div class="osu-page osu-page--comment">
-        <div class="js-react--comments-show u-contents"></div>
+        <div class="js-react u-contents" data-react="comments-show"></div>
     </div>
 
     <script id="json-show" type="application/json">

--- a/resources/views/contest_entries/judge-results.blade.php
+++ b/resources/views/contest_entries/judge-results.blade.php
@@ -17,7 +17,7 @@
     ]])
 
     <div class="osu-page">
-        <div class="js-react--contest-judge-results"></div>
+        <div class="js-react" data-react="contest-judge-results"></div>
     </div>
 @endsection
 

--- a/resources/views/contests/_countdown.blade.php
+++ b/resources/views/contests/_countdown.blade.php
@@ -4,6 +4,6 @@
 --}}
 @if($deadline)
   <div class='contest__countdown-timer'>
-    <div class='js-react--countdownTimer' data-deadline='{{json_time($deadline)}}'></div>
+    <div class='js-react' data-react='countdownTimer' data-deadline='{{json_time($deadline)}}'></div>
   </div>
 @endif

--- a/resources/views/contests/_voting-entrylist.blade.php
+++ b/resources/views/contests/_voting-entrylist.blade.php
@@ -3,9 +3,9 @@
     See the LICENCE file in the repository root for full licence text.
 --}}
 @if ($contest->hasThumbnails())
-    <div class="js-react--contestArtList" data-src="contest-{{$contest->id}}"></div>
+    <div class="js-react" data-react="contestArtList" data-src="contest-{{$contest->id}}"></div>
 @else
-    <div class="js-react--contestList" data-src="contest-{{$contest->id}}"></div>
+    <div class="js-react" data-react="contestList" data-src="contest-{{$contest->id}}"></div>
 @endif
 <script id="contest-{{$contest->id}}" type="application/json">
     {!! $contest->defaultJson(Auth::user()) !!}

--- a/resources/views/contests/enter.blade.php
+++ b/resources/views/contests/enter.blade.php
@@ -16,12 +16,12 @@
         @if (!$contestMeta->isSubmissionOpen())
           @if ($contestMeta->entry_starts_at !== null && $contestMeta->entry_starts_at->isPast())
             <div class='contest__voting-notice'>{{osu_trans('authorization.contest.entry.over')}}</div>
-            <div class='js-react--userContestEntry'></div>
+            <div class='js-react' data-react='userContestEntry'></div>
           @else
             <div class='contest__voting-notice contest__voting-notice--padding'>{{osu_trans('contest.entry.preparation')}}</div>
           @endif
         @else
-          <div class='js-react--userContestEntry'></div>
+          <div class='js-react' data-react='userContestEntry'></div>
         @endif
       @endif
     @endif

--- a/resources/views/contests/judge.blade.php
+++ b/resources/views/contests/judge.blade.php
@@ -17,7 +17,7 @@
     ]])
 
     <div class="osu-page">
-        <div class="js-react--contest-judge"></div>
+        <div class="js-react" data-react="contest-judge"></div>
     </div>
 @endsection
 

--- a/resources/views/follows/comment.blade.php
+++ b/resources/views/follows/comment.blade.php
@@ -5,7 +5,7 @@
 @extends('master', ['titlePrepend' => osu_trans('follows.comment.page_title')])
 
 @section('content')
-    <div class="js-react--follows-comment u-contents"></div>
+    <div class="js-react u-contents" data-react="follows-comment"></div>
 
     <script id="json-follows-comment" type="application/json">
         {!! json_encode($followsJson) !!}

--- a/resources/views/follows/mapping.blade.php
+++ b/resources/views/follows/mapping.blade.php
@@ -5,7 +5,7 @@
 @extends('master', ['titlePrepend' => osu_trans('follows.mapping.page_title')])
 
 @section('content')
-    <div class="js-react--follows-mapping u-contents"></div>
+    <div class="js-react u-contents" data-react="follows-mapping"></div>
 
     <script id="json-follows-mapping" type="application/json">
         {!! json_encode($followsJson) !!}

--- a/resources/views/forum/topics/show.blade.php
+++ b/resources/views/forum/topics/show.blade.php
@@ -28,7 +28,7 @@
         'background' => $headerCover,
     ])
 
-    <div class="js-react--forum-post-report hidden"></div>
+    <div class="js-react hidden" data-react="forum-post-report"></div>
     <div
         class="hidden js-forum--topic-meta"
         data-user-can-moderate="{{ $userCanModerate }}"

--- a/resources/views/friends/index.blade.php
+++ b/resources/views/friends/index.blade.php
@@ -5,7 +5,7 @@
 @extends('master', ['titlePrepend' => osu_trans('friends.title_compact')])
 
 @section('content')
-    <div class="js-react--friends-index"></div>
+    <div class="js-react" data-react="friends-index"></div>
 @endsection
 
 @section("script")

--- a/resources/views/group_history/index.blade.php
+++ b/resources/views/group_history/index.blade.php
@@ -6,7 +6,7 @@
 
 @section('content')
     <div
-        class="js-react--group-history u-contents"
+        class="js-react u-contents" data-react="group-history"
         data-json="{{ json_encode($json) }}"
     ></div>
     @include('layout._react_js', ['src' => 'js/group-history.js'])

--- a/resources/views/groups/show.blade.php
+++ b/resources/views/groups/show.blade.php
@@ -5,7 +5,7 @@
 @extends('master', ['titlePrepend' => $groupJson['name']])
 
 @section('content')
-    <div class="js-react--groups-show"></div>
+    <div class="js-react" data-react="groups-show"></div>
 @endsection
 
 @section("script")

--- a/resources/views/home/_search_result_artist_track.blade.php
+++ b/resources/views/home/_search_result_artist_track.blade.php
@@ -10,7 +10,7 @@
 <div class="u-contents js-audio--group">
     @foreach ($search->data() as $entry)
         <div
-            class="js-react--artist-track u-contents"
+            class="js-react u-contents"
             data-props="{{ json_encode([
                 'modifiers' => 'search',
                 'showAlbum' => true,
@@ -20,6 +20,7 @@
                     $transformer::CARD_INCLUDES,
                 ),
             ]) }}"
+            data-react="artist-track"
         ></div>
     @endforeach
 </div>

--- a/resources/views/home/_search_result_beatmapset.blade.php
+++ b/resources/views/home/_search_result_beatmapset.blade.php
@@ -4,7 +4,8 @@
 --}}
 @foreach ($search->data() as $entry)
     <div
-        class="js-react--beatmapset-panel u-contents"
+        class="js-react u-contents"
         data-beatmapset-panel="{{ json_encode(['beatmapset' => json_item($entry, 'Beatmapset', ['beatmaps'])]) }}"
+        data-react="beatmapset-panel"
     ></div>
 @endforeach

--- a/resources/views/home/_search_result_team.blade.php
+++ b/resources/views/home/_search_result_team.blade.php
@@ -53,7 +53,7 @@
                 <span class="fal fa-extra-mode-{{ App\Models\Beatmap::modeStr($team->default_ruleset_id) }}"></span>
             </span>
             <div
-                class="js-react--team-extra-menu u-contents u-hover"
+                class="js-react u-contents u-hover" data-react="team-extra-menu"
                 data-props="{{ json_encode([
                     'leaderUsername' => $leader->username,
                     'teamId' => $team->getKey(),

--- a/resources/views/home/_search_result_user.blade.php
+++ b/resources/views/home/_search_result_user.blade.php
@@ -5,8 +5,9 @@
 @php
     use App\Transformers\UserCompactTransformer;
 @endphp
-<div class="js-react--user-cards"
+<div class="js-react"
     data-modifiers="{{ json_encode(['search']) }}"
+    data-react="user-cards"
     data-users="{{ json_encode(json_collection(
         $search->data(),
         new UserCompactTransformer(),

--- a/resources/views/home/landing.blade.php
+++ b/resources/views/home/landing.blade.php
@@ -122,7 +122,7 @@
         </div>
     </div>
 
-    <div class="osu-page js-react--landing-news">
+    <div class="osu-page js-react" data-react="landing-news">
     </div>
 
     <footer class="osu-layout__section osu-layout__section--landing-footer">

--- a/resources/views/home/user.blade.php
+++ b/resources/views/home/user.blade.php
@@ -16,7 +16,7 @@
 
     <div class="osu-page">
         @if (count($menuImages) > 0)
-            <div class="js-react--menu-images u-contents">
+            <div class="js-react u-contents" data-react="menu-images">
                 <div class="menu-images menu-images--placeholder">
                     <div class="menu-images__images">
                         {!! spinner() !!}

--- a/resources/views/layout/_header_mobile.blade.php
+++ b/resources/views/layout/_header_mobile.blade.php
@@ -77,8 +77,9 @@
                     </button>
 
                     <a
-                        class="mobile-menu-tab js-click-menu js-react--chat-icon"
+                        class="mobile-menu-tab js-click-menu js-react"
                         data-click-menu-target="mobile-chat-notification"
+                        data-react="chat-icon"
                         data-turbo-permanent
                         data-type='mobile'
                         id="notification-widget-chat-icon-mobile"
@@ -91,8 +92,9 @@
                     </a>
 
                     <a
-                        class="mobile-menu-tab js-click-menu js-react--main-notification-icon"
+                        class="mobile-menu-tab js-click-menu js-react"
                         data-click-menu-target="mobile-notification"
+                        data-react="main-notification-icon"
                         data-turbo-permanent
                         data-type='mobile'
                         id="notification-widget-icon-mobile"
@@ -115,22 +117,27 @@
             </div>
 
             @if (isset($user))
-                <div class="mobile-menu__item mobile-menu__item--search js-click-menu js-react--quick-search" data-click-menu-id="mobile-search">
-                </div>
+                <div
+                    class="mobile-menu__item mobile-menu__item--search js-click-menu js-react"
+                    data-click-menu-id="mobile-search"
+                    data-react="quick-search"
+                ></div>
 
                 <div
-                    class="mobile-menu__item js-click-menu js-react--notification-widget"
+                    class="mobile-menu__item js-click-menu js-react"
                     data-click-menu-id="mobile-chat-notification"
                     data-notification-widget="{{ json_encode(['only' => 'channel']) }}"
+                    data-react="notification-widget"
                     data-visibility="hidden"
                     data-turbo-permanent
                     id="notification-widget-chat-mobile"
                 ></div>
 
                 <div
-                    class="mobile-menu__item js-click-menu js-react--notification-widget"
+                    class="mobile-menu__item js-click-menu js-react"
                     data-click-menu-id="mobile-notification"
                     data-notification-widget="{{ json_encode(['excludes' => ['channel']]) }}"
+                    data-react="notification-widget"
                     data-visibility="hidden"
                     data-turbo-permanent
                     id="notification-widget-mobile"

--- a/resources/views/layout/_nav2.blade.php
+++ b/resources/views/layout/_nav2.blade.php
@@ -53,7 +53,7 @@
             </div>
         @endforeach
 
-        <div class="nav2__col nav2__col--menu js-react--quick-search-button">
+        <div class="nav2__col nav2__col--menu js-react" data-react="quick-search-button">
             <a
                 href="{{ route('search') }}"
                 class="
@@ -97,8 +97,9 @@
             <div class="nav2__col nav2__col--notifications">
                 <div class="nav2__notification-container">
                     <a
-                        class="nav-button nav-button--notifications js-click-menu js-react--chat-icon"
+                        class="nav-button nav-button--notifications js-click-menu js-react"
                         data-click-menu-target="nav2-chat-notification-widget"
+                        data-react="chat-icon"
                         data-turbo-permanent
                         id="notification-widget-chat-icon"
                         href="{{ route('chat.index') }}"
@@ -109,8 +110,9 @@
                         </span>
                     </a>
                     <div
-                        class="nav-click-popup js-click-menu js-react--notification-widget"
+                        class="nav-click-popup js-click-menu js-react"
                         data-click-menu-id="nav2-chat-notification-widget"
+                        data-react="notification-widget"
                         data-visibility="hidden"
                         data-notification-widget="{{ json_encode(['extraClasses' => 'js-nav2--centered-popup hidden', 'only' => 'channel']) }}"
                         data-turbo-permanent
@@ -118,8 +120,9 @@
                     ></div>
 
                     <a
-                        class="nav-button nav-button--notifications js-click-menu js-react--main-notification-icon"
+                        class="nav-button nav-button--notifications js-click-menu js-react"
                         data-click-menu-target="nav2-notification-widget"
+                        data-react="main-notification-icon"
                         data-turbo-permanent
                         id="notification-widget-icon"
                         href="{{ route('notifications.index') }}"
@@ -130,8 +133,9 @@
                         </span>
                     </a>
                     <div
-                        class="nav-click-popup js-click-menu js-react--notification-widget"
+                        class="nav-click-popup js-click-menu js-react"
                         data-click-menu-id="nav2-notification-widget"
+                        data-react="notification-widget"
                         data-visibility="hidden"
                         data-notification-widget="{{ json_encode(['extraClasses' => 'js-nav2--centered-popup hidden', 'excludes' => ['channel']]) }}"
                         data-turbo-permanent

--- a/resources/views/layout/_score_mode_toggle.blade.php
+++ b/resources/views/layout/_score_mode_toggle.blade.php
@@ -25,7 +25,8 @@
 
 @if (!$legacyScoreMode)
     <div
-        class="js-react--scoring-mode-toggle u-contents"
+        class="js-react u-contents"
         data-class="{{ $class }}"
+        data-react="scoring-mode-toggle"
     ></div>
 @endif

--- a/resources/views/layout/header_mobile/user.blade.php
+++ b/resources/views/layout/header_mobile/user.blade.php
@@ -19,8 +19,9 @@
         </a>
     @else
         <div
-            class="navbar-mobile-item__main js-react--user-card"
+            class="navbar-mobile-item__main js-react"
             data-is-current-user="1"
+            data-react="user-card"
         ></div>
 
         @include('layout._score_mode_toggle', ['class' => 'navbar-mobile-item__main'])

--- a/resources/views/legacy_matches/show.blade.php
+++ b/resources/views/legacy_matches/show.blade.php
@@ -5,7 +5,7 @@
 @extends('master', ['titlePrepend' => $match->name])
 
 @section('content')
-    <div class="js-react--mp-history"></div>
+    <div class="js-react" data-react="mp-history"></div>
 @endsection
 
 @section("script")

--- a/resources/views/multiplayer/rooms/events.blade.php
+++ b/resources/views/multiplayer/rooms/events.blade.php
@@ -7,7 +7,7 @@
 ])
 
 @section('content')
-    <div class="u-contents js-react--multiplayer-room-events"></div>
+    <div class="u-contents js-react" data-react="multiplayer-room-events"></div>
     <script id="json-events" type="application/json">
         {!! json_encode($json) !!}
     </script>

--- a/resources/views/news/index.blade.php
+++ b/resources/views/news/index.blade.php
@@ -6,7 +6,7 @@
 
 @section('content')
     <div
-        class="js-react--news-index u-contents"
+        class="js-react u-contents" data-react="news-index"
         data-props="{{ json_encode(['data' => $postsJson]) }}"
     ></div>
 

--- a/resources/views/news/show.blade.php
+++ b/resources/views/news/show.blade.php
@@ -8,7 +8,7 @@
 ])
 
 @section('content')
-    <div class="js-react--news-show u-contents"></div>
+    <div class="js-react u-contents" data-react="news-show"></div>
 
     <script id="json-show" type="application/json">
         {!! json_encode($postJson) !!}

--- a/resources/views/notifications/index.blade.php
+++ b/resources/views/notifications/index.blade.php
@@ -5,7 +5,7 @@
 @extends('master')
 
 @section('content')
-    <div class="js-react--notifications-index u-contents"></div>
+    <div class="js-react u-contents" data-react="notifications-index"></div>
 @endsection
 
 @section("script")

--- a/resources/views/objects/_basic_select_options.blade.php
+++ b/resources/views/objects/_basic_select_options.blade.php
@@ -3,8 +3,9 @@
     See the LICENCE file in the repository root for full licence text.
 --}}
 <div
-    class="js-react--basic-select-options"
+    class="js-react"
     data-basic-select-options="{{ json_encode($selectOptions) }}"
+    data-react="basic-select-options"
 >
     <div class="{{ class_with_modifiers('select-options', $selectOptions['modifiers'] ?? null) }}">
         <div class="select-options__select">

--- a/resources/views/rankings/_beatmapsets.blade.php
+++ b/resources/views/rankings/_beatmapsets.blade.php
@@ -6,8 +6,9 @@
 <div class="{{ class_with_modifiers('rankings-beatmapsets', $modifiers ?? null, ['single' => count($beatmapsets) === 1]) }}">
     @foreach ($beatmapsets as $beatmapset)
         <div
-            class="js-react--beatmapset-panel u-contents"
+            class="js-react u-contents"
             data-beatmapset-panel="{{ json_encode(['beatmapset' => json_item($beatmapset, 'Beatmapset', ['beatmaps'])]) }}"
+            data-react="beatmapset-panel"
         >
             <div class="beatmapset-panel beatmapset-panel--size-normal"></div>
         </div>

--- a/resources/views/rankings/_country_filter.blade.php
+++ b/resources/views/rankings/_country_filter.blade.php
@@ -10,7 +10,7 @@
     $country = $countryStats?->country;
 @endphp
 
-<div class="js-react--ranking-country-filter u-contents">
+<div class="js-react u-contents" data-react="ranking-country-filter">
     <div class="ranking-filter ranking-filter--full">
         <div class="ranking-filter__title">
             {{ osu_trans('rankings.countries.title') }}

--- a/resources/views/rankings/_user_filter.blade.php
+++ b/resources/views/rankings/_user_filter.blade.php
@@ -3,7 +3,7 @@
     See the LICENCE file in the repository root for full licence text.
 --}}
 @if (Auth::check())
-    <div class="js-react--ranking-user-filter u-contents">
+    <div class="js-react u-contents" data-react="ranking-user-filter">
         <div class="ranking-filter">
             <div class="ranking-filter__title">
                 {{ osu_trans('rankings.filter.title') }}

--- a/resources/views/rankings/global.blade.php
+++ b/resources/views/rankings/global.blade.php
@@ -18,7 +18,7 @@
                 }
             @endphp
             @if ($variants !== null)
-                <div class="js-react--ranking-variant-filter u-contents">
+                <div class="js-react u-contents" data-react="ranking-variant-filter">
                     <div class="ranking-filter">
                         <div class="ranking-filter__title">
                             {{ osu_trans('rankings.filter.variant.title') }}

--- a/resources/views/rankings/top_plays.blade.php
+++ b/resources/views/rankings/top_plays.blade.php
@@ -21,11 +21,12 @@
     @endsection
     @section('scores')
         <div
-            class="u-contents js-react--ranking-top-plays"
+            class="u-contents js-react"
             data-props="{{ json_encode([
                 'first_score_rank' => $scores->firstItem(),
                 'scores' => $scoresJson,
             ]) }}"
+            data-react="ranking-top-plays"
         >
             <div class="ranking-page-grid">
                 <div class="ranking-page-grid-item ranking-page-grid-item--header">

--- a/resources/views/scores/show.blade.php
+++ b/resources/views/scores/show.blade.php
@@ -15,7 +15,7 @@
 ])
 
 @section('content')
-    <div class="js-react--scores-show u-contents"></div>
+    <div class="js-react u-contents" data-react="scores-show"></div>
 
     <script id="json-show" type="application/json">
         {!! json_encode($scoreJson) !!}

--- a/resources/views/seasons/show.blade.php
+++ b/resources/views/seasons/show.blade.php
@@ -33,7 +33,7 @@
     <div class="osu-page osu-page--ranking-info">
         @include('rankings._playlist_selector')
     </div>
-    <div class="js-react--seasons-show u-contents"></div>
+    <div class="js-react u-contents" data-react="seasons-show"></div>
 @endsection
 
 @section('scores')

--- a/resources/views/store/products/supporter-tag.blade.php
+++ b/resources/views/store/products/supporter-tag.blade.php
@@ -10,8 +10,9 @@
     {!! require_login('store.supporter_tag.require_login._', 'store.supporter_tag.require_login.link_text') !!}
 @else
     <div
-        class="js-react--store-supporter-tag"
+        class="js-react"
         data-max-message-length={{ ExtraDataSupporterTag::MAX_MESSAGE_LENGTH }}
+        data-react="store-supporter-tag"
     ></div>
     <input name="item[product_id]" type="hidden" value={{ $product->product_id }} />
     <input class="js-store-item-quantity" name="item[quantity]" type="hidden" value="1" />

--- a/resources/views/teams/show.blade.php
+++ b/resources/views/teams/show.blade.php
@@ -138,11 +138,12 @@
                     </form>
                 @endif
                 <div
-                    class="js-react--team-extra-menu u-contents"
+                    class="js-react u-contents"
                     data-props="{{ json_encode([
                         'leaderUsername' => $leader['username'],
                         'teamId' => $team->getKey(),
                     ]) }}"
+                    data-react="team-extra-menu"
                 >
                     <div class="btn-circle btn-circle--page-toggle btn-circle--page-toggle-detail">
                         <button class="popup-menu" type="button">
@@ -280,7 +281,8 @@
                             {{ osu_trans('teams.show.members.owner') }}
                         </div>
                         <div
-                            class="js-react--user-card u-contents"
+                            class="js-react u-contents"
+                            data-react="user-card"
                             data-user="{{ json_encode($leader) }}"
                         ></div>
                     </div>
@@ -296,7 +298,8 @@
                         </div>
                         @foreach ($members as $memberJson)
                             <div
-                                class="js-react--user-card u-contents"
+                                class="js-react u-contents"
+                                data-react="user-card"
                                 data-user="{{ json_encode($memberJson) }}"
                             ></div>
                         @endforeach

--- a/resources/views/tournaments/show.blade.php
+++ b/resources/views/tournaments/show.blade.php
@@ -85,7 +85,11 @@
 
             @if($tournament->isRegistrationOpen())
                 <div class='tournament__countdown-timer'>
-                    <div class='js-react--countdownTimer' data-deadline='{{json_time($tournament->signup_close)}}'></div>
+                    <div
+                        class='js-react'
+                        data-react='countdownTimer'
+                        data-deadline='{{json_time($tournament->signup_close)}}'
+                    ></div>
                 </div>
 
                 <div class="tournament__body">

--- a/resources/views/user_totp/create.blade.php
+++ b/resources/views/user_totp/create.blade.php
@@ -37,13 +37,14 @@
                     </p>
                     <div>
                         <div
-                            class="js-react--click-to-copy u-contents"
+                            class="js-react u-contents"
                             data-props="{{ json_encode([
                                 'label' => osu_trans('user_totp.create.key_copy'),
                                 'showIcon' => true,
                                 'value' => $totp->getSecret(),
                                 'valueAsUrl' => false,
                             ]) }}"
+                            data-react="click-to-copy"
                         ></div>
                     </div>
                 </div>

--- a/resources/views/users/beatmapset_activities.blade.php
+++ b/resources/views/users/beatmapset_activities.blade.php
@@ -11,7 +11,7 @@
 @section('content')
     @include('users._restricted_banner', compact('user'))
 
-    <div class="js-react--modding-profile u-contents"></div>
+    <div class="js-react u-contents" data-react="modding-profile"></div>
 @endsection
 
 @section ("script")

--- a/resources/views/users/multiplayer/index.blade.php
+++ b/resources/views/users/multiplayer/index.blade.php
@@ -11,7 +11,7 @@
 @section('content')
     @include('users._restricted_banner', compact('user'))
 
-    <div class="js-react--user-multiplayer-index u-contents"></div>
+    <div class="js-react u-contents" data-react="user-multiplayer-index"></div>
 @endsection
 
 @section ("script")

--- a/resources/views/users/show.blade.php
+++ b/resources/views/users/show.blade.php
@@ -13,8 +13,9 @@
     @include('users._restricted_banner', compact('user'))
 
     <div
-        class="js-react--profile-page u-contents"
+        class="js-react u-contents"
         data-initial-data="{{ json_encode($initialData) }}"
+        data-react="profile-page"
     ></div>
 @endsection
 

--- a/resources/views/wiki/main.blade.php
+++ b/resources/views/wiki/main.blade.php
@@ -22,7 +22,7 @@
     <div class="osu-page osu-page--wiki osu-page--wiki-main">
         @include('wiki._notice')
 
-        <div class="js-react--wiki-search"></div>
+        <div class="js-react" data-react="wiki-search"></div>
 
         <div class="wiki-main-page">
             {!! $page->get()["output"] !!}


### PR DESCRIPTION
Rather than looping by the ever-growing `reactTurbolinks.components`, check for the actually existing elements on the page instead.