### PR TITLE
Add `pool_id` to `matchmaking_user_stats`

### DIFF
--- a/database/migrations/2025_11_19_000000_add_pool_id_to_matchmaking_user_stats.php
+++ b/database/migrations/2025_11_19_000000_add_pool_id_to_matchmaking_user_stats.php
@@ -45,7 +45,7 @@ return new class extends Migration
             $table->dropIndex(['pool_id', 'total_points']);
             $table->dropPrimary();
 
-            $table->integer('rating');
+            $table->integer('rating')->default(1500);
 
             $table->smallInteger('ruleset_id');
             $table->index(['ruleset_id', 'first_placements']);


### PR DESCRIPTION
- Replaces `ruleset_id` with `pool_id`. Migration is somewhat complex due to primary key uniqueness, and has a caveat documented in code. Wanted to not lose data here yet.
- Removes `rating` column.

@nanaya @peppy Note that this should be merged alongside https://github.com/ppy/osu-server-spectator/pull/374 as spectator will start immediately failing once this is deployed.

Please re-test. I've been testing with data [here](https://discord.com/channels/90072389919997952/1327149041511043134/1433416249164955720).