### PR TITLE
Fix url of top plays ruleset selector

### DIFF
--- a/resources/views/rankings/index.blade.php
+++ b/resources/views/rankings/index.blade.php
@@ -14,7 +14,11 @@
         ];
     }
 
-    $currentRoute ??= 'rankings';
+    $rulesetSelectorUrlFn ??= fn (string $r): string => route('rankings', [
+        ...$params,
+        'mode' => $r,
+        'variant' => $r === $params['mode'] ? ($params['variant'] ?? null) : null,
+    ]);
     $hasFilter ??= true;
     $hasMode ??= true;
     $hasPager ??= true;
@@ -27,11 +31,7 @@
     @section('rulesetSelector')
         @include('objects._ruleset_selector', [
             'currentRuleset' => $params['mode'],
-            'urlFn' => fn (string $r): string => route($currentRoute, [
-                ...$params,
-                'mode' => $r,
-                'variant' => $r === $params['mode'] ? ($params['variant'] ?? null) : null,
-            ]),
+            'urlFn' => $rulesetSelectorUrlFn,
         ])
     @endsection
 @endif

--- a/resources/views/rankings/top_plays.blade.php
+++ b/resources/views/rankings/top_plays.blade.php
@@ -3,9 +3,9 @@
     See the LICENCE file in the repository root for full licence text.
 --}}
 @extends('rankings.index', [
-    'currentRoute' => 'rankings.top-plays',
     'hasPager' => $scores !== null,
     'params' => ['mode' => $rulesetName, 'type' => 'top_plays'],
+    'rulesetSelectorUrlFn' => fn (string $r): string => route('rankings.top-plays', ['mode' => $r]),
     'titlePrepend' => osu_trans('rankings.type.top_plays'),
 ])
 


### PR DESCRIPTION
The silly trick to shortcut work ended up with silly `type=top_plays` in the url query string so just pass a good old url generator function instead. It's probably clearer as well.