### PR TITLE
Add support for country-specific top plays

### DIFF
--- a/app/Console/Commands/RankingsRecalculateTopPlays.php
+++ b/app/Console/Commands/RankingsRecalculateTopPlays.php
@@ -9,6 +9,7 @@ namespace App\Console\Commands;
 
 use App\Libraries\Score\TopPlays;
 use App\Models\Beatmap;
+use App\Models\Country;
 use Illuminate\Console\Command;
 
 class RankingsRecalculateTopPlays extends Command
@@ -18,10 +19,18 @@ class RankingsRecalculateTopPlays extends Command
 
     public function handle()
     {
+        $countriesQuery = Country::where('rankedscore', '>', 0);
+        $countries = $countriesQuery->get();
+
         foreach (Beatmap::MODES as $rulesetName => $rulesetId) {
             $this->info("Updating top plays data for {$rulesetName}");
             new TopPlays($rulesetId)->updateCache();
+
+            foreach ($countries as $country) {
+                new TopPlays($rulesetId, $country->acronym)->updateCache();
+            }
         }
+
         $this->info('Done');
     }
 }

--- a/app/Http/Controllers/Ranking/TopPlaysController.php
+++ b/app/Http/Controllers/Ranking/TopPlaysController.php
@@ -10,6 +10,7 @@ namespace App\Http\Controllers\Ranking;
 use App\Http\Controllers\Controller;
 use App\Libraries\Score\TopPlays;
 use App\Models\Beatmap;
+use App\Models\CountryStatistics;
 use App\Models\Solo\Score;
 use App\Transformers\ScoreTransformer;
 use Symfony\Component\HttpFoundation\Response;
@@ -27,7 +28,16 @@ class TopPlaysController extends Controller
 
         $rulesetId = Beatmap::MODES[$rulesetName] ?? abort(422, 'invalid ruleset parameter');
         $page = \Number::clamp(get_int(\Request::input('page')) ?? 1, 1, static::PAGES);
-        $data = new TopPlays($rulesetId)->get();
+        $country = \Request::input('country');
+
+        $countryStats = $country !== null
+            ? CountryStatistics
+                ::where('country_code', $country)
+                ->where('mode', $rulesetId)
+                ->firstOrFail()
+            : null;
+
+        $data = new TopPlays($rulesetId, $country)->get();
 
         if (isset($data)) {
             $lastUpdate = parse_time_to_carbon($data['time']);
@@ -57,6 +67,7 @@ class TopPlaysController extends Controller
             'rulesetName',
             'scores',
             'scoresJson',
+            'countryStats',
         ));
     }
 }

--- a/app/Libraries/Score/TopPlays.php
+++ b/app/Libraries/Score/TopPlays.php
@@ -16,9 +16,15 @@ class TopPlays
 
     private readonly string $key;
 
-    public function __construct(private readonly int $rulesetId)
+    public function __construct(private readonly int $rulesetId, private readonly ?string $countryCode = null)
     {
-        $this->key = static::KEY.':'.$this->rulesetId;
+        $key = static::KEY.':'.$this->rulesetId;
+
+        if ($this->countryCode !== null) {
+            $key = $key.':'.$this->countryCode;
+        }
+
+        $this->key = $key;
     }
 
     public function updateCache(): void
@@ -28,6 +34,8 @@ class TopPlays
             'limit' => 3000,
             'ruleset_id' => $this->rulesetId,
             'sort' => 'pp_desc',
+            'country_code' => $this->countryCode,
+            'type' => $this->countryCode === null ? 'global' : 'country',
         ]));
         $search->connectionName = 'scores_slow';
         $search->searchTimeout = "{$GLOBALS['cfg']['elasticsearch']['connections']['scores_slow']['connectionParams']['client']['timeout']}s";

--- a/resources/js/ranking-top-plays/index.tsx
+++ b/resources/js/ranking-top-plays/index.tsx
@@ -18,6 +18,7 @@ import { displayMods, hasMenu } from 'utils/score-helper';
 
 interface Props {
   first_score_rank: number;
+  mode: string;
   scores: ScoreJsonForTopPlays[];
 }
 
@@ -60,9 +61,9 @@ export default function RankingScores(props: Props) {
             <div className='ranking-page-grid-item__col ranking-page-grid-item__col--main'>
               <div className='ranking-page-table-main'>
                 <span className='ranking-page-table-main__flag'>
-                  <span className='u-contents u-hover'>
+                  <a className='u-contents u-hover' href={route('rankings.top-plays', { country: score.user.country_code, mode: props.mode })}>
                     <FlagCountry country={score.user.country} />
-                  </span>
+                  </a>
                 </span>
                 {score.user.team != null &&
                   <span className='ranking-page-table-main__flag'>

--- a/resources/views/rankings/top_plays.blade.php
+++ b/resources/views/rankings/top_plays.blade.php
@@ -14,6 +14,13 @@
         {{ osu_trans('rankings.top_plays.empty') }}
     @endsection
 @else
+    @section('ranking-header')
+        <div class="osu-page osu-page--ranking-info">
+            <div class="grid-items grid-items--ranking-filter">
+                @include('rankings._country_filter', ['params' => ['mode' => $rulesetName]])
+            </div>
+        </div>
+    @endsection
     @section('scores-header')
         <p>
             <small>{{ osu_trans('rankings.top_plays.last_updated') }}: {!! timeago($lastUpdate) !!}</small>
@@ -24,6 +31,7 @@
             class="u-contents js-react"
             data-props="{{ json_encode([
                 'first_score_rank' => $scores->firstItem(),
+                'mode' => $rulesetName,
                 'scores' => $scoresJson,
             ]) }}"
             data-react="ranking-top-plays"


### PR DESCRIPTION
<img width="1994" height="812" alt="image" src="https://github.com/user-attachments/assets/76547dfc-bbc4-4efa-8245-25e0d9b6e7f5" />

Addresses part of #12556.

There's probably a non-zero chance that the time required to recalculate top plays for each country is too much on a production-sized index, but I don't have a good way to measure this nor make assumptions. In the worst case, country-specific top plays could fetch a lower score count, or maybe the country recalculation could be split into a separate command that runs less frequently?