### PR TITLE
Don't return error when receiving non ECheck pending IPN from Paypal

### DIFF
--- a/app/Libraries/Payments/PaymentProcessor.php
+++ b/app/Libraries/Payments/PaymentProcessor.php
@@ -12,7 +12,6 @@ use App\Models\Store\Payment;
 use App\Traits\Memoizes;
 use App\Traits\Validatable;
 use DB;
-use Sentry\Severity;
 use Sentry\State\Scope;
 
 abstract class PaymentProcessor implements \ArrayAccess
@@ -209,25 +208,6 @@ abstract class PaymentProcessor implements \ArrayAccess
     {
         $this->sandboxAssertion();
         $this->assertValidTransaction();
-
-        DB::connection('mysql-store')->transaction(function () {
-            $order = $this->getOrder()->lockSelf();
-
-            $reason = $this['pending_reason'] === 'echeck' ? Order::PENDING_ECHECK : $this['pending_reason'];
-            // Log warning if non echeck pending status will overwrite the echeck field.
-            if ($order->tracking_code === Order::PENDING_ECHECK && $order->tracking_code !== $reason) {
-                app('sentry')->getClient()->captureMessage(
-                    "Trying to overwrite pending echeck with {$reason}",
-                    new Severity(Severity::WARNING),
-                    (new Scope())->setExtra('order_id', $order->getKey())
-                );
-            } else {
-                $order->tracking_code = $reason;
-            }
-
-            $order->transaction_id = $this->getTransactionId();
-            $order->saveOrExplode();
-        });
 
         datadog_increment('store.payments.pending', ['provider' => $this->getPaymentProvider()]);
     }


### PR DESCRIPTION
So Paypal doesn't keep retrying it.

Paypal sends more than `echeck` as the reason for `Pending` now, but the IPN payload itself doesn't have enough information to determine what is going on (cancellation, bank/card provider delays/confirmation, etc) without digging through the transaction history.

We don't really treat pending differently other than recording information since it all looks the same from our end.