### PR TITLE
Skip counting global non-default variant players for ranking page

### DIFF
--- a/app/Http/Controllers/RankingController.php
+++ b/app/Http/Controllers/RankingController.php
@@ -398,8 +398,8 @@ class RankingController extends Controller
 
                 $maxResults = static::MAX_RESULTS;
 
-                // use slower row count as there's no statistics entry for variants
-                if ($params['variant'] !== null) {
+                // use slower row count as there's no country statistics entry for variants
+                if ($params['variant'] !== null && $countryStats !== null) {
                     sort($params);
                     $cacheKey = 'ranking_count:'.json_encode($params);
 

--- a/app/Http/Controllers/RankingController.php
+++ b/app/Http/Controllers/RankingController.php
@@ -398,8 +398,12 @@ class RankingController extends Controller
 
                 $maxResults = static::MAX_RESULTS;
 
+                if ($countryStats === null) {
+                    return $maxResults;
+                }
+
                 // use slower row count as there's no country statistics entry for variants
-                if ($params['variant'] !== null && $countryStats !== null) {
+                if ($params['variant'] !== null) {
                     sort($params);
                     $cacheKey = 'ranking_count:'.json_encode($params);
 
@@ -411,9 +415,7 @@ class RankingController extends Controller
                     );
                 }
 
-                return $countryStats === null
-                    ? $maxResults
-                    : min($countryStats->user_count, $maxResults);
+                return min($countryStats->user_count, $maxResults);
         }
     }
 


### PR DESCRIPTION
It'll definitely always be more than the maximum number of pages. The default variant one is already using the same logic anyway and the comment really only apply for country statistics.