### PR TITLE
Fix News post notification not sent when directly syncing the page

### DIFF
--- a/app/Models/NewsPost.php
+++ b/app/Models/NewsPost.php
@@ -414,11 +414,14 @@ class NewsPost extends Model implements Commentable, Wiki\WikiObject
 
     public function save(array $options = [])
     {
-        if ($this->isDirty('published_at') && $this->getOriginal('published_at') === null) {
-            $this->getConnection()->afterCommit(fn () => new NewsPostNew($this)->dispatch());
-        }
+        // adding afterCommit needs to be after the transaction starts
+        return $this->getConnection()->transaction(function () use ($options) {
+            if ($this->isDirty('published_at') && $this->getOriginal('published_at') === null) {
+                $this->getConnection()->afterCommit(fn () => new NewsPostNew($this)->dispatch());
+            }
 
-        return parent::save($options);
+            return parent::save($options);
+        });
     }
 
     public function title()


### PR DESCRIPTION
Turns out that `afterCommit()` __does not__ run after `save` and runs immediately when not explicitly in a transaction, which causes the job to dispatch before it's saved.

`NewsPost::syncAll()` creates the record first and doesn't have this issue.