### PR TITLE
Adjust quickplay rank display on profile page

### DIFF
--- a/app/Transformers/MatchmakingPoolTransformer.php
+++ b/app/Transformers/MatchmakingPoolTransformer.php
@@ -14,6 +14,7 @@ class MatchmakingPoolTransformer extends TransformerAbstract
     public function transform(MatchmakingPool $pool): array
     {
         return [
+            'active' => $pool->active,
             'id' => $pool->getKey(),
             'name' => $pool->name,
             'ruleset_id' => $pool->ruleset_id,

--- a/resources/js/interfaces/matchmaking-pool-json.ts
+++ b/resources/js/interfaces/matchmaking-pool-json.ts
@@ -4,6 +4,7 @@
 import { RulesetId, RulesetVariantId } from './ruleset';
 
 export default interface MatchmakingPoolJson {
+  active: boolean;
   id: number;
   name: string;
   ruleset_id: RulesetId;

--- a/resources/js/profile-page/matchmaking.tsx
+++ b/resources/js/profile-page/matchmaking.tsx
@@ -14,6 +14,9 @@ interface Props {
 @observer
 export default class Matchmaking extends React.Component<Props> {
   render() {
+    if (this.props.allStats.length === 0) {
+      return null;
+    }
     let highestRank: null | number = null;
     for (const stats of this.props.allStats) {
       const rank = stats.rank;

--- a/resources/js/profile-page/matchmaking.tsx
+++ b/resources/js/profile-page/matchmaking.tsx
@@ -20,7 +20,8 @@ export default class Matchmaking extends React.Component<Props> {
     let highestRank: null | number = null;
     for (const stats of this.props.allStats) {
       const rank = stats.rank;
-      if (rank != null) {
+      // only show active stats for profile page
+      if (stats.pool.active && rank != null) {
         if (highestRank == null) {
           highestRank = rank;
         } else if (rank < highestRank) {


### PR DESCRIPTION
- Hide the quickplay badge if there's no play at all (more like bugfix)
- Only consider active pool ranks for the "highest" rank

Resolves #12590