### PR TITLE
Add yearly playcount table

### DIFF
--- a/app/Models/YearlyPlaycount.php
+++ b/app/Models/YearlyPlaycount.php
@@ -1,0 +1,40 @@
+<?php
+
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
+declare(strict_types=1);
+
+namespace App\Models;
+
+/**
+ * @property int $playcount
+ * @property int $year
+ */
+class YearlyPlaycount extends Model
+{
+    public $timestamps = false;
+    protected $table = 'yearly_playcount';
+
+    public static function getPosition(int $year, int $userId): array
+    {
+        $users = \Cache::remember(
+            "yearly_playcount_users:{$year}",
+            3600,
+            fn () => max(1, static::where('year', $year)->count()),
+        );
+
+        $yearString = substr((string) $year, 2, 2);
+        $playcount = (int) UserMonthlyPlaycount
+            ::where('user_id', $userId)
+            ->whereBetween('year_month', ["{$yearString}01", "{$yearString}12"])
+            ->sum('playcount');
+        $pos = static::where('year', $year)->where('playcount', '>', $playcount)->count();
+
+        return [
+            'playcount' => $playcount,
+            'pos' => $pos + 1,
+            'top_percent' => max(0.01, $pos / $users),
+        ];
+    }
+}

--- a/database/migrations/2025_12_17_105755_create_yearly_playcount.php
+++ b/database/migrations/2025_12_17_105755_create_yearly_playcount.php
@@ -1,0 +1,28 @@
+<?php
+
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('yearly_playcount', function (Blueprint $table) {
+            $table->id();
+            $table->unsignedSmallInteger('year');
+            $table->unsignedInteger('playcount');
+            $table->index(['year', 'playcount']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('yearly_playcount');
+    }
+};


### PR DESCRIPTION
This will be used for calculating percentile of a user's playcount for the year.

The actual data will be inserted separately, probably calculated in a different server and then inserted directly. Slight inaccuracies shouldn't affect the result too much.

The query:
```sql
insert into yearly_playcount (year,playcount)
  select 2025, sum(playcount)
  from osu_user_month_playcount
  where `year_month` between '2501' and '2512' group by user_id;
```