### PR TITLE
Support returning user global rank on lookup endpoint

### DIFF
--- a/app/Transformers/UserCompactTransformer.php
+++ b/app/Transformers/UserCompactTransformer.php
@@ -68,6 +68,7 @@ class UserCompactTransformer extends TransformerAbstract
         'follow_user_mapping',
         'follower_count',
         'friends',
+        'global_rank',
         'graveyard_beatmapset_count',
         'groups',
         'guest_beatmapset_count',
@@ -278,6 +279,14 @@ class UserCompactTransformer extends TransformerAbstract
             $user->relationFriends,
             new UserRelationTransformer()
         );
+    }
+
+    public function includeGlobalRank(User $user)
+    {
+        return $this->primitive([
+            'rank' => $user->statistics($this->mode)?->globalRank(),
+            'ruleset_id' => Beatmap::MODES[$this->mode],
+        ]);
     }
 
     public function includeGraveyardBeatmapsetCount(User $user)


### PR DESCRIPTION
To be used by client. Only the specific field to minimise response size.

Requires parameter `ruleset_id`.

Not sure if the `ruleset_id` is useful to be included in the response but the lack of the field in `statistics` has been kind of weird...

```json
{
  "global_rank": {
    "rank": 1000,
    "ruleset_id": 0
  }
}
```