### PR TITLE
Fix turbo not scrolling to correct element

### DIFF
--- a/app/Libraries/Markdown/Osu/DocumentProcessor.php
+++ b/app/Libraries/Markdown/Osu/DocumentProcessor.php
@@ -149,7 +149,8 @@ class DocumentProcessor
 
         $title = presence($this->getText($this->node));
         $slug = $this->node->data['attributes']['id']
-            ?? presence(mb_strtolower(strtr($title ?? '', ' ', '-')))
+            // turbo can't handle non-percent encoded id
+            ?? presence(urlencode(mb_strtolower(strtr($title ?? '', ' ', '-'))))
             ?? 'page';
 
         if (array_key_exists($slug, $this->tocSlugs)) {


### PR DESCRIPTION
Apparently html allows percent encoded id for matching with anchor link...? The resulting ids and links are **a bit** long.

Resolves #12649