### PR TITLE
 Clean up route name for score show/download

### DIFF
--- a/app/Http/Controllers/ScoresController.php
+++ b/app/Http/Controllers/ScoresController.php
@@ -53,12 +53,12 @@ class ScoresController extends Controller
         $shouldRedirect = !is_api_request() && !from_app_url();
         if ($id === null) {
             if ($shouldRedirect) {
-                return ujs_redirect(route('scores.show', ['rulesetOrScore' => $rulesetOrSoloId]));
+                return ujs_redirect(route('scores.show', ['score' => $rulesetOrSoloId]));
             }
             $score = Score::where('has_replay', true)->findOrFail($rulesetOrSoloId);
         } else {
             if ($shouldRedirect) {
-                return ujs_redirect(route('scores.show', ['rulesetOrScore' => $rulesetOrSoloId, 'score' => $id]));
+                return ujs_redirect(route('scores.show', ['ruleset' => $rulesetOrSoloId, 'score' => $id]));
             }
             // don't limit downloading replays of restricted users for review purpose
             $score = Score::where([

--- a/app/Models/Score/Best/Model.php
+++ b/app/Models/Score/Best/Model.php
@@ -75,7 +75,7 @@ abstract class Model extends BaseModel implements Traits\ReportableInterface
 
     public function url(): string
     {
-        return route('scores.show', ['rulesetOrScore' => $this->getMode(), 'score' => $this->getKey()]);
+        return route('scores.show', ['ruleset' => $this->getMode(), 'score' => $this->getKey()]);
     }
 
     public function scopeDefault($query)

--- a/app/Models/Solo/Score.php
+++ b/app/Models/Solo/Score.php
@@ -533,7 +533,7 @@ class Score extends Model implements Traits\ReportableInterface
 
     public function url(): string
     {
-        return route('scores.show', ['rulesetOrScore' => $this->getKey()]);
+        return route('scores.show', ['score' => $this->getKey()]);
     }
 
     public function userRank(?array $params = null): int

--- a/resources/js/beatmapsets-show/scoreboard/table-row.tsx
+++ b/resources/js/beatmapsets-show/scoreboard/table-row.tsx
@@ -19,7 +19,7 @@ import PpValue from 'scores/pp-value';
 import { classWithModifiers, Modifiers } from 'utils/css';
 import { formatNumber } from 'utils/html';
 import { trans } from 'utils/lang';
-import { accuracy, displayMods, hasMenu, isPerfectCombo, calculateStatisticsFor, rank, scoreUrl } from 'utils/score-helper';
+import { accuracy, displayMods, hasMenu, isPerfectCombo, calculateStatisticsFor, rank } from 'utils/score-helper';
 
 const bn = 'beatmap-scoreboard-table';
 
@@ -55,7 +55,7 @@ interface Props {
 export default class ScoreboardTableRow extends React.Component<Props> {
   @computed
   get scoreUrl() {
-    return scoreUrl(this.props.score);
+    return route('scores.show', { score: this.props.score.id });
   }
 
   constructor(props: Props) {

--- a/resources/js/beatmapsets-show/scoreboard/top-card.tsx
+++ b/resources/js/beatmapsets-show/scoreboard/top-card.tsx
@@ -21,7 +21,7 @@ import { rulesetName, shouldShowPp } from 'utils/beatmap-helper';
 import { classWithModifiers, Modifiers } from 'utils/css';
 import { formatNumber } from 'utils/html';
 import { trans } from 'utils/lang';
-import { accuracy, displayMods, isPerfectCombo, calculateStatisticsFor, rank, scoreUrl } from 'utils/score-helper';
+import { accuracy, displayMods, isPerfectCombo, calculateStatisticsFor, rank } from 'utils/score-helper';
 
 interface Props {
   beatmap: BeatmapJson;
@@ -40,7 +40,7 @@ export default class TopCard extends React.PureComponent<Props> {
       <div className={classWithModifiers('beatmap-score-top', this.props.modifiers)}>
         <a
           className='beatmap-score-top__link-container'
-          href={scoreUrl(this.props.score)}
+          href={route('scores.show', { score: this.props.score.id })}
         />
 
         <div className='beatmap-score-top__section'>

--- a/resources/js/components/play-detail-menu.tsx
+++ b/resources/js/components/play-detail-menu.tsx
@@ -4,12 +4,13 @@
 import ScorePin from 'components/score-pin';
 import ScoreJson from 'interfaces/score-json';
 import UserJson from 'interfaces/user-json';
+import { route } from 'laroute';
 import { observer } from 'mobx-react';
 import core from 'osu-core-singleton';
 import * as React from 'react';
 import { rulesetName } from 'utils/beatmap-helper';
 import { trans } from 'utils/lang';
-import { canBeReported, hasReplay, hasShow, scoreDownloadUrl, scoreUrl } from 'utils/score-helper';
+import { canBeReported, hasReplay, hasShow } from 'utils/score-helper';
 import { PopupMenuPersistent } from './popup-menu-persistent';
 import { ReportReportable } from './report-reportable';
 
@@ -35,7 +36,7 @@ export class PlayDetailMenu extends React.Component<Props> {
         )}
 
         {hasShow(score) && (
-          <a className='simple-menu__item' href={scoreUrl(score)}>
+          <a className='simple-menu__item' href={route('scores.show', { score: score.id })}>
             {trans('users.show.extra.top_ranks.view_details')}
           </a>
         )}
@@ -43,7 +44,7 @@ export class PlayDetailMenu extends React.Component<Props> {
         {hasReplay(score) && (
           <a
             className='simple-menu__item js-login-required--click'
-            href={scoreDownloadUrl(score)}
+            href={route('scores.download', { score: score.id })}
             onClick={dismiss}
           >
             {trans('users.show.extra.top_ranks.download_replay')}

--- a/resources/js/ranking-top-plays/index.tsx
+++ b/resources/js/ranking-top-plays/index.tsx
@@ -54,7 +54,7 @@ export default function RankingScores(props: Props) {
         <div key={score.id} className='ranking-page-grid-item'>
           <a
             className='ranking-page-grid-item__link-bg'
-            href={route('scores.show', { rulesetOrScore: score.id })}
+            href={route('scores.show', { score: score.id })}
           />
           <div className='ranking-page-grid-item__content'>
             <div className='ranking-page-grid-item__col ranking-page-grid-item__col--number ranking-page-grid-item__col--number-focus'>

--- a/resources/js/scores-show/buttons.tsx
+++ b/resources/js/scores-show/buttons.tsx
@@ -5,11 +5,12 @@ import { PopupMenuPersistent } from 'components/popup-menu-persistent';
 import { ReportReportable } from 'components/report-reportable';
 import ScorePin from 'components/score-pin';
 import { ScoreJsonForShow } from 'interfaces/score-json';
+import { route } from 'laroute';
 import core from 'osu-core-singleton';
 import * as React from 'react';
 import { rulesetName } from 'utils/beatmap-helper';
 import { trans } from 'utils/lang';
-import { canBeReported, hasReplay, scoreDownloadUrl } from 'utils/score-helper';
+import { canBeReported, hasReplay } from 'utils/score-helper';
 
 interface Props {
   score: ScoreJsonForShow;
@@ -33,7 +34,7 @@ export default function Buttons(props: Props) {
       {hasReplay(props.score) && (
         <a
           className='js-login-required--click btn-osu-big btn-osu-big--rounded'
-          href={scoreDownloadUrl(props.score)}
+          href={route('scores.download', { score: props.score.id })}
         >
           {trans('users.show.extra.top_ranks.download_replay')}
         </a>

--- a/resources/js/utils/score-helper.ts
+++ b/resources/js/utils/score-helper.ts
@@ -4,7 +4,6 @@
 import Ruleset from 'interfaces/ruleset';
 import ScoreJson, { ScoreStatisticsAttribute } from 'interfaces/score-json';
 import ScoreModJson from 'interfaces/score-mod-json';
-import { route } from 'laroute';
 import modNames from 'mod-names.json';
 import core from 'osu-core-singleton';
 import { rulesetName } from './beatmap-helper';
@@ -210,36 +209,6 @@ function differenceBetweenConsecutiveElements(arr: number[]): number[] {
   }
 
   return result;
-}
-
-export function scoreDownloadUrl(score: ScoreJson) {
-  if (score.type === 'solo_score') {
-    return route('scores.download', { score: score.id });
-  }
-
-  if (score.best_id != null) {
-    return route('scores.download-legacy', {
-      rulesetOrScore: rulesetName(score.ruleset_id),
-      score: score.best_id,
-    });
-  }
-
-  throw new Error('score json doesn\'t have download url');
-}
-
-export function scoreUrl(score: ScoreJson) {
-  if (score.type === 'solo_score') {
-    return route('scores.show', { rulesetOrScore: score.id });
-  }
-
-  if (score.best_id != null) {
-    return route('scores.show', {
-      rulesetOrScore: rulesetName(score.ruleset_id),
-      score: score.best_id,
-    });
-  }
-
-  throw new Error('score json doesn\'t have url');
 }
 
 function shouldReturnLegacyValue(score: ScoreJson) {

--- a/resources/js/wrapped-show/index.tsx
+++ b/resources/js/wrapped-show/index.tsx
@@ -92,7 +92,7 @@ function Mappers(props: { beatmap: BeatmapForWrappedJson }) {
 function TopPlay(props: { beatmap?: BeatmapForWrappedJson; play: ScoreJson }) {
   const beatmapset = props.beatmap?.beatmapset;
   return (
-    <a className={classWithModifiers('wrapped__top-plays', 'summary-beatmap')} href={route('scores.show', { rulesetOrScore: props.play.id })}>
+    <a className={classWithModifiers('wrapped__top-plays', 'summary-beatmap')} href={route('scores.show', { score: props.play.id })}>
       <div className={classWithModifiers('wrapped__list-item', 'summary-beatmap')}
       >
         <BeatmapsetCover
@@ -149,7 +149,7 @@ function WrappedStat(props: WrappedStatProps) {
         <span data-tooltip-position='right center' title={props.tooltip}>
           {props.scoreId == null || props.scoreId === 0
             ? text
-            : <a className='wrapped__stat-value-link' href={route('scores.show', { rulesetOrScore: props.scoreId })}>{text}</a>
+            : <a className='wrapped__stat-value-link' href={route('scores.show', { score: props.scoreId })}>{text}</a>
           }
         </span>
       </div>
@@ -788,7 +788,7 @@ export default class WrappedShow extends React.Component<WrappedData> {
         {selectedBeatmap != null && (
           <div className='wrapped__list-details'>
             {this.renderListDetailsTitle(
-              <a className={classWithModifiers('wrapped__text', 'container')} href={route('scores.show', { rulesetOrScore: selectedItem.id })}>
+              <a className={classWithModifiers('wrapped__text', 'container')} href={route('scores.show', { score: selectedItem.id })}>
                 <div className={classWithModifiers('wrapped__text', 'top')}>
                   {title}
                   <span className={classWithModifiers('wrapped__text', 'artist')}>

--- a/routes/web.php
+++ b/routes/web.php
@@ -121,9 +121,10 @@ Route::group(['middleware' => ['web']], function () {
 
     Route::group(['prefix' => 'scores', 'as' => 'scores.'], function () {
         Route::get('{score}/download', 'ScoresController@download')->name('download');
-        Route::get('{rulesetOrScore}/{score}/download', 'ScoresController@download')->name('download-legacy');
+        Route::get('{ruleset}/{score}/download', 'ScoresController@download')->name('download-legacy');
 
-        Route::get('{rulesetOrScore}/{score?}', 'ScoresController@show')->name('show');
+        Route::get('{ruleset}/{score}', 'ScoresController@show')->name('show-legacy');
+        Route::get('{score}', 'ScoresController@show')->name('show');
     });
 
     Route::get('ss/{screenshot}/{hash?}', 'ScreenshotsController@show')->name('screenshots.show');
@@ -545,9 +546,10 @@ Route::group(['as' => 'api.', 'prefix' => 'api', 'middleware' => ['api', Throttl
 
         Route::group(['prefix' => 'scores', 'as' => 'scores.'], function () {
             Route::get('{score}/download', 'ScoresController@download')->middleware(ThrottleRequests::getApiThrottle('scores_download'))->name('download');
-            Route::get('{rulesetOrScore}/{score}/download', 'ScoresController@download')->middleware(ThrottleRequests::getApiThrottle('scores_download'))->name('download-legacy');
+            Route::get('{ruleset}/{score}/download', 'ScoresController@download')->middleware(ThrottleRequests::getApiThrottle('scores_download'))->name('download-legacy');
 
-            Route::get('{rulesetOrScore}/{score?}', 'ScoresController@show')->name('show');
+            Route::get('{ruleset}/{score}', 'ScoresController@show')->name('show-legacy');
+            Route::get('{score}', 'ScoresController@show')->name('show');
 
             Route::get('/', 'ScoresController@index');
         });

--- a/tests/Browser/SanityTest.php
+++ b/tests/Browser/SanityTest.php
@@ -472,11 +472,11 @@ class SanityTest extends DuskTestCase
                 'daily_challenge' => DailyChallengeDateHelper::roomId(self::$scaffolding['daily_challenge_room']),
             ],
             'scores.download-legacy' => [
-                'rulesetOrScore' => static::$scaffolding['score']->getMode(),
+                'ruleset' => static::$scaffolding['score']->getMode(),
                 'score' => static::$scaffolding['score']->getKey(),
             ],
-            'scores.show' => [
-                'rulesetOrScore' => static::$scaffolding['score']->getMode(),
+            'scores.show-legacy' => [
+                'ruleset' => static::$scaffolding['score']->getMode(),
                 'score' => static::$scaffolding['score']->getKey(),
             ],
             'legal' => [

--- a/tests/api_routes.json
+++ b/tests/api_routes.json
@@ -1156,7 +1156,7 @@
         ]
     },
     {
-        "uri": "api/v2/scores/{rulesetOrScore}/{score}/download",
+        "uri": "api/v2/scores/{ruleset}/{score}/download",
         "methods": [
             "GET",
             "HEAD"
@@ -1173,7 +1173,23 @@
         ]
     },
     {
-        "uri": "api/v2/scores/{rulesetOrScore}/{score?}",
+        "uri": "api/v2/scores/{ruleset}/{score}",
+        "methods": [
+            "GET",
+            "HEAD"
+        ],
+        "controller": "App\\Http\\Controllers\\ScoresController@show",
+        "middlewares": [
+            "App\\Http\\Middleware\\ThrottleRequests:1200,1,api:",
+            "App\\Http\\Middleware\\RequireScopes",
+            "App\\Http\\Middleware\\RequireScopes:public"
+        ],
+        "scopes": [
+            "public"
+        ]
+    },
+    {
+        "uri": "api/v2/scores/{score}",
         "methods": [
             "GET",
             "HEAD"


### PR DESCRIPTION
Converted most of score download tests to use new score model while at it.

I also forgot the existence of `scoreUrl` function... which isn't relevant anymore because only new score models are exposed to web now.

- [x] depends on #12536