### PR TITLE
Remove user profile cover from watchlist pages

### DIFF
--- a/resources/js/entrypoints/follows-comment.tsx
+++ b/resources/js/entrypoints/follows-comment.tsx
@@ -7,5 +7,5 @@ import * as React from 'react';
 import { parseJson } from 'utils/json';
 
 core.reactTurbolinks.register('follows-comment', () => (
-  <Main follows={parseJson('json-follows-comment')} user={core.currentUserOrFail} />
+  <Main follows={parseJson('json-follows-comment')} />
 ));

--- a/resources/js/entrypoints/follows-mapping.tsx
+++ b/resources/js/entrypoints/follows-mapping.tsx
@@ -7,5 +7,5 @@ import * as React from 'react';
 import { parseJson } from 'utils/json';
 
 core.reactTurbolinks.register('follows-mapping', () => (
-  <Main follows={parseJson('json-follows-mapping')} user={core.currentUserOrFail} />
+  <Main follows={parseJson('json-follows-mapping')} />
 ));

--- a/resources/js/follows-comment/main.tsx
+++ b/resources/js/follows-comment/main.tsx
@@ -7,7 +7,6 @@ import HeaderV4 from 'components/header-v4';
 import StringWithComponent from 'components/string-with-component';
 import TimeWithTooltip from 'components/time-with-tooltip';
 import homeLinks from 'home-links';
-import CurrentUserJson from 'interfaces/current-user-json';
 import FollowCommentJson from 'interfaces/follow-comment-json';
 import { route } from 'laroute';
 import * as React from 'react';
@@ -15,7 +14,6 @@ import { trans } from 'utils/lang';
 
 interface Props {
   follows: FollowCommentJson[];
-  user: CurrentUserJson;
 }
 
 export default class Main extends React.PureComponent<Props> {
@@ -23,7 +21,6 @@ export default class Main extends React.PureComponent<Props> {
     return (
       <div className='osu-layout osu-layout--full'>
         <HeaderV4
-          backgroundImage={this.props.user.cover.url}
           links={homeLinks('follows.index')}
           theme='settings'
         />

--- a/resources/js/follows-mapping/main.tsx
+++ b/resources/js/follows-mapping/main.tsx
@@ -6,7 +6,6 @@ import FollowToggle from 'components/follow-toggle';
 import FollowsSubtypes from 'components/follows-subtypes';
 import HeaderV4 from 'components/header-v4';
 import homeLinks from 'home-links';
-import CurrentUserJson from 'interfaces/current-user-json';
 import FollowMappingJson from 'interfaces/follow-mapping-json';
 import { route } from 'laroute';
 import * as React from 'react';
@@ -15,7 +14,6 @@ import { trans } from 'utils/lang';
 
 interface Props {
   follows: FollowMappingJson[];
-  user: CurrentUserJson;
 }
 
 export default class Main extends React.PureComponent<Props> {
@@ -23,7 +21,6 @@ export default class Main extends React.PureComponent<Props> {
     return (
       <div className='osu-layout osu-layout--full'>
         <HeaderV4
-          backgroundImage={this.props.user.cover?.url}
           links={homeLinks('follows.index')}
           theme='settings'
         />


### PR DESCRIPTION
Resolves #12572

Removes profile cover from "mapper" and "comment" watchlists
All watchlist pages now use a generic image.