### PR TITLE
Fix score pin auth check still allowing legacy scores

### DIFF
--- a/app/Singletons/OsuAuthorize.php
+++ b/app/Singletons/OsuAuthorize.php
@@ -28,8 +28,7 @@ use App\Models\Language;
 use App\Models\LegacyMatch\LegacyMatch;
 use App\Models\Multiplayer\Room;
 use App\Models\OAuth\Client;
-use App\Models\Score\Best\Model as ScoreBest;
-use App\Models\Solo;
+use App\Models\Solo\Score;
 use App\Models\Team;
 use App\Models\TeamApplication;
 use App\Models\Traits\ReportableInterface;
@@ -1888,11 +1887,11 @@ class OsuAuthorize
 
     /**
      * @param User|null $user
-     * @param \App\Models\Score\Best\Model $score
+     * @param \App\Models\Solo\Score $score
      * @return string
      * @throws AuthorizationCheckException
      */
-    public function checkScorePin(?User $user, ScoreBest|Solo\Score $score): string
+    public function checkScorePin(?User $user, Score $score): string
     {
         $prefix = 'score.pin.';
 


### PR DESCRIPTION
The support for it has been removed a long time ago.