### PR TITLE
Add count for lazer multiplayer games

### DIFF
--- a/app/Libraries/CurrentStats.php
+++ b/app/Libraries/CurrentStats.php
@@ -26,7 +26,7 @@ class CurrentStats
 
             return [
                 'currentOnline' => $latest['users'] ?? 0,
-                'currentGames' => $latest['multiplayer_games'] ?? 0,
+                'currentGames' => ($latest['multiplayer_games'] ?? 0) + ($latest['multiplayer_games_lazer'] ?? 0),
                 'graphData' => array_to_graph_json($stats, 'users'),
                 'totalUsers' => Count::totalUsers()->count,
             ];

--- a/app/Models/BanchoStats.php
+++ b/app/Models/BanchoStats.php
@@ -5,8 +5,6 @@
 
 namespace App\Models;
 
-use Illuminate\Support\Facades\DB;
-
 /**
  * @property int $banchostats_id
  * @property \Carbon\Carbon $date
@@ -26,7 +24,7 @@ class BanchoStats extends Model
     {
         return array_reverse(
             static::whereRaw('banchostats_id mod 10 = 0')
-                ->select(['users_irc', DB::raw('(users_osu + users_lazer) AS users'), 'multiplayer_games', 'date'])
+                ->selectRaw('(users_osu + users_lazer) AS users, multiplayer_games, multiplayer_games_lazer')
                 ->orderBy('banchostats_id', 'DESC')
                 ->limit(24 * 60 / 10)
                 ->get()

--- a/database/migrations/2026_01_16_114540_add_multiplayer_games_lazer_to_banchostats.php
+++ b/database/migrations/2026_01_16_114540_add_multiplayer_games_lazer_to_banchostats.php
@@ -1,0 +1,27 @@
+<?php
+
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('osu_banchostats', function (Blueprint $table) {
+            $table->smallInteger('multiplayer_games_lazer')->default(0)->after('multiplayer_games');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('osu_banchostats', function (Blueprint $table) {
+            $table->dropColumn('multiplayer_games_lazer');
+        });
+    }
+};


### PR DESCRIPTION
Resolves #12667.

- [x] migration entry `2026_01_16_114540_add_multiplayer_games_lazer_to_banchostats` (has been run in prod)