### PR TITLE
Add option to hide anime style beatmap covers

### DIFF
--- a/resources/lang/en/accounts.php
+++ b/resources/lang/en/accounts.php
@@ -106,6 +106,7 @@ return [
     ],
 
     'options' => [
+        'beatmapset_show_anime_cover' => 'show anime style beatmap covers',
         'beatmapset_show_nsfw' => 'hide warnings for explicit content in beatmaps',
         'beatmapset_title_show_original' => 'show beatmap metadata in original language',
         'title' => 'Options',

--- a/resources/views/accounts/_edit_options.blade.php
+++ b/resources/views/accounts/_edit_options.blade.php
@@ -82,9 +82,30 @@
                     </div>
                 </label>
             </div>
-        </div>
 
-        <div class="account-edit__input-group">
+            <div
+                class="account-edit-entry account-edit-entry--no-label js-account-edit js-account-edit-auto-submit"
+                data-url="{{ route('account.options') }}"
+                data-skip-ajax-error-popup="1"
+                data-user-preferences-update="1"
+            >
+                <label class="account-edit-entry__checkbox">
+                    @include('objects._switch', ['locals' => [
+                        'additionalClass'=> 'js-account-edit__input',
+                        'checked' => $customization['beatmapset_show_nsfw'],
+                        'name' => 'user_profile_customization[beatmapset_show_anime_cover]',
+                    ]])
+
+                    <span class="account-edit-entry__checkbox-label">
+                        {{ osu_trans('accounts.options.beatmapset_show_anime_cover') }}
+                    </span>
+
+                    <div class="account-edit-entry__checkbox-status">
+                        @include('accounts._edit_entry_status', ['modifiers' => ['left']])
+                    </div>
+                </label>
+            </div>
+
             <div
                 class="account-edit-entry account-edit-entry--no-label js-account-edit js-account-edit-auto-submit"
                 data-url="{{ route('account.options') }}"


### PR DESCRIPTION
Actually show the option in account settings page. The option itself has existed for a long time now and the background check process seems to be close to completion or something (done by a separate process).

Resolves #12415.

![](https://s.kohaku.love/2026/01/firefox_2026-01-19_19-55-43.png)

- [x] all beatmaps have their background checked