### PR TITLE
Fix error on invalid/missing notifiable type

### DIFF
--- a/app/Models/Follow.php
+++ b/app/Models/Follow.php
@@ -52,6 +52,11 @@ class Follow extends Model
         $this->notifiable()->associate($value);
     }
 
+    public function getNotifiableIdAttribute($value): ?int
+    {
+        return isset($this->attributes['notifiable_type']) ? $value : null;
+    }
+
     public function setNotifiableTypeAttribute($value)
     {
         if (MorphMap::getClass($value) === null) {


### PR DESCRIPTION
I'm not sure how laravel ends up doing a nonsense lookup when the type column is null. (seems to be still the case in the latest laravel)