### PR TITLE
Hide user command chat messages

### DIFF
--- a/app/Events/ChatMessageEvent.php
+++ b/app/Events/ChatMessageEvent.php
@@ -29,9 +29,13 @@ class ChatMessageEvent extends BroadcastableEventBase implements ShouldBroadcast
      */
     public function broadcastOn()
     {
+        $userIds = $this->message->isUserCommand()
+            ? [$this->message->user_id]
+            : $this->message->channel->activeUserIds();
+
         return array_map(
             fn ($userId) => new Channel("private:user:{$userId}"),
-            $this->message->channel->activeUserIds()
+            $userIds,
         );
     }
 

--- a/app/Http/Controllers/Chat/Channels/MessagesController.php
+++ b/app/Http/Controllers/Chat/Channels/MessagesController.php
@@ -128,7 +128,7 @@ class MessagesController extends BaseController
             $messages = $messages->orderBy('message_id', 'desc')->get()->reverse();
         }
 
-        $messages = Message::filterBacklogs($channel, $messages);
+        $messages = Message::filter($channel, $messages);
 
         if (!$returnObject) {
             return json_collection(
@@ -142,7 +142,7 @@ class MessagesController extends BaseController
             'messages' => json_collection($messages, new MessageTransformer()),
             // FIXME: messages with null used should be removed from db...
             'users' => json_collection(
-                $messages->pluck('sender')->filter()->uniqueStrict('user_id')->values(),
+                collect($messages)->pluck('sender')->filter()->uniqueStrict('user_id')->values(),
                 new UserCompactTransformer()
             ),
         ];

--- a/app/Http/Controllers/Chat/Channels/MessagesController.php
+++ b/app/Http/Controllers/Chat/Channels/MessagesController.php
@@ -128,7 +128,7 @@ class MessagesController extends BaseController
             $messages = $messages->orderBy('message_id', 'desc')->get()->reverse();
         }
 
-        $messages = Message::filter($channel, $messages);
+        $messages = Message::filter($messages, $channel, $user->getKey());
 
         if (!$returnObject) {
             return json_collection(

--- a/app/Models/Chat/Channel.php
+++ b/app/Models/Chat/Channel.php
@@ -480,9 +480,8 @@ class Channel extends Model
 
             if (!$message->isUserCommand()) {
                 $message->dispatchNotification();
-
-                new ChatMessageEvent($message)->broadcast(true);
             }
+            new ChatMessageEvent($message)->broadcast(true);
         });
 
         datadog_increment('chat.channel.send', ['target' => $this->type]);

--- a/app/Models/Chat/Channel.php
+++ b/app/Models/Chat/Channel.php
@@ -478,9 +478,11 @@ class Channel extends Model
 
             $this->unhide();
 
-            $message->dispatchNotification();
+            if (!$message->isUserCommand()) {
+                $message->dispatchNotification();
 
-            new ChatMessageEvent($message)->broadcast(true);
+                new ChatMessageEvent($message)->broadcast(true);
+            }
         });
 
         datadog_increment('chat.channel.send', ['target' => $this->type]);

--- a/app/Models/Chat/Message.php
+++ b/app/Models/Chat/Message.php
@@ -122,11 +122,7 @@ class Message extends Model implements ReportableInterface
 
     public function isUserCommand(): bool
     {
-        $content = $this->content;
-
-        return strlen($content) > 1
-            && $content[0] === '!'
-            && ($content[1] !== ' ' && $content[1] !== '!');
+        return preg_match('/^![^ !]/', $this->content) === 1;
     }
 
     public function reportableAdditionalInfo(): ?string

--- a/app/Models/Chat/Message.php
+++ b/app/Models/Chat/Message.php
@@ -28,6 +28,14 @@ class Message extends Model implements ReportableInterface
 {
     use Reportable;
 
+    public ?string $uuid = null;
+
+    protected $primaryKey = 'message_id';
+    protected $casts = [
+        'is_action' => 'boolean',
+        'timestamp' => 'datetime',
+    ];
+
     public static function filter(iterable $messages, Channel $channel, ?int $userId): iterable
     {
         return static::filterUserCommands(static::filterBacklogs($messages, $channel), $userId);
@@ -62,14 +70,6 @@ class Message extends Model implements ReportableInterface
 
         return $ret;
     }
-
-    public ?string $uuid = null;
-
-    protected $primaryKey = 'message_id';
-    protected $casts = [
-        'is_action' => 'boolean',
-        'timestamp' => 'datetime',
-    ];
 
     public function channel()
     {

--- a/app/Models/Chat/Message.php
+++ b/app/Models/Chat/Message.php
@@ -41,7 +41,7 @@ class Message extends Model implements ReportableInterface
         return static::filterUserCommands(static::filterBacklogs($messages, $channel), $userId);
     }
 
-    public static function filterBacklogs(iterable $messages, Channel $channel): iterable
+    private static function filterBacklogs(iterable $messages, Channel $channel): iterable
     {
         if (!$channel->isPublic()) {
             return $messages;
@@ -59,7 +59,7 @@ class Message extends Model implements ReportableInterface
         return $ret;
     }
 
-    public static function filterUserCommands(iterable $messages, ?int $userId): iterable
+    private static function filterUserCommands(iterable $messages, ?int $userId): iterable
     {
         $ret = [];
         foreach ($messages as $message) {

--- a/app/Models/Chat/Message.php
+++ b/app/Models/Chat/Message.php
@@ -28,12 +28,12 @@ class Message extends Model implements ReportableInterface
 {
     use Reportable;
 
-    public static function filter(Channel $channel, iterable $messages): iterable
+    public static function filter(iterable $messages, Channel $channel, ?int $userId): iterable
     {
-        return static::filterUserCommands(static::filterBacklogs($channel, $messages));
+        return static::filterUserCommands(static::filterBacklogs($messages, $channel), $userId);
     }
 
-    public static function filterBacklogs(Channel $channel, iterable $messages): iterable
+    public static function filterBacklogs(iterable $messages, Channel $channel): iterable
     {
         if (!$channel->isPublic()) {
             return $messages;
@@ -51,11 +51,11 @@ class Message extends Model implements ReportableInterface
         return $ret;
     }
 
-    public static function filterUserCommands(iterable $messages): iterable
+    public static function filterUserCommands(iterable $messages, ?int $userId): iterable
     {
         $ret = [];
         foreach ($messages as $message) {
-            if (!$message->isUserCommand()) {
+            if ($message->user_id === $userId || !$message->isUserCommand()) {
                 $ret[] = $message;
             }
         }

--- a/app/Models/Chat/Message.php
+++ b/app/Models/Chat/Message.php
@@ -126,7 +126,7 @@ class Message extends Model implements ReportableInterface
 
         return strlen($content) > 1
             && $content[0] === '!'
-            && ($content[1] !== ' ' || $content[1] !== '!');
+            && ($content[1] !== ' ' && $content[1] !== '!');
     }
 
     public function reportableAdditionalInfo(): ?string

--- a/app/Transformers/Chat/ChannelTransformer.php
+++ b/app/Transformers/Chat/ChannelTransformer.php
@@ -80,7 +80,7 @@ class ChannelTransformer extends TransformerAbstract
     public function includeRecentMessages(Channel $channel)
     {
         if ($channel->exists) {
-            $messages = Message::filterBacklogs(
+            $messages = Message::filter(
                 $channel,
                 $channel
                     ->messages()

--- a/app/Transformers/Chat/ChannelTransformer.php
+++ b/app/Transformers/Chat/ChannelTransformer.php
@@ -81,7 +81,6 @@ class ChannelTransformer extends TransformerAbstract
     {
         if ($channel->exists) {
             $messages = Message::filter(
-                $channel,
                 $channel
                     ->messages()
                     // assumes sender will be included by the Message transformer
@@ -90,6 +89,8 @@ class ChannelTransformer extends TransformerAbstract
                     ->limit(50)
                     ->get()
                     ->reverse(),
+                $channel,
+                $this->user?->getKey(),
             );
         } else {
             $messages = [];

--- a/tests/Models/Chat/MessageTest.php
+++ b/tests/Models/Chat/MessageTest.php
@@ -1,0 +1,79 @@
+<?php
+
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
+declare(strict_types=1);
+
+namespace Tests\Models\Chat;
+
+use App\Models\Chat\Channel;
+use App\Models\Chat\Message;
+use Carbon\Carbon;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Tests\TestCase;
+
+class MessageTest extends TestCase
+{
+    public static function dataProviderForTestIsUserCommand(): array
+    {
+        return [
+            ['! report', false],
+            ['!!', false],
+            ['!', false],
+            ['!mp 1', true],
+            ['!report', true],
+            ['hello', false],
+        ];
+    }
+
+    public function testFilterOldMessage(): void
+    {
+        $channel = Channel::factory()->make(['type' => Channel::TYPES['public']]);
+        $message = Message::factory()->make([
+            'timestamp' => Carbon::now()->subHours($GLOBALS['cfg']['osu']['chat']['public_backlog_limit'] + 1),
+        ]);
+
+        $this->assertSame(0, count(Message::filter([$message], $channel, null)));
+    }
+
+    public function testFilterCurrentMessage(): void
+    {
+        $channel = Channel::factory()->make(['type' => Channel::TYPES['public']]);
+        $message = Message::factory()->make([
+            'timestamp' => Carbon::now(),
+        ]);
+
+        $this->assertSame(1, count(Message::filter([$message], $channel, null)));
+    }
+
+    public function testFilterUserCommand(): void
+    {
+        $userId = 1;
+        $channel = Channel::factory()->make(['type' => Channel::TYPES['public']]);
+        $messageCommand = Message::factory()->make([
+            'content' => '!report what',
+            'timestamp' => Carbon::now(),
+            'user_id' => $userId,
+        ]);
+        $messageNormal = Message::factory()->make([
+            'content' => '!!',
+            'timestamp' => Carbon::now(),
+            'user_id' => $userId,
+        ]);
+        $messages = [$messageCommand, $messageNormal];
+
+        $filterOwn = Message::filter($messages, $channel, $userId);
+        $this->assertSame(2, count($filterOwn));
+
+        $filterOther = Message::filter($messages, $channel, $userId + 1);
+        $this->assertSame(1, count($filterOther));
+        $this->assertSame($messageNormal, $filterOther[0]);
+    }
+
+    #[DataProvider('dataProviderForTestIsUserCommand')]
+    public function testIsUserCommand(string $content, bool $result): void
+    {
+        $this->assertSame($result, new Message(compact('content'))->isUserCommand());
+    }
+}


### PR DESCRIPTION
Resolves #12689

I don't know if there's a valid indicator when the message isn't a valid command...

It'll at least still show messages that start with two exclamation marks `!!` or followed by a space `! thing`