### PR TITLE
Fix docker compose build timing and add missing build

### DIFF
--- a/docker/development/prepare.sh
+++ b/docker/development/prepare.sh
@@ -28,14 +28,15 @@ for envfile in .env .env.testing .env.dusk.local; do
     fi
 done
 
+docker compose build
+docker compose build testjs
+
 if [ -n "${GITHUB_TOKEN:-}" ]; then
     _run composer config -g github-oauth.github.com "${GITHUB_TOKEN}"
     for envfile in .env .env.dusk.local; do
         grep -q '^GITHUB_TOKEN=' "${envfile}" || echo "GITHUB_TOKEN=${GITHUB_TOKEN}" >> "${envfile}"
     done
 fi
-
-docker compose build
 
 _run yarn --network-timeout 100000 --frozen-lockfile
 


### PR DESCRIPTION
It should be run before any other docker usage. And services on different profile need to be built separately.

As for that profile thing, not sure if it's better than just making it part of default profile with a `true` command and let it be used with `run --rm testjs test js`.