### PR TITLE
Revert "Fix error on invalid notifiable type"

### DIFF
--- a/app/Models/Follow.php
+++ b/app/Models/Follow.php
@@ -52,11 +52,6 @@ class Follow extends Model
         $this->notifiable()->associate($value);
     }
 
-    public function getNotifiableIdAttribute($value): ?int
-    {
-        return isset($this->attributes['notifiable_type']) ? $value : null;
-    }
-
     public function setNotifiableTypeAttribute($value)
     {
         if (MorphMap::getClass($value) === null) {


### PR DESCRIPTION
This reverts commit 9ea880b8d219f918e2b705e138d87b76fb9905e2.

It broke the case when the model is queried without the other field.

Resolves #12725 (also the beatmapset search errors in sentry)

I'll need to figure out a better fix for the problem the commit was supposed to fix later...