### PR TITLE
Check for login state first before authenticating for oauth app

### DIFF
--- a/app/Http/Controllers/Passport/AuthorizationController.php
+++ b/app/Http/Controllers/Passport/AuthorizationController.php
@@ -37,6 +37,9 @@ class AuthorizationController extends PassportAuthorizationController
         TokenRepository $tokens
     ) {
         try {
+            if (\Auth::user() === null) {
+                throw new AuthenticationException();
+            }
             return parent::authorize($this->normalizeRequestScopes($psrRequest), $request, $clients, $tokens);
         } catch (AuthenticationException $_e) {
             $cancelUrl = $request->fullUrl();


### PR DESCRIPTION
Request scope normalisation requires actual user for the result to be correct. Otherwise it'll be incorrectly checked as if it's a client credentials.