### PR TITLE
Always use standardised scoring for played map search

### DIFF
--- a/app/Libraries/Search/BeatmapsetSearch.php
+++ b/app/Libraries/Search/BeatmapsetSearch.php
@@ -454,14 +454,6 @@ class BeatmapsetSearch extends RecordSearch
             ->where('user_id', $this->params->user->getKey())
             ->whereIn('ruleset_id', $this->getSelectedModes());
 
-        $showLegacyOnly = ScoreSearchParams::showLegacyForUser($this->params->user) ?? false;
-        if ($showLegacyOnly) {
-            $scoreField = 'legacy_total_score';
-            $query->where('legacy_score_id', '>', 0);
-        } else {
-            $scoreField = 'total_score';
-        }
-
         if ($rank === null) {
             return $query->distinct('beatmap_id')->pluck('beatmap_id')->all();
         }
@@ -470,15 +462,9 @@ class BeatmapsetSearch extends RecordSearch
         foreach ($query->get() as $score) {
             $prevScore = $topScores[$score->beatmap_id] ?? null;
 
-            $scoreValue = $score->$scoreField;
-            if ($scoreValue !== null && ($prevScore === null || $prevScore->$scoreField < $scoreValue)) {
+            $scoreValue = $score->total_score;
+            if ($scoreValue !== null && ($prevScore === null || $prevScore->total_score < $scoreValue)) {
                 $topScores[$score->beatmap_id] = $score;
-            }
-        }
-
-        if ($showLegacyOnly) {
-            foreach ($topScores as $beatmapId => $score) {
-                $topScores[$beatmapId] = $score->makeLegacyEntry();
             }
         }
 

--- a/resources/css/bem/wiki-notice.less
+++ b/resources/css/bem/wiki-notice.less
@@ -8,6 +8,15 @@
   color: @osu-colour-orange-1;
   margin-bottom: 10px;
 
+  &--beatmapset-search {
+    border-radius: @border-radius-large;
+    background-color: hsl(var(--hsl-b3));
+    color: hsl(var(--hsl-c1));
+    font-size: @font-size--normal;
+    margin: 5px;
+    width: calc(100% - 10px);
+  }
+
   &--important {
     font-weight: bold;
   }

--- a/resources/js/beatmaps/search-content.tsx
+++ b/resources/js/beatmaps/search-content.tsx
@@ -108,6 +108,13 @@ export class SearchContent extends React.Component<Props> {
               </div>
             )}
             <div className='beatmapsets__content js-audio--group'>
+              {this.controller.filters.rank != null &&
+                <div className='wiki-notice wiki-notice--beatmapset-search'>
+                  <span className='fas fa-info-circle' />
+                  {' '}
+                  {trans('beatmaps.listing.search.rank_filter_note')}
+                </div>
+              }
               {this.controller.isSupporterMissing ? this.renderSupporterRequired() : this.renderList() }
             </div>
             {!this.controller.isSupporterMissing && (

--- a/resources/lang/en/beatmaps.php
+++ b/resources/lang/en/beatmaps.php
@@ -245,6 +245,7 @@ return [
             'prompt' => 'type in keywords...',
             'login_required' => 'Sign in to search.',
             'options' => 'More Search Options',
+            'rank_filter_note' => 'Profile top rank counts and results shown on this page are based on your highest "standardised" (aka "lazer") scores on beatmaps.',
             'supporter_filter' => 'Filtering by :filters requires an active osu!supporter tag',
             'not-found' => 'no results',
             'not-found-quote' => '... nope, nothing found.',


### PR DESCRIPTION
The user stats are based on lazer scoring so it gets confusing when the search is based on classic scoring and people can't find the score on their stats number.

<sub>then it may show different score on leaderboard but that's a different issue</sub>