### PR TITLE
Show top watched replays on profile page

### DIFF
--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -23,6 +23,7 @@ use App\Models\User;
 use App\Models\UserAccountHistory;
 use App\Models\UserAchievement;
 use App\Transformers\CurrentUserTransformer;
+use App\Transformers\ScoreReplayStatsTransformer;
 use App\Transformers\ScoreTransformer;
 use App\Transformers\UserCompactTransformer;
 use App\Transformers\UserMonthlyPlaycountTransformer;
@@ -44,6 +45,8 @@ class UsersController extends Controller
     const LAZY_EXTRA_PAGES = ['beatmaps', 'kudosu', 'recent_activity', 'top_ranks', 'historical'];
 
     const PER_PAGE = [
+        'scoreReplayStats' => 5,
+
         'scoresBest' => 5,
         'scoresFirsts' => 5,
         'scoresPinned' => 5,
@@ -89,6 +92,7 @@ class UsersController extends Controller
             'index',
             'kudosu',
             'recentActivity',
+            'scoreReplayStats',
             'scores',
             'show',
         ]]);
@@ -98,7 +102,7 @@ class UsersController extends Controller
 
             return $next($request);
         }, [
-            'only' => ['extraPages', 'scores', 'beatmapsets', 'kudosu', 'recentActivity'],
+            'only' => ['extraPages', 'scores', 'beatmapsets', 'kudosu', 'recentActivity', 'scoreReplayStats'],
         ]);
 
         parent::__construct();
@@ -169,6 +173,10 @@ class UsersController extends Controller
                         $this->user->soloScores()->recent($this->mode, false)->count(),
                     ),
                     'replays_watched_counts' => json_collection($this->user->replaysWatchedCounts, new UserReplaysWatchedCountTransformer()),
+                    'score_replay_stats' => $this->getExtraSection(
+                        'scoreReplayStats',
+                        min($this->maxResults, $this->user->scoreReplayStats()->count()),
+                    ),
                 ];
 
             case 'kudosu':
@@ -481,6 +489,11 @@ class UsersController extends Controller
     public function recentActivity($_userId)
     {
         return $this->getExtra('recentActivity', [], $this->perPage, $this->offset);
+    }
+
+    public function scoreReplayStats()
+    {
+        return $this->getExtra('scoreReplayStats', [], $this->perPage, $this->offset);
     }
 
     /**
@@ -827,6 +840,15 @@ class UsersController extends Controller
                         $morphTo->morphWith([BeatmapDiscussion::class => ['beatmap', 'beatmapset']]);
                     }])
                     ->orderBy('exchange_id', 'desc');
+                break;
+
+            case 'scoreReplayStats':
+                $transformer = new ScoreReplayStatsTransformer();
+                $includes = ScoreReplayStatsTransformer::USER_PROFILE_INCLUDES;
+                $query = $this->user->scoreReplayStats()
+                    ->whereHas('score')
+                    ->orderByDesc('watch_count')
+                    ->with(ScoreReplayStatsTransformer::USER_PROFILE_INCLUDES_PRELOAD);
                 break;
 
             // Score

--- a/app/Models/ScoreReplayStats.php
+++ b/app/Models/ScoreReplayStats.php
@@ -7,8 +7,15 @@ declare(strict_types=1);
 
 namespace App\Models;
 
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+
 class ScoreReplayStats extends Model
 {
     public $incrementing = false;
     protected $primaryKey = 'score_id';
+
+    public function score(): BelongsTo
+    {
+        return $this->belongsTo(Solo\Score::class);
+    }
 }

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -1330,6 +1330,11 @@ class User extends Model implements AfterCommit, AuthenticatableContract, HasLoc
         return $this->profileBanners()->active()->with('tournamentBanner')->orderBy('banner_id');
     }
 
+    public function scoreReplayStats(): HasMany
+    {
+        return $this->hasMany(ScoreReplayStats::class);
+    }
+
     public function storeAddresses()
     {
         return $this->hasMany(Store\Address::class);

--- a/app/Transformers/ScoreReplayStatsTransformer.php
+++ b/app/Transformers/ScoreReplayStatsTransformer.php
@@ -1,0 +1,35 @@
+<?php
+
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
+declare(strict_types=1);
+
+namespace App\Transformers;
+
+use App\Models\ScoreReplayStats;
+use League\Fractal\Resource\ResourceInterface;
+
+class ScoreReplayStatsTransformer extends TransformerAbstract
+{
+    // Like ScoreTransformer::USER_PROFILE_INCLUDES but without user
+    const USER_PROFILE_INCLUDES = ['score.beatmap', 'score.beatmapset'];
+    const USER_PROFILE_INCLUDES_PRELOAD = ['score.beatmap.beatmapset'];
+
+    protected array $availableIncludes = [
+        'score',
+    ];
+
+    public function transform(ScoreReplayStats $stats): array
+    {
+        return [
+            'score_id' => $stats->score_id,
+            'watch_count' => $stats->watch_count,
+        ];
+    }
+
+    public function includeScore(ScoreReplayStats $stats): ResourceInterface
+    {
+        return $this->item($stats->score, new ScoreTransformer());
+    }
+}

--- a/resources/css/bem/play-detail.less
+++ b/resources/css/bem/play-detail.less
@@ -178,6 +178,7 @@
   }
 
   &__pp {
+    --desktop-width: 110px;
     align-content: flex-end;
     flex: none;
     font-size: @font-size--title-small-3;
@@ -191,7 +192,7 @@
       bottom: auto;
       padding: @_padding-vertical-desktop @_padding-horizontal
         @_padding-vertical-desktop (@_padding-horizontal + 10px);
-      min-width: 110px;
+      min-width: var(--desktop-width);
       flex: none;
       background: var(--bg);
       border-radius: 0 var(--border-radius) var(--border-radius) 0;
@@ -208,6 +209,10 @@
         background-color: var(--bg-main);
         clip-path: polygon(0% 0%, 100% 50%, 0% 100%);
       }
+    }
+
+    &--watch-count {
+      --desktop-width: 130px; // 5 digits
     }
   }
 

--- a/resources/js/interfaces/score-replay-stats-json.ts
+++ b/resources/js/interfaces/score-replay-stats-json.ts
@@ -1,0 +1,19 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
+import ScoreJson, { ScoreJsonForUser } from './score-json';
+
+interface ScoreReplayStatsJsonAvailableIncludes {
+  score: ScoreJson;
+}
+
+interface ScoreReplayStatsJsonDefaultAttributes {
+  score_id: number;
+  watch_count: number;
+}
+
+type ScoreReplayStatsJson = ScoreReplayStatsJsonDefaultAttributes & Partial<ScoreReplayStatsJsonAvailableIncludes>;
+
+export default ScoreReplayStatsJson;
+
+export type ScoreReplayStatsJsonForUser = ScoreReplayStatsJson & { score: ScoreJsonForUser };

--- a/resources/js/profile-page/controller.tsx
+++ b/resources/js/profile-page/controller.tsx
@@ -9,6 +9,7 @@ import EventJson from 'interfaces/event-json';
 import KudosuHistoryJson from 'interfaces/kudosu-history-json';
 import Ruleset from 'interfaces/ruleset';
 import ScoreJson, { isScoreJsonForUser, ScoreJsonForUser } from 'interfaces/score-json';
+import { ScoreReplayStatsJsonForUser } from 'interfaces/score-replay-stats-json';
 import UserCoverJson from 'interfaces/user-cover-json';
 import UserCoverPresetJson from 'interfaces/user-cover-preset-json';
 import { ProfileExtraPage, profileExtraPages } from 'interfaces/user-extended-json';
@@ -35,6 +36,7 @@ const sectionToUrlType = {
   nominatedBeatmapsets: 'nominated',
   pendingBeatmapsets: 'pending',
   rankedBeatmapsets: 'ranked',
+  scoreReplayStats: 'score-replay-stats',
   scoresBest: 'best',
   scoresFirsts: 'firsts',
   scoresPinned: 'pinned',
@@ -50,6 +52,7 @@ interface HistoricalJson {
   monthly_playcounts: UserMonthlyPlaycountJson[];
   recent: PageSectionJson<ScoreJsonForUser>;
   replays_watched_counts: UserReplaysWatchedCountJson[];
+  score_replay_stats: PageSectionJson<ScoreReplayStatsJsonForUser>;
 }
 
 type TopScoresKeys = 'best' | 'firsts' | 'pinned';
@@ -366,6 +369,17 @@ export default class Controller {
 
       case 'recentlyReceivedKudosu':
         // do nothing
+        break;
+
+      case 'scoreReplayStats':
+        if (this.state.lazy.historical?.score_replay_stats != null) {
+          this.xhr[section] = apiShowMore(
+            this.state.lazy.historical.score_replay_stats,
+            'users.score-replay-stats',
+            baseParams,
+          );
+        }
+
         break;
 
       case 'scoresBest':

--- a/resources/js/profile-page/extra-page-props.ts
+++ b/resources/js/profile-page/extra-page-props.ts
@@ -21,7 +21,7 @@ export type BeatmapsetSection = typeof beatmapsetSections[number];
 export const topScoreSections = ['scoresPinned', 'scoresBest', 'scoresFirsts'] as const;
 export type TopScoreSection = typeof topScoreSections[number];
 
-const historicalSections = ['beatmapPlaycounts', 'scoresRecent'] as const;
+const historicalSections = ['beatmapPlaycounts', 'scoresRecent', 'scoreReplayStats'] as const;
 export type HistoricalSection = typeof historicalSections[number];
 
 type ProfilePageIncludes =

--- a/resources/js/profile-page/historical.tsx
+++ b/resources/js/profile-page/historical.tsx
@@ -15,6 +15,7 @@ import Chart, { ChartData } from './chart';
 import ExtraHeader from './extra-header';
 import ExtraPageProps, { HistoricalSection } from './extra-page-props';
 import PlayDetailList from './play-detail-list';
+import ScoreReplayStatsEntry from './score-replay-stats-entry';
 
 type ChartSection = 'monthly_playcounts' | 'replays_watched_counts';
 
@@ -156,6 +157,31 @@ export default class Historical extends React.Component<ExtraPageProps> {
 
             <div className='page-extra__chart'>
               <Chart data={this.replaysWatchedCountsData} labelY={`${trans('users.show.extra.historical.replays_watched_counts.count_label')}`} />
+            </div>
+          </>
+        }
+
+        {this.data.score_replay_stats.count > 0 &&
+          <>
+            <ProfilePageExtraSectionTitle
+              count={this.data.score_replay_stats.count}
+              titleKey='users.show.extra.historical.score_replay_stats.title'
+            />
+            <div className='play-detail-list'>
+              {this.data.score_replay_stats.items.map((stats) => (
+                <ScoreReplayStatsEntry
+                  key={stats.score_id}
+                  stats={stats}
+                  user={this.props.controller.state.user}
+                />
+              ))}
+
+              <ShowMoreLink
+                {...this.data.score_replay_stats.pagination}
+                callback={this.onShowMore}
+                data={'scoreReplayStats' as const}
+                modifiers='profile-page'
+              />
             </div>
           </>
         }

--- a/resources/js/profile-page/play-detail-list.tsx
+++ b/resources/js/profile-page/play-detail-list.tsx
@@ -51,9 +51,14 @@ export default class PlayDetailList extends React.Component<Props> {
 
   @computed
   private get scores() {
-    return this.sectionMap.key === 'recent'
-      ? this.props.controller.state.lazy.historical?.recent
-      : this.props.controller.state.lazy.top_ranks?.[this.sectionMap.key];
+    const key = this.sectionMap.key;
+
+    switch (key) {
+      case 'recent':
+        return this.props.controller.state.lazy.historical?.[key];
+    }
+
+    return this.props.controller.state.lazy.top_ranks?.[key];
   }
 
   @computed

--- a/resources/js/profile-page/score-replay-stats-entry.tsx
+++ b/resources/js/profile-page/score-replay-stats-entry.tsx
@@ -1,0 +1,112 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
+import Mod from 'components/mod';
+import { PlayDetailMenu } from 'components/play-detail-menu';
+import TimeWithTooltip from 'components/time-with-tooltip';
+import { rulesetIdToName } from 'interfaces/ruleset';
+import { ScoreReplayStatsJsonForUser } from 'interfaces/score-replay-stats-json';
+import UserJson from 'interfaces/user-json';
+import * as React from 'react';
+import PpValue from 'scores/pp-value';
+import { rulesetName, shouldShowPp } from 'utils/beatmap-helper';
+import { getArtist, getTitle } from 'utils/beatmapset-helper';
+import { formatNumber } from 'utils/html';
+import { trans } from 'utils/lang';
+import { accuracy, displayMods, hasMenu, rank } from 'utils/score-helper';
+import { beatmapUrl } from 'utils/url';
+
+interface Props {
+  stats: ScoreReplayStatsJsonForUser;
+  user: UserJson;
+}
+
+export default function ScoreReplayStatsEntry(props: Props) {
+  const user = props.user;
+  const stats = props.stats;
+  const score = stats.score;
+  const scoreRank = rank(score);
+  const { beatmap, beatmapset } = score;
+
+  return (
+    <div className='play-detail'>
+      <div className='play-detail__group play-detail__group--top'>
+        <div className='play-detail__icon play-detail__icon--main'>
+          <div className={`score-rank score-rank--full score-rank--${scoreRank}`} />
+        </div>
+
+        <div className='play-detail__detail'>
+          <a
+            className='play-detail__title u-ellipsis-overflow'
+            href={beatmapUrl(beatmap, rulesetName(score.ruleset_id))}
+          >
+            {getTitle(beatmapset)}
+            {' '}
+            <small className='play-detail__artist'>
+              {trans('users.show.extra.beatmaps.by_artist', { artist: getArtist(beatmapset) })}
+            </small>
+          </a>
+          <div className='play-detail__beatmap-and-time'>
+            <span className='play-detail__beatmap'>
+              <span className={`fal fa-extra-mode-${rulesetIdToName[score.ruleset_id]}`} />
+              {' '}
+              {beatmap.version}
+            </span>
+            <span className='play-detail__time'>
+              <TimeWithTooltip dateTime={score.ended_at} relative />
+            </span>
+          </div>
+        </div>
+      </div>
+
+      <div className='play-detail__group play-detail__group--bottom'>
+        <div className='play-detail__score-detail'>
+          <div className='play-detail__icon play-detail__icon--extra'>
+            <div className={`score-rank score-rank--full score-rank--${scoreRank}`} />
+          </div>
+          <div className='play-detail__score-detail-top-right'>
+            <div className='play-detail__accuracy-and-weighted-pp'>
+              <span className='play-detail__accuracy'>
+                {formatNumber(accuracy(score), 2, { style: 'percent' })}
+              </span>
+              <span className='play-detail__weighted-pp'>
+                {shouldShowPp(beatmap) ? (
+                  <PpValue
+                    score={score}
+                    suffix='pp'
+                  />
+                ) : (
+                  <span title={trans('users.show.extra.top_ranks.not_ranked')}>
+                    {(beatmap.status === 'loved') ? (
+                      <span className='fas fa-heart' />
+                    ) : (
+                      '-'
+                    )}
+                  </span>
+                )}
+              </span>
+            </div>
+          </div>
+        </div>
+
+        <div className='play-detail__mods-pp'>
+          <div className='play-detail__mods'>
+            {displayMods(score, false).map((mod) => <Mod key={mod.acronym} mod={mod} />)}
+          </div>
+
+          <div className='play-detail__pp play-detail__pp--watch-count'>
+            <span>
+              <small><span className='fas fa-eye' /></small>
+              {' '}
+              {formatNumber(stats.watch_count)}
+            </span>
+          </div>
+        </div>
+
+        <div className='play-detail__more'>
+          {hasMenu(score) && <PlayDetailMenu score={score} user={user} />}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/resources/lang/en/users.php
+++ b/resources/lang/en/users.php
@@ -333,6 +333,9 @@ return [
                     'title' => 'Replays Watched History',
                     'count_label' => 'Replays Watched',
                 ],
+                'score_replay_stats' => [
+                    'title' => 'Most Watched Replays',
+                ],
             ],
             'kudosu' => [
                 'recent_entries' => 'Recent Kudosu History',

--- a/routes/web.php
+++ b/routes/web.php
@@ -356,6 +356,7 @@ Route::group(['middleware' => ['web']], function () {
 
         Route::get('kudosu', 'UsersController@kudosu')->name('kudosu');
         Route::get('recent_activity', 'UsersController@recentActivity')->name('recent-activity');
+        Route::get('score-replay-stats', 'UsersController@scoreReplayStats')->name('score-replay-stats');
         Route::get('scores/{type}', 'UsersController@scores')->name('scores');
         Route::get('beatmapsets/{type}', 'UsersController@beatmapsets')->name('beatmapsets');
     });


### PR DESCRIPTION
<del>I just remembered we probably never migrated the old data to the new table...</del> Which doesn't matter because the old table is still being updated so it can just replace whatever currently in the new table.

![](https://s.kohaku.love/2026/02/firefox_2026-02-03_18-37-02.png)

I skipped the popup context thing because that's a lot of boilerplate and doesn't seem all that useful and copying the play-detail is already bad enough.

If we want to disallow interacting with everything else when the popup is shown, might as well show an invisible full screen div.

Resolves #6412