### PR TITLE
Unify qtip positioning settings

### DIFF
--- a/resources/js/beatmap-discussions/editor-discussion-component.tsx
+++ b/resources/js/beatmap-discussions/editor-discussion-component.tsx
@@ -12,6 +12,7 @@ import { ReactEditor } from 'slate-react';
 import { formatTimestamp, makeUrl, nearbyDiscussions, parseTimestamp, timestampRegex } from 'utils/beatmapset-discussion-helper';
 import { classWithModifiers } from 'utils/css';
 import { trans, transArray } from 'utils/lang';
+import { qtipPosition } from 'utils/qtip-helper';
 import { linkHtml } from 'utils/url';
 import DiscussionsState from './discussions-state';
 import { DraftsContext } from './drafts-context';
@@ -119,11 +120,7 @@ export default class EditorDiscussionComponent extends React.Component<Props> {
         delay: 200,
         fixed: true,
       },
-      position: {
-        at: 'top center',
-        my: 'bottom center',
-        viewport: $(window),
-      },
+      position: qtipPosition('top center'),
       show: {
         delay: 200,
         ready: true,

--- a/resources/js/components/beatmap-icon.tsx
+++ b/resources/js/components/beatmap-icon.tsx
@@ -6,6 +6,7 @@ import * as React from 'react';
 import { renderToStaticMarkup } from 'react-dom/server';
 import { getDiffColour } from 'utils/beatmap-helper';
 import { classWithModifiers, Modifiers } from 'utils/css';
+import { qtipPosition } from 'utils/qtip-helper';
 import { nextVal } from 'utils/seq';
 import DifficultyBadge from './difficulty-badge';
 
@@ -83,11 +84,7 @@ export class BeatmapIcon extends React.Component<Props> {
         event: 'click mouseleave',
       },
       overwrite: false,
-      position: {
-        at: 'top center',
-        my: 'bottom center',
-        viewport: $(window),
-      },
+      position: qtipPosition('top center'),
       show: {
         event: event.type,
         ready: true,

--- a/resources/js/components/user-card-tooltip.tsx
+++ b/resources/js/components/user-card-tooltip.tsx
@@ -11,6 +11,7 @@ import { unmountComponentAtNode } from 'react-dom';
 import { renderToStaticMarkup } from 'react-dom/server';
 import { activeKeyDidChange as contextActiveKeyDidChange, ContainerContext, KeyContext, State as ActiveKeyState } from 'stateful-activation-context';
 import { TooltipContext } from 'tooltip-context';
+import { qtipPosition, PositionAt } from 'utils/qtip-helper';
 import { presence } from 'utils/string';
 import { apiLookupUsers } from 'utils/user';
 import { UserCard } from './user-card';
@@ -29,7 +30,7 @@ let inCard = false;
 let tooltipWithActiveMenu: any;
 
 function createTooltipOptions(card: HTMLElement) {
-  const at = card.dataset.tooltipPosition ?? 'right center';
+  const at = (card.dataset.tooltipPosition ?? 'right center') as PositionAt;
 
   return {
     content: {
@@ -45,10 +46,8 @@ function createTooltipOptions(card: HTMLElement) {
       fixed: true,
     },
     position: {
+      ...qtipPosition(at),
       adjust: { scroll: false },
-      at,
-      my: my(at),
-      viewport: $(window),
     },
     show: {
       delay: 200,
@@ -94,21 +93,6 @@ function createTooltip(element: HTMLElement) {
   }
 
   $(element).qtip(createTooltipOptions(card));
-}
-
-function my(at: string) {
-  switch (at) {
-    case 'top center':
-      return 'bottom center';
-    case 'top right':
-      return 'bottom left';
-    case 'left center':
-      return 'right center';
-    case 'bottom center':
-      return 'top center';
-  }
-
-  return 'left center';
 }
 
 function onBeforeCache() {

--- a/resources/js/components/user-list-popup.tsx
+++ b/resources/js/components/user-list-popup.tsx
@@ -8,18 +8,13 @@ import { autorun } from 'mobx';
 import * as React from 'react';
 import { renderToStaticMarkup } from 'react-dom/server';
 import { transChoice } from 'utils/lang';
+import { qtipPosition, PositionAt } from 'utils/qtip-helper';
 
 interface Props {
   count: number;
   title?: string;
   users: Partial<Pick<UserJson, 'avatar_url' | 'id' | 'username'>>[];
 }
-
-type PositionAt = `${'right' | 'top'} center`;
-const atToMy = {
-  'right center': 'left center',
-  'top center': 'bottom center',
-};
 
 export function createTooltip(targetFn: () => HTMLElement | null, propsFn: () => Props, positionAt: PositionAt) {
   $(targetFn() ?? []).qtip({
@@ -33,11 +28,7 @@ export function createTooltip(targetFn: () => HTMLElement | null, propsFn: () =>
       },
       fixed: true,
     },
-    position: {
-      at: positionAt,
-      my: atToMy[positionAt],
-      viewport: $(window),
-    },
+    position: qtipPosition(positionAt),
     show: {
       delay: 100,
       effect(this: HTMLElement) {

--- a/resources/js/core-legacy/tooltip-default.coffee
+++ b/resources/js/core-legacy/tooltip-default.coffee
@@ -1,6 +1,7 @@
 # Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 # See the LICENCE file in the repository root for full licence text.
 
+import { qtipPosition } from 'utils/qtip-helper'
 import { presence } from 'utils/string'
 
 export default class TooltipDefault
@@ -55,10 +56,7 @@ export default class TooltipDefault
     options =
       overwrite: false
       content: $content
-      position:
-        my: my
-        at: at
-        viewport: $(window)
+      position: qtipPosition(at)
       show:
         event: event.type
         ready: true

--- a/resources/js/core/wiki/reference-link-tooltip.ts
+++ b/resources/js/core/wiki/reference-link-tooltip.ts
@@ -1,6 +1,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+import { qtipPosition } from 'utils/qtip-helper';
+
 export default class ReferenceLinkTooltip {
   constructor() {
     $(document).on('mouseover', '.js-reference-link', this.showTooltip);
@@ -18,11 +20,7 @@ export default class ReferenceLinkTooltip {
         },
         fixed: true,
       },
-      position: {
-        at: 'top center',
-        my: 'bottom center',
-        viewport: $(window),
-      },
+      position: qtipPosition('top center'),
       show: {
         delay: 200,
         effect() {

--- a/resources/js/profile-page/achievement-badge.tsx
+++ b/resources/js/profile-page/achievement-badge.tsx
@@ -5,6 +5,7 @@ import AchievementJson from 'interfaces/achievement-json';
 import * as React from 'react';
 import { renderToStaticMarkup } from 'react-dom/server';
 import { mergeModifiers, Modifiers } from 'utils/css';
+import { qtipPosition } from 'utils/qtip-helper';
 import { nextVal } from 'utils/seq';
 import AchievementBadgeIcon from './achievement-badge-icon';
 import AchievementBadgePopup from './achievement-badge-popup';
@@ -58,12 +59,8 @@ export default class AchievementBadge extends React.PureComponent<Props> {
       },
       overwrite: false,
       position: {
-        adjust: {
-          scroll: false,
-        },
-        at: 'top center',
-        my: 'bottom center',
-        viewport: $(window),
+        ...qtipPosition('top center'),
+        adjust: { scroll: false },
       },
       show: {
         delay: 200,

--- a/resources/js/profile-page/daily-challenge.tsx
+++ b/resources/js/profile-page/daily-challenge.tsx
@@ -11,6 +11,7 @@ import { renderToStaticMarkup } from 'react-dom/server';
 import { classWithModifiers, Modifiers } from 'utils/css';
 import { formatNumber } from 'utils/html';
 import { trans } from 'utils/lang';
+import { qtipPosition } from 'utils/qtip-helper';
 
 function tier(days: number) {
   const tiers = [
@@ -164,12 +165,8 @@ export default class DailyChallenge extends React.Component<Props> {
       },
       overwrite: false,
       position: {
-        adjust: {
-          scroll: false,
-        },
-        at: 'top left',
-        my: 'bottom left',
-        viewport: $(window),
+        ...qtipPosition('top left'),
+        adjust: { scroll: false },
       },
       show: {
         delay: 200,

--- a/resources/js/profile-page/matchmaking.tsx
+++ b/resources/js/profile-page/matchmaking.tsx
@@ -9,6 +9,7 @@ import * as React from 'react';
 import { renderToStaticMarkup } from 'react-dom/server';
 import { formatNumber } from 'utils/html';
 import { trans } from 'utils/lang';
+import { qtipPosition } from 'utils/qtip-helper';
 import { ProfilePageMatchmakingStatsJson } from './extra-page-props';
 
 function poolDisplayName(pool: MatchmakingPoolJson) {
@@ -131,12 +132,8 @@ export default class Matchmaking extends React.Component<Props> {
       },
       overwrite: false,
       position: {
-        adjust: {
-          scroll: false,
-        },
-        at: 'top left',
-        my: 'bottom left',
-        viewport: $(window),
+        ...qtipPosition('top left'),
+        adjust: { scroll: false },
       },
       show: {
         delay: 200,

--- a/resources/js/profile-page/season-stats.tsx
+++ b/resources/js/profile-page/season-stats.tsx
@@ -9,6 +9,7 @@ import * as React from 'react';
 import { renderToStaticMarkup } from 'react-dom/server';
 import { formatNumber } from 'utils/html';
 import { trans } from 'utils/lang';
+import { qtipPosition } from 'utils/qtip-helper';
 
 function colourStyle(tier: string) {
   return {
@@ -101,13 +102,11 @@ export default class SeasonStats extends React.Component<Props> {
       },
       overwrite: false,
       position: {
+        ...qtipPosition('top center'),
         adjust: {
           method: 'shift flip',
           scroll: false,
         },
-        at: 'top center',
-        my: 'bottom center',
-        viewport: $(window),
       },
       show: {
         delay: 200,

--- a/resources/js/utils/qtip-helper.ts
+++ b/resources/js/utils/qtip-helper.ts
@@ -1,0 +1,21 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
+const atToMy = {
+  'bottom center': 'top center',
+  'bottom left': 'top left',
+  'left center': 'right center',
+  'right center': 'left center',
+  'top center': 'bottom center',
+  'top left': 'bottom left',
+  'top right': 'bottom left',
+} as const;
+export type PositionAt = keyof typeof atToMy;
+
+export function qtipPosition(at: PositionAt) {
+  return {
+    at,
+    my: atToMy[at] ?? 'left center',
+    viewport: $(window),
+  };
+}


### PR DESCRIPTION
Don't add even more at/my mapping...

<del>I removed the `adjust.scroll` option because I couldn't figure out what scenario it's fixing. It looks like the default `true` makes more sense.</del> nvm it's something with the tooltip repositioning top/bottom when scrolling around (mainly on mobile). I'm not touching that here.