### PR TITLE
Add user silence notification

### DIFF
--- a/app/Jobs/Notifications/UserSilencedNotification.php
+++ b/app/Jobs/Notifications/UserSilencedNotification.php
@@ -1,0 +1,43 @@
+<?php
+
+namespace App\Jobs\Notifications;
+
+use App\Models\Notification;
+use App\Models\User;
+use App\Models\UserAccountHistory;
+
+class UserSilencedNotification extends BroadcastNotificationBase
+{
+    /** @var UserAccountHistory */
+    private $history;
+
+    public function __construct(UserAccountHistory $history)
+    {
+        parent::__construct(null);
+        $this->history = $history;
+        $this->name = Notification::USER_SILENCED;
+    }
+
+    public static function getMailLink(Notification $notification): string
+    {
+        return route('users.show', ['user' => $notification->notifiable_id]).'#account-standing';
+    }
+
+    public function getDetails(): array
+    {
+        return [
+            'reason' => $this->history->reason,
+            'duration' => $this->history->period / 60, // minutes
+        ];
+    }
+
+    public function getListeningUserIds(): array
+    {
+        return [$this->history->user_id];
+    }
+
+    public function getNotifiable()
+    {
+        return $this->history->user;
+    }
+}

--- a/app/Models/Notification.php
+++ b/app/Models/Notification.php
@@ -51,6 +51,7 @@ class Notification extends Model
     const USER_ACHIEVEMENT_UNLOCK = 'user_achievement_unlock';
     const USER_BEATMAPSET_NEW = 'user_beatmapset_new';
     const USER_BEATMAPSET_REVIVE = 'user_beatmapset_revive';
+    const USER_SILENCED = 'user_silenced';
 
     // sync with resources/js/notification-maps/category.ts
     const NAME_TO_CATEGORY = [
@@ -79,6 +80,7 @@ class Notification extends Model
         self::USER_ACHIEVEMENT_UNLOCK => 'user_achievement_unlock',
         self::USER_BEATMAPSET_NEW => 'user_beatmapset_new',
         self::USER_BEATMAPSET_REVIVE => 'user_beatmapset_new',
+        self::USER_SILENCED => 'global',
     ];
 
     const NOTIFIABLE_CLASSES = [

--- a/app/Observers/UserAccountHistoryObserver.php
+++ b/app/Observers/UserAccountHistoryObserver.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Observers;
+
+use App\Jobs\Notifications\UserSilencedNotification;
+use App\Models\UserAccountHistory;
+
+class UserAccountHistoryObserver
+{
+    public function created(UserAccountHistory $history)
+    {
+        if ($history->ban_status === UserAccountHistory::TYPES['silence']) {
+            (new UserSilencedNotification($history))->dispatch();
+        }
+    }
+}

--- a/app/Providers/AppServiceProvider.php
+++ b/app/Providers/AppServiceProvider.php
@@ -82,6 +82,8 @@ class AppServiceProvider extends ServiceProvider
         Scribe::normalizeEndpointUrlUsing(fn ($url) => $url);
 
         \Hash::extend('osubcrypt', fn () => new OsuBcryptHasher());
+
+        \App\Models\UserAccountHistory::observe(\App\Observers\UserAccountHistoryObserver::class);
     }
 
     /**

--- a/tests/Unit/Notifications/UserSilencedNotificationTest.php
+++ b/tests/Unit/Notifications/UserSilencedNotificationTest.php
@@ -1,0 +1,112 @@
+<?php
+
+namespace Tests\Unit\Notifications;
+
+use App\Jobs\Notifications\UserSilencedNotification;
+use App\Models\Notification;
+use App\Models\User;
+use App\Models\UserAccountHistory;
+use App\Models\UserNotification;
+use Illuminate\Foundation\Testing\DatabaseTransactions;
+use Illuminate\Support\Facades\Dataset;
+use Illuminate\Support\Facades\Bus;
+use Illuminate\Support\Facades\Notification as NotificationFacade;
+use Tests\TestCase;
+
+class UserSilencedNotificationTest extends TestCase
+{
+    use DatabaseTransactions;
+
+    public function testSilenceTriggersNotification()
+    {
+        $user = User::factory()->create();
+        $admin = User::factory()->create();
+
+        Bus::fake();
+
+        // $this->expectsJobs(UserSilencedNotification::class);
+
+        UserAccountHistory::create([
+            'user_id' => $user->id,
+            'banner_id' => $admin->id,
+            'ban_status' => UserAccountHistory::TYPES['silence'],
+            'period' => 60,
+            'reason' => 'Misbehavior',
+        ]);
+
+        Bus::assertDispatched(UserSilencedNotification::class);
+    }
+
+    public function testNotificationDetails()
+    {
+        $user = User::factory()->create();
+        $admin = User::factory()->create();
+
+        $history = UserAccountHistory::create([
+            'user_id' => $user->id,
+            'banner_id' => $admin->id,
+            'ban_status' => UserAccountHistory::TYPES['silence'],
+            'period' => 120, // 2 minutes
+            'reason' => 'Spamming',
+        ]);
+
+        $notification = new UserSilencedNotification($history);
+        $details = $notification->getDetails();
+
+        $this->assertEquals('Spamming', $details['reason']);
+        $this->assertEquals(2, $details['duration']);
+        $this->assertEquals([$user->id], $notification->getListeningUserIds());
+        $this->assertEquals($user->id, $notification->getNotifiable()->id);
+
+        // Test Mail Link
+        $dbNotification = new Notification();
+        $dbNotification->notifiable_id = $user->id;
+        $this->assertStringContainsString(route('users.show', ['user' => $user->id]).'#account-standing', UserSilencedNotification::getMailLink($dbNotification));
+    }
+    
+    public function testNonSilenceDoesNotTriggerNotification()
+    {
+        $user = User::factory()->create();
+        $admin = User::factory()->create();
+
+        Bus::fake();
+
+        // $this->doesntExpectJobs(UserSilencedNotification::class);
+
+        UserAccountHistory::create([
+            'user_id' => $user->id,
+            'banner_id' => $admin->id,
+            'ban_status' => UserAccountHistory::TYPES['note'],
+            'reason' => 'Just a note',
+        ]);
+
+        Bus::assertNotDispatched(UserSilencedNotification::class);
+    }
+
+    public function testJobExecutionCreatesNotification()
+    {
+        $user = User::factory()->create();
+        $admin = User::factory()->create();
+
+        $history = UserAccountHistory::create([
+            'user_id' => $user->id,
+            'banner_id' => $admin->id,
+            'ban_status' => UserAccountHistory::TYPES['silence'],
+            'period' => 60,
+            'reason' => 'Bad behavior',
+        ]);
+
+        $job = new UserSilencedNotification($history);
+        $job->handle();
+
+        $this->assertDatabaseHas('notifications', [
+            'name' => Notification::USER_SILENCED,
+            'notifiable_id' => $user->id,
+            'notifiable_type' => $user->getMorphClass(),
+        ]);
+
+        $this->assertDatabaseHas('user_notifications', [
+            'user_id' => $user->id,
+        ]);
+    }
+}


### PR DESCRIPTION
Implements notification system for when users are silenced.

## Changes
- Add UserSilencedNotification job class that sends notifications when a user is silenced
- Add UserAccountHistoryObserver to trigger notifications on silence events
- Add USER_SILENCED constant to Notification model with 'global' category
- Add unit tests for notification triggering and content

## Notification details
- Contains the silence reason and duration
- Links to the user's Account Standing tab (/users/{id}#account_standing)
- Uses the 'global' notification category

Closes #11908