### PR TITLE
Actually fix deprecation in config

### DIFF
--- a/config/database.php
+++ b/config/database.php
@@ -37,7 +37,7 @@ $mysqlDefaults = [
     ],
     'options' => [
         Pdo\Mysql::ATTR_PERSISTENT => true,
-        Pdo\Mysql::MYSQL_ATTR_INIT_COMMAND => "SET time_zone = '+00:00'",
+        Pdo\Mysql::ATTR_INIT_COMMAND => "SET time_zone = '+00:00'",
     ],
 ];
 


### PR DESCRIPTION
...by using the correct non-deprecated constant.

`Pdo\Mysql` currently still extends `PDO` so `MYSQL_ATTR_INIT_COMMAND` doesn't actually error, just keeps spitting out the deprecation warning