### PR TITLE
Reduce selected columns for initial user best query

### DIFF
--- a/app/Libraries/Score/FetchDedupedScores.php
+++ b/app/Libraries/Score/FetchDedupedScores.php
@@ -23,7 +23,7 @@ class FetchDedupedScores
         $this->limit = $this->params->size;
     }
 
-    public function all(): array
+    public function all(?array $columns = null): array
     {
         $this->params->size = $this->limit + 50;
         $search = new ScoreSearch($this->params);
@@ -40,7 +40,11 @@ class FetchDedupedScores
             $response = $search->response();
             $search->assertNoError();
 
-            $records = $response->records()->whereHas('beatmap.beatmapset')->get()->all();
+            $query = $response->records()->whereHas('beatmap.beatmapset');
+            if ($columns !== null) {
+                $query->select($columns);
+            }
+            $records = $query->get()->all();
             if ($this->append($records)) {
                 break;
             }

--- a/app/Models/Traits/UserScoreable.php
+++ b/app/Models/Traits/UserScoreable.php
@@ -14,7 +14,6 @@ use Illuminate\Database\Eloquent\Collection;
 trait UserScoreable
 {
     private array $beatmapBestScoreIds = [];
-    private array $beatmapBestScores = [];
 
     public function aggregatedScoresBest(string $mode, int $size): array
     {
@@ -24,44 +23,30 @@ trait UserScoreable
             'ruleset_id' => Beatmap::MODES[$mode],
             'sort' => 'pp_desc',
             'user_id' => $this->getKey(),
-        ]), "aggregatedScoresBest_{$mode}"))->all();
+        ]), "aggregatedScoresBest_{$mode}"))->all(['beatmap_id', 'id']);
     }
 
     public function beatmapBestScoreIds(string $mode)
     {
-        if (!isset($this->beatmapBestScoreIds[$mode])) {
-            // aggregations do not support regular pagination.
-            // always fetching 200 to cache; we're not supporting beyond 200, either.
-            $this->beatmapBestScoreIds[$mode] = cache_remember_mutexed(
-                "search-cache:beatmapBestScoresSolo-v2:{$this->getKey()}:{$mode}",
-                $GLOBALS['cfg']['osu']['scores']['es_cache_duration'],
-                [],
-                function () use ($mode) {
-                    $this->beatmapBestScores[$mode] = $this->aggregatedScoresBest($mode, 200);
-
-                    return array_column($this->beatmapBestScores[$mode], 'id');
-                },
-                function () {
-                    // TODO: propagate a more useful message back to the client
-                    // for now we just mark the exception as handled.
-                    return true;
-                }
-            );
-        }
-
-        return $this->beatmapBestScoreIds[$mode];
+        // aggregations do not support regular pagination.
+        // always fetching 200 to cache; we're not supporting beyond 200, either.
+        return $this->beatmapBestScoreIds[$mode] ??= cache_remember_mutexed(
+            "search-cache:beatmapBestScoresSolo-v2:{$this->getKey()}:{$mode}",
+            $GLOBALS['cfg']['osu']['scores']['es_cache_duration'],
+            [],
+            fn () => array_column($this->aggregatedScoresBest($mode, 200), 'id'),
+            function () {
+                // TODO: propagate a more useful message back to the client
+                // for now we just mark the exception as handled.
+                return true;
+            }
+        );
     }
 
     public function beatmapBestScores(string $mode, int $limit, int $offset, array $with): Collection
     {
-        $ids = $this->beatmapBestScoreIds($mode);
-
-        if (isset($this->beatmapBestScores[$mode])) {
-            $results = new Collection(array_slice($this->beatmapBestScores[$mode], $offset, $limit));
-        } else {
-            $ids = array_slice($ids, $offset, $limit);
-            $results = Score::whereKey($ids)->orderByField('id', $ids)->default()->get();
-        }
+        $ids = array_slice($this->beatmapBestScoreIds($mode), $offset, $limit);
+        $results = Score::whereKey($ids)->orderByField('id', $ids)->default()->get();
 
         $results->load($with);
         // make outdated index less obvious


### PR DESCRIPTION
This will select the scores twice - first for the ids and dedupe, second for the response - but the second one is usually a lot lower in number (5, up to 100) than the first one (250 - or more if a lot of scores on same beatmap).