### PR TITLE
Add `matchmaking_user_elo_history` table

### DIFF
--- a/database/migrations/2026_02_25_000000_create_matchmaking_user_elo_history.php
+++ b/database/migrations/2026_02_25_000000_create_matchmaking_user_elo_history.php
@@ -1,0 +1,37 @@
+<?php
+
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('matchmaking_user_elo_history', function (Blueprint $table) {
+            $table->id();
+
+            $table->bigInteger('room_id')->unsigned();
+            $table->integer('pool_id')->unsigned();
+            $table->integer('user_id')->unsigned();
+            $table->integer('opponent_id')->unsigned();
+
+            $table->enum('result', ['win', 'loss', 'draw']);
+
+            $table->integer('elo_before');
+            $table->integer('elo_after');
+
+            $table->timestamps();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('matchmaking_user_elo_history');
+    }
+};


### PR DESCRIPTION
No indexes to keep it simple, because I'm not sure what the queries on this are going to look like yet. Hoping web team can figure this out when it comes to rewind 2026 or user profile graphs.

Something like this:

```sql
SELECT * FROM matchmaking_user_elo_history
# Given their user id and a pool_id (e.g. so we can show multiple graphs, one for each pool).
    WHERE user_id = @UserId
    AND pool_id = @PoolId
# Ordered chronologically by match date.
    ORDER BY created_at
# or...
    # ORDER BY room_id
;

# initial elo -> first in the list
# elo change -> elo_after - elo_before
```