### PR TITLE
Skip queuing event broadcasts when running user notification cleanup command

### DIFF
--- a/app/Console/Commands/UserNotificationsCleanup.php
+++ b/app/Console/Commands/UserNotificationsCleanup.php
@@ -58,7 +58,8 @@ class UserNotificationsCleanup extends Command
             foreach ($notificationIdByUserIds as $userId => $notificationIds) {
                 UserNotification::batchDestroy(
                     $userId,
-                    BatchIdentities::fromParams(['notifications' => $notificationIds])
+                    BatchIdentities::fromParams(['notifications' => $notificationIds]),
+                    true,
                 );
                 $deleted = count($notificationIds);
                 $deletedTotal += $deleted;

--- a/app/Events/NotificationDeleteEvent.php
+++ b/app/Events/NotificationDeleteEvent.php
@@ -12,20 +12,14 @@ class NotificationDeleteEvent extends NotificationEventBase
 {
     use SerializesModels;
 
-    public $params;
-    public $userId;
-
     /**
      * Create a new event instance.
      *
      * @return void
      */
-    public function __construct($userId, array $params)
+    public function __construct(public $userId, public array $params, public bool $shouldBroadcastNow = false)
     {
         parent::__construct();
-
-        $this->params = $params;
-        $this->userId = $userId;
     }
 
     public function broadcastAs()
@@ -46,5 +40,10 @@ class NotificationDeleteEvent extends NotificationEventBase
     public function broadcastWith()
     {
         return $this->params;
+    }
+
+    public function shouldBroadcastNow()
+    {
+        return $this->shouldBroadcastNow;
     }
 }

--- a/app/Models/UserNotification.php
+++ b/app/Models/UserNotification.php
@@ -22,7 +22,7 @@ class UserNotification extends Model
         'is_read' => 'boolean',
     ];
 
-    public static function batchDestroy(int $userId, BatchIdentities $batchIdentities)
+    public static function batchDestroy(int $userId, BatchIdentities $batchIdentities, bool $sync = false)
     {
         $notificationIds = $batchIdentities->getNotificationIds();
         $identities = $batchIdentities->getIdentities();
@@ -60,11 +60,11 @@ class UserNotification extends Model
             $readCount += $unreadCountInitial - $unreadCountCurrent;
         }
 
-        (new NotificationDeleteEvent($userId, [
+        new NotificationDeleteEvent($userId, [
             'notifications' => $identities,
             'read_count' => $readCount,
             'timestamp' => $now,
-        ]))->broadcast();
+        ], $sync)->broadcast();
     }
 
     public static function batchMarkAsRead(User $user, BatchIdentities $batchIdentities)


### PR DESCRIPTION
Clogging up the queue with channel broadcast jobs when running from command line seems unnecessary...

`shouldBroadcastNow` annoyingly needs to be a method unlike `broadcastQueue`