### PR TITLE
Remove team flag in user cards on team page

### DIFF
--- a/resources/views/teams/show.blade.php
+++ b/resources/views/teams/show.blade.php
@@ -17,15 +17,16 @@
         }
     }
     $userTransformer = new UserCompactTransformer();
+    $userTransformerIncludes = array_diff(UserCompactTransformer::CARD_INCLUDES, ['team']);
     $members = json_collection(
         $members,
         $userTransformer,
-        UserCompactTransformer::CARD_INCLUDES,
+        $userTransformerIncludes,
     );
     $leader = json_item(
         $leader ?? $team->members()->make(['user_id' => $team->leader_id])->userOrDeleted(),
         $userTransformer,
-        UserCompactTransformer::CARD_INCLUDES,
+        $userTransformerIncludes,
     );
     $headerUrl = $team->header()->url();
 


### PR DESCRIPTION
Seems kinda redundant?

The preload in controller can also be removed for the html path but it'll be done separately to also adjust other related things.