### PR TITLE
Actually set closing tag at the end of table of content

### DIFF
--- a/resources/views/wiki/_toc.blade.php
+++ b/resources/views/wiki/_toc.blade.php
@@ -36,10 +36,9 @@
 
     @if ($loop->last)
         @foreach ($currentLevels as $level)
-            @if ($level === 0)
-                @break
+            @if ($level !== 0)
+                </ol>
             @endif
-            </ol>
         @endforeach
     @endif
 @endforeach


### PR DESCRIPTION
The loop starts with first item which means it'll stop right away.