### PR TITLE
Add function to regenerate audio preview

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -88,6 +88,8 @@ SLACK_ENDPOINT=https://myconan.net/null/
 # AVATAR_CACHE_PURGE_AUTHORIZATION_KEY=
 # DEFAULT_AVATAR=http://localhost/images/layout/avatar-guest@2x.png
 
+# S3_BEATMAPSET_BUCKET=beatmapsets
+
 # S3_SCREENSHOT_BUCKET=screenshots
 # SCREENSHOTS_SHARED_SECRET=1234567890abcd
 # SCREENSHOTS_LEGACY_ID_CUTOFF=1

--- a/Dockerfile.deployment
+++ b/Dockerfile.deployment
@@ -56,6 +56,7 @@ RUN echo "install_weak_deps=False" >> /etc/dnf/dnf.conf && \
     rpm -i https://rpm.henderkes.com/static-php-1-1.noarch.rpm && \
     microdnf module enable -y php-zts:static-$(cat /.php-version) && \
     microdnf install -y \
+      ffmpeg-free \
       frankenphp \
       libjpeg-turbo-utils \
       nginx \

--- a/Dockerfile.development
+++ b/Dockerfile.development
@@ -10,6 +10,7 @@ RUN echo "install_weak_deps=False" >> /etc/dnf/dnf.conf && \
     microdnf install -y \
       chromedriver \
       chromium \
+      ffmpeg-free \
       frankenphp \
       git \
       libjpeg-turbo-utils \

--- a/app/Models/Beatmapset.php
+++ b/app/Models/Beatmapset.php
@@ -6,7 +6,6 @@
 namespace App\Models;
 
 use App\Enums\Ruleset;
-use App\Exceptions\BeatmapProcessorException;
 use App\Exceptions\ImageProcessorServiceException;
 use App\Exceptions\InvariantException;
 use App\Jobs\CheckBeatmapsetCovers;
@@ -454,6 +453,11 @@ class Beatmapset extends Model implements AfterCommit, Commentable, Indexable, T
         return $urls;
     }
 
+    public function archive(): ?BeatmapsetArchive
+    {
+        return $this->memoize(__FUNCTION__, fn () => BeatmapsetArchive::fetch($this));
+    }
+
     public function coverURL($coverSize = 'cover', $customTimestamp = null)
     {
         $timestamp = $customTimestamp ?? $this->defaultCoverTimestamp();
@@ -499,53 +503,14 @@ class Beatmapset extends Model implements AfterCommit, Commentable, Indexable, T
         $this->update(['cover_updated_at' => $this->freshTimestamp()]);
     }
 
-    public function fetchBeatmapsetArchive()
-    {
-        $oszFile = tmpfile();
-        $mirror = BeatmapMirror::getRandomFromList($GLOBALS['cfg']['osu']['beatmap_processor']['mirrors_to_use'])
-            ?? throw new \Exception('no available mirror');
-        $url = $mirror->generateURL($this, true);
-
-        if ($url === false) {
-            return false;
-        }
-
-        $curl = curl_init($url);
-        curl_setopt_array($curl, [
-            CURLOPT_FILE => $oszFile,
-            CURLOPT_TIMEOUT => 30,
-        ]);
-        curl_exec($curl);
-
-        if (curl_errno($curl) > 0) {
-            throw new BeatmapProcessorException('Failed downloading osz: '.curl_error($curl));
-        }
-
-        $statusCode = curl_getinfo($curl, CURLINFO_HTTP_CODE);
-        // archive file is gone, nothing to do for now
-        if ($statusCode === 302) {
-            return false;
-        }
-        if ($statusCode !== 200) {
-            throw new BeatmapProcessorException('Failed downloading osz: HTTP Error '.$statusCode);
-        }
-
-        try {
-            return new BeatmapsetArchive(get_stream_filename($oszFile));
-        } catch (BeatmapProcessorException $e) {
-            // zip file is broken, nothing to do for now
-            return false;
-        }
-    }
-
     public function regenerateCovers(?array $sizesToRegenerate = null)
     {
         if (empty($sizesToRegenerate)) {
             $sizesToRegenerate = static::coverSizes();
         }
 
-        $osz = $this->fetchBeatmapsetArchive();
-        if ($osz === false) {
+        $osz = $this->archive();
+        if ($osz === null) {
             return false;
         }
 

--- a/app/Models/Beatmapset.php
+++ b/app/Models/Beatmapset.php
@@ -562,7 +562,7 @@ class Beatmapset extends Model implements AfterCommit, Commentable, Indexable, T
         $this->update(['cover_updated_at' => $this->freshTimestamp()]);
     }
 
-    public function regenerateAudioPreview(): mixed
+    public function regenerateAudioPreview(): bool
     {
         $preview = $this->archive()->generateAudioPreview();
 

--- a/app/Models/Beatmapset.php
+++ b/app/Models/Beatmapset.php
@@ -562,6 +562,21 @@ class Beatmapset extends Model implements AfterCommit, Commentable, Indexable, T
         $this->update(['cover_updated_at' => $this->freshTimestamp()]);
     }
 
+    public function regenerateAudioPreview(): mixed
+    {
+        $preview = $this->archive()->generateAudioPreview();
+
+        if ($preview === null) {
+            return false;
+        }
+
+        return storage_disk('beatmapset')->put(
+            "preview/{$this->getKey()}.mp3",
+            $preview,
+            ['Content-Type' => 'audio/ogg'],
+        );
+    }
+
     public function allCoverImagesPresent()
     {
         foreach ($this->allCoverURLs() as $_size => $url) {

--- a/app/Models/BeatmapsetArchive.php
+++ b/app/Models/BeatmapsetArchive.php
@@ -3,6 +3,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+declare(strict_types=1);
+
 namespace App\Models;
 
 use App\Exceptions\BeatmapProcessorException;
@@ -180,6 +182,8 @@ class BeatmapsetArchive
                 }
             }
         }
+
+        return null;
     }
 
     public function scanBeatmapsForBackground(): ?string

--- a/app/Models/BeatmapsetArchive.php
+++ b/app/Models/BeatmapsetArchive.php
@@ -164,13 +164,7 @@ class BeatmapsetArchive
 
     public function generateAudioPreview(): ?string
     {
-        foreach ($this->osuFileList() as $file) {
-            $parsedFile = $this->getParsedFile($file);
-
-            if ($parsedFile === null) {
-                continue;
-            }
-
+        foreach ($this->getParsedFiles() as $parsedFile) {
             $previewTime = $parsedFile->previewTime;
             $audioFilename = $parsedFile->audioFilename;
 
@@ -188,8 +182,8 @@ class BeatmapsetArchive
 
     public function scanBeatmapsForBackground(): ?string
     {
-        foreach ($this->osuFileList() as $file) {
-            $filename = $this->getParsedFile($file)?->backgroundImage;
+        foreach ($this->getParsedFiles() as $parsedFile) {
+            $filename = $parsedFile->backgroundImage;
 
             // return if background is set in the file and present in .osz
             if ($filename !== null && $this->hasFile($filename)) {
@@ -211,5 +205,16 @@ class BeatmapsetArchive
         }
 
         return $this->parsedFiles[$file];
+    }
+
+    private function getParsedFiles(): iterable
+    {
+        foreach ($this->osuFileList() as $file) {
+            $parsedFile = $this->getParsedFile($file);
+
+            if ($parsedFile !== null) {
+                yield $parsedFile;
+            }
+        }
     }
 }

--- a/app/Models/BeatmapsetArchive.php
+++ b/app/Models/BeatmapsetArchive.php
@@ -59,7 +59,7 @@ class BeatmapsetArchive
         }
 
         try {
-            return new BeatmapsetArchive(get_stream_filename($oszFile), $beatmapset);
+            return new static(get_stream_filename($oszFile), $beatmapset);
         } catch (BeatmapProcessorException) {
             // zip file is broken, nothing to do for now
             return null;

--- a/app/Models/BeatmapsetArchive.php
+++ b/app/Models/BeatmapsetArchive.php
@@ -25,6 +25,45 @@ class BeatmapsetArchive
         }
     }
 
+    public function fetch(Beatmapset $beatmapset): ?static
+    {
+        $oszFile = tmpfile();
+        $mirror = BeatmapMirror::getRandomFromList($GLOBALS['cfg']['osu']['beatmap_processor']['mirrors_to_use'])
+            ?? throw new \Exception('no available mirror');
+        $url = $mirror->generateURL($beatmapset, true);
+
+        if ($url === false) {
+            return null;
+        }
+
+        $curl = curl_init($url);
+        curl_setopt_array($curl, [
+            CURLOPT_FILE => $oszFile,
+            CURLOPT_TIMEOUT => 30,
+        ]);
+        curl_exec($curl);
+
+        if (curl_errno($curl) > 0) {
+            throw new BeatmapProcessorException('Failed downloading osz: '.curl_error($curl));
+        }
+
+        $statusCode = curl_getinfo($curl, CURLINFO_HTTP_CODE);
+        // archive file is gone, nothing to do for now
+        if ($statusCode === 302) {
+            return null;
+        }
+        if ($statusCode !== 200) {
+            throw new BeatmapProcessorException('Failed downloading osz: HTTP Error '.$statusCode);
+        }
+
+        try {
+            return new BeatmapsetArchive(get_stream_filename($oszFile));
+        } catch (BeatmapProcessorException) {
+            // zip file is broken, nothing to do for now
+            return null;
+        }
+    }
+
     public function __destruct()
     {
         if ($this->errorCode === true) {

--- a/app/Models/BeatmapsetArchive.php
+++ b/app/Models/BeatmapsetArchive.php
@@ -10,12 +10,14 @@ use App\Libraries\BeatmapFile;
 
 class BeatmapsetArchive
 {
-    private $fileList;
     private $errorCode;
+    private $fileList;
+    private array $osuFileList;
     private $osz;
+    private array $parsedFiles = [];
     private $zip;
 
-    public function __construct(string $osz)
+    public function __construct(string $osz, private ?Beatmapset $beatmapset = null)
     {
         $this->osz = $osz;
         $this->zip = new \ZipArchive();
@@ -25,7 +27,7 @@ class BeatmapsetArchive
         }
     }
 
-    public function fetch(Beatmapset $beatmapset): ?static
+    public static function fetch(Beatmapset $beatmapset): ?static
     {
         $oszFile = tmpfile();
         $mirror = BeatmapMirror::getRandomFromList($GLOBALS['cfg']['osu']['beatmap_processor']['mirrors_to_use'])
@@ -57,11 +59,57 @@ class BeatmapsetArchive
         }
 
         try {
-            return new BeatmapsetArchive(get_stream_filename($oszFile));
+            return new BeatmapsetArchive(get_stream_filename($oszFile), $beatmapset);
         } catch (BeatmapProcessorException) {
             // zip file is broken, nothing to do for now
             return null;
         }
+    }
+
+    private static function convertAudioForPreview(string $audioFile, int $previewTime): ?string
+    {
+        $srcFile = tmpfile();
+        fwrite($srcFile, $audioFile);
+        $srcFilename = get_stream_filename($srcFile);
+        $dstFile = tmpfile();
+        $dstFilename = get_stream_filename($dstFile);
+
+        $duration = 10000;
+        $previewTime = max($previewTime, 0);
+
+        $fadeInExtension = min($previewTime, 100);
+        $fadeIn = $fadeInExtension + 100;
+        $duration += $fadeInExtension;
+        $previewTime -= $fadeInExtension;
+
+        $fadeOut = $duration - 1000;
+
+        $filter = implode(',', [
+            // unify output to 44.1kHz stereo
+            // note that vorbis doesn't have bit depth
+            'aresample=osr=44100:ochl=stereo',
+            "afade=t=in:st=0:d={$fadeIn}ms:curve=ipar",
+            "afade=t=out:st={$fadeOut}ms:d=1000ms:curve=tri",
+        ]);
+
+        exec(implode(' ', [
+            'timeout 20s',
+            'ffmpeg',
+            '-loglevel quiet',
+            '-nostdin',
+            "-ss {$previewTime}ms",
+            "-t {$duration}ms",
+            '-i '.escapeshellarg($srcFilename),
+            "-af {$filter}",
+            '-map 0:a', // strip out non-audio streams
+            '-map_metadata -1', // strip out metadata
+            '-c:a libvorbis -q 1.0',
+            '-f ogg',
+            '-y',
+            escapeshellarg($dstFilename),
+        ]));
+
+        return presence(file_get_contents($dstFilename));
     }
 
     public function __destruct()
@@ -87,7 +135,11 @@ class BeatmapsetArchive
 
     public function osuFileList()
     {
-        return preg_grep('/\.osu$/i', $this->fileList());
+        return $this->osuFileList ??= array_values(array_unique([
+            // use db order
+            ...($this->beatmapset?->beatmaps->pluck('filename') ?? []),
+            ...preg_grep('/\.osu$/i', $this->fileList()),
+        ]));
     }
 
     public function readFile(?string $filename)
@@ -108,33 +160,52 @@ class BeatmapsetArchive
         return $this->zip->locateName($filename, \ZipArchive::FL_NOCASE) !== false;
     }
 
-    // Parses given list (of .osu files) and finds background images referenced.
-    // If $performFallback is enabled, all .osu files in archive are scanned if $filelist yields no result.
-    // This allows beatmap order to dictate the priority (to match existing behaviour).
-    public function scanBeatmapsForBackground(array $filelist, bool $performFallback = false)
+    public function generateAudioPreview(): ?string
     {
-        if ($performFallback) {
-            $filelist = array_merge($filelist, $this->osuFileList());
-        }
+        foreach ($this->osuFileList() as $file) {
+            $parsedFile = $this->getParsedFile($file);
 
-        if (empty($filelist)) {
-            return;
-        }
-
-        foreach ($filelist as $file) {
-            $content = $this->readFile($file);
-            if ($content === false) {
-                // missing .osu (usually due to mismatching filename from unicode stripping)
+            if ($parsedFile === null) {
                 continue;
             }
 
-            $filename = new BeatmapFile($content)->backgroundImage;
+            $previewTime = $parsedFile->previewTime;
+            $audioFilename = $parsedFile->audioFilename;
+
+            if (isset($audioFilename, $previewTime)) {
+                $audioFile = $this->readFile($audioFilename);
+
+                if ($audioFile !== null) {
+                    return static::convertAudioForPreview($audioFile, $previewTime);
+                }
+            }
+        }
+    }
+
+    public function scanBeatmapsForBackground(): ?string
+    {
+        foreach ($this->osuFileList() as $file) {
+            $filename = $this->getParsedFile($file)?->backgroundImage;
+
             // return if background is set in the file and present in .osz
             if ($filename !== null && $this->hasFile($filename)) {
                 return $filename;
             }
         }
 
-        return false;
+        return null;
+    }
+
+    private function getParsedFile(string $file): ?BeatmapFile
+    {
+        if (!array_key_exists($file, $this->parsedFiles)) {
+            $content = $this->readFile($file);
+
+            $this->parsedFiles[$file] = $content === false
+                ? null
+                : new BeatmapFile($content);
+        }
+
+        return $this->parsedFiles[$file];
     }
 }

--- a/config/filesystems.php
+++ b/config/filesystems.php
@@ -84,6 +84,12 @@ return [
             'visibility' => 'public',
         ],
 
+        'local-beatmapset' => [
+            'driver' => 'local',
+            'root' => public_path('uploads/beatmapset'),
+            'visibility' => 'private',
+        ],
+
         'local-central' => [
             'driver' => 'local',
             'root' => public_path('/uploads/central'),
@@ -116,6 +122,12 @@ return [
             'key' => env('S3_AVATAR_KEY'),
             'region' => env('S3_AVATAR_REGION'),
             'secret' => env('S3_AVATAR_SECRET'),
+        ],
+
+        's3-beatmapset' => [
+            ...$s3Default,
+            'bucket' => presence(env('S3_BEATMAPSET_BUCKET')) ?? 'beatmapsets',
+            'visibility' => 'private',
         ],
 
         's3-central' => [


### PR DESCRIPTION
Only accessible through ad hoc tinker etc.

depends on
- [x] #12820
- [x] #12814

for testing. drop osz files on top directory, create `public/test` directory, and then include the file in a tinker session.
```php
<?php

$t = time();
$html = 'public/test/index.html';
file_put_contents($html, '<!doctype html>');

foreach (glob('./*.osz') as $f) {
    $oszName = substr($f, 2);
    $bid = intval($oszName);
    $path = "{$t}-{$bid}.ogg";
    file_put_contents(
        "public/test/{$path}",
        (new BeatmapsetArchive($f, null))->generateAudioPreview(),
    );
    file_put_contents(
        $html,
        "<p>{$oszName}<br><audio src='{$path}' controls></audio></p>",
        FILE_APPEND,
    );
}

file_put_contents($html, '<script src="index.js"></script>', FILE_APPEND);
```

`index.js`
```javascript
const players = document.querySelectorAll('audio');

for (let i = 0; i < players.length; i++) {
  const player = players[i];
  const nextPlayer = players[(i + 1) % players.length];
  player.addEventListener('ended', () => nextPlayer.play());
}
```