### PR TITLE
Skip null filename when processing beatmapset archive

### DIFF
--- a/app/Models/BeatmapsetArchive.php
+++ b/app/Models/BeatmapsetArchive.php
@@ -139,7 +139,8 @@ class BeatmapsetArchive
     {
         return $this->osuFileList ??= array_values(array_unique([
             // use db order
-            ...($this->beatmapset?->beatmaps->pluck('filename') ?? []),
+            // filename column in beatmaps table is nullable
+            ...array_reject_null($this->beatmapset?->beatmaps->pluck('filename') ?? []),
             ...preg_grep('/\.osu$/i', $this->fileList()),
         ]));
     }


### PR DESCRIPTION
This shouldn't happen but it did a bit ago due to a bug somewhere else. It should be ignored here instead of exploding.