### PR TITLE
Fix incorrect check on beatmapset search query update

### DIFF
--- a/resources/js/beatmaps/beatmapset-search-controller.ts
+++ b/resources/js/beatmaps/beatmapset-search-controller.ts
@@ -154,6 +154,7 @@ export class BeatmapsetSearchController {
 
   @action
   private readonly filterChangedHandler = (change: IObjectDidChange<BeatmapsetSearchFilters>) => {
+    if (change.name === 'queryRaw') return;
     if (change.type === 'update' && change.oldValue === change.newValue) return;
 
     this.searchStatus.state = 'input';

--- a/resources/js/beatmapset-search-filters.ts
+++ b/resources/js/beatmapset-search-filters.ts
@@ -92,12 +92,11 @@ export class BeatmapsetSearchFilters {
 
   constructor(url: string) {
     const filters = filtersFromUrl(url);
+    this.queryRaw = filters.query ?? '';
     for (const key of keyNames) {
       const value = filters[key] ?? null;
-      this[key] = value === this.getDefault(key) ? null : value;
+      this[key] = this.sanitiseValue(key, value);
     }
-
-    this.queryRaw = this.query ?? '';
 
     makeObservable(this);
   }
@@ -170,11 +169,8 @@ export class BeatmapsetSearchFilters {
   update(key: FilterKey, value: FilterValueType) {
     if (key === 'query') {
       this.queryRaw = value ?? '';
-      value = presence(value?.trim());
     }
-    if (value === this.getDefault(key)) {
-      value = null;
-    }
+    value = this.sanitiseValue(key, value);
 
     if (value === this[key]) return;
     if (changesResetSorts.includes(key)) {
@@ -182,5 +178,15 @@ export class BeatmapsetSearchFilters {
     }
 
     this[key] = value;
+  }
+
+  private sanitiseValue(key: FilterKey, value: FilterValueType) {
+    if (key === 'query') {
+      value = presence(value?.trim());
+    }
+
+    return value === this.getDefault(key)
+      ? null
+      : value;
   }
 }

--- a/resources/js/beatmapset-search-filters.ts
+++ b/resources/js/beatmapset-search-filters.ts
@@ -2,7 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 import { invert } from 'lodash';
-import { action, computed, intercept, makeObservable, observable } from 'mobx';
+import { action, computed, makeObservable, observable } from 'mobx';
 import core from 'osu-core-singleton';
 import { presence, present } from 'utils/string';
 import { updateQueryString } from 'utils/url';
@@ -100,13 +100,6 @@ export class BeatmapsetSearchFilters {
     this.queryRaw = this.query ?? '';
 
     makeObservable(this);
-
-    intercept(this, 'query', (change) => {
-      this.queryRaw = change.newValue ?? '';
-      change.newValue = presence((change.newValue)?.trim()) ?? null;
-
-      return change;
-    });
   }
 
   getDefault(key: FilterKey) {
@@ -175,6 +168,10 @@ export class BeatmapsetSearchFilters {
 
   @action
   update(key: FilterKey, value: FilterValueType) {
+    if (key === 'query') {
+      this.queryRaw = value ?? '';
+      value = presence(value?.trim());
+    }
     const oldValue = this[key];
     if (value === oldValue) return;
     if (changesResetSorts.includes(key)) {

--- a/resources/js/beatmapset-search-filters.ts
+++ b/resources/js/beatmapset-search-filters.ts
@@ -172,12 +172,15 @@ export class BeatmapsetSearchFilters {
       this.queryRaw = value ?? '';
       value = presence(value?.trim());
     }
-    const oldValue = this[key];
-    if (value === oldValue) return;
+    if (value === this.getDefault(key)) {
+      value = null;
+    }
+
+    if (value === this[key]) return;
     if (changesResetSorts.includes(key)) {
       this.sort = null;
     }
 
-    this[key] = value === this.getDefault(key) ? null : value;
+    this[key] = value;
   }
 }

--- a/tests/karma/beatmapset-search-filters.spec.ts
+++ b/tests/karma/beatmapset-search-filters.spec.ts
@@ -12,24 +12,23 @@ describe('BeatmapsetSearchFilters', () => {
     });
 
     it('should remove leading whitespace', () => {
-      subject.query = '  whee 12 ああ';
+      subject.update('query', '  whee 12 ああ');
 
       expect(subject.query).toBe('whee 12 ああ');
       expect(subject.queryRaw).toBe('  whee 12 ああ');
     });
 
     it('should remove trailing whitespace', () => {
-      subject.query = 'whee 12 ああ  ';
+      subject.update('query', 'whee 12 ああ  ');
 
       expect(subject.query).toBe('whee 12 ああ');
       expect(subject.queryRaw).toBe('whee 12 ああ  ');
     });
 
     it('should treat empty string as null', () => {
-      subject.query = '';
+      subject.update('query', '');
 
-      // type inference was a bit _too_ smart.
-      expect(subject.query as string | null).toBe(null);
+      expect(subject.query).toBe(null);
       expect(subject.queryRaw).toBe('');
     });
   });


### PR DESCRIPTION
`update` is already the entrypoint for updating any filter attributes so intercepting the `query` field doesn't really mean much - it still can't be updated directly regardless.

There's also another problem of debounce for query change stopped working because it monitors all fields.

Resolves #12850