### PR TITLE
Fix return error check

### DIFF
--- a/app/Models/BeatmapsetArchive.php
+++ b/app/Models/BeatmapsetArchive.php
@@ -190,7 +190,7 @@ class BeatmapsetArchive
             if (isset($audioFilename)) {
                 $audioFile = $this->readFile($audioFilename);
 
-                if ($audioFile !== null) {
+                if ($audioFile !== false) {
                     return static::convertAudioForPreview($audioFile, $previewTime);
                 }
             }


### PR DESCRIPTION
The function returns false on error, not null.