### PR TITLE
Fix user cards re-rendering too often

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -55,7 +55,7 @@ jobs:
       - name: Install js dependencies
         run: yarn --frozen-lockfile
 
-      - run: 'yarn lint --max-warnings 54 > /dev/null'
+      - run: 'yarn lint --max-warnings 53 > /dev/null'
 
       - run: yarn pretty
 

--- a/resources/js/beatmapsets-show/scoreboard/table.tsx
+++ b/resources/js/beatmapsets-show/scoreboard/table.tsx
@@ -21,9 +21,7 @@ interface Props {
 @observer
 export default class Table extends React.Component<Props> {
   @observable activeKey: number | null = null;
-  private readonly containerContextValue: {
-    activeKeyDidChange: typeof this.activeKeyDidChange;
-  };
+  private readonly containerContextValue;
 
   @computed
   get showPp() {

--- a/resources/js/components/user-cards.tsx
+++ b/resources/js/components/user-cards.tsx
@@ -2,11 +2,11 @@
 // See the LICENCE file in the repository root for full licence text.
 
 import UserJson from 'interfaces/user-json';
-import { action, makeObservable, observable } from 'mobx';
+import { action, computed, makeObservable, observable } from 'mobx';
 import { observer } from 'mobx-react';
 import * as React from 'react';
 import { ContainerContext, KeyContext } from 'stateful-activation-context';
-import { classWithModifiers, mergeModifiers, Modifiers } from 'utils/css';
+import { classWithModifiers, isModifiersEqual, mergeModifiers, Modifiers } from 'utils/css';
 import { UserCard, ViewMode } from './user-card';
 
 interface Props {
@@ -19,11 +19,24 @@ interface Props {
 export class UserCards extends React.PureComponent<Props> {
   @observable activeKey: number | null = null;
   private readonly containerContextValue;
+  @observable private observableModifiers = this.props.modifiers;
+
+  @computed
+  private get modifiers() {
+    return mergeModifiers('has-outline', this.observableModifiers);
+  }
 
   constructor(props: Props) {
     super(props);
     makeObservable(this);
     this.containerContextValue = { activeKeyDidChange: this.activeKeyDidChange };
+  }
+
+  @action
+  componentDidUpdate(prevProps: Readonly<Props>) {
+    if (!isModifiersEqual(prevProps.modifiers, this.props.modifiers)) {
+      this.observableModifiers = this.props.modifiers;
+    }
   }
 
   render() {
@@ -44,7 +57,7 @@ export class UserCards extends React.PureComponent<Props> {
                   <UserCard
                     activated={activated}
                     mode={this.props.viewMode}
-                    modifiers={mergeModifiers('has-outline', this.props.modifiers)}
+                    modifiers={this.modifiers}
                     user={user}
                   />
                 </KeyContext.Provider>

--- a/resources/js/components/user-cards.tsx
+++ b/resources/js/components/user-cards.tsx
@@ -2,8 +2,10 @@
 // See the LICENCE file in the repository root for full licence text.
 
 import UserJson from 'interfaces/user-json';
+import { action, makeObservable, observable } from 'mobx';
+import { observer } from 'mobx-react';
 import * as React from 'react';
-import { activeKeyDidChange, ContainerContext, KeyContext, State as ActiveKeyState } from 'stateful-activation-context';
+import { ContainerContext, KeyContext } from 'stateful-activation-context';
 import { classWithModifiers, mergeModifiers, Modifiers } from 'utils/css';
 import { UserCard, ViewMode } from './user-card';
 
@@ -13,22 +15,29 @@ interface Props {
   viewMode: ViewMode;
 }
 
+@observer
 export class UserCards extends React.PureComponent<Props> {
-  readonly activeKeyDidChange = activeKeyDidChange.bind(this);
-  readonly state: ActiveKeyState = {};
+  @observable activeKey: number | null = null;
+  private readonly containerContextValue;
+
+  constructor(props: Props) {
+    super(props);
+    makeObservable(this);
+    this.containerContextValue = { activeKeyDidChange: this.activeKeyDidChange };
+  }
 
   render() {
     const classMods = {
-      'menu-active': this.state.activeKey != null,
+      'menu-active': this.activeKey != null,
       [this.props.viewMode]: true,
     };
 
     return (
-      <ContainerContext.Provider value={{ activeKeyDidChange: this.activeKeyDidChange }}>
+      <ContainerContext.Provider value={this.containerContextValue}>
         <div className={classWithModifiers('user-cards', classMods)}>
           {
             this.props.users.map((user) => {
-              const activated = this.state.activeKey === user.id;
+              const activated = this.activeKey === user.id;
 
               return (
                 <KeyContext.Provider key={user.id} value={user.id}>
@@ -46,4 +55,9 @@ export class UserCards extends React.PureComponent<Props> {
       </ContainerContext.Provider>
     );
   }
+
+  @action
+  private readonly activeKeyDidChange = (key: number | null) => {
+    this.activeKey = key;
+  };
 }

--- a/resources/js/profile-page/play-detail-list.tsx
+++ b/resources/js/profile-page/play-detail-list.tsx
@@ -44,9 +44,7 @@ interface Props {
 @observer
 export default class PlayDetailList extends React.Component<Props> {
   @observable activeKey: number | null = null;
-  private readonly containerContextValue: {
-    activeKeyDidChange: (key: number | null) => void;
-  };
+  private readonly containerContextValue;
   private readonly listRef = React.createRef<HTMLDivElement>();
 
   @computed

--- a/resources/js/stateful-activation-context.ts
+++ b/resources/js/stateful-activation-context.ts
@@ -20,4 +20,4 @@ export const ContainerContext = createContext<ContainerContextValue>({
   activeKeyDidChange: (_key: any) => { /* do nothing */},
 });
 
-export const KeyContext = createContext<any>(null);
+export const KeyContext = createContext<Key | null | undefined>(null);

--- a/resources/js/stateful-activation-context.ts
+++ b/resources/js/stateful-activation-context.ts
@@ -1,10 +1,14 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
-import { Component, createContext } from 'react';
+import { Component, createContext, Key } from 'react';
 
 export interface State {
   activeKey?: any;
+}
+
+interface ContainerContextValue<T = (Key | null | undefined)> {
+  activeKeyDidChange: (key: T) => void;
 }
 
 // TODO: need a better way of doing this without this.setState
@@ -12,7 +16,7 @@ export function activeKeyDidChange(this: Component, key: any) {
   this.setState({ activeKey: key });
 }
 
-export const ContainerContext = createContext({
+export const ContainerContext = createContext<ContainerContextValue>({
   activeKeyDidChange: (_key: any) => { /* do nothing */},
 });
 

--- a/resources/js/utils/css.ts
+++ b/resources/js/utils/css.ts
@@ -47,6 +47,12 @@ export function mergeModifiers(...modifiersArray: Modifiers[]) {
   return ret;
 }
 
+export function isModifiersEqual(a: Modifiers, b: Modifiers) {
+  const flatA = mergeModifiers(a);
+  const flatB = mergeModifiers(b);
+  return flatA.length === flatB.length && flatA.every((mod, index) => mod === flatB[index]);
+}
+
 export function urlPresence(url?: string | null) {
   // Wrapping the string with quotes and escaping the used quotes inside
   // is sufficient. Use double quote as it's easy to figure out with


### PR DESCRIPTION
seeing https://github.com/ppy/osu-web/pull/12837/changes#diff-beae6c5ff40beb4d5425b33c73d1a7ed16115fe27e3fbddc8e37e5d653805412R122 reminded me of the problem of unwanted re-renders triggering; in this case, `mergeModifiers` in the parent is always returning a new array, so the `props` are always changing...