### PR TITLE
Streamline SelectOptions rendering

### DIFF
--- a/resources/css/bem/select-options.less
+++ b/resources/css/bem/select-options.less
@@ -13,7 +13,6 @@
   --selector-overflow-y: auto;
 
   &--beatmap-discussions-user-filter {
-    --decoration-colour: hsl(var(--hsl-c1));
     --selector-max-height: auto;
 
     @media @desktop {
@@ -60,10 +59,6 @@
 
     &--selected {
       background-color: @osu-colour-b3;
-    }
-
-    .@{_top}--beatmap-discussions-user-filter & {
-      --colour: var(--group-colour, hsl(var(--hsl-c1)));
     }
 
     .link-hover({

--- a/resources/css/utilities.less
+++ b/resources/css/utilities.less
@@ -71,6 +71,10 @@
   .full-size();
 }
 
+.u-group-colour {
+  color: var(--group-colour);
+}
+
 .u-hidden {
   display: none !important;
 }

--- a/resources/js/beatmap-discussions/user-filter.tsx
+++ b/resources/js/beatmap-discussions/user-filter.tsx
@@ -64,7 +64,7 @@ export class UserFilter extends React.Component<Props> {
     }
 
     const style = groupColour(this.getGroup(this.props.discussionsState.selectedUser));
-    return <span className='u-group-colour u-ellipsis-overflow' style={style}>{this.props.discussionsState.selectedUser?.username}</span>;
+    return <span className='u-group-colour u-ellipsis-overflow' style={style}>{this.props.discussionsState.selectedUser.username}</span>;
   }
 
   @computed

--- a/resources/js/beatmap-discussions/user-filter.tsx
+++ b/resources/js/beatmap-discussions/user-filter.tsx
@@ -2,7 +2,7 @@
 // See the LICENCE file in the repository root for full licence text.
 
 import mapperGroup from 'beatmap-discussions/mapper-group';
-import SelectOptions, { OptionRenderProps } from 'components/select-options';
+import SelectOptions from 'components/select-options';
 import BeatmapsetDiscussionsStore from 'interfaces/beatmapset-discussions-store';
 import UserJson from 'interfaces/user-json';
 import { action, computed, makeObservable } from 'mobx';
@@ -12,22 +12,18 @@ import * as React from 'react';
 import { makeUrl, parseUrl } from 'utils/beatmapset-discussion-helper';
 import { groupColour } from 'utils/css';
 import { trans } from 'utils/lang';
+import { getInt } from 'utils/math';
 import DiscussionsState from './discussions-state';
 
 const allUsers = Object.freeze({
   id: null,
-  text: trans('beatmap_discussions.user_filter.everyone'),
-});
-
-const noSelection = Object.freeze({
-  id: null,
-  text: trans('beatmap_discussions.user_filter.label'),
+  username: trans('beatmap_discussions.user_filter.everyone'),
 });
 
 interface Option {
-  groups: UserJson['groups'];
+  groups?: UserJson['groups'];
   id: UserJson['id'] | null;
-  text: UserJson['username'];
+  username: UserJson['username'];
 }
 
 interface Props {
@@ -35,25 +31,10 @@ interface Props {
   store: BeatmapsetDiscussionsStore;
 }
 
-function mapUserProperties(user: UserJson): Option {
-  return {
-    groups: user.groups,
-    id: user.id,
-    text: user.username,
-  };
-}
-
 @observer
 export class UserFilter extends React.Component<Props> {
   private get ownerId() {
     return this.props.discussionsState.beatmapset.user_id;
-  }
-
-  @computed
-  private get selected() {
-    return this.props.discussionsState.selectedUser != null
-      ? mapUserProperties(this.props.discussionsState.selectedUser)
-      : noSelection;
   }
 
   @computed
@@ -69,11 +50,26 @@ export class UserFilter extends React.Component<Props> {
     }
 
     return [
-      allUsers,
+      this.mapUserProperties(allUsers),
       ...[...usersWithDicussions.values()]
         .sort(usernameSortAscending)
-        .map(mapUserProperties),
+        .map(this.mapUserProperties),
     ];
+  }
+
+  @computed
+  private get text() {
+    if (this.props.discussionsState.selectedUser == null) {
+      return trans('beatmap_discussions.user_filter.label');
+    }
+
+    const style = groupColour(this.getGroup(this.props.discussionsState.selectedUser));
+    return <span className='u-group-colour u-ellipsis-overflow' style={style}>{this.props.discussionsState.selectedUser?.username}</span>;
+  }
+
+  @computed
+  private get urlOptions() {
+    return parseUrl(this.props.discussionsState.url);
   }
 
   constructor(props: Props) {
@@ -84,50 +80,47 @@ export class UserFilter extends React.Component<Props> {
   render() {
     return (
       <SelectOptions
+        href={this.props.discussionsState.url}
         modifiers='beatmap-discussions-user-filter'
-        onChange={this.handleChange}
+        onSelect={this.handleSelect}
         options={this.options}
-        renderOption={this.renderOption}
-        selected={this.selected}
-      />
+        selected={this.props.discussionsState.selectedUserId}
+      >
+        {this.text}
+      </SelectOptions>
     );
   }
 
-  private getGroup(option: Option) {
-    if (this.isOwner(option)) return mapperGroup;
+  private getGroup(user: Option) {
+    if (this.isOwner(user)) return mapperGroup;
 
-    return option.groups?.[0];
+    return user.groups?.[0];
   }
 
   @action
-  private readonly handleChange = (option: Option) => {
-    this.props.discussionsState.selectedUserId = option.id;
+  private readonly handleSelect = (id?: string) => {
+    const userId = getInt(id) ?? null;
+    this.props.discussionsState.selectedUserId = userId;
   };
 
-  private isOwner(user?: Option) {
+  private isOwner(user?: Option): boolean {
     return user != null && user.id === this.ownerId;
   }
 
-  private readonly renderOption = ({ cssClasses, children, onClick, option }: OptionRenderProps<Option>) => {
-    const group = this.getGroup(option);
+  private readonly mapUserProperties = (user: Option) => {
+    const group = this.getGroup(user);
     const style = groupColour(group);
 
-    const urlOptions = parseUrl();
+    const urlOptions = structuredClone(this.urlOptions);
     // means it doesn't work on non-beatmapset discussion paths
-    if (urlOptions == null) return null;
+    if (urlOptions != null) {
+      urlOptions.user = user.id ?? undefined;
+    }
 
-    urlOptions.user = option.id ?? undefined;
-
-    return (
-      <a
-        key={option.id}
-        className={cssClasses}
-        href={makeUrl(urlOptions)}
-        onClick={onClick}
-        style={style}
-      >
-        {children}
-      </a>
-    );
+    return {
+      children: <span className='u-group-colour u-ellipsis-overflow' style={style}>{user.username}</span>,
+      href: urlOptions != null ? makeUrl(urlOptions) : '#',
+      id: user.id,
+    };
   };
 }

--- a/resources/js/beatmap-discussions/user-filter.tsx
+++ b/resources/js/beatmap-discussions/user-filter.tsx
@@ -85,8 +85,9 @@ export class UserFilter extends React.Component<Props> {
         onSelect={this.handleSelect}
         options={this.options}
         selected={this.props.discussionsState.selectedUserId}
-        text={this.text}
-      />
+      >
+        {this.text}
+      </SelectOptions>
     );
   }
 

--- a/resources/js/beatmap-discussions/user-filter.tsx
+++ b/resources/js/beatmap-discussions/user-filter.tsx
@@ -85,9 +85,8 @@ export class UserFilter extends React.Component<Props> {
         onSelect={this.handleSelect}
         options={this.options}
         selected={this.props.discussionsState.selectedUserId}
-      >
-        {this.text}
-      </SelectOptions>
+        text={this.text}
+      />
     );
   }
 
@@ -118,9 +117,9 @@ export class UserFilter extends React.Component<Props> {
     }
 
     return {
-      children: <span className='u-group-colour u-ellipsis-overflow' style={style}>{user.username}</span>,
       href: urlOptions != null ? makeUrl(urlOptions) : '#',
       id: user.id,
+      text: <span className='u-group-colour u-ellipsis-overflow' style={style}>{user.username}</span>,
     };
   };
 }

--- a/resources/js/components/basic-select-options.tsx
+++ b/resources/js/components/basic-select-options.tsx
@@ -8,7 +8,6 @@ import { route } from 'laroute';
 import * as React from 'react';
 import { Modifiers } from 'utils/css';
 import { fail } from 'utils/fail';
-import { navigate } from 'utils/turbolinks';
 import { updateQueryString } from 'utils/url';
 
 interface PropsBase {
@@ -39,7 +38,6 @@ export default class BasicSelectOptions extends React.PureComponent<Props> {
       <SelectOptions
         href={this.href(this.props.currentItem.id)}
         modifiers={this.props.modifiers}
-        onSelect={this.handleSelect}
         options={this.options}
         selected={this.props.currentItem.id}
       >
@@ -47,10 +45,6 @@ export default class BasicSelectOptions extends React.PureComponent<Props> {
       </SelectOptions>
     );
   }
-
-  private readonly handleSelect = (id?: string) => {
-    navigate(this.href(id));
-  };
 
   private href(id?: string | number) {
     switch (this.props.type) {

--- a/resources/js/components/basic-select-options.tsx
+++ b/resources/js/components/basic-select-options.tsx
@@ -27,9 +27,8 @@ type Props = PropsBase & ({
 export default class BasicSelectOptions extends React.PureComponent<Props> {
   private get options() {
     return this.props.items.map((item) => ({
+      ...item,
       href: this.href(item.id),
-      id: item.id,
-      text: item.text,
     }));
   }
 

--- a/resources/js/components/basic-select-options.tsx
+++ b/resources/js/components/basic-select-options.tsx
@@ -27,9 +27,9 @@ type Props = PropsBase & ({
 export default class BasicSelectOptions extends React.PureComponent<Props> {
   private get options() {
     return this.props.items.map((item) => ({
-      children: item.text,
       href: this.href(item.id),
       id: item.id,
+      text: item.text,
     }));
   }
 
@@ -40,9 +40,8 @@ export default class BasicSelectOptions extends React.PureComponent<Props> {
         modifiers={this.props.modifiers}
         options={this.options}
         selected={this.props.currentItem.id}
-      >
-        {this.props.currentItem.text}
-      </SelectOptions>
+        text={this.props.currentItem.text}
+      />
     );
   }
 

--- a/resources/js/components/basic-select-options.tsx
+++ b/resources/js/components/basic-select-options.tsx
@@ -39,8 +39,9 @@ export default class BasicSelectOptions extends React.PureComponent<Props> {
         modifiers={this.props.modifiers}
         options={this.options}
         selected={this.props.currentItem.id}
-        text={this.props.currentItem.text}
-      />
+      >
+        {this.props.currentItem.text}
+      </SelectOptions>
     );
   }
 

--- a/resources/js/components/basic-select-options.tsx
+++ b/resources/js/components/basic-select-options.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
-import SelectOptions, { OptionRenderProps } from 'components/select-options';
+import SelectOptions from 'components/select-options';
 import Ruleset from 'interfaces/ruleset';
 import SelectOptionJson from 'interfaces/select-option-json';
 import { route } from 'laroute';
@@ -24,31 +24,42 @@ type Props = PropsBase & ({
   type: 'matchmaking';
 });
 
+// TODO: stricter typing; require only one of string or number at a time, not both.
 export default class BasicSelectOptions extends React.PureComponent<Props> {
+  private get options() {
+    return this.props.items.map((item) => ({
+      children: item.text,
+      href: this.href(item.id),
+      id: item.id,
+    }));
+  }
+
   render() {
     return (
       <SelectOptions
+        href={this.href(this.props.currentItem.id)}
         modifiers={this.props.modifiers}
-        onChange={this.handleChange}
-        options={this.props.items}
-        renderOption={this.renderOption}
-        selected={this.props.currentItem}
-      />
+        onSelect={this.handleSelect}
+        options={this.options}
+        selected={this.props.currentItem.id}
+      >
+        {this.props.currentItem.text}
+      </SelectOptions>
     );
   }
 
-  private readonly handleChange = (option: SelectOptionJson) => {
-    navigate(this.href(option.id));
+  private readonly handleSelect = (id?: string) => {
+    navigate(this.href(id));
   };
 
-  private href(id: number | null) {
+  private href(id?: string | number) {
     switch (this.props.type) {
       case 'daily_challenge':
         return route('daily-challenge.show', { daily_challenge: id ?? fail('missing id parameter') });
       case 'download':
         return route('download', { platform: id });
       case 'matchmaking':
-        return route('rankings.matchmaking', { mode: this.props.ruleset, pool: id ?? undefined });
+        return route('rankings.matchmaking', { mode: this.props.ruleset, pool: id });
       case 'multiplayer':
         return route('multiplayer.rooms.show', { room: id ?? 'latest' });
       case 'seasons':
@@ -57,15 +68,4 @@ export default class BasicSelectOptions extends React.PureComponent<Props> {
         return updateQueryString(null, { spotlight: id?.toString() });
     }
   }
-
-  private readonly renderOption = (props: OptionRenderProps<SelectOptionJson>) => (
-    <a
-      key={props.option.id}
-      className={props.cssClasses}
-      href={this.href(props.option.id)}
-      onClick={props.onClick}
-    >
-      {props.children}
-    </a>
-  );
 }

--- a/resources/js/components/ranking-country-filter.tsx
+++ b/resources/js/components/ranking-country-filter.tsx
@@ -24,7 +24,7 @@ const allCountries = { id: null, text: trans('rankings.countries.all') };
 @observer
 export default class RankingFilter extends React.Component<Props> {
   @computed
-  private get items() {
+  private get options() {
     const ordered = [allCountries, ...this.props.items.sort((a, b) => {
       // prioritizes current user's country
       if (core.currentUser?.country_code === a.id) return -1;
@@ -34,9 +34,9 @@ export default class RankingFilter extends React.Component<Props> {
     })];
 
     return ordered.map((option) => ({
-      children: option.text,
       href: this.href(option.id),
       id: option.id,
+      text: option.text,
     }));
   }
 
@@ -57,11 +57,10 @@ export default class RankingFilter extends React.Component<Props> {
         <SelectOptions
           href={this.href(currentItem.id)}
           modifiers='ranking'
-          options={this.items}
+          options={this.options}
           selected={currentItem.id}
-        >
-          {currentItem.text}
-        </SelectOptions>
+          text={currentItem.text}
+        />
       </div>
     );
   }

--- a/resources/js/components/ranking-country-filter.tsx
+++ b/resources/js/components/ranking-country-filter.tsx
@@ -59,8 +59,9 @@ export default class RankingFilter extends React.Component<Props> {
           modifiers='ranking'
           options={this.options}
           selected={currentItem.id}
-          text={currentItem.text}
-        />
+        >
+          {currentItem.text}
+        </SelectOptions>
       </div>
     );
   }

--- a/resources/js/components/ranking-country-filter.tsx
+++ b/resources/js/components/ranking-country-filter.tsx
@@ -7,7 +7,6 @@ import { observer } from 'mobx-react';
 import core from 'osu-core-singleton';
 import * as React from 'react';
 import { trans } from 'utils/lang';
-import { navigate } from 'utils/turbolinks';
 import { updateQueryString } from 'utils/url';
 
 interface CountryOption {
@@ -58,7 +57,6 @@ export default class RankingFilter extends React.Component<Props> {
         <SelectOptions
           href={this.href(currentItem.id)}
           modifiers='ranking'
-          onSelect={this.handleSelect}
           options={this.items}
           selected={currentItem.id}
         >
@@ -67,10 +65,6 @@ export default class RankingFilter extends React.Component<Props> {
       </div>
     );
   }
-
-  private readonly handleSelect = (id?: string) => {
-    navigate(this.href(id));
-  };
 
   private href(id?: string | null) {
     return updateQueryString(null, { country: id, page: null });

--- a/resources/js/components/ranking-country-filter.tsx
+++ b/resources/js/components/ranking-country-filter.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
-import SelectOptions, { Option, OptionRenderProps } from 'components/select-options';
+import SelectOptions from 'components/select-options';
 import { computed, makeObservable } from 'mobx';
 import { observer } from 'mobx-react';
 import core from 'osu-core-singleton';
@@ -10,7 +10,7 @@ import { trans } from 'utils/lang';
 import { navigate } from 'utils/turbolinks';
 import { updateQueryString } from 'utils/url';
 
-interface CountryOption extends Option {
+interface CountryOption {
   id: string | null;
   text: string;
 }
@@ -26,13 +26,19 @@ const allCountries = { id: null, text: trans('rankings.countries.all') };
 export default class RankingFilter extends React.Component<Props> {
   @computed
   private get items() {
-    return [allCountries, ...this.props.items.sort((a, b) => {
+    const ordered = [allCountries, ...this.props.items.sort((a, b) => {
       // prioritizes current user's country
       if (core.currentUser?.country_code === a.id) return -1;
       if (core.currentUser?.country_code === b.id) return 1;
 
       return a.text.localeCompare(b.text);
     })];
+
+    return ordered.map((option) => ({
+      children: option.text,
+      href: this.href(option.id),
+      id: option.id,
+    }));
   }
 
   constructor(props: Props) {
@@ -42,35 +48,31 @@ export default class RankingFilter extends React.Component<Props> {
   }
 
   render() {
+    const currentItem = this.props.currentItem ?? allCountries;
+
     return (
       <div className='ranking-filter ranking-filter--full'>
         <div className='ranking-filter__title'>
           {trans('rankings.countries.title')}
         </div>
         <SelectOptions
+          href={this.href(currentItem.id)}
           modifiers='ranking'
-          onChange={this.onChange}
+          onSelect={this.handleSelect}
           options={this.items}
-          renderOption={this.handleRenderOption}
-          selected={this.props.currentItem ?? allCountries}
-        />
+          selected={currentItem.id}
+        >
+          {currentItem.text}
+        </SelectOptions>
       </div>
     );
   }
 
-  private readonly handleRenderOption = (props: OptionRenderProps<CountryOption>) => (
-    <a
-      key={props.option.id}
-      className={props.cssClasses}
-      href={updateQueryString(null, { country: props.option.id, page: null })}
-      onClick={props.onClick}
-    >
-      {props.children}
-    </a>
-  );
-
-  private readonly onChange = (option: CountryOption) => {
-    navigate(updateQueryString(null, { country: option.id, page: null }));
+  private readonly handleSelect = (id?: string) => {
+    navigate(this.href(id));
   };
-}
 
+  private href(id?: string | null) {
+    return updateQueryString(null, { country: id, page: null });
+  }
+}

--- a/resources/js/components/report-form.tsx
+++ b/resources/js/components/report-form.tsx
@@ -16,6 +16,10 @@ import StringWithComponent from './string-with-component';
 const bn = 'report-form';
 const maxLength = 2000;
 
+function isValidReportType(value: unknown): value is ReportType {
+  return typeof value === 'string' && value in availableOptions;
+}
+
 export function showReportForm(params: { reportableId: string; reportableType: ReportableType; username: string }) {
   const root = document.createElement('div');
 
@@ -26,7 +30,6 @@ export function showReportForm(params: { reportableId: string; reportableType: R
     username={params.username}
   />, root);
 }
-
 
 type GroupKey =
   | 'beatmapset'
@@ -63,6 +66,8 @@ const availableOptions = {
 } as const;
 /* eslint-enable sort-keys */
 
+type ReportType = keyof typeof availableOptions;
+
 const reasons = {
   beatmapset: ['UnwantedContent', 'CopyrightInfringement', 'Other'],
   post: ['Insults', 'Spam', 'UnwantedContent', 'Nonsense', 'Other'],
@@ -71,7 +76,7 @@ const reasons = {
   user: ['Cheating', 'MultipleAccounts', 'InappropriateChat', 'UnwantedContent', 'Other'],
 } as const;
 
-const availableOptionsByGroupKey: Partial<Record<GroupKey, readonly (keyof typeof availableOptions)[]>> = {
+const availableOptionsByGroupKey: Partial<Record<GroupKey, readonly ReportType[]>> = {
   beatmapset: reasons.beatmapset,
   beatmapset_discussion_post: reasons.post,
   comment: reasons.post,
@@ -89,17 +94,12 @@ interface Props {
   username: string;
 }
 
-interface ReportOption {
-  id: string;
-  text: string;
-}
-
 @observer
 export default class ReportForm extends React.Component<Props> {
   @observable private comments = '';
   @observable private completed = false;
   @observable private disabled = false;
-  @observable private selectedReason = this.options[0];
+  @observable private selectedReasonKey = this.options[0].id;
   private timeout: number | undefined;
 
   private get canSubmit() {
@@ -111,16 +111,18 @@ export default class ReportForm extends React.Component<Props> {
   }
 
   private get isDmca() {
-    return this.selectedReason.id === 'CopyrightInfringement';
+    return this.selectedReasonKey === 'CopyrightInfringement';
   }
 
   @computed
   private get options() {
     const options = availableOptionsByGroupKey[this.groupKey]
-      ?? Object.keys(availableOptions) as (keyof typeof availableOptions)[];
+      ?? Object.keys(availableOptions) as ReportType[];
 
     return options.map((option) => ({
-      id: option as string, text: availableOptions[option],
+      children: availableOptions[option],
+      href: '#',
+      id: option,
     }));
   }
 
@@ -171,8 +173,9 @@ export default class ReportForm extends React.Component<Props> {
   };
 
   @action
-  private readonly handleReasonChange = (option: ReportOption) => {
-    this.selectedReason = option;
+  private readonly handleReasonChange = (id?: string) => {
+    if (!isValidReportType(id)) return;
+    this.selectedReasonKey = id;
   };
 
   @action
@@ -181,7 +184,7 @@ export default class ReportForm extends React.Component<Props> {
 
     const data = {
       comments: this.comments,
-      reason: this.selectedReason.id,
+      reason: this.selectedReasonKey,
       reportable_id: this.props.reportableId,
       reportable_type: this.props.reportableType,
     };
@@ -234,11 +237,14 @@ export default class ReportForm extends React.Component<Props> {
             <div className={`${bn}__row`}>
               <SelectOptions
                 blackout={false}
+                href='#'
                 modifiers='report'
-                onChange={this.handleReasonChange}
+                onSelect={this.handleReasonChange}
                 options={this.options}
-                selected={this.selectedReason}
-              />
+                selected={this.selectedReasonKey}
+              >
+                {availableOptions[this.selectedReasonKey]}
+              </SelectOptions>
             </div>
           </>
         )}

--- a/resources/js/components/report-form.tsx
+++ b/resources/js/components/report-form.tsx
@@ -120,9 +120,9 @@ export default class ReportForm extends React.Component<Props> {
       ?? Object.keys(availableOptions) as ReportType[];
 
     return options.map((option) => ({
-      children: availableOptions[option],
       href: '#',
       id: option,
+      text: availableOptions[option],
     }));
   }
 
@@ -242,9 +242,8 @@ export default class ReportForm extends React.Component<Props> {
                 onSelect={this.handleReasonChange}
                 options={this.options}
                 selected={this.selectedReasonKey}
-              >
-                {availableOptions[this.selectedReasonKey]}
-              </SelectOptions>
+                text={availableOptions[this.selectedReasonKey]}
+              />
             </div>
           </>
         )}

--- a/resources/js/components/report-form.tsx
+++ b/resources/js/components/report-form.tsx
@@ -242,8 +242,9 @@ export default class ReportForm extends React.Component<Props> {
                 onSelect={this.handleReasonChange}
                 options={this.options}
                 selected={this.selectedReasonKey}
-                text={availableOptions[this.selectedReasonKey]}
-              />
+              >
+                {availableOptions[this.selectedReasonKey]}
+              </SelectOptions>
             </div>
           </>
         )}

--- a/resources/js/components/select-options.tsx
+++ b/resources/js/components/select-options.tsx
@@ -10,13 +10,14 @@ import { classWithModifiers, Modifiers, ModifiersExtended } from 'utils/css';
 const bn = 'select-options';
 
 interface RenderableOption<T> {
-  children: string | React.ReactNode;
   href: string;
   id: T | null;
+  text: React.ReactNode;
 }
 
 interface Props<T> {
   blackout: boolean;
+
   href: string;
   modifiers?: Modifiers;
   // the callback should return the display state the selector should go into after the click, or undefined for the default.
@@ -24,10 +25,11 @@ interface Props<T> {
   onSelect?: (id?: string) => boolean | void;
   options: Iterable<RenderableOption<T>>;
   selected: RenderableOption<T>['id'] | Set<RenderableOption<T>['id']>;
+  text: React.ReactNode;
 }
 
 @observer
-export default class SelectOptions<T extends string | number> extends React.PureComponent<React.PropsWithChildren<Props<T>>> {
+export default class SelectOptions<T extends string | number> extends React.PureComponent<Props<T>> {
   static readonly defaultProps = { blackout: true };
 
   private readonly ref = React.createRef<HTMLDivElement>();
@@ -61,7 +63,7 @@ export default class SelectOptions<T extends string | number> extends React.Pure
       <div ref={this.ref} className={className}>
         <div className={`${bn}__select`}>
           <a className={`${bn}__option`} href={this.props.href} onClick={this.toggleSelector}>
-            {this.renderText(this.props.children)}
+            {this.renderText(this.props.text)}
             <div className={`${bn}__decoration`}>
               <span className='fas fa-chevron-down' />
             </div>
@@ -105,7 +107,7 @@ export default class SelectOptions<T extends string | number> extends React.Pure
         href={option.href}
         onClick={this.optionSelected}
       >
-        {this.renderText(option.children)}
+        {this.renderText(option.text)}
       </a>
     );
   }
@@ -120,12 +122,12 @@ export default class SelectOptions<T extends string | number> extends React.Pure
     }
   }
 
-  private renderText(children: RenderableOption<T>['children']) {
-    return typeof children === 'string' ? (
+  private renderText(text: RenderableOption<T>['text']) {
+    return typeof text === 'string' ? (
       <div className='u-ellipsis-overflow'>
-        {children}
+        {text}
       </div>
-    ) : children;
+    ) : text;
   }
 
   @action

--- a/resources/js/components/select-options.tsx
+++ b/resources/js/components/select-options.tsx
@@ -17,7 +17,7 @@ interface RenderableOption<T> {
 
 interface Props<T> {
   blackout: boolean;
-
+  children: React.ReactNode;
   href: string;
   modifiers?: Modifiers;
   // the callback should return the display state the selector should go into after the click, or undefined for the default.
@@ -25,7 +25,6 @@ interface Props<T> {
   onSelect?: (id?: string) => boolean | void;
   options: Iterable<RenderableOption<T>>;
   selected: RenderableOption<T>['id'] | Set<RenderableOption<T>['id']>;
-  text: React.ReactNode;
 }
 
 @observer
@@ -63,7 +62,7 @@ export default class SelectOptions<T extends string | number> extends React.Pure
       <div ref={this.ref} className={className}>
         <div className={`${bn}__select`}>
           <a className={`${bn}__option`} href={this.props.href} onClick={this.toggleSelector}>
-            {this.renderText(this.props.text)}
+            {this.renderText(this.props.children)}
             <div className={`${bn}__decoration`}>
               <span className='fas fa-chevron-down' />
             </div>

--- a/resources/js/components/select-options.tsx
+++ b/resources/js/components/select-options.tsx
@@ -86,12 +86,13 @@ export default class SelectOptions<T extends string | number> extends React.Pure
   @action
   private readonly optionSelected = (event: React.MouseEvent<HTMLAnchorElement>) => {
     if (event.button !== 0) return;
-    event.preventDefault();
-
-    const id = event.currentTarget.dataset.id;
-    this.showingSelector = this.props.onSelect?.(id) ?? false;
-    if (this.showingSelector) {
-      event.currentTarget.blur(); // deactivate element is selector if still open.
+    if (this.props.onSelect != null) {
+      event.preventDefault();
+      const id = event.currentTarget.dataset.id;
+      this.showingSelector = this.props.onSelect(id) ?? false;
+      if (this.showingSelector) {
+        event.currentTarget.blur(); // deactivate element is selector if still open.
+      }
     }
   };
 

--- a/resources/js/components/select-options.tsx
+++ b/resources/js/components/select-options.tsx
@@ -1,44 +1,33 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
-import { action, autorun, makeObservable, observable } from 'mobx';
+import { action, autorun, isObservableSet, makeObservable, observable } from 'mobx';
 import { disposeOnUnmount, observer } from 'mobx-react';
 import * as React from 'react';
 import { blackoutToggle } from 'utils/blackout';
-import { classWithModifiers, Modifiers } from 'utils/css';
+import { classWithModifiers, Modifiers, ModifiersExtended } from 'utils/css';
 
 const bn = 'select-options';
 
-export interface Option {
-  id: string | number | null;
-  text: string | React.ReactNode;
+interface RenderableOption<T> {
+  children: string | React.ReactNode;
+  href: string;
+  id: T | null;
 }
 
-export interface OptionRenderProps<T extends Option> {
-  children: React.ReactNode;
-  cssClasses: string;
-  onClick: (event: React.MouseEvent) => void;
-  option: T;
-}
-
-interface ComponentOptionRenderProps<T extends Option> {
-  children: OptionRenderProps<T>['children'];
-  onClick: OptionRenderProps<T>['onClick'];
-  option: OptionRenderProps<T>['option'];
-  selected?: boolean;
-}
-
-interface Props<T extends Option> {
+interface Props<T> {
   blackout: boolean;
+  href: string;
   modifiers?: Modifiers;
-  onChange: (option: T) => void;
-  options: T[];
-  renderOption?(props: OptionRenderProps<T>): React.ReactNode;
-  selected: T;
+  // the callback should return the display state the selector should go into after the click, or undefined for the default.
+  // the typing of id is to match dataset, so the component doesn't handle the parsing.
+  onSelect?: (id?: string) => boolean | void;
+  options: Iterable<RenderableOption<T>>;
+  selected: RenderableOption<T>['id'] | Set<RenderableOption<T>['id']>;
 }
 
 @observer
-export default class SelectOptions<T extends Option> extends React.Component<Props<T>> {
+export default class SelectOptions<T extends string | number> extends React.PureComponent<React.PropsWithChildren<Props<T>>> {
   static readonly defaultProps = { blackout: true };
 
   private readonly ref = React.createRef<HTMLDivElement>();
@@ -71,23 +60,16 @@ export default class SelectOptions<T extends Option> extends React.Component<Pro
     return (
       <div ref={this.ref} className={className}>
         <div className={`${bn}__select`}>
-          {this.renderOption({
-            children: (
-              <>
-                {this.renderText(this.props.selected.text)}
-
-                <div className={`${bn}__decoration`}>
-                  <span className='fas fa-chevron-down' />
-                </div>
-              </>
-            ),
-            onClick: this.toggleSelector,
-            option: this.props.selected,
-          })}
+          <a className={`${bn}__option`} href={this.props.href} onClick={this.toggleSelector}>
+            {this.renderText(this.props.children)}
+            <div className={`${bn}__decoration`}>
+              <span className='fas fa-chevron-down' />
+            </div>
+          </a>
         </div>
 
         <div className={`${bn}__selector`}>
-          {this.renderOptions()}
+          {[...this.renderOptions()]}
         </div>
       </div>
     );
@@ -102,50 +84,47 @@ export default class SelectOptions<T extends Option> extends React.Component<Pro
   };
 
   @action
-  private readonly optionSelected = (event: React.MouseEvent, option: T) => {
+  private readonly optionSelected = (event: React.MouseEvent<HTMLAnchorElement>) => {
     if (event.button !== 0) return;
-
     event.preventDefault();
-    this.showingSelector = false;
-    this.props.onChange?.(option);
+
+    const id = event.currentTarget.dataset.id;
+    this.showingSelector = this.props.onSelect?.(id) ?? false;
+    if (this.showingSelector) {
+      event.currentTarget.blur(); // deactivate element is selector if still open.
+    }
   };
 
-  private renderOption({ children, onClick, option, selected = false }: ComponentOptionRenderProps<T>) {
-    const cssClasses = classWithModifiers(`${bn}__option`, { selected });
-
-    if (this.props.renderOption != null) {
-      return this.props.renderOption({ children, cssClasses, onClick, option });
-    }
-
+  private renderOption(option: RenderableOption<T>, modifiers?: ModifiersExtended) {
     return (
       <a
         key={option.id}
-        className={cssClasses}
-        href='#'
-        onClick={onClick}
+        className={classWithModifiers(`${bn}__option`, modifiers)}
+        data-id={option.id ?? undefined}
+        href={option.href}
+        onClick={this.optionSelected}
       >
-        {children}
+        {this.renderText(option.children)}
       </a>
     );
   }
 
-  private renderOptions() {
-    return this.props.options.map((option) => this.renderOption({
-      children: this.renderText(option.text),
-      onClick: (event: React.MouseEvent) => {
-        this.optionSelected(event, option);
-      },
-      option,
-      selected: this.props.selected?.id === option.id,
-    }));
+  private *renderOptions() {
+    for (const option of this.props.options) {
+      const selected = this.props.selected instanceof Set || isObservableSet(this.props.selected)
+        ? this.props.selected.has(option.id)
+        : this.props.selected === option.id;
+
+      yield this.renderOption(option, { selected });
+    }
   }
 
-  private renderText(text: T['text']) {
-    return typeof text === 'string' ? (
+  private renderText(children: RenderableOption<T>['children']) {
+    return typeof children === 'string' ? (
       <div className='u-ellipsis-overflow'>
-        {text}
+        {children}
       </div>
-    ) : text;
+    ) : children;
   }
 
   @action

--- a/resources/js/components/select-options.tsx
+++ b/resources/js/components/select-options.tsx
@@ -113,8 +113,9 @@ export default class SelectOptions<T extends string | number> extends React.Pure
   }
 
   private *renderOptions() {
+    const isSet = this.props.selected instanceof Set || isObservableSet(this.props.selected);
     for (const option of this.props.options) {
-      const selected = this.props.selected instanceof Set || isObservableSet(this.props.selected)
+      const selected = isSet
         ? this.props.selected.has(option.id)
         : this.props.selected === option.id;
 

--- a/resources/js/contest-judge-results/header.tsx
+++ b/resources/js/contest-judge-results/header.tsx
@@ -47,8 +47,9 @@ export default class Header extends React.PureComponent<Props> {
           modifiers='ranking'
           options={this.options}
           selected={this.props.entry.id}
-          text={<OptionText entry={this.props.entry} />}
-        />
+        >
+          <OptionText entry={this.props.entry} />
+        </SelectOptions>
 
         <div className='contest-judge-results-header__values'>
           {totalScoreStd != null && (

--- a/resources/js/contest-judge-results/header.tsx
+++ b/resources/js/contest-judge-results/header.tsx
@@ -19,9 +19,9 @@ interface Props {
 
 function entryToOption(entry: ContestEntryJsonForResults) {
   return {
-    children: <OptionText entry={entry} />,
     href: route('contests.entries.judge-results', { contest: entry.contest_id, contest_entry: entry.id }),
     id: entry.id,
+    text: <OptionText entry={entry} />,
   };
 }
 
@@ -47,9 +47,8 @@ export default class Header extends React.PureComponent<Props> {
           modifiers='ranking'
           options={this.options}
           selected={this.props.entry.id}
-        >
-          <OptionText entry={this.props.entry} />
-        </SelectOptions>
+          text={<OptionText entry={this.props.entry} />}
+        />
 
         <div className='contest-judge-results-header__values'>
           {totalScoreStd != null && (

--- a/resources/js/contest-judge-results/header.tsx
+++ b/resources/js/contest-judge-results/header.tsx
@@ -10,8 +10,6 @@ import { route } from 'laroute';
 import * as React from 'react';
 import { formatNumber } from 'utils/html';
 import { trans } from 'utils/lang';
-import { getInt } from 'utils/math';
-import { navigate } from 'utils/turbolinks';
 
 interface Props {
   contest: ContestJsonForResults;
@@ -47,7 +45,6 @@ export default class Header extends React.PureComponent<Props> {
         <SelectOptions
           href={this.href(this.props.entry.id)}
           modifiers='ranking'
-          onSelect={this.handleSelect}
           options={this.options}
           selected={this.props.entry.id}
         >
@@ -80,10 +77,6 @@ export default class Header extends React.PureComponent<Props> {
       </div>
     );
   }
-
-  private readonly handleSelect = (id?: string) => {
-    navigate(this.href(getInt(id)));
-  };
 
   private href(entryId?: number) {
     return route('contests.entries.judge-results', { contest: this.props.contest.id, contest_entry: entryId });

--- a/resources/js/contest-judge-results/header.tsx
+++ b/resources/js/contest-judge-results/header.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
-import SelectOptions, { Option, OptionRenderProps } from 'components/select-options';
+import SelectOptions from 'components/select-options';
 import UserLink from 'components/user-link';
 import ValueDisplay from 'components/value-display';
 import { ContestEntryJsonForResults } from 'interfaces/contest-entry-json';
@@ -10,12 +10,8 @@ import { route } from 'laroute';
 import * as React from 'react';
 import { formatNumber } from 'utils/html';
 import { trans } from 'utils/lang';
+import { getInt } from 'utils/math';
 import { navigate } from 'utils/turbolinks';
-
-interface ContestOption extends Option {
-  contest_id: ContestEntryJsonForResults['contest_id'];
-  id: ContestEntryJsonForResults['id'];
-}
 
 interface Props {
   contest: ContestJsonForResults;
@@ -25,10 +21,16 @@ interface Props {
 
 function entryToOption(entry: ContestEntryJsonForResults) {
   return {
-    contest_id: entry.contest_id,
+    children: <OptionText entry={entry} />,
+    href: route('contests.entries.judge-results', { contest: entry.contest_id, contest_entry: entry.id }),
     id: entry.id,
-    text: <ValueDisplay label={entry.title} modifiers='select-option' value={entry.user.username} />,
   };
+}
+
+function OptionText(props: { entry: ContestEntryJsonForResults }) {
+  return (
+    <ValueDisplay label={props.entry.title} modifiers='select-option' value={props.entry.user.username} />
+  );
 }
 
 export default class Header extends React.PureComponent<Props> {
@@ -43,12 +45,14 @@ export default class Header extends React.PureComponent<Props> {
     return (
       <div className='contest-judge-results-header'>
         <SelectOptions
+          href={this.href(this.props.entry.id)}
           modifiers='ranking'
-          onChange={this.handleChange}
+          onSelect={this.handleSelect}
           options={this.options}
-          renderOption={this.renderOption}
-          selected={entryToOption(this.props.entry)}
-        />
+          selected={this.props.entry.id}
+        >
+          <OptionText entry={this.props.entry} />
+        </SelectOptions>
 
         <div className='contest-judge-results-header__values'>
           {totalScoreStd != null && (
@@ -77,18 +81,11 @@ export default class Header extends React.PureComponent<Props> {
     );
   }
 
-  private readonly handleChange = (option: ContestOption) => {
-    navigate(route('contests.entries.judge-results', { contest: option.contest_id, contest_entry: option.id }));
+  private readonly handleSelect = (id?: string) => {
+    navigate(this.href(getInt(id)));
   };
 
-  private readonly renderOption = ({ cssClasses, children, onClick, option }: OptionRenderProps<ContestOption>) => (
-    <a
-      key={option.id}
-      className={cssClasses}
-      href={route('contests.entries.judge-results', { contest: option.contest_id, contest_entry: option.id })}
-      onClick={onClick}
-    >
-      {children}
-    </a>
-  );
+  private href(entryId?: number) {
+    return route('contests.entries.judge-results', { contest: this.props.contest.id, contest_entry: entryId });
+  }
 }

--- a/resources/js/interfaces/select-option-json.ts
+++ b/resources/js/interfaces/select-option-json.ts
@@ -1,8 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
-import { Option } from 'components/select-options';
-
-export default interface SelectOptionJson extends Option {
-  id: number;
+export default interface SelectOptionJson {
+  id: string | number;
+  text: string;
 }


### PR DESCRIPTION
Removes the render callbacks and let other components using `SelectOptions` to have more control and directly specify what to render instead of callbacks. 

Extracted from the branch that is adding support for #11666 and other sorting and filtering enhancements, so the component already supports multi selection, but the other parts are not included in this PR.