### PR TITLE
Use standard analyzer for wiki page title autocomplete search

### DIFF
--- a/config/schemas/wiki_page.json
+++ b/config/schemas/wiki_page.json
@@ -48,7 +48,7 @@
         "fields": {
           "autocomplete": {
             "analyzer": "autocomplete",
-            "search_analyzer": "autocomplete_search",
+            "search_analyzer": "standard",
             "type": "text"
           },
           "keyword": {
@@ -72,9 +72,6 @@
               "lowercase"
             ],
             "tokenizer": "autocomplete"
-          },
-          "autocomplete_search": {
-            "tokenizer": "lowercase"
           }
         },
         "tokenizer": {


### PR DESCRIPTION
`lowercase` doesn't include numbers and apparently `standard` now applies the `lowercase` filter by default.
fixes #12889

Can be applied directly without reindexing:
```
PUT /wiki_pages/_mapping
{
    "properties": {
        "title": {
            "fields": {
                "autocomplete": {
                    "analyzer": "autocomplete",
                    "search_analyzer": "standard",
                    "type": "text"
                }
            },
            "type": "text"
        }
    }
}
```