### PR TITLE
cleanup string ReactNode props declared types

### DIFF
--- a/resources/js/components/click-to-copy.tsx
+++ b/resources/js/components/click-to-copy.tsx
@@ -7,7 +7,7 @@ import { trans } from 'utils/lang';
 
 interface Props {
   className?: string;
-  label?: string | React.ReactNode;
+  label?: React.ReactNode;
   showIcon: boolean;
   tooltipPosition?: string;
   value: string;

--- a/resources/js/components/select-options.tsx
+++ b/resources/js/components/select-options.tsx
@@ -11,7 +11,7 @@ const bn = 'select-options';
 
 export interface Option {
   id: string | number | null;
-  text: string | React.ReactNode;
+  text: React.ReactNode;
 }
 
 export interface OptionRenderProps<T extends Option> {

--- a/resources/js/profile-page/links.tsx
+++ b/resources/js/profile-page/links.tsx
@@ -27,7 +27,7 @@ type LinkKey = BioKey | MediaKey;
 
 interface LinkProps {
   icon: string;
-  text: string | React.ReactNode;
+  text: React.ReactNode;
   title?: string;
   url?: string | null;
 }

--- a/resources/js/wrapped-show/index.tsx
+++ b/resources/js/wrapped-show/index.tsx
@@ -124,7 +124,7 @@ interface WrappedStatProps {
   skippable?: boolean;
   title: string;
   tooltip?: string;
-  value: number | string | React.ReactNode;
+  value: React.ReactNode;
 }
 
 function WrappedStat(props: WrappedStatProps) {


### PR DESCRIPTION
At some point `ReactNode` properly includes/discriminates between string/number/element 