### PR TITLE
Fix incorrect warning when calculating judged contest scores

### DIFF
--- a/resources/views/admin/contests/show.blade.php
+++ b/resources/views/admin/contests/show.blade.php
@@ -8,7 +8,10 @@
 
     if ($contest->isJudged()) {
         foreach ($contest->judges as $judge) {
-            $hasMissingVotes = $hasMissingVotes || ($judgeVoteCounts[$judge->getKey()]->judge_vote_count ?? 0) !== $entriesCount;
+            if (($judgeVoteCounts[$judge->getKey()]->judge_vote_count ?? 0) !== $entriesCount) {
+                $hasMissingVotes = true;
+                break;
+            }
         }
     }
 @endphp

--- a/resources/views/admin/contests/show.blade.php
+++ b/resources/views/admin/contests/show.blade.php
@@ -8,7 +8,7 @@
 
     if ($contest->isJudged()) {
         foreach ($contest->judges as $judge) {
-            $hasMissingVotes |= $judgeVoteCounts[$judge->getKey()]->judge_vote_count ?? 0 !== $entriesCount;
+            $hasMissingVotes = $hasMissingVotes || ($judgeVoteCounts[$judge->getKey()]->judge_vote_count ?? 0) !== $entriesCount;
         }
     }
 @endphp


### PR DESCRIPTION
`|=` is bitwise or and assign; php doesn't have an equivalent `||=`  
Also the operator precedence was wrong. 🙈