### PR TITLE
Notify user on mention in chat

### DIFF
--- a/app/Jobs/Notifications/ChannelMention.php
+++ b/app/Jobs/Notifications/ChannelMention.php
@@ -1,0 +1,52 @@
+<?php
+
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
+declare(strict_types=1);
+
+namespace App\Jobs\Notifications;
+
+use App\Libraries\User\UsernamesForDbLookup;
+use App\Models\Chat\UserChannel;
+use App\Models\Notification;
+use App\Models\User;
+use App\Models\UserNotificationOption;
+
+class ChannelMention extends ChannelMessageBase
+{
+    const CONTENT_TRUNCATE = 200;
+    const NOTIFICATION_OPTION_NAME = UserNotificationOption::CHANNEL_MENTION;
+
+    public static function getMailGroupingKey(Notification $notification): string
+    {
+        $base = parent::getMailGroupingKey($notification);
+
+        return "{$base}-{$notification->notifiable_id}-{$notification->source_user_id}";
+    }
+
+    public function getDetails(): array
+    {
+        $channel = $this->message->channel;
+
+        return [
+            ...parent::getDetails(),
+            'message_id' => $this->message->getKey(),
+            'name' => $channel->name,
+        ];
+    }
+
+    public function getListeningUserIds(): array
+    {
+        $username = $this->message->mention();
+        $usernamesForDbLookup = UsernamesForDbLookup::make($username, trimPrefix: true);
+
+        $userId = User::whereIn('username', $usernamesForDbLookup)->pluck('user_id')->first();
+
+        return UserChannel
+            ::where('channel_id', $this->message->channel_id)
+            ->where('user_id', $userId)
+            ->pluck('user_id')
+            ->all();
+    }
+}

--- a/app/Jobs/Notifications/ChannelMention.php
+++ b/app/Jobs/Notifications/ChannelMention.php
@@ -8,7 +8,6 @@ declare(strict_types=1);
 namespace App\Jobs\Notifications;
 
 use App\Libraries\User\UsernamesForDbLookup;
-use App\Models\Chat\UserChannel;
 use App\Models\Notification;
 use App\Models\User;
 use App\Models\UserNotificationOption;
@@ -41,12 +40,6 @@ class ChannelMention extends ChannelMessageBase
         $username = $this->message->mention();
         $usernamesForDbLookup = UsernamesForDbLookup::make($username, trimPrefix: true);
 
-        $userId = User::whereIn('username', $usernamesForDbLookup)->pluck('user_id')->first();
-
-        return UserChannel
-            ::where('channel_id', $this->message->channel_id)
-            ->where('user_id', $userId)
-            ->pluck('user_id')
-            ->all();
+        return User::whereIn('username', $usernamesForDbLookup)->pluck('user_id')->all();
     }
 }

--- a/app/Libraries/UsernameValidation.php
+++ b/app/Libraries/UsernameValidation.php
@@ -17,6 +17,10 @@ use Illuminate\Support\Collection;
 
 class UsernameValidation
 {
+    // also note that totp key generator forbids `:` in username
+    const ALLOWED_CHARACTERS = 'A-Za-z0-9-\[\]_';
+    const ALLOWED_CHARACTERS_WITH_SPACE = self::ALLOWED_CHARACTERS.' ';
+
     public static function allowedName(string $username): bool
     {
         foreach (model_pluck(DB::table('phpbb_disallow'), 'disallow_username') as $check) {
@@ -75,7 +79,7 @@ class UsernameValidation
         }
 
         // also note that totp key generator forbids `:` in username
-        if (strpos($username, '  ') !== false || !preg_match('#^[A-Za-z0-9-\[\]_ ]+$#u', $username)) {
+        if (strpos($username, '  ') !== false || !preg_match('#^['.static::ALLOWED_CHARACTERS_WITH_SPACE.']+$#u', $username)) {
             $errors->add('username', '.username_invalid_characters');
         }
 

--- a/app/Libraries/UsernameValidation.php
+++ b/app/Libraries/UsernameValidation.php
@@ -20,6 +20,8 @@ class UsernameValidation
     // also note that totp key generator forbids `:` in username
     const ALLOWED_CHARACTERS = 'A-Za-z0-9-\[\]_';
     const ALLOWED_CHARACTERS_WITH_SPACE = self::ALLOWED_CHARACTERS.' ';
+    const LENGTH_MIN = 3;
+    const LENGTH_MAX = 15;
 
     public static function allowedName(string $username): bool
     {
@@ -70,11 +72,11 @@ class UsernameValidation
             $errors->add('username', '.username_no_spaces');
         }
 
-        if (strlen($username) < 3) {
+        if (strlen($username) < static::LENGTH_MIN) {
             $errors->add('username', '.username_too_short');
         }
 
-        if (strlen($username) > 15) {
+        if (strlen($username) > static::LENGTH_MAX) {
             $errors->add('username', '.username_too_long');
         }
 

--- a/app/Models/Chat/Message.php
+++ b/app/Models/Chat/Message.php
@@ -141,7 +141,7 @@ class Message extends Model implements ReportableInterface
         return strpos($this->content, '@') !== false;
     }
 
-    public function mention()
+    public function mention(): ?string
     {
         static $chars = UsernameValidation::ALLOWED_CHARACTERS;
 

--- a/app/Models/Chat/Message.php
+++ b/app/Models/Chat/Message.php
@@ -145,9 +145,17 @@ class Message extends Model implements ReportableInterface
     {
         static $chars = UsernameValidation::ALLOWED_CHARACTERS;
 
-        preg_match("/(?<=^|\s|'|\"|,|\.|\/)(?:@([{$chars}]+))/", $this->content, $ret);
+        preg_match("/(?<=^|\s|'|\"|,|\.|\/)(?:@([{$chars}]+))/", $this->content, $match);
 
-        return $ret[1] ?? null;
+        if (isset($match[1])) {
+            $length = strlen($match[1]);
+
+            if ($length >= UsernameValidation::LENGTH_MIN && $length <= UsernameValidation::LENGTH_MAX) {
+                return $match[1];
+            }
+        }
+
+        return null;
     }
 
     public function reportableAdditionalInfo(): ?string

--- a/app/Models/Chat/Message.php
+++ b/app/Models/Chat/Message.php
@@ -6,8 +6,10 @@
 namespace App\Models\Chat;
 
 use App\Jobs\Notifications\ChannelAnnouncement;
+use App\Jobs\Notifications\ChannelMention;
 use App\Jobs\Notifications\ChannelMessage;
 use App\Jobs\Notifications\ChannelTeam;
+use App\Libraries\UsernameValidation;
 use App\Models\Traits\Reportable;
 use App\Models\Traits\ReportableInterface;
 use App\Models\User;
@@ -112,7 +114,8 @@ class Message extends Model implements ReportableInterface
             return;
         }
 
-        $class = match ($this->channel->type) {
+        $channelType = $this->channel->type;
+        $class = match ($channelType) {
             Channel::TYPES['announce'] => ChannelAnnouncement::class,
             Channel::TYPES['pm'] => ChannelMessage::class,
             Channel::TYPES['team'] => ChannelTeam::class,
@@ -122,11 +125,29 @@ class Message extends Model implements ReportableInterface
         if ($class !== null) {
             new $class($this, $this->sender)->dispatch();
         }
+
+        if ($channelType === Channel::TYPES['public'] && $this->mayContainMention()) {
+            new ChannelMention($this, $this->sender)->dispatch();
+        }
     }
 
     public function isUserCommand(): bool
     {
-        return preg_match('/^![^ !]/', $this->content) === 1;
+        return preg_match('/^![^ !]/', $this->content ?? '') === 1;
+    }
+
+    public function mayContainMention(): bool
+    {
+        return strpos($this->content, '@') !== false;
+    }
+
+    public function mention()
+    {
+        static $chars = UsernameValidation::ALLOWED_CHARACTERS;
+
+        preg_match("/(?<=^|\s|'|\"|,|\.|\/)(?:@([{$chars}]+))/", $this->content, $ret);
+
+        return $ret[1] ?? null;
     }
 
     public function reportableAdditionalInfo(): ?string

--- a/app/Models/Notification.php
+++ b/app/Models/Notification.php
@@ -40,6 +40,7 @@ class Notification extends Model
     const BEATMAPSET_REMOVE_FROM_LOVED = 'beatmapset_remove_from_loved';
     const BEATMAPSET_RESET_NOMINATIONS = 'beatmapset_reset_nominations';
     const CHANNEL_ANNOUNCEMENT = 'channel_announcement';
+    const CHANNEL_MENTION = 'channel_mention';
     const CHANNEL_MESSAGE = 'channel_message';
     const CHANNEL_TEAM = 'channel_team';
     const COMMENT_NEW = 'comment_new';
@@ -69,6 +70,7 @@ class Notification extends Model
         self::BEATMAPSET_RESET_NOMINATIONS => 'beatmapset_state',
         self::CHANNEL_ANNOUNCEMENT => 'announcement',
         self::CHANNEL_MESSAGE => 'channel',
+        self::CHANNEL_MENTION => 'channel_mention',
         self::CHANNEL_TEAM => 'channel_team',
         self::COMMENT_NEW => 'comment',
         self::FORUM_TOPIC_REPLY => 'forum_topic_reply',

--- a/app/Models/UserNotificationOption.php
+++ b/app/Models/UserNotificationOption.php
@@ -28,6 +28,7 @@ class UserNotificationOption extends Model
 
     const BEATMAPSET_MODDING = 'beatmapset:modding'; // matches Follow notifiable_type:subtype
     const CHANNEL_ANNOUNCEMENT = 'channel_announcement';
+    const CHANNEL_MENTION = 'channel_mention';
     const COMMENT_REPLY = 'comment_reply';
     const DELIVERY_MODES = ['mail', 'push'];
     const FORUM_TOPIC_REPLY = Notification::FORUM_TOPIC_REPLY;
@@ -43,6 +44,7 @@ class UserNotificationOption extends Model
         Notification::BEATMAP_OWNER_CHANGE,
         self::MAPPING,
         self::BEATMAPSET_MODDING,
+        Notification::CHANNEL_MENTION,
         Notification::CHANNEL_MESSAGE,
         Notification::CHANNEL_TEAM,
         Notification::COMMENT_NEW,

--- a/resources/js/interfaces/notification-json.ts
+++ b/resources/js/interfaces/notification-json.ts
@@ -22,6 +22,7 @@ export default interface NotificationJson {
       problems: number;
       suggestions: number;
     };
+    message_id?: number;
     name?: string;
     news_post_id?: number;
     post_id?: number;

--- a/resources/js/notification-maps/category.ts
+++ b/resources/js/notification-maps/category.ts
@@ -35,6 +35,7 @@ export const nameToCategory: Partial<Record<string, string>> = {
   beatmapset_remove_from_loved: 'beatmapset_state',
   beatmapset_reset_nominations: 'beatmapset_state',
   channel_announcement: 'announcement',
+  channel_mention: 'channel_mention',
   channel_message: 'channel',
   channel_team: 'channel_team',
   comment_new: 'comment',

--- a/resources/js/notification-maps/icons.ts
+++ b/resources/js/notification-maps/icons.ts
@@ -1,9 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
-interface IconsMap {
-  [key: string]: string[];
-}
+type IconsMap = Partial<Record<string, string[]>>;
 
 export const categoryToIcons: IconsMap = {
   announcement: ['fas fa-bullhorn'],
@@ -12,6 +10,7 @@ export const categoryToIcons: IconsMap = {
   beatmapset_problem: ['fas fa-drafting-compass', 'fas fa-exclamation-circle'],
   beatmapset_state: ['fas fa-drafting-compass'],
   channel: ['fas fa-comments'],
+  channel_mention: ['fas fa-at'],
   channel_team: ['fas fa-comments'],
   comment: ['fas fa-comment'],
   forum_topic_reply: ['fas fa-comment-medical'],
@@ -34,6 +33,7 @@ export const nameToIcons: IconsMap = {
   beatmapset_remove_from_loved: ['fas fa-drafting-compass', 'fas fa-heart-broken'],
   beatmapset_reset_nominations: ['fas fa-drafting-compass', 'fas fa-undo'],
   channel_announcement: ['fas fa-bullhorn'],
+  channel_mention: ['fas fa-at'],
   channel_message: ['fas fa-comments'],
   channel_team: ['fas fa-comments'],
   comment_new: ['fas fa-comment'],
@@ -61,6 +61,7 @@ export const nameToIconsCompact: IconsMap = {
   beatmapset_remove_from_loved: ['fas fa-heart-broken'],
   beatmapset_reset_nominations: ['fas fa-undo'],
   channel_announcement: ['fas fa-bullhorn'],
+  channel_mention: ['fas fa-at'],
   channel_message: ['fas fa-comments'],
   channel_team: ['fas fa-comments'],
   comment_new: ['fas fa-comment'],

--- a/resources/js/notification-maps/message.ts
+++ b/resources/js/notification-maps/message.ts
@@ -32,6 +32,7 @@ function formatBeatmapsetReviewCounts(counts: NonNullable<Notification['details'
 export function formatMessage(item: Notification, compact = false) {
   const replacements: Replacements = {
     content: item.details.content,
+    name: item.details.name,
     title: item.title,
     username: item.details.username,
   };
@@ -66,6 +67,7 @@ export function formatMessage(item: Notification, compact = false) {
 export function formatMessageGroup(item: Notification) {
   if (item.objectType === 'channel') {
     const replacements = {
+      name: item.details.name,
       title: item.title,
       username: item.details.username,
     };

--- a/resources/js/notification-maps/url.ts
+++ b/resources/js/notification-maps/url.ts
@@ -66,6 +66,7 @@ export function urlSingular(item: Notification) {
     case 'beatmapset_rank':
       return route('beatmapsets.show', { beatmapset: item.objectId });
     case 'channel_announcement':
+    case 'channel_mention':
     case 'channel_message':
     case 'channel_team':
       return route('chat.index', { channel_id: item.objectId });

--- a/resources/lang/en/accounts.php
+++ b/resources/lang/en/accounts.php
@@ -89,6 +89,7 @@ return [
             'beatmap_owner_change' => 'guest difficulty',
             'beatmapset:modding' => 'beatmap modding',
             'channel_message' => 'private chat messages',
+            'channel_mention' => 'chat mention',
             'channel_team' => 'team chat messages',
             'comment_new' => 'new comments',
             'forum_topic_reply' => 'topic reply',

--- a/resources/lang/en/notifications.php
+++ b/resources/lang/en/notifications.php
@@ -124,6 +124,16 @@ return [
                 ],
             ],
 
+            'channel_mention' => [
+                '_' => 'Chat mention',
+
+                'public' => [
+                    'channel_mention' => ':username mentioned you in :name ":title"',
+                    'channel_mention_compact' => ':username ":title"',
+                    'channel_mention_group' => 'mentioned in :name',
+                ],
+            ],
+
             'channel_team' => [
                 '_' => 'New team message',
 
@@ -259,6 +269,10 @@ return [
             'channel' => [
                 'channel_message' => 'You\'ve received a new message from :username',
             ],
+            'channel_mention' => [
+                'channel_mention' => ':username mentioned you in :name ":title"',
+            ],
+
             'channel_team' => [
                 'channel_team' => 'There is a new message in team ":name"',
             ],

--- a/tests/Libraries/ChatTest.php
+++ b/tests/Libraries/ChatTest.php
@@ -15,6 +15,7 @@ use App\Models\Chat\Channel;
 use App\Models\Chat\Message;
 use App\Models\OAuth\Client;
 use App\Models\User;
+use App\Models\UserNotificationOption;
 use Event;
 use Exception;
 use Mail;
@@ -154,6 +155,35 @@ class ChatTest extends TestCase
         }
 
         Chat::sendMessage($sender, $channel, 'test', false);
+    }
+
+    public function testSendMessageMentionNotifiesUser(): void
+    {
+        \Event::fake();
+        \Mail::fake();
+
+        $sender = User::factory()->create();
+        $mention = User::factory()->create();
+        $mention->notificationOptions()->create([
+            'name' => UserNotificationOption::CHANNEL_MENTION,
+            'details' => [
+                'mail' => true,
+                'push' => true,
+            ],
+        ]);
+        $mentionUsername = strtr($mention->username, [' ' => '_']);
+
+        $channel = Channel::factory()->type('public')->create();
+        $channel->addUser($sender);
+        $channel->addUser($mention);
+
+        $sender->markSessionVerified();
+
+        Chat::sendMessage($sender, $channel, "hello @{$mentionUsername}!", false);
+        $this->artisan('notifications:send-mail');
+
+        Event::assertDispatched(NewPrivateNotificationEvent::class);
+        Mail::assertSent(UserNotificationDigest::class);
     }
 
     public function testSendPM()

--- a/tests/Libraries/ChatTest.php
+++ b/tests/Libraries/ChatTest.php
@@ -171,19 +171,53 @@ class ChatTest extends TestCase
                 'push' => true,
             ],
         ]);
-        $mentionUsername = strtr($mention->username, [' ' => '_']);
 
         $channel = Channel::factory()->type('public')->create();
         $channel->addUser($sender);
-        $channel->addUser($mention);
 
         $sender->markSessionVerified();
 
+        $mentionUsername = strtr($mention->username, [' ' => '_']);
         Chat::sendMessage($sender, $channel, "hello @{$mentionUsername}!", false);
         $this->artisan('notifications:send-mail');
 
         Event::assertDispatched(NewPrivateNotificationEvent::class);
         Mail::assertSent(UserNotificationDigest::class);
+    }
+
+    public function testSendMessageMentionOnUsernameWithSpaceAsIs(): void
+    {
+        \Event::fake();
+
+        $sender = User::factory()->create();
+        $mention = User::factory()->create(['username' => 'test user']);
+        $channel = Channel::factory()->type('public')->create();
+        $channel->addUser($sender);
+
+        $sender->markSessionVerified();
+
+        Chat::sendMessage($sender, $channel, "hello @{$mention->username}!", false);
+
+        Event::assertNotDispatched(NewPrivateNotificationEvent::class);
+    }
+
+    public function testSendMessageMentionOnUsernameWithSpaceReplaced(): void
+    {
+        \Event::fake();
+
+        $sender = User::factory()->create();
+        $mention = User::factory()->create(['username' => 'test user']);
+
+        $channel = Channel::factory()->type('public')->create();
+        $channel->addUser($sender);
+
+        $sender->markSessionVerified();
+
+        $mentionUsername = strtr($mention->username, [' ' => '_']);
+        Chat::sendMessage($sender, $channel, "hello @{$mentionUsername}!", false);
+        $this->artisan('notifications:send-mail');
+
+        Event::assertDispatched(NewPrivateNotificationEvent::class);
     }
 
     public function testSendPM()


### PR DESCRIPTION
This is just the notification part. No autocomplete or link to jump to the message or anything fancy like that.

Limited to single mention (for now? or should it be configurable? or more mentions for certain groups?)

I wonder what a good delivery mode defaults should be for this (currently the same as others - web push only).

- [x] depends on #12871