### PR TITLE
Fix user difficulty check for finding default beatmap

### DIFF
--- a/resources/js/utils/beatmap-helper.ts
+++ b/resources/js/utils/beatmap-helper.ts
@@ -5,7 +5,7 @@ import * as d3 from 'd3';
 import BeatmapExtendedJson, { isValid as isBeatmapExtendedJson } from 'interfaces/beatmap-extended-json';
 import BeatmapJson from 'interfaces/beatmap-json';
 import BeatmapsetJson from 'interfaces/beatmapset-json';
-import Ruleset, { rulesetNames, rulesets } from 'interfaces/ruleset';
+import Ruleset, { rulesets } from 'interfaces/ruleset';
 import WithBeatmapOwners from 'interfaces/with-beatmap-owners';
 import * as _ from 'lodash';
 import core from 'osu-core-singleton';
@@ -36,7 +36,6 @@ type FindDefaultParams<T> = {
   items?: undefined;
 } | {
   items: T[];
-  ruleset?: Ruleset;
 };
 
 export function findDefault<T extends BeatmapJson | BeatmapExtendedJson>(params: FindDefaultParams<T>): T | null {
@@ -45,7 +44,7 @@ export function findDefault<T extends BeatmapJson | BeatmapExtendedJson>(params:
 
     let currentDiffDelta: number | null = null;
     let currentItem: T | null = null;
-    const targetDiff = userRecommendedDifficulty(params.ruleset ?? rulesetNames[0]);
+    const targetDiff = userRecommendedDifficulty(params.items[0].mode);
 
     for (const item of params.items) {
       const diffDelta = Math.abs(item.difficulty_rating - targetDiff);
@@ -61,7 +60,7 @@ export function findDefault<T extends BeatmapJson | BeatmapExtendedJson>(params:
 
   for (const findRuleset of userModes()) {
     const beatmaps = (params.group.get(findRuleset) ?? []).filter((b) => !('convert' in b) || b.convert !== true);
-    const beatmap = findDefault({ items: beatmaps, ruleset: findRuleset });
+    const beatmap = findDefault({ items: beatmaps });
 
     if (beatmap != null) return beatmap;
   }

--- a/resources/js/utils/beatmap-helper.ts
+++ b/resources/js/utils/beatmap-helper.ts
@@ -41,6 +41,8 @@ type FindDefaultParams<T> = {
 
 export function findDefault<T extends BeatmapJson | BeatmapExtendedJson>(params: FindDefaultParams<T>): T | null {
   if (params.items != null) {
+    if (params.items.length === 0) return null;
+
     let currentDiffDelta: number | null = null;
     let currentItem: T | null = null;
     const targetDiff = userRecommendedDifficulty(params.ruleset ?? rulesetNames[0]);
@@ -54,7 +56,7 @@ export function findDefault<T extends BeatmapJson | BeatmapExtendedJson>(params:
       }
     }
 
-    return currentItem ?? _.last(params.items) ?? null;
+    return currentItem ?? params.items[params.items.length - 1];
   }
 
   for (const findRuleset of userModes()) {


### PR DESCRIPTION
There are a few places where the ruleset parameter isn't passed (and thus results in potentially wrong ruleset for user difficulty) and the items always contain maps from one ruleset anyway.

The current difficulty check doesn't make sense on mixed ruleset either and will require a lot more rejigging for the nonexistent use case.

- [x] depends on #12881