### PR TITLE
Add required utility package

### DIFF
--- a/Dockerfile.deployment
+++ b/Dockerfile.deployment
@@ -3,7 +3,8 @@ FROM --platform=$BUILDPLATFORM almalinux:10-minimal as buildenv
 COPY .php-version .node-version /
 
 RUN echo "install_weak_deps=False" >> /etc/dnf/dnf.conf && \
-    microdnf install -y epel-release && \
+    # shadow-utils is required for build script and frankenphp package install
+    microdnf install -y epel-release shadow-utils && \
     rpm -i https://rpm.henderkes.com/static-php-1-1.noarch.rpm && \
     microdnf module enable -y php-zts:static-$(cat /.php-version) && \
     (curl -fsSL https://rpm.nodesource.com/setup_$(cat /.node-version).x | bash -) && \
@@ -52,7 +53,8 @@ FROM almalinux:10-minimal as runenv
 COPY .php-version /
 
 RUN echo "install_weak_deps=False" >> /etc/dnf/dnf.conf && \
-    microdnf install -y epel-release && \
+    # shadow-utils is required for build script and frankenphp package install
+    microdnf install -y epel-release shadow-utils && \
     rpm -i https://rpm.henderkes.com/static-php-1-1.noarch.rpm && \
     microdnf module enable -y php-zts:static-$(cat /.php-version) && \
     microdnf install -y \

--- a/Dockerfile.development
+++ b/Dockerfile.development
@@ -3,7 +3,8 @@ FROM almalinux:10-minimal
 COPY .php-version .node-version /
 
 RUN echo "install_weak_deps=False" >> /etc/dnf/dnf.conf && \
-    microdnf install -y epel-release && \
+    # shadow-utils is required for build and entrypoint scripts and frankenphp package install
+    microdnf install -y epel-release shadow-utils && \
     rpm -i https://rpm.henderkes.com/static-php-1-1.noarch.rpm && \
     microdnf module enable -y php-zts:static-$(cat /.php-version) && \
     (curl -fsSL https://rpm.nodesource.com/setup_$(cat /.node-version).x | bash -) && \


### PR DESCRIPTION
Apparently frankenphp updated itself to run the groupadd operation earlier? And shadow-utils got installed by something else (chromium) and everything were only worked by a coincidence since frankenphp itself doesn't pull in shadow-utils.

I wonder if it's better to just pull in `10` image instead of `10-minimal`...