### PR TITLE
Add typeguard to string.present

### DIFF
--- a/resources/js/utils/string.ts
+++ b/resources/js/utils/string.ts
@@ -5,6 +5,6 @@ export function presence(value?: string | null) {
   return value != null && value !== '' ? value : null;
 }
 
-export function present(value?: string | null) {
+export function present(value?: string | null): value is NonNullable<typeof value> {
   return presence(value) != null;
 }


### PR DESCRIPTION
Something I found while cleaning up old branches, not sure how useful it actually is other than narrowing the type down (which doesn't seem to be relied on in the current cases it's used)