### PR TITLE
Limit bbcode image size fetching to 10

### DIFF
--- a/app/Jobs/CacheImagesize.php
+++ b/app/Jobs/CacheImagesize.php
@@ -1,0 +1,28 @@
+<?php
+
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
+declare(strict_types=1);
+
+namespace App\Jobs;
+
+use Illuminate\Bus\Queueable;
+use Illuminate\Contracts\Queue\ShouldQueue;
+use Illuminate\Foundation\Bus\Dispatchable;
+use Illuminate\Queue\InteractsWithQueue;
+
+class CacheImagesize implements ShouldQueue
+{
+    use Dispatchable, InteractsWithQueue, Queueable;
+
+    public function __construct(private string $url)
+    {
+        $this->onQueue('imagesize');
+    }
+
+    public function handle(): void
+    {
+        fast_imagesize($this->url);
+    }
+}

--- a/app/Libraries/BBCodeFromDB.php
+++ b/app/Libraries/BBCodeFromDB.php
@@ -5,6 +5,8 @@
 
 namespace App\Libraries;
 
+use App\Jobs\CacheImagesize;
+
 /*
 * Note that this class doesn't actually parse random bbcode.
 * It only does "second pass" parsing of phpbb-preprocessed bbcode.
@@ -13,12 +15,15 @@ namespace App\Libraries;
 */
 class BBCodeFromDB
 {
+    const IMAGESIZE_MAX_FETCH = 10;
+
     public $text;
     public $uid;
     public $refId;
     public $withGallery;
 
     private array $options;
+    private int $imagesizeFetchCount = 0;
 
     public function __construct($text, $uid = '', $options = [])
     {
@@ -165,7 +170,7 @@ class BBCodeFromDB
                             'loading' => 'lazy',
                             'src' => $imageUrl,
                         ];
-                        $imageSize = fast_imagesize($imageUrl);
+                        $imageSize = $this->imagesize($imageUrl);
                         if ($imageSize !== null) {
                             $imageAttributes['width'] = $imageSize[0];
                             $imageAttributes['height'] = $imageSize[1];
@@ -207,7 +212,7 @@ class BBCodeFromDB
                 'loading' => 'lazy',
             ];
 
-            $imageSize = fast_imagesize($proxiedSrc);
+            $imageSize = $this->imagesize($proxiedSrc);
             if ($imageSize !== null && $imageSize[1] !== 0) {
                 $aspectRatio = round($imageSize[0] / $imageSize[1], 4);
 
@@ -357,6 +362,8 @@ class BBCodeFromDB
 
     public function toHTML()
     {
+        $this->imagesizeFetchCount = 0;
+
         $text = $this->text;
 
         // block
@@ -464,5 +471,22 @@ class BBCodeFromDB
         }
 
         return $text;
+    }
+
+    private function imagesize(string $url): ?array
+    {
+        [$isCached, $size] = fast_imagesize_cache_get($url);
+
+        if (!$isCached) {
+            if ($this->imagesizeFetchCount < static::IMAGESIZE_MAX_FETCH) {
+                $this->imagesizeFetchCount++;
+
+                $size = fast_imagesize_cache_put($url);
+            } else {
+                dispatch(new CacheImagesize($url));
+            }
+        }
+
+        return $size;
     }
 }

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -1483,16 +1483,33 @@ function json_options(mixed $current, iterable $items, ?callable $transformer = 
     ];
 }
 
-function fast_imagesize($url, ?string $logErrorId = null)
+function fast_imagesize(string $url, ?string $logErrorId = null): ?array
+{
+    $cached = fast_imagesize_cache_get($url);
+
+    return $cached[0]
+        ? $cached[1]
+        : fast_imagesize_cache_put($url, $logErrorId);
+}
+
+function fast_imagesize_cache_get(string $url): array
+{
+    $value = Cache::get("imageSize:{$url}");
+
+    $isCached = $value !== null;
+
+    return [$isCached, null_if_false($value)];
+}
+
+function fast_imagesize_cache_put(string $url, ?string $logErrorId = null): ?array
 {
     static $oneMonthInSeconds = 30 * 24 * 60 * 60;
 
-    return null_if_false(Cache::remember(
-        "imageSize:{$url}",
-        $oneMonthInSeconds,
-        // null can't be cached
-        fn () => (imagesize($url, $logErrorId) ?? false),
-    ));
+    $value = imagesize($url, $logErrorId) ?? false;
+
+    Cache::put("imageSize:{$url}", $value, $oneMonthInSeconds);
+
+    return null_if_false($value);
 }
 
 function imagesize(string $url, ?string $logErrorId = null): ?array

--- a/docker/development/run.sh
+++ b/docker/development/run.sh
@@ -17,7 +17,7 @@ _assets() {
 }
 
 _job() {
-    exec ./artisan queue:listen --queue=notification,default,beatmap_high,beatmap_default --tries=3 --timeout=1000
+    exec ./artisan queue:listen --queue=notification,default,beatmap_high,beatmap_default,imagesize --tries=3 --timeout=1000
 }
 
 _migrate() {


### PR DESCRIPTION
Maybe? Side effect may include broken gallery on first load and moving scroll position on image load (or maybe it's fixed now? it's kinda hard to test)

- [x] depends on #12914

Also will need queue worker adjustment to handle the new queue `imagesize` (and maybe remove `store-notifications` if it's still being used) @ThePooN 

(related to #1622)