### PR TITLE
Clean up and update quick/ranked play rankings

### DIFF
--- a/app/Http/Controllers/Ranking/MatchmakingController.php
+++ b/app/Http/Controllers/Ranking/MatchmakingController.php
@@ -47,7 +47,7 @@ class MatchmakingController extends Controller
         $query = $pool->allUserStats()->with('user.team')->default();
 
         $sort = get_string(request('sort'));
-        if (!array_key_exists($sort, static::SORTS)) {
+        if (!array_key_exists($sort, static::SORTS) || !$pool->hasPoints()) {
             $sort = 'rating';
         }
         foreach (static::SORTS[$sort] as $dbSort) {

--- a/app/Http/Controllers/Ranking/MatchmakingController.php
+++ b/app/Http/Controllers/Ranking/MatchmakingController.php
@@ -18,17 +18,27 @@ class MatchmakingController extends Controller
         'rating' => [['rating', 'DESC'], ['total_points', 'DESC']],
     ];
 
-    public function show(?string $rulesetName = null, ?string $poolId = null)
+    public function show(?string $poolType = null, ?string $rulesetName = null, ?string $poolId = null)
     {
+        $poolType ??= MatchmakingPool::TYPES[0];
+
         $rulesetName ??= default_mode();
         $rulesetId = Beatmap::MODES[$rulesetName] ?? abort(422, 'invalid ruleset parameter');
 
-        $poolsQuery = MatchmakingPool::where(['ruleset_id' => $rulesetId])->orderByDesc('active')->orderByDesc('id');
+
+        $poolsQuery = MatchmakingPool::where([
+            'type' => $poolType,
+            'ruleset_id' => $rulesetId,
+        ])->orderByDesc('active')->orderByDesc('id');
 
         if ($poolId === null) {
             $pool = $poolsQuery->firstOrFail();
 
-            return ujs_redirect(route('rankings.matchmaking', ['mode' => $rulesetName, 'pool' => $pool->getKey()]));
+            return ujs_redirect(route('rankings.matchmaking', [
+                'poolType' => $poolType,
+                'mode' => $rulesetName,
+                'pool' => $pool->getKey(),
+            ]));
         }
 
         $pools = $poolsQuery->get();

--- a/app/Http/Controllers/Ranking/MatchmakingController.php
+++ b/app/Http/Controllers/Ranking/MatchmakingController.php
@@ -25,7 +25,6 @@ class MatchmakingController extends Controller
         $rulesetName ??= default_mode();
         $rulesetId = Beatmap::MODES[$rulesetName] ?? abort(422, 'invalid ruleset parameter');
 
-
         $poolsQuery = MatchmakingPool::where([
             'type' => $poolType,
             'ruleset_id' => $rulesetId,

--- a/app/Http/Controllers/RankingController.php
+++ b/app/Http/Controllers/RankingController.php
@@ -8,6 +8,7 @@ namespace App\Http\Controllers;
 use App\Models\Beatmap;
 use App\Models\Country;
 use App\Models\CountryStatistics;
+use App\Models\MatchmakingPool;
 use App\Models\Model;
 use App\Models\Spotlight;
 use App\Models\TeamStatistics;
@@ -64,7 +65,10 @@ class RankingController extends Controller
                 'type' => $params['type'],
             ]),
             'kudosu' => route('rankings.kudosu'),
-            'matchmaking' => route('rankings.matchmaking', ['mode' => $params['mode'] ?? default_mode()]),
+            'matchmaking' => route('rankings.matchmaking', [
+                'poolType' => $params['poolType'] ?? MatchmakingPool::TYPES[0],
+                'mode' => $params['mode'] ?? default_mode(),
+            ]),
             'playlists' => match ($params['list'] ?? 'seasons') {
                 'charts' => route('rankings', [
                     'mode' => $params['mode'] ?? default_mode(),

--- a/app/Models/MatchmakingPool.php
+++ b/app/Models/MatchmakingPool.php
@@ -24,6 +24,8 @@ use Illuminate\Database\Eloquent\Relations\HasMany;
  */
 class MatchmakingPool extends Model
 {
+    const array TYPES = ['ranked_play', 'quick_play'];
+
     protected $casts = [
         'active' => 'bool',
     ];

--- a/app/Models/MatchmakingPool.php
+++ b/app/Models/MatchmakingPool.php
@@ -46,4 +46,9 @@ class MatchmakingPool extends Model
 
         return $prefix.$name;
     }
+
+    public function hasPoints(): bool
+    {
+        return $this->type === 'quick_play';
+    }
 }

--- a/resources/css/bem/ranking-page-grid.less
+++ b/resources/css/bem/ranking-page-grid.less
@@ -11,4 +11,14 @@
     --item-padding: 6px 20px;
     grid-template-columns: auto 10fr 1fr 1fr 1fr 1fr;
   }
+
+  &--quick_play {
+    --item-padding: 6px 20px;
+    grid-template-columns: auto 10fr 1fr 1fr 1fr 1fr;
+  }
+
+  &--ranked_play {
+    --item-padding: 6px 20px;
+    grid-template-columns: auto 10fr 1fr 1fr 1fr;
+  }
 }

--- a/resources/js/components/basic-select-options.tsx
+++ b/resources/js/components/basic-select-options.tsx
@@ -19,6 +19,7 @@ interface PropsBase {
 type Props = PropsBase & ({
   type: 'daily_challenge' | 'download' | 'multiplayer' | 'seasons' | 'spotlight';
 } | {
+  poolType: 'ranked_play' | 'quick_play';
   ruleset: Ruleset;
   type: 'matchmaking';
 });
@@ -52,7 +53,7 @@ export default class BasicSelectOptions extends React.PureComponent<Props> {
       case 'download':
         return route('download', { platform: id });
       case 'matchmaking':
-        return route('rankings.matchmaking', { mode: this.props.ruleset, pool: id });
+        return route('rankings.matchmaking', { mode: this.props.ruleset, pool: id, poolType: this.props.poolType });
       case 'multiplayer':
         return route('multiplayer.rooms.show', { room: id ?? 'latest' });
       case 'seasons':

--- a/resources/lang/en/rankings.php
+++ b/resources/lang/en/rankings.php
@@ -34,6 +34,10 @@ return [
     ],
 
     'matchmaking' => [
+        'pool_types' => [
+            'quick_play' => 'quick play',
+            'ranked_play' => 'ranked play',
+        ],
         'plays' => 'Plays',
         'points' => 'Points',
         'provisional' => 'Not enough matches played to accurately determine rating',
@@ -66,7 +70,7 @@ return [
         'daily_challenge' => 'daily challenge',
         'global' => 'global',
         'kudosu' => 'kudosu',
-        'matchmaking' => 'quick play',
+        'matchmaking' => 'matchmaking',
         'playlists' => 'playlists',
         'team' => 'team',
         'top_plays' => 'top plays',

--- a/resources/views/rankings/_pool_type_selector.blade.php
+++ b/resources/views/rankings/_pool_type_selector.blade.php
@@ -1,0 +1,20 @@
+{{--
+    Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+    See the LICENCE file in the repository root for full licence text.
+--}}
+@php
+    use App\Models\MatchmakingPool;
+@endphp
+<div class="page-tabs page-tabs--follows">
+    @foreach(MatchmakingPool::TYPES as $tab)
+        <a
+            class="{{ class_with_modifiers('page-tabs__tab', ['active' => $tab === $params['poolType']]) }}"
+            href="{{ route('rankings.matchmaking', [
+                'poolType' => $tab,
+                'mode' => $params['mode'] ?? default_mode(),
+            ]) }}"
+        >
+            {{ osu_trans("rankings.matchmaking.pool_types.{$tab}") }}
+        </a>
+    @endforeach
+</div>

--- a/resources/views/rankings/matchmaking.blade.php
+++ b/resources/views/rankings/matchmaking.blade.php
@@ -5,29 +5,34 @@
 @php
     use App\Http\Controllers\Ranking\MatchmakingController;
 
-    $params = ['mode' => $rulesetName];
+    $params = ['poolType' => $pool->type, 'mode' => $rulesetName];
 @endphp
 @extends('rankings.index', [
     'hasPager' => $scores !== null,
     'params' => [...$params, 'type' => 'matchmaking'],
     'rulesetSelectorUrlFn' => fn (string $r): string => route('rankings.matchmaking', [...$params, 'mode' => $r, 'sort' => $sort]),
-    'titlePrepend' => osu_trans('rankings.type.matchmaking').': '.$pool->getDisplayName(),
+    'titlePrepend' => osu_trans("rankings.matchmaking.pool_types.{$pool->type}").': '.$pool->getDisplayName(),
 ])
 
-@if (count($pools) > 1)
-    @section('ranking-header')
-        <div class="osu-page osu-page--ranking-info">
+@section('ranking-header')
+    <div class="osu-page osu-page--ranking-info">
+        @include('rankings._pool_type_selector', compact('params'))
+    </div>
+
+    @if (count($pools) > 1)
+        <div class="osu-page osu-page--ranking-info osu-page--ranking-info-extra">
             @include('objects._basic_select_options', ['selectOptions' => [
                 ...json_options($pool, $pools, fn ($pool) => [
                     'id' => $pool->getKey(),
                     'text' => $pool->getDisplayName(),
                 ]),
+                'poolType' => $pool->type,
                 'ruleset' => $rulesetName,
                 'type' => 'matchmaking',
             ]])
         </div>
-    @endsection
-@endif
+    @endif
+@endsection
 
 @section('scores-header')
     <div class="sort">

--- a/resources/views/rankings/matchmaking.blade.php
+++ b/resources/views/rankings/matchmaking.blade.php
@@ -35,25 +35,27 @@
 @endsection
 
 @section('scores-header')
-    <div class="sort">
-        <div class="sort__items">
-            <div class="sort__item sort__item--title">
-                {{ osu_trans('sort._') }}
+    @if ($pool->hasPoints())
+        <div class="sort">
+            <div class="sort__items">
+                <div class="sort__item sort__item--title">
+                    {{ osu_trans('sort._') }}
+                </div>
+                @foreach (MatchmakingController::SORTS as $newSort => $_dbColumns)
+                    <a
+                        class="{{ class_with_modifiers('sort__item', 'button', ['active' => $newSort === $sort]) }}"
+                        href="{{ route('rankings.matchmaking', [...$params, 'pool' => $pool->getKey(), 'sort' => $newSort]) }}"
+                    >
+                        {{ osu_trans("rankings.matchmaking.{$newSort}") }}
+                    </a>
+                @endforeach
             </div>
-            @foreach (MatchmakingController::SORTS as $newSort => $_dbColumns)
-                <a
-                    class="{{ class_with_modifiers('sort__item', 'button', ['active' => $newSort === $sort]) }}"
-                    href="{{ route('rankings.matchmaking', [...$params, 'pool' => $pool->getKey(), 'sort' => $newSort]) }}"
-                >
-                    {{ osu_trans("rankings.matchmaking.{$newSort}") }}
-                </a>
-            @endforeach
         </div>
-    </div>
+    @endif
 @endsection
 
 @section('scores')
-    <div class="ranking-page-grid ranking-page-grid--matchmaking">
+    <div class="ranking-page-grid ranking-page-grid--{{ $pool->type }}">
         <div class="ranking-page-grid-item ranking-page-grid-item--header">
             <div class="ranking-page-grid-item__content">
                 <div class="ranking-page-grid-item__col">
@@ -66,9 +68,11 @@
                 <div class="ranking-page-grid-item__col">
                     {{ osu_trans('rankings.matchmaking.plays') }}
                 </div>
-                <div class="{{ class_with_modifiers('ranking-page-grid-item__col', ['number-focus' => $sort === 'points']) }}">
-                    {{ osu_trans('rankings.matchmaking.points') }}
-                </div>
+                @if ($pool->hasPoints())
+                    <div class="{{ class_with_modifiers('ranking-page-grid-item__col', ['number-focus' => $sort === 'points']) }}">
+                        {{ osu_trans('rankings.matchmaking.points') }}
+                    </div>
+                @endif
                 <div class="{{ class_with_modifiers('ranking-page-grid-item__col', ['number-focus' => $sort === 'rating']) }}">
                     {{ osu_trans('rankings.matchmaking.rating') }}
                 </div>
@@ -92,12 +96,14 @@
                     <div class="ranking-page-grid-item__col ranking-page-grid-item__col--number">
                         {{ i18n_number_format($score->elo_data['contest_count']) }}
                     </div>
-                    <div class="{{ class_with_modifiers(
-                        'ranking-page-grid-item__col',
-                        $sort === 'points' ? 'number-focus' : 'number',
-                    ) }}">
-                        {{ i18n_number_format($score->total_points) }}
-                    </div>
+                    @if ($pool->hasPoints())
+                        <div class="{{ class_with_modifiers(
+                            'ranking-page-grid-item__col',
+                            $sort === 'points' ? 'number-focus' : 'number',
+                        ) }}">
+                            {{ i18n_number_format($score->total_points) }}
+                        </div>
+                    @endif
                     <div class="{{ class_with_modifiers(
                         'ranking-page-grid-item__col',
                         $sort === 'rating' ? 'number-focus' : 'number',

--- a/routes/web.php
+++ b/routes/web.php
@@ -307,7 +307,7 @@ Route::group(['middleware' => ['web']], function () {
 
     Route::get('rankings/kudosu', 'RankingController@kudosu')->name('rankings.kudosu');
     Route::resource('rankings/daily-challenge', 'Ranking\DailyChallengeController', ['only' => ['index', 'show']]);
-    Route::get('rankings/quickplay/{mode?}/{pool?}', 'Ranking\MatchmakingController@show')->name('rankings.matchmaking');
+    Route::get('rankings/matchmaking/{poolType?}/{mode?}/{pool?}', 'Ranking\MatchmakingController@show')->name('rankings.matchmaking');
     Route::get('rankings/top-plays/{mode?}', 'Ranking\TopPlaysController@show')->name('rankings.top-plays');
     Route::get('rankings/{mode?}/{type?}/{sort?}', 'RankingController@index')->name('rankings');
 


### PR DESCRIPTION
* split ranked and quick play into separate tabs
* remove points sort/column for ranked play

notably this changes the tab on the ranking page from `quick play` to `matchmaking` while still being under the same translation key which should be fine cuz crowdin should catch that, while also changing the routes a bit.

<img width="995" height="545" alt="image" src="https://github.com/user-attachments/assets/464c2b3e-817d-4114-baa5-b6cc86e28ead" />

<img width="995" height="516" alt="image" src="https://github.com/user-attachments/assets/b8d96ef4-91fe-4261-9bde-e6a52104e025" />

~~the ranked play tab is showing no dropdown here since i only had one pool in the DB (which i believe is the current behaviour anyway). also sorry for not having any test data in here.~~ updated the screenshots