### PR TITLE
Rename quick play to ranked play

### DIFF
--- a/app/Http/Controllers/Ranking/MatchmakingController.php
+++ b/app/Http/Controllers/Ranking/MatchmakingController.php
@@ -23,7 +23,10 @@ class MatchmakingController extends Controller
         $rulesetName ??= default_mode();
         $rulesetId = Beatmap::MODES[$rulesetName] ?? abort(422, 'invalid ruleset parameter');
 
-        $poolsQuery = MatchmakingPool::where(['ruleset_id' => $rulesetId])->orderByDesc('active')->orderByDesc('id');
+        $poolsQuery = MatchmakingPool::where([
+            'ruleset_id' => $rulesetId,
+            'type' => 'ranked_play',
+        ])->orderByDesc('active')->orderByDesc('id');
 
         if ($poolId === null) {
             $pool = $poolsQuery->firstOrFail();
@@ -34,23 +37,19 @@ class MatchmakingController extends Controller
         $pools = $poolsQuery->get();
 
         $pool = $pools->findOrFail($poolId);
-        $query = $pool->allUserStats()->with('user.team')->default();
-
-        $sort = get_string(request('sort'));
-        if (!array_key_exists($sort, static::SORTS)) {
-            $sort = 'rating';
-        }
-        foreach (static::SORTS[$sort] as $dbSort) {
-            $query->orderBy(...$dbSort);
-        }
-        $scores = $query->paginate()->withQueryString();
+        $scores = $pool
+            ->allUserStats()
+            ->with('user.team')
+            ->default()
+            ->orderByDesc('rating')
+            ->paginate()
+            ->withQueryString();
 
         return ext_view('rankings.matchmaking', compact(
             'pool',
             'pools',
             'rulesetName',
             'scores',
-            'sort',
         ));
     }
 }

--- a/app/Models/Multiplayer/Room.php
+++ b/app/Models/Multiplayer/Room.php
@@ -74,12 +74,13 @@ class Room extends Model
     const CATEGORIES = ['normal', 'spotlight', 'featured_artist', 'daily_challenge'];
     const TYPE_GROUPS = [
         'playlists' => [self::PLAYLIST_TYPE],
+        'ranked-play' => [self::RANKED_PLAY_TYPE],
         'realtime' => self::REALTIME_STANDARD_TYPES,
-        'quickplay' => self::MATCHMAKING_TYPES,
     ];
 
     const PLAYLIST_TYPE = 'playlists';
-    const MATCHMAKING_TYPES = ['matchmaking', 'ranked_play'];
+    const RANKED_PLAY_TYPE = 'ranked_play';
+    const MATCHMAKING_TYPES = ['matchmaking', self::RANKED_PLAY_TYPE];
     const REALTIME_DEFAULT_TYPE = 'head_to_head';
     const REALTIME_STANDARD_TYPES = ['head_to_head', 'team_versus'];
     const REALTIME_TYPES = [...self::REALTIME_STANDARD_TYPES, ...self::MATCHMAKING_TYPES];
@@ -370,9 +371,12 @@ class Room extends Model
 
     public function getNameAttribute(?string $value): ?string
     {
-        return $this->isMatchmaking() && $value === 'Unnamed room'
-            ? 'Quick Play Match'
-            : $value;
+        return $value === 'Unnamed room'
+            ? match ($this->type) {
+                'matchmaking' => 'Quick Play Match',
+                'ranked_play' => 'Ranked Play Match',
+                default => $value,
+            } : $value;
     }
 
     public function assertCorrectPassword(?string $password): void

--- a/app/Transformers/MatchmakingPoolTransformer.php
+++ b/app/Transformers/MatchmakingPoolTransformer.php
@@ -18,6 +18,7 @@ class MatchmakingPoolTransformer extends TransformerAbstract
             'id' => $pool->getKey(),
             'name' => $pool->name,
             'ruleset_id' => $pool->ruleset_id,
+            'type' => $pool->type,
             'variant_id' => $pool->variant_id,
         ];
     }

--- a/app/Transformers/UserCompactTransformer.php
+++ b/app/Transformers/UserCompactTransformer.php
@@ -371,8 +371,10 @@ class UserCompactTransformer extends TransformerAbstract
     {
         $allStats = $user
             ->matchmakingStats()
-            ->whereRulesetId(Beatmap::MODES[$this->mode])
-            ->withRank()
+            ->whereHas('pool', fn ($q) => $q->where([
+                'ruleset_id' => Beatmap::MODES[$this->mode],
+                'type' => 'ranked_play',
+            ]))->withRank()
             ->with('pool')
             ->get();
 

--- a/resources/css/bem/matchmaking-popup.less
+++ b/resources/css/bem/matchmaking-popup.less
@@ -9,7 +9,7 @@
   padding: 15px;
   gap: 10px;
   display: grid;
-  grid-template-columns: 1fr auto auto auto auto auto;
+  grid-template-columns: 1fr auto auto auto auto;
 
   &__row {
     display: contents;

--- a/resources/css/bem/ranking-page-grid.less
+++ b/resources/css/bem/ranking-page-grid.less
@@ -9,6 +9,6 @@
 
   &--matchmaking {
     --item-padding: 6px 20px;
-    grid-template-columns: auto 10fr 1fr 1fr 1fr 1fr;
+    grid-template-columns: auto 10fr 1fr 1fr 1fr;
   }
 }

--- a/resources/js/interfaces/user-multiplayer-history-json.ts
+++ b/resources/js/interfaces/user-multiplayer-history-json.ts
@@ -3,7 +3,7 @@
 
 import RoomListJson from './room-list-json';
 
-export type MultiplayerTypeGroup = 'playlists' | 'quickplay' | 'realtime';
+export type MultiplayerTypeGroup = 'playlists' | 'ranked-play' | 'realtime';
 
 export default interface UserMultiplayerHistoryJson extends RoomListJson {
   type_group: MultiplayerTypeGroup;

--- a/resources/js/profile-page/header-links.ts
+++ b/resources/js/profile-page/header-links.ts
@@ -9,12 +9,12 @@ import { trans } from 'utils/lang';
 
 type LinkMode = 'modding' | 'show' | MultiplayerTypeGroup;
 
-const nonBotModes: LinkMode[] = ['modding', 'playlists', 'realtime', 'quickplay'];
+const nonBotModes: LinkMode[] = ['modding', 'playlists', 'realtime', 'ranked-play'];
 
 const url = {
   modding: (userId: number) => route('users.modding.index', { user: userId }),
   playlists: (userId: number) => route('users.multiplayer.index', { typeGroup: 'playlists', user: userId }),
-  quickplay: (userId: number) => route('users.multiplayer.index', { typeGroup: 'quickplay', user: userId }),
+  'ranked-play': (userId: number) => route('users.multiplayer.index', { typeGroup: 'ranked-play', user: userId }),
   realtime: (userId: number) => route('users.multiplayer.index', { typeGroup: 'realtime', user: userId }),
   show: (userId: number) => route('users.show', { user: userId }),
 };

--- a/resources/js/profile-page/matchmaking.tsx
+++ b/resources/js/profile-page/matchmaking.tsx
@@ -41,9 +41,6 @@ function popup(allStats: ProfilePageMatchmakingStatsJson[]) {
           {trans('rankings.matchmaking.plays')}
         </div>
         <div className='matchmaking-popup__value'>
-          {trans('rankings.matchmaking.points')}
-        </div>
-        <div className='matchmaking-popup__value'>
           {trans('rankings.matchmaking.rating')}
         </div>
       </div>
@@ -60,9 +57,6 @@ function popup(allStats: ProfilePageMatchmakingStatsJson[]) {
           </div>
           <div className='matchmaking-popup__value'>
             {formatNumber(stats.plays)}
-          </div>
-          <div className='matchmaking-popup__value'>
-            {formatNumber(stats.total_points)}
           </div>
           <div className='matchmaking-popup__value'>
             {formatNumber(stats.rating)}{stats.is_rating_provisional ? '*' : ''}

--- a/resources/lang/en/layout.php
+++ b/resources/lang/en/layout.php
@@ -53,7 +53,7 @@ return [
         'users' => [
             'modding' => 'modding',
             'playlists' => 'playlists',
-            'quickplay' => 'quick play',
+            'ranked-play' => 'ranked play',
             'realtime' => 'multiplayer',
             'show' => 'info',
         ],

--- a/resources/lang/en/multiplayer.php
+++ b/resources/lang/en/multiplayer.php
@@ -8,7 +8,7 @@ return [
         'active' => 'Not currently in any in-progress osu!(lazer) :type_group games!',
         'ended' => 'Not in any completed osu!(lazer) :type_group games yet!',
         'playlists' => 'playlist',
-        'quickplay' => 'quick play',
+        'ranked-play' => 'ranked play',
         'realtime' => 'multiplayer',
     ],
 

--- a/resources/lang/en/rankings.php
+++ b/resources/lang/en/rankings.php
@@ -66,7 +66,7 @@ return [
         'daily_challenge' => 'daily challenge',
         'global' => 'global',
         'kudosu' => 'kudosu',
-        'matchmaking' => 'quick play',
+        'matchmaking' => 'ranked play',
         'playlists' => 'playlists',
         'team' => 'team',
         'top_plays' => 'top plays',

--- a/resources/lang/en/users.php
+++ b/resources/lang/en/users.php
@@ -402,8 +402,8 @@ return [
                 'title_longer' => 'Recent Posts',
                 'show_more' => 'see more posts',
             ],
-            'quickplay' => [
-                'title' => 'Quick Play Matches',
+            'ranked-play' => [
+                'title' => 'Ranked Play Matches',
             ],
             'recent_activity' => [
                 'title' => 'Recent',
@@ -475,7 +475,7 @@ return [
         ],
 
         'matchmaking' => [
-            'title' => 'Quick Play',
+            'title' => 'Ranked Play',
         ],
 
         'not_found' => [

--- a/resources/views/rankings/matchmaking.blade.php
+++ b/resources/views/rankings/matchmaking.blade.php
@@ -10,7 +10,7 @@
 @extends('rankings.index', [
     'hasPager' => $scores !== null,
     'params' => [...$params, 'type' => 'matchmaking'],
-    'rulesetSelectorUrlFn' => fn (string $r): string => route('rankings.matchmaking', [...$params, 'mode' => $r, 'sort' => $sort]),
+    'rulesetSelectorUrlFn' => fn (string $r): string => route('rankings.matchmaking', [...$params, 'mode' => $r]),
     'titlePrepend' => osu_trans('rankings.type.matchmaking').': '.$pool->getDisplayName(),
 ])
 
@@ -29,24 +29,6 @@
     @endsection
 @endif
 
-@section('scores-header')
-    <div class="sort">
-        <div class="sort__items">
-            <div class="sort__item sort__item--title">
-                {{ osu_trans('sort._') }}
-            </div>
-            @foreach (MatchmakingController::SORTS as $newSort => $_dbColumns)
-                <a
-                    class="{{ class_with_modifiers('sort__item', 'button', ['active' => $newSort === $sort]) }}"
-                    href="{{ route('rankings.matchmaking', [...$params, 'pool' => $pool->getKey(), 'sort' => $newSort]) }}"
-                >
-                    {{ osu_trans("rankings.matchmaking.{$newSort}") }}
-                </a>
-            @endforeach
-        </div>
-    </div>
-@endsection
-
 @section('scores')
     <div class="ranking-page-grid ranking-page-grid--matchmaking">
         <div class="ranking-page-grid-item ranking-page-grid-item--header">
@@ -61,10 +43,7 @@
                 <div class="ranking-page-grid-item__col">
                     {{ osu_trans('rankings.matchmaking.plays') }}
                 </div>
-                <div class="{{ class_with_modifiers('ranking-page-grid-item__col', ['number-focus' => $sort === 'points']) }}">
-                    {{ osu_trans('rankings.matchmaking.points') }}
-                </div>
-                <div class="{{ class_with_modifiers('ranking-page-grid-item__col', ['number-focus' => $sort === 'rating']) }}">
+                <div class="ranking-page-grid-item__col ranking-page-grid-item__col--number-focus">
                     {{ osu_trans('rankings.matchmaking.rating') }}
                 </div>
             </div>
@@ -87,16 +66,7 @@
                     <div class="ranking-page-grid-item__col ranking-page-grid-item__col--number">
                         {{ i18n_number_format($score->elo_data['contest_count']) }}
                     </div>
-                    <div class="{{ class_with_modifiers(
-                        'ranking-page-grid-item__col',
-                        $sort === 'points' ? 'number-focus' : 'number',
-                    ) }}">
-                        {{ i18n_number_format($score->total_points) }}
-                    </div>
-                    <div class="{{ class_with_modifiers(
-                        'ranking-page-grid-item__col',
-                        $sort === 'rating' ? 'number-focus' : 'number',
-                    ) }}">
+                    <div class="ranking-page-grid-item__col ranking-page-grid-item__col--number-focus">
                         @php
                             [$provisionalTitle, $provisionalSign] = $score->isRatingProvisional()
                                 ? [osu_trans('rankings.matchmaking.provisional'), '*']

--- a/routes/web.php
+++ b/routes/web.php
@@ -307,7 +307,7 @@ Route::group(['middleware' => ['web']], function () {
 
     Route::get('rankings/kudosu', 'RankingController@kudosu')->name('rankings.kudosu');
     Route::resource('rankings/daily-challenge', 'Ranking\DailyChallengeController', ['only' => ['index', 'show']]);
-    Route::get('rankings/quickplay/{mode?}/{pool?}', 'Ranking\MatchmakingController@show')->name('rankings.matchmaking');
+    Route::get('rankings/ranked-play/{mode?}/{pool?}', 'Ranking\MatchmakingController@show')->name('rankings.matchmaking');
     Route::get('rankings/top-plays/{mode?}', 'Ranking\TopPlaysController@show')->name('rankings.top-plays');
     Route::get('rankings/{mode?}/{type?}/{sort?}', 'RankingController@index')->name('rankings');
 
@@ -344,7 +344,7 @@ Route::group(['middleware' => ['web']], function () {
         Route::get('extra-pages/{page}', 'UsersController@extraPages')->name('extra-page');
         Route::put('page', 'UsersController@updatePage')->name('page');
         Route::group(['namespace' => 'Users'], function () {
-            Route::resource('{typeGroup}', 'MultiplayerController', ['only' => 'index'])->where(['typeGroup' => 'multiplayer|playlists|quickplay|realtime'])->names('multiplayer');
+            Route::resource('{typeGroup}', 'MultiplayerController', ['only' => 'index'])->where(['typeGroup' => 'multiplayer|playlists|ranked-play|realtime'])->names('multiplayer');
 
             Route::group(['as' => 'modding.', 'prefix' => 'modding'], function () {
                 Route::get('/', 'ModdingHistoryController@index')->name('index');


### PR DESCRIPTION
Or more precisely, hide quick play and only show ranked play (until someone complains and we bring the listing for the other one... somehow)

Resolves #12921

I wonder if it's useful to have the old link redirected.