### PR TITLE
Fix cut off ranking label on profile page

### DIFF
--- a/resources/css/bem/value-display.less
+++ b/resources/css/bem/value-display.less
@@ -43,7 +43,6 @@
     --value-color: hsl(var(--hsl-c2));
     --value-font-size-desktop: @font-size--new-header-title;
     --value-font-size: @font-size--large;
-    line-height: 1;
 
     @media @desktop {
       flex: none;


### PR DESCRIPTION
The recent addition to clip off long label/value broke the display when line height is 1 and the label is expected to be drawn beyond its own box

The rank value can be moved back up by adding some negative margin to rank-value class but the new distance still seems fine