### PR TITLE
Remove schedule service from docker compose

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -131,7 +131,6 @@ There are multiple services involved:
 - php: main service for php server. Also serves as entry point for doing other stuff like testing etc
 - assets: builds assets. It sometimes behaves weirdly in which case try restarting it
 - job: runs queued job
-- schedule: runs scheduled job every 5 minutes
 - migrator: prepare database and elasticsearch (service should exit with status 0 after finishing its task)
 - beatmap-difficulty-lookup-cache: for computing beatmap difficulty attributes
 - notification-server: main service for notification websocket server

--- a/compose.yaml
+++ b/compose.yaml
@@ -54,10 +54,6 @@ services:
     profiles: ['testjs']
     command: ['test', 'js']
 
-  schedule:
-    <<: *x-web
-    command: ['schedule']
-
   migrator:
     <<: *x-web
     command: ['migrate']


### PR DESCRIPTION
Less messing around with data in unexpected way and just less work in general (especially on larger dev data).