### PR TITLE
Add API endpoints for ranked play rankings

### DIFF
--- a/app/Http/Controllers/Ranking/MatchmakingController.php
+++ b/app/Http/Controllers/Ranking/MatchmakingController.php
@@ -10,6 +10,10 @@ namespace App\Http\Controllers\Ranking;
 use App\Http\Controllers\Controller;
 use App\Models\Beatmap;
 use App\Models\MatchmakingPool;
+use App\Models\Model;
+use App\Transformers\MatchmakingPoolTransformer;
+use App\Transformers\MatchmakingUserStatsTransformer;
+use Illuminate\Pagination\LengthAwarePaginator;
 
 class MatchmakingController extends Controller
 {
@@ -18,38 +22,91 @@ class MatchmakingController extends Controller
         'rating' => [['rating', 'DESC'], ['total_points', 'DESC']],
     ];
 
+    public function __construct()
+    {
+        parent::__construct();
+
+        $this->middleware('require-scopes:public');
+    }
+
+    public function index(string $rulesetName)
+    {
+        $pools = $this->getPoolsQuery($rulesetName)->get();
+
+        return json_collection($pools, new MatchmakingPoolTransformer());
+    }
+
     public function show(?string $rulesetName = null, ?string $poolId = null)
+    {
+        $poolsQuery = $this->getPoolsQuery($rulesetName);
+
+        if (is_api_request()) {
+            // we can just query directly, since the api route
+            // requires the pool id to be specified
+            $pool = $poolsQuery->findOrFail($poolId);
+        } else {
+            if ($poolId === null) {
+                $pool = $poolsQuery->firstOrFail();
+
+                return ujs_redirect(route('rankings.matchmaking', ['mode' => $rulesetName, 'pool' => $pool->getKey()]));
+            }
+
+            $pools = $poolsQuery->get();
+            $pool = $pools->findOrFail($poolId);
+        }
+
+        $scoresQuery = $pool
+            ->allUserStats()
+            ->with('user.team')
+            ->default()
+            ->orderByDesc('rating');
+
+        $maxResults = $scoresQuery->count();
+        $maxPages = ceil($maxResults / Model::PER_PAGE);
+        $page = get_int(cursor_from_params(\Request::input())['page'] ?? null)
+            ?? get_int(\Request::input('page'))
+            ?? 1;
+        $page = \Number::clamp($page, 1, $maxPages);
+
+        $scores = $scoresQuery
+            ->limit(Model::PER_PAGE)
+            ->offset(Model::PER_PAGE * ($page - 1))
+            ->get();
+
+        if (is_api_request()) {
+            return [
+                ...cursor_for_response(
+                    empty($scores) || $page >= $maxPages ? null : ['page' => $page + 1],
+                ),
+                'ranking' => json_collection($scores, new MatchmakingUserStatsTransformer(), MatchmakingUserStatsTransformer::RANKING_INCLUDES),
+                'total' => $maxResults,
+            ];
+        } else {
+            $scores = new LengthAwarePaginator(
+                $scores,
+                $maxResults,
+                Model::PER_PAGE,
+                $page,
+                ['path' => route('rankings.matchmaking', ['mode' => $rulesetName, 'pool' => $pool->getKey()])],
+            );
+
+            return ext_view('rankings.matchmaking', compact(
+                'pool',
+                'pools',
+                'rulesetName',
+                'scores',
+            ));
+        }
+    }
+
+    private function getPoolsQuery(string $rulesetName)
     {
         $rulesetName ??= default_mode();
         $rulesetId = Beatmap::MODES[$rulesetName] ?? abort(422, 'invalid ruleset parameter');
 
-        $poolsQuery = MatchmakingPool::where([
+        return MatchmakingPool::where([
             'ruleset_id' => $rulesetId,
             'type' => 'ranked_play',
         ])->orderByDesc('active')->orderByDesc('id');
-
-        if ($poolId === null) {
-            $pool = $poolsQuery->firstOrFail();
-
-            return ujs_redirect(route('rankings.matchmaking', ['mode' => $rulesetName, 'pool' => $pool->getKey()]));
-        }
-
-        $pools = $poolsQuery->get();
-
-        $pool = $pools->findOrFail($poolId);
-        $scores = $pool
-            ->allUserStats()
-            ->with('user.team')
-            ->default()
-            ->orderByDesc('rating')
-            ->paginate()
-            ->withQueryString();
-
-        return ext_view('rankings.matchmaking', compact(
-            'pool',
-            'pools',
-            'rulesetName',
-            'scores',
-        ));
     }
 }

--- a/app/Http/Controllers/Ranking/MatchmakingController.php
+++ b/app/Http/Controllers/Ranking/MatchmakingController.php
@@ -57,7 +57,7 @@ class MatchmakingController extends Controller
 
         $scoresQuery = $pool
             ->allUserStats()
-            ->with('user.team')
+            ->with(['user', 'user.country', 'user.team'])
             ->default()
             ->orderByDesc('rating');
 

--- a/app/Http/Controllers/Ranking/MatchmakingController.php
+++ b/app/Http/Controllers/Ranking/MatchmakingController.php
@@ -57,7 +57,7 @@ class MatchmakingController extends Controller
 
         $scoresQuery = $pool
             ->allUserStats()
-            ->with(['user', 'user.country', 'user.team'])
+            ->with(['user', 'user.team'])
             ->default()
             ->orderByDesc('rating');
 

--- a/app/Http/Controllers/Ranking/MatchmakingController.php
+++ b/app/Http/Controllers/Ranking/MatchmakingController.php
@@ -59,7 +59,8 @@ class MatchmakingController extends Controller
             ->allUserStats()
             ->with(['user', 'user.team'])
             ->default()
-            ->orderByDesc('rating');
+            ->orderByDesc('rating')
+            ->orderBy('sigma');
 
         $maxResults = $scoresQuery->count();
         $maxPages = ceil($maxResults / Model::PER_PAGE);

--- a/app/Transformers/MatchmakingUserStatsTransformer.php
+++ b/app/Transformers/MatchmakingUserStatsTransformer.php
@@ -12,8 +12,11 @@ use League\Fractal\Resource\ResourceInterface;
 
 class MatchmakingUserStatsTransformer extends TransformerAbstract
 {
+    const array RANKING_INCLUDES = UserStatisticsTransformer::RANKING_INCLUDES;
+
     protected array $availableIncludes = [
         'pool',
+        'user',
     ];
 
     public function transform(MatchmakingUserStats $stats): array
@@ -33,5 +36,10 @@ class MatchmakingUserStatsTransformer extends TransformerAbstract
     public function includePool(MatchmakingUserStats $stats): ResourceInterface
     {
         return $this->item($stats->pool, new MatchmakingPoolTransformer());
+    }
+
+    public function includeUser(MatchmakingUserStats $stats): ResourceInterface
+    {
+        return $this->item($stats->user, new UserTransformer());
     }
 }

--- a/app/Transformers/MatchmakingUserStatsTransformer.php
+++ b/app/Transformers/MatchmakingUserStatsTransformer.php
@@ -40,6 +40,6 @@ class MatchmakingUserStatsTransformer extends TransformerAbstract
 
     public function includeUser(MatchmakingUserStats $stats): ResourceInterface
     {
-        return $this->item($stats->user, new UserTransformer());
+        return $this->item($stats->user, new UserCompactTransformer());
     }
 }

--- a/database/migrations/2026_05_21_191940_add_sigma_to_matchmaking_user_stats.php
+++ b/database/migrations/2026_05_21_191940_add_sigma_to_matchmaking_user_stats.php
@@ -1,0 +1,27 @@
+<?php
+
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('matchmaking_user_stats', function (Blueprint $table) {
+            $table->double('sigma')->storedAs("JSON_EXTRACT(elo_data, '$.approximate_posterior.sig')");
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('matchmaking_user_stats', function (Blueprint $table) {
+            $table->dropColumn('sigma');
+        });
+    }
+};

--- a/routes/web.php
+++ b/routes/web.php
@@ -615,6 +615,8 @@ Route::group(['as' => 'api.', 'prefix' => 'api', 'middleware' => ['api', Throttl
         Route::post('notifications/mark-read', 'NotificationsController@markRead')->name('notifications.mark-read');
 
         Route::get('rankings/kudosu', 'RankingController@kudosu');
+        Route::get('rankings/{mode}/ranked-play', 'Ranking\MatchmakingController@index')->name('rankings.matchmaking.index');
+        Route::get('rankings/{mode}/ranked-play/{pool}', 'Ranking\MatchmakingController@show')->name('rankings.matchmaking.show');
         //  GET /api/v2/rankings/:mode/:type
         Route::get('rankings/{mode}/{type}', 'RankingController@index')->name('rankings');
         Route::resource('spotlights', 'SpotlightsController', ['only' => ['index']]);

--- a/routes/web.php
+++ b/routes/web.php
@@ -615,8 +615,8 @@ Route::group(['as' => 'api.', 'prefix' => 'api', 'middleware' => ['api', Throttl
         Route::post('notifications/mark-read', 'NotificationsController@markRead')->name('notifications.mark-read');
 
         Route::get('rankings/kudosu', 'RankingController@kudosu');
-        Route::get('rankings/{mode}/ranked-play', 'Ranking\MatchmakingController@index')->name('rankings.matchmaking.index');
-        Route::get('rankings/{mode}/ranked-play/{pool}', 'Ranking\MatchmakingController@show')->name('rankings.matchmaking.show');
+        Route::get('rankings/ranked-play/{mode}', 'Ranking\MatchmakingController@index')->name('rankings.matchmaking.index');
+        Route::get('rankings/ranked-play/{mode}/{pool}', 'Ranking\MatchmakingController@show')->name('rankings.matchmaking.show');
         //  GET /api/v2/rankings/:mode/:type
         Route::get('rankings/{mode}/{type}', 'RankingController@index')->name('rankings');
         Route::resource('spotlights', 'SpotlightsController', ['only' => ['index']]);

--- a/tests/api_routes.json
+++ b/tests/api_routes.json
@@ -1643,6 +1643,38 @@
         ]
     },
     {
+        "uri": "api/v2/rankings/{mode}/ranked-play",
+        "methods": [
+            "GET",
+            "HEAD"
+        ],
+        "controller": "App\\Http\\Controllers\\Ranking\\MatchmakingController@index",
+        "middlewares": [
+            "App\\Http\\Middleware\\ThrottleRequests:1200,1,api:",
+            "App\\Http\\Middleware\\RequireScopes",
+            "App\\Http\\Middleware\\RequireScopes:public"
+        ],
+        "scopes": [
+            "public"
+        ]
+    },
+    {
+        "uri": "api/v2/rankings/{mode}/ranked-play/{pool}",
+        "methods": [
+            "GET",
+            "HEAD"
+        ],
+        "controller": "App\\Http\\Controllers\\Ranking\\MatchmakingController@show",
+        "middlewares": [
+            "App\\Http\\Middleware\\ThrottleRequests:1200,1,api:",
+            "App\\Http\\Middleware\\RequireScopes",
+            "App\\Http\\Middleware\\RequireScopes:public"
+        ],
+        "scopes": [
+            "public"
+        ]
+    },
+    {
         "uri": "api/v2/rankings/{mode}/{type}",
         "methods": [
             "GET",

--- a/tests/api_routes.json
+++ b/tests/api_routes.json
@@ -1643,7 +1643,7 @@
         ]
     },
     {
-        "uri": "api/v2/rankings/{mode}/ranked-play",
+        "uri": "api/v2/rankings/ranked-play/{mode}",
         "methods": [
             "GET",
             "HEAD"
@@ -1659,7 +1659,7 @@
         ]
     },
     {
-        "uri": "api/v2/rankings/{mode}/ranked-play/{pool}",
+        "uri": "api/v2/rankings/ranked-play/{mode}/{pool}",
         "methods": [
             "GET",
             "HEAD"


### PR DESCRIPTION
This is needed to get ranked play leaderboards in lazer.

Retrieving matchmaking pools and actual rankings is split across two separate endpoints because there's no reason to resend them on every ranking fetch.

Also reworked the controller to use cursors for pagination like `RankingController`. I noticed a [TODO](https://github.com/ppy/osu-web/blob/master/app/Http/Controllers/RankingController.php#L321) saying that these should be converted to offset/limit, but I'm not sure how up to date that is, and also it probably makes sense for all rankings to have consistent implementation for pagination, and then be eventually refactored all at once.

Also I wonder if we should limit the amount of pages on this, since currently on production there's already >570 pages compared to the global ranking's 200.