### PR TITLE
Log elasticsearch errors for top score recalculation

### DIFF
--- a/app/Libraries/Score/TopPlays.php
+++ b/app/Libraries/Score/TopPlays.php
@@ -33,6 +33,13 @@ class TopPlays
         $search->searchTimeout = "{$GLOBALS['cfg']['elasticsearch']['connections']['scores_slow']['connectionParams']['client']['timeout']}s";
 
         $scores = $search->records();
+
+        $error = $search->getError();
+        if ($error !== null) {
+            log_error($error, ['source' => 'top_plays', 'ruleset_id' => $this->rulesetId]);
+            return;
+        }
+
         $ids = [];
         foreach ($scores as $score) {
             // the loop is in descending order so the first assignment will be the highest pp score.


### PR DESCRIPTION
The search doesn't throw by default and thus explicit check is needed to prevent it from storing invalid data.