### PR TITLE
Separate timing log for top plays es query

### DIFF
--- a/app/Libraries/Score/TopPlays.php
+++ b/app/Libraries/Score/TopPlays.php
@@ -31,6 +31,7 @@ class TopPlays
         ]));
         $search->connectionName = 'scores_slow';
         $search->searchTimeout = "{$GLOBALS['cfg']['elasticsearch']['connections']['scores_slow']['connectionParams']['client']['timeout']}s";
+        $search->loggingTag = "top_plays_{$this->rulesetId}";
 
         $scores = $search->records();
         $ids = [];


### PR DESCRIPTION
Separate it from the general score search operation.