### PR TITLE
Fix same url navigation skipping turbo

### DIFF
--- a/resources/js/setup-turbo.ts
+++ b/resources/js/setup-turbo.ts
@@ -42,14 +42,21 @@ document.addEventListener('turbo:before-fetch-response', (e) => {
 
 // disable turbo navigation for old webs
 document.addEventListener('turbo:click', (event) => {
+  const currentUrl = document.location.href;
+  const targetUrl = event.detail.url;
+
+  if (currentUrl === targetUrl) {
+    return;
+  }
+
   // work around anchor links not correctly detected
   // reference: https://github.com/hotwired/turbo/pull/1285#discussion_r2799488011
-  if (document.location.href.replace(/#.*/, '') === event.detail.url.replace(/#.*/, '')) {
+  if (currentUrl.replace(/#.*/, '') === targetUrl.replace(/#.*/, '')) {
     event.preventDefault();
     return;
   }
 
-  const url = new URL(event.detail.url);
+  const url = new URL(targetUrl);
 
   if (
     url.origin === Turbo.session.navigator.rootLocation.origin


### PR DESCRIPTION
The code was only intended for anchor/hash navigation. Doing it for normal navigation triggers browser-based page load instead.