### PR TITLE
Treat relayed chat message empty string uuid as null

### DIFF
--- a/app/Models/Chat/Channel.php
+++ b/app/Models/Chat/Channel.php
@@ -463,7 +463,7 @@ class Channel extends Model
         ]);
 
         $message->sender()->associate($sender)->channel()->associate($this)
-            ->uuid = $uuid; // relay any message uuid back.
+            ->uuid = presence($uuid); // relay any message uuid back.
 
         $message->getConnection()->transaction(function () use ($message, $sender) {
             $message->save();


### PR DESCRIPTION
possibly fixes #12918

Messages received with empty string uuids are not considered null and don't get unique keys generated for rendering in lists, which confuses React causing it to reuse the wrong parts of the DOM when switching channels.