### PR TITLE
Update Apidoc for legacy beatmap nomination rulesets

### DIFF
--- a/resources/views/docs/_structures/nomination.md
+++ b/resources/views/docs/_structures/nomination.md
@@ -1,8 +1,8 @@
 ## Nomination
 
-Field            | Type
------------------|-----
-beatmapset_id    | integer
-rulesets         | [Ruleset](#ruleset)[]
-reset            | boolean
-user_id          | integer
+Field            | Type                   | Description
+---------------- | ---------------------- | -----------
+beatmapset_id    | integer                | |
+rulesets         | [Ruleset](#ruleset)[]? | Nominations under the old system have a `null` value.
+reset            | boolean                | |
+user_id          | integer                | |


### PR DESCRIPTION
legacy nominations have `null` `rulesets`

closes #12903