### PR TITLE
Skip existence checks for user replay stats

### DIFF
--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -176,7 +176,7 @@ class UsersController extends Controller
                     'replays_watched_counts' => json_collection($this->user->replaysWatchedCounts, new UserReplaysWatchedCountTransformer()),
                     'score_replay_stats' => $this->getExtraSection(
                         'scoreReplayStats',
-                        $this->user->scoreReplayStats()->whereHas('score.beatmap')->countLimit($this->maxResults),
+                        $this->user->scoreReplayStats()->countLimit($this->maxResults),
                     ),
                 ];
 
@@ -853,7 +853,6 @@ class UsersController extends Controller
                 $transformer = new ScoreReplayStatsTransformer();
                 $includes = ScoreReplayStatsTransformer::USER_PROFILE_INCLUDES;
                 $query = $this->user->scoreReplayStats()
-                    ->whereHas('score.beatmap')
                     ->orderByDesc('watch_count')
                     ->with(ScoreReplayStatsTransformer::USER_PROFILE_INCLUDES_PRELOAD);
                 break;

--- a/app/Transformers/ScoreReplayStatsTransformer.php
+++ b/app/Transformers/ScoreReplayStatsTransformer.php
@@ -30,6 +30,8 @@ class ScoreReplayStatsTransformer extends TransformerAbstract
 
     public function includeScore(ScoreReplayStats $stats): ResourceInterface
     {
-        return $this->item($stats->score, new ScoreTransformer());
+        return $stats->score !== null
+            ? $this->item($stats->score, new ScoreTransformer())
+            : $this->null();
     }
 }

--- a/resources/js/interfaces/score-replay-stats-json.ts
+++ b/resources/js/interfaces/score-replay-stats-json.ts
@@ -4,7 +4,7 @@
 import ScoreJson, { ScoreJsonForUser } from './score-json';
 
 interface ScoreReplayStatsJsonAvailableIncludes {
-  score: ScoreJson;
+  score: ScoreJson|null;
 }
 
 interface ScoreReplayStatsJsonDefaultAttributes {
@@ -16,4 +16,4 @@ type ScoreReplayStatsJson = ScoreReplayStatsJsonDefaultAttributes & Partial<Scor
 
 export default ScoreReplayStatsJson;
 
-export type ScoreReplayStatsJsonForUser = ScoreReplayStatsJson & { score: ScoreJsonForUser };
+export type ScoreReplayStatsJsonForUser = ScoreReplayStatsJson & { score: ScoreJsonForUser|null };

--- a/resources/js/profile-page/score-replay-stats-entry.tsx
+++ b/resources/js/profile-page/score-replay-stats-entry.tsx
@@ -25,6 +25,10 @@ export default function ScoreReplayStatsEntry(props: Props) {
   const user = props.user;
   const stats = props.stats;
   const score = stats.score;
+  if (score == null) {
+    return null;
+  }
+
   const scoreRank = rank(score);
   const { beatmap, beatmapset } = score;
 


### PR DESCRIPTION
#12945 and #12946 take 2, with extra `null` handling

duplicates `fireTransformer` to insert our extra `null` handling