### PR TITLE
Faster query for user ranked play summary

### DIFF
--- a/app/Models/MatchmakingUserStats.php
+++ b/app/Models/MatchmakingUserStats.php
@@ -52,13 +52,11 @@ class MatchmakingUserStats extends Model
 
     public function scopeWithRank(Builder $query): void
     {
+        // this won't be accurate when there are restricted users
         $rankQuery = new static()
-            // mainly so whereHas in default() uses the correct table alias
-            ->setTable('mus')
             ->newQuery()
             ->from($this->tableName(true), 'mus')
             ->selectRaw('COUNT(*) + 1')
-            ->default()
             ->whereColumn('rating', '>', $query->qualifyColumn('rating'))
             ->whereColumn('pool_id', '=', $query->qualifyColumn('pool_id'));
 


### PR DESCRIPTION
Apparently the user restriction check is too slow here. It shouldn't be too visible here except for the top ranked players when there are high ranked restricted user.

The leaderboard page itself isn't changed because it shouldn't take as long even with the check.

A better solution would be to have a visibility flag or just outright deleting the stats for restricted users.