### PR TITLE
Skip checking existence of beatmapset

### DIFF
--- a/app/Http/Controllers/Ranking/TopPlaysController.php
+++ b/app/Http/Controllers/Ranking/TopPlaysController.php
@@ -37,7 +37,7 @@ class TopPlaysController extends Controller
                     ->with('user.team')
                     ->with('beatmap.beatmapset')
                     ->whereHas('user', fn ($q) => $q->default())
-                    ->whereHas('beatmap.beatmapset')
+                    ->whereHas('beatmap')
                     ->orderByDesc('pp')
                     ->paginate(static::PAGE_SIZE, ['*'], 'page', $page, static::PAGE_SIZE * static::PAGES);
 

--- a/app/Http/Controllers/ScoresController.php
+++ b/app/Http/Controllers/ScoresController.php
@@ -212,7 +212,7 @@ class ScoresController extends Controller
         if (\Auth::user()?->isAdmin() !== true) {
             $scoreQuery->visibleUsers();
         }
-        $score = $scoreQuery->whereHas('beatmap.beatmapset')->firstOrFail();
+        $score = $scoreQuery->whereHas('beatmap')->firstOrFail();
 
         $userIncludes = array_map(function ($include) {
             return "user.{$include}";

--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -176,7 +176,7 @@ class UsersController extends Controller
                     'replays_watched_counts' => json_collection($this->user->replaysWatchedCounts, new UserReplaysWatchedCountTransformer()),
                     'score_replay_stats' => $this->getExtraSection(
                         'scoreReplayStats',
-                        $this->user->scoreReplayStats()->whereHas('score.beatmap.beatmapset')->countLimit($this->maxResults),
+                        $this->user->scoreReplayStats()->whereHas('score.beatmap')->countLimit($this->maxResults),
                     ),
                 ];
 
@@ -784,7 +784,7 @@ class UsersController extends Controller
                 $transformer = 'BeatmapPlaycount';
                 $query = $this->user->beatmapPlaycounts()
                     ->with('beatmap', 'beatmap.beatmapset')
-                    ->whereHas('beatmap.beatmapset')
+                    ->whereHas('beatmap')
                     ->orderBy('playcount', 'desc')
                     ->orderBy('beatmap_id', 'desc'); // for consistent sorting
                 break;
@@ -853,7 +853,7 @@ class UsersController extends Controller
                 $transformer = new ScoreReplayStatsTransformer();
                 $includes = ScoreReplayStatsTransformer::USER_PROFILE_INCLUDES;
                 $query = $this->user->scoreReplayStats()
-                    ->whereHas('score.beatmap.beatmapset')
+                    ->whereHas('score.beatmap')
                     ->orderByDesc('watch_count')
                     ->with(ScoreReplayStatsTransformer::USER_PROFILE_INCLUDES_PRELOAD);
                 break;

--- a/app/Libraries/Score/FetchDedupedScores.php
+++ b/app/Libraries/Score/FetchDedupedScores.php
@@ -40,7 +40,7 @@ class FetchDedupedScores
             $response = $search->response();
             $search->assertNoError();
 
-            $query = $response->records()->whereHas('beatmap.beatmapset');
+            $query = $response->records()->whereHas('beatmap');
             if ($columns !== null) {
                 $query->select($columns);
             }

--- a/app/Models/BeatmapLeader.php
+++ b/app/Models/BeatmapLeader.php
@@ -27,7 +27,7 @@ class BeatmapLeader extends Model
 
     public function scopeDefault(Builder $query): void
     {
-        $query->whereHas('beatmap.beatmapset')->whereHas('score');
+        $query->whereHas('beatmap')->whereHas('score');
     }
 
     public function scopeRuleset(Builder $query, string $ruleset): void

--- a/app/Models/LegacyScoreFirst/Model.php
+++ b/app/Models/LegacyScoreFirst/Model.php
@@ -23,7 +23,7 @@ abstract class Model extends BaseModel
 
     public function scopeDefault(Builder $query): Builder
     {
-        return $query->whereHas('beatmap.beatmapset')->whereHas('score');
+        return $query->whereHas('beatmap')->whereHas('score');
     }
 
     public function beatmap(): BelongsTo

--- a/app/Models/ScorePin.php
+++ b/app/Models/ScorePin.php
@@ -28,7 +28,7 @@ class ScorePin extends Model
 
     public function scopeWithVisibleScore($query): Builder
     {
-        return $query->whereHas('score', fn ($q) => $q->whereHas('beatmap'));
+        return $query->whereHas('score.beatmap');
     }
 
     public function score(): BelongsTo

--- a/app/Models/ScorePin.php
+++ b/app/Models/ScorePin.php
@@ -28,7 +28,7 @@ class ScorePin extends Model
 
     public function scopeWithVisibleScore($query): Builder
     {
-        return $query->whereHas('score', fn ($q) => $q->whereHas('beatmap.beatmapset'));
+        return $query->whereHas('score', fn ($q) => $q->whereHas('beatmap'));
     }
 
     public function score(): BelongsTo

--- a/app/Models/Solo/Score.php
+++ b/app/Models/Solo/Score.php
@@ -182,7 +182,7 @@ class Score extends Model implements Traits\ReportableInterface
 
     public function scopeDefault(Builder $query): Builder
     {
-        return $query->whereHas('beatmap.beatmapset');
+        return $query->whereHas('beatmap');
     }
 
     /**


### PR DESCRIPTION
Scores on beatmap without beatmapset shouldn't ever happen. Such thing should be fixed when encountered instead of being ignored.

...I think?