### PR TITLE
Add beatmapset graveyard profile event

### DIFF
--- a/app/Http/Controllers/InterOp/BeatmapsetsController.php
+++ b/app/Http/Controllers/InterOp/BeatmapsetsController.php
@@ -43,6 +43,15 @@ class BeatmapsetsController extends Controller
         return response()->noContent();
     }
 
+    public function broadcastGraveyard($id)
+    {
+        $beatmapset = Beatmapset::findOrFail($id);
+
+        Event::generate('beatmapsetGraveyard', ['beatmapset' => $beatmapset]);
+
+        return response()->noContent();
+    }
+
     public function broadcastUpdate($id)
     {
         $beatmapset = Beatmapset::findOrFail($id);

--- a/app/Models/Event.php
+++ b/app/Models/Event.php
@@ -47,6 +47,7 @@ class Event extends Model
         'beatmapPlaycount' => "!^<a href='(?<beatmapUrl>.+?)'>(?<beatmapTitle>.+?)</a> has been played (?<count>[\d,]+) times\!$!",
         'beatmapsetApprove' => "!^<a href='(?<beatmapsetUrl>.+?)'>(?<beatmapsetTitle>.+?)</a> by <b><a href='(?<userUrl>.+?)'>(?<userName>.+?)</a></b> has just been (?<approval>ranked|approved|qualified|loved)\!$!",
         'beatmapsetDelete' => "!^<a href='(?<beatmapsetUrl>.+?)'>(?<beatmapsetTitle>.*?)</a> has been deleted.$!",
+        'beatmapsetGraveyard' => "!^<a href='(?<beatmapsetUrl>.+?)'>(?<beatmapsetTitle>.*?)</a> has been moved to the graveyard\.$!",
         'beatmapsetRevive' => "!^<a href='(?<beatmapsetUrl>.+?)'>(?<beatmapsetTitle>.*?)</a> has been revived from eternal slumber(?: by <b><a href='(?<userUrl>.+?)'>(?<userName>.+?)</a></b>)?\.$!",
         'beatmapsetUpdate' => "!^<b><a href='(?<userUrl>.+?)'>(?<userName>.+?)</a></b> has updated the beatmap \"<a href='(?<beatmapsetUrl>.+?)'>(?<beatmapsetTitle>.*?)</a>\"$!",
         'beatmapsetUpload' => "!^<b><a href='(?<userUrl>.+?)'>(?<userName>.+?)</a></b> has submitted a new beatmap \"<a href='(?<beatmapsetUrl>.+?)'>(?<beatmapsetTitle>.*?)</a>\"$!",
@@ -113,6 +114,22 @@ class Event extends Model
                     'text' => "{$beatmapsetLink['html']} has been deleted.",
                     'beatmapset_id' => $beatmapset->getKey(),
                     'user_id' => $options['user']->getKey(),
+                    'private' => false,
+                    'epicfactor' => 1,
+                ];
+
+                break;
+
+            case 'beatmapsetGraveyard':
+                $beatmapset = $options['beatmapset'];
+                $beatmapsetLink = static::beatmapsetLink($beatmapset);
+
+                $template = '%s has been moved to the graveyard.';
+                $params = [
+                    'text' => sprintf($template, $beatmapsetLink['html']),
+                    'text_clean' => sprintf($template, $beatmapsetLink['clean']),
+                    'beatmapset_id' => $beatmapset->getKey(),
+                    'user_id' => $beatmapset->user->getKey(),
                     'private' => false,
                     'epicfactor' => 1,
                 ];
@@ -399,6 +416,13 @@ class Event extends Model
     }
 
     public function parseMatchesBeatmapsetDelete($matches)
+    {
+        return [
+            'beatmapset' => $this->arrayBeatmapset($matches),
+        ];
+    }
+
+    public function parseMatchesBeatmapsetGraveyard($matches)
     {
         return [
             'beatmapset' => $this->arrayBeatmapset($matches),

--- a/resources/css/bem/profile-extra-entries.less
+++ b/resources/css/bem/profile-extra-entries.less
@@ -111,6 +111,10 @@
       color: hsl(var(--beatmapset-approved-bg-hsl));
     }
 
+    &--graveyard {
+      color: hsl(var(--beatmapset-graveyard-colour));
+    }
+
     &--danger {
       color: hsl(var(--hsl-red-1));
     }

--- a/resources/js/interfaces/event-json.ts
+++ b/resources/js/interfaces/event-json.ts
@@ -10,6 +10,7 @@ type EventType =
   | 'beatmapPlaycount'
   | 'beatmapsetApprove'
   | 'beatmapsetDelete'
+  | 'beatmapsetGraveyard'
   | 'beatmapsetRevive'
   | 'beatmapsetUpdate'
   | 'beatmapsetUpload'
@@ -64,6 +65,11 @@ interface BeatmapsetApproveEvent extends EventBase {
 interface BeatmapsetDeleteEvent extends EventBase {
   beatmapset: EventBeatmapset;
   type: 'beatmapsetDelete';
+}
+
+interface BeatmapsetGraveyardEvent extends EventBase {
+  beatmapset: EventBeatmapset;
+  type: 'beatmapsetGraveyard';
 }
 
 interface BeatmapsetReviveEvent extends EventBase {
@@ -127,6 +133,7 @@ type EventJson =
   | BeatmapPlaycountEvent
   | BeatmapsetApproveEvent
   | BeatmapsetDeleteEvent
+  | BeatmapsetGraveyardEvent
   | BeatmapsetReviveEvent
   | BeatmapsetUpdateEvent
   | BeatmapsetUploadEvent

--- a/resources/js/profile-page/parse-event.tsx
+++ b/resources/js/profile-page/parse-event.tsx
@@ -64,6 +64,15 @@ export default function parseEvent(event: EventJson, modifiers: Modifiers): { ba
       };
     }
 
+    case 'beatmapsetGraveyard':
+      return {
+        badge: <span className='fas fa-archive' />,
+        iconModifiers: 'graveyard',
+        mappings: {
+          beatmapset: <a href={event.beatmapset.url}>{event.beatmapset.title}</a>,
+        },
+      };
+
     case 'beatmapsetRevive':
       return {
         badge: <span className='fas fa-trash-restore' />,

--- a/resources/lang/en/events.php
+++ b/resources/lang/en/events.php
@@ -8,6 +8,7 @@ return [
     'beatmap_playcount' => ':beatmap has been played :count times!',
     'beatmapset_approve' => ':beatmapset by :user has been :approval!',
     'beatmapset_delete' => ':beatmapset has been deleted.',
+    'beatmapset_graveyard' => ':beatmapset has been moved to the graveyard.',
     'beatmapset_revive' => ':beatmapset has been revived from eternal slumber by :user.',
     'beatmapset_update' => ':user has updated the beatmap ":beatmapset"',
     'beatmapset_upload' => ':user has submitted a new beatmap ":beatmapset"',

--- a/resources/views/docs/_structures/event.md
+++ b/resources/views/docs/_structures/event.md
@@ -78,6 +78,14 @@ Field      | Type
 -----------|--------------------------------------
 beatmapset | [Event.Beatmapset](#event-beatmapset)
 
+#### beatmapsetGraveyard
+
+When a beatmapset is moved to the graveyard.
+
+Field      | Type
+-----------|--------------------------------------
+beatmapset | [Event.Beatmapset](#event-beatmapset)
+
 #### beatmapsetRevive
 
 When a beatmapset in graveyard state is updated.

--- a/routes/web.php
+++ b/routes/web.php
@@ -656,6 +656,7 @@ Route::group(['prefix' => '_lio', 'middleware' => 'lio', 'as' => 'interop.'], fu
 
         Route::group(['as' => 'beatmapsets.', 'prefix' => 'beatmapsets'], function () {
             Route::group(['prefix' => '{beatmapset}'], function () {
+                Route::post('broadcast-graveyard', 'BeatmapsetsController@broadcastGraveyard')->name('broadcast-graveyard');
                 Route::post('broadcast-new', 'BeatmapsetsController@broadcastNew')->name('broadcast-new');
                 Route::post('broadcast-revive', 'BeatmapsetsController@broadcastRevive')->name('broadcast-revive');
                 Route::post('broadcast-update', 'BeatmapsetsController@broadcastUpdate')->name('broadcast-update');

--- a/tests/Models/EventTest.php
+++ b/tests/Models/EventTest.php
@@ -81,6 +81,29 @@ class EventTest extends TestCase
         $this->assertSame('beatmapsetDelete', $event->type);
     }
 
+    public function testBeatmapsetGraveyardEventEscaping()
+    {
+        $user = User::factory()->create([
+            'user_id' => 222,
+            'username' => 'john123',
+        ]);
+        $beatmapset = BeatmapSet::factory()->create([
+            'beatmapset_id' => 333,
+            'user_id' => $user->getKey(),
+            'artist' => 'artist & artist',
+            'title' => '< title >',
+            'approved' => Beatmapset::STATES['graveyard'],
+        ]);
+
+        $event = Event::generate('beatmapsetGraveyard', ['beatmapset' => $beatmapset]);
+
+        $this->assertSame('<a href=\'/beatmapsets/333\'>artist &amp; artist - &lt; title &gt;</a> has been moved to the graveyard.', $event->text);
+        $this->assertSame('[http://localhost/beatmapsets/333 artist & artist - < title >] has been moved to the graveyard.', $event->text_clean);
+
+        $this->assertArrayNotHasKey('parse_error', $event->parse()->details);
+        $this->assertSame('beatmapsetGraveyard', $event->type);
+    }
+
     public function testBeatmapsetReviveEventEscaping()
     {
         $user = User::factory()->create([


### PR DESCRIPTION
## Summary
- add backend parsing/generation for a `beatmapsetGraveyard` profile event
- expose the event in the API docs and TypeScript event shape
- render the new profile activity entry with a graveyard-coloured archive icon
- add a beatmapset interop hook for beatmap processing to create the event

Fixes #10134.

## Validation
- `git diff --check`
- `tsc --noEmit --pretty false` currently cannot run in this local clone because project JS dependencies/type packages are not installed (`cloudflare-turnstile`, `jquery.fileupload`, `jquery.scrollto`, `jqueryui`, `timeago`).
- PHP lint/tests could not be run locally because `php` is not installed on this machine.

If this contribution is eligible for the project contribution reward process, PayPal works for me: https://paypal.me/JulianAcero897