### PR TITLE
Add persistent Featured Artist track links

### DIFF
--- a/app/Http/Controllers/ArtistTracksController.php
+++ b/app/Http/Controllers/ArtistTracksController.php
@@ -51,6 +51,6 @@ class ArtistTracksController extends Controller
             abort(404);
         }
 
-        return ujs_redirect(route('artists.show', $artist));
+        return ujs_redirect(route('artists.show', $artist)."#track-{$track->getKey()}");
     }
 }

--- a/resources/css/bem/artist-track.less
+++ b/resources/css/bem/artist-track.less
@@ -27,6 +27,11 @@
     --cover-play-opacity: 1;
   }
 
+  &:target {
+    --bg-hover: hsl(var(--hsl-b2));
+    background-color: hsl(var(--hsl-b2));
+  }
+
   &[data-audio-state="loading"],
   &[data-audio-state="playing"] {
     --cover-play-opacity: 1;
@@ -146,6 +151,15 @@
 
   &__title {
     font-size: @font-size--title-small-3;
+  }
+
+  &__title-link {
+    .link-plain();
+    color: inherit;
+
+    .link-hover({
+      color: hsl(var(--hsl-c1));
+    });
   }
 
   &__version {

--- a/resources/js/components/tracklist-track.tsx
+++ b/resources/js/components/tracklist-track.tsx
@@ -40,7 +40,7 @@ export default class TracklistTrack extends React.PureComponent<Props> {
     blockClass += ' js-audio--player';
 
     return (
-      <div className={blockClass} data-audio-url={this.props.track.preview}>
+      <div id={`track-${this.props.track.id}`} className={blockClass} data-audio-url={this.props.track.preview}>
         <div
           className='artist-track__col artist-track__col--preview'
           style={{
@@ -55,15 +55,17 @@ export default class TracklistTrack extends React.PureComponent<Props> {
 
         <div className='artist-track__col artist-track__col--names'>
           <div className='artist-track__title u-ellipsis-overflow'>
-            {this.props.track.title}
-            {present(this.props.track.version) && (
-              <>
-                {' '}
-                <span className='artist-track__version'>
-                  {this.props.track.version}
-                </span>
-              </>
-            )}
+            <a className='artist-track__title-link' href={route('tracks.show', { track: this.props.track.id })}>
+              {this.props.track.title}
+              {present(this.props.track.version) && (
+                <>
+                  {' '}
+                  <span className='artist-track__version'>
+                    {this.props.track.version}
+                  </span>
+                </>
+              )}
+            </a>
           </div>
           <div className='artist-track__info'>
             <a href={route('artists.show', { artist: this.artist.id })}>

--- a/tests/Controllers/ArtistTracksControllerTest.php
+++ b/tests/Controllers/ArtistTracksControllerTest.php
@@ -1,0 +1,25 @@
+<?php
+
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
+declare(strict_types=1);
+
+namespace Tests\Controllers;
+
+use App\Models\Artist;
+use App\Models\ArtistTrack;
+use Tests\TestCase;
+
+class ArtistTracksControllerTest extends TestCase
+{
+    public function testShowRedirectsToArtistPageTrackAnchor(): void
+    {
+        $artist = Artist::factory()->create();
+        $track = ArtistTrack::factory()->create(['artist_id' => $artist->getKey()]);
+
+        $this
+            ->get(route('tracks.show', $track))
+            ->assertRedirect(route('artists.show', $artist)."#track-{$track->getKey()}");
+    }
+}


### PR DESCRIPTION
## Summary
- make `/beatmaps/artists/tracks/{id}` redirect to the artist page with a stable `#track-{id}` anchor
- add anchors to rendered Featured Artist track cards and highlight the targeted track
- make track titles link to the persistent track URL
- add controller coverage for the redirect target

Fixes #9508.

## Validation
- `git diff --check`
- `tsc --noEmit --pretty false` currently cannot run in this local clone because project JS dependencies/type packages are not installed (`cloudflare-turnstile`, `jquery.fileupload`, `jquery.scrollto`, `jqueryui`, `timeago`).
- PHP lint/tests could not be run locally because `php` is not installed on this machine.

If this contribution is eligible for the project contribution reward process, PayPal works for me: https://paypal.me/JulianAcero897