### PR TITLE
Count forum posts from searchable forums

### DIFF
--- a/app/Models/Forum/Authorize.php
+++ b/app/Models/Forum/Authorize.php
@@ -59,12 +59,12 @@ class Authorize extends Model
 
     public static function increasesPostsCount($user, $forum)
     {
-        return static::aclCheck($user, 'f_postcount', $forum);
+        return $forum->enable_indexing === true;
     }
 
     public static function postsCountedForums($user)
     {
-        return static::aclGetAllowedForums($user, 'f_postcount');
+        return model_pluck(Forum::where('enable_indexing', true), 'forum_id');
     }
 
     public function scopeDirectAcl($query, $groupIds, $authOptionId)

--- a/tests/Models/UserTest.php
+++ b/tests/Models/UserTest.php
@@ -8,6 +8,9 @@ declare(strict_types=1);
 namespace Tests\Models;
 
 use App\Libraries\Session\Store;
+use App\Models\Forum\Forum;
+use App\Models\Forum\Post;
+use App\Models\Forum\Topic;
 use App\Models\OAuth\Token;
 use App\Models\User;
 use App\Models\UsernameChangeHistory;
@@ -228,6 +231,43 @@ class UserTest extends TestCase
             ->create();
 
         $this->assertSame($cost, $user->usernameChangeCost());
+    }
+
+    public function testRefreshForumCacheCountsSearchableForums(): void
+    {
+        $user = User::factory()->create();
+        $searchableForum = Forum::factory()->create(['enable_indexing' => true]);
+        $unsearchableForum = Forum::factory()->create(['enable_indexing' => false]);
+        $searchableTopic = Topic::factory()->create(['forum_id' => $searchableForum->getKey()]);
+        $unsearchableTopic = Topic::factory()->create(['forum_id' => $unsearchableForum->getKey()]);
+
+        Post::factory()->create([
+            'forum_id' => $searchableForum->getKey(),
+            'poster_id' => $user->getKey(),
+            'topic_id' => $searchableTopic->getKey(),
+        ]);
+        Post::factory()->create([
+            'forum_id' => $unsearchableForum->getKey(),
+            'poster_id' => $user->getKey(),
+            'topic_id' => $unsearchableTopic->getKey(),
+        ]);
+
+        $user->refreshForumCache();
+
+        $this->assertSame(1, $user->fresh()->user_posts);
+    }
+
+    public function testRefreshForumCacheIncrementOnlyCountsSearchableForums(): void
+    {
+        $user = User::factory()->create();
+        $searchableForum = Forum::factory()->create(['enable_indexing' => true]);
+        $unsearchableForum = Forum::factory()->create(['enable_indexing' => false]);
+
+        $user->refreshForumCache($searchableForum, 1);
+        $this->assertSame(1, $user->fresh()->user_posts);
+
+        $user->refreshForumCache($unsearchableForum, 1);
+        $this->assertSame(1, $user->fresh()->user_posts);
     }
 
     /**


### PR DESCRIPTION
## Summary
- count user forum posts from forums with `enable_indexing` instead of phpBB `f_postcount` ACLs
- apply the same searchable-forum rule to incremental post-count cache updates
- add coverage for full refresh and incremental cache updates

Fixes #7821.

## Validation
- `git diff --check`
- PHP lint/tests could not be run locally because `php` is not installed on this machine.

If this contribution is eligible for the project contribution reward process, PayPal works for me: https://paypal.me/JulianAcero897