### PR TITLE
Add PlayDetailMenu to scores in multiplayer room events page

### DIFF
--- a/resources/css/bem/mp-history-game.less
+++ b/resources/css/bem/mp-history-game.less
@@ -113,8 +113,8 @@
     border-radius: 0 0 @border-radius-base @border-radius-base;
 
     @media @desktop {
-      // shape name mods combo acc score rank
-      grid-template-columns: var(--shape-size) 1fr auto auto auto auto auto;
+      // shape name mods combo acc score rank menu
+      grid-template-columns: var(--shape-size) 1fr auto auto auto auto auto auto;
       column-gap: 0;
     }
 

--- a/resources/css/bem/mp-history-player-score.less
+++ b/resources/css/bem/mp-history-player-score.less
@@ -60,8 +60,8 @@
   &__main {
     padding: 10px 20px;
     display: grid;
-    // for mods and rank element (in mobile), using order and grid-column combination
-    grid-template-columns: 1fr auto;
+    // for mods, rank and menu element (in mobile), using order and grid-column combination
+    grid-template-columns: 1fr auto auto;
     gap: 5px;
     grid-column: 2 / -1;
 
@@ -99,6 +99,18 @@
     &--rank {
       order: 1;
       grid-column: 2 / 3;
+      @media @desktop {
+        order: 0;
+        grid-column: initial;
+      }
+    }
+
+    &--menu {
+      position: relative;
+      width: 16px;
+      height: 100%;
+      order: 1;
+      grid-column: 3 / 4;
       @media @desktop {
         padding-right: 0; // TODO: replace with gap at __main if fixed in firefox
         order: 0;

--- a/resources/js/legacy-match/score.tsx
+++ b/resources/js/legacy-match/score.tsx
@@ -3,6 +3,7 @@
 
 import FlagCountry from 'components/flag-country';
 import Mods from 'components/mods';
+import { PlayDetailMenu } from 'components/play-detail-menu';
 import UserLink from 'components/user-link';
 import { PlaylistItemJsonForMultiplayerEvent } from 'interfaces/playlist-item-json';
 import { rulesetNames } from 'interfaces/ruleset';
@@ -13,7 +14,7 @@ import * as React from 'react';
 import { classWithModifiers } from 'utils/css';
 import { formatNumber } from 'utils/html';
 import { trans } from 'utils/lang';
-import { calculateStatisticsFor, rank } from 'utils/score-helper';
+import { calculateStatisticsFor, hasMenu, rank } from 'utils/score-helper';
 import { Data } from './content';
 
 interface Props {
@@ -126,6 +127,9 @@ export default observer(function Score(props: Props) {
         </div>
         <div className={classWithModifiers('mp-history-player-score__info-box', 'rank')}>
           <div className={classWithModifiers('score-rank', 'profile-page', rank(props.score))} />
+        </div>
+        <div className={classWithModifiers('mp-history-player-score__info-box', 'menu')}>
+          {hasMenu(props.score) && <PlayDetailMenu score={props.score} user={user} />}
         </div>
       </div>
     </div>


### PR DESCRIPTION
Desktop:
<img width="277" height="78" alt="image" src="https://github.com/user-attachments/assets/65a1ead8-c24e-4dbc-8d02-4f29469a1614" />

Mobile:
<img width="187" height="120" alt="image" src="https://github.com/user-attachments/assets/2d7cf76e-6d9f-4966-a474-79fcd3eaf41f" />
