### PR TITLE
Ranked Play: Add cron job to apply daily rating decay

### DIFF
--- a/app/Console/Commands/RankedPlayDecayRatings.php
+++ b/app/Console/Commands/RankedPlayDecayRatings.php
@@ -1,0 +1,36 @@
+<?php
+
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
+declare(strict_types=1);
+
+namespace App\Console\Commands;
+
+use Illuminate\Console\Command;
+use Illuminate\Support\Facades\DB;
+
+class RankedPlayDecayRatings extends Command
+{
+    /**
+     * The name and signature of the console command.
+     *
+     * @var string
+     */
+    protected $signature = 'ranked-play:decay-ratings';
+
+    /**
+     * The console command description.
+     *
+     * @var string
+     */
+    protected $description = 'Applies rating decay to all users in active pools.';
+
+    /**
+     * Execute the console command.
+     */
+    public function handle()
+    {
+        DB::statement('UPDATE matchmaking_user_stats SET elo_data = JSON_SET(elo_data, \'$.approximate_posterior.sig\', elo_data->\'$.approximate_posterior.sig\' + 1) WHERE pool_id IN (SELECT id FROM matchmaking_pools WHERE active = 1);');
+    }
+}

--- a/app/Console/Kernel.php
+++ b/app/Console/Kernel.php
@@ -105,5 +105,9 @@ class Kernel extends ConsoleKernel
             ->cron('20 0 * * *')
             ->withoutOverlapping(120)
             ->onOneServer();
+
+        $schedule->command('ranked-play:decay-ratings')
+            ->daily()
+            ->onOneServer();
     }
 }


### PR DESCRIPTION
See: https://github.com/ppy/osu-server-spectator/pull/507

> sigma decay, simply increment sigma by some number per day
> - the idea is that every day we grow less confident about a player's rating the more days pass by without any matches recorded
> - incentive to play more actively
> - needs to be implemented as a cron-kinda thing? i have no clue about how exactly you want this implemented
> - should take roughly 30 days of inactivity for player to become unranked. ballpark value of +1 sigma/day. a 70 sigma player would become unranked after 1 month. a player who plays 1 match/day will stabilize at roughly 60 sigma.