### PR TITLE
Don't record builds with no users

### DIFF
--- a/app/Console/Commands/BuildsUpdatePropagationHistory.php
+++ b/app/Console/Commands/BuildsUpdatePropagationHistory.php
@@ -49,6 +49,7 @@ class BuildsUpdatePropagationHistory extends Command
 
             $builds = Build::propagationHistory()
                 ->whereIn('stream_id', $GLOBALS['cfg']['osu']['changelog']['update_streams'])
+                ->where('users', '>', 0)
                 ->get();
 
             foreach ($builds as $build) {


### PR DESCRIPTION
This causes weird chart especially when all the builds for the specific time point has no users.

![](https://s.kohaku.love/2026/05/firefox_2026-05-18_18-00-45.png)