### PR TITLE
Add support for LGA banners

### DIFF
--- a/app/Libraries/Fulfillments/BannerFulfillment.php
+++ b/app/Libraries/Fulfillments/BannerFulfillment.php
@@ -16,6 +16,7 @@ abstract class BannerFulfillment extends OrderFulfiller
     const ALLOWED_TAGGED_NAMES = [
         'owc-supporter',
         'mwc7-supporter',
+        'player-supporter',
         'twc-supporter',
         'cwc-supporter',
         'mwc4-supporter',
@@ -42,6 +43,16 @@ abstract class BannerFulfillment extends OrderFulfiller
         $this->incrementRevoke();
     }
 
+    protected function applyBanner(OrderItem $orderItem)
+    {
+        $extraData = $orderItem->extra_data;
+        $user = $orderItem->order->user;
+        $user->profileBanners()->create([
+            'tournament_id' => $extraData->tournamentId,
+            'country_acronym' => $extraData->countryAcronym,
+        ]);
+    }
+
     protected function getOrderItems()
     {
         if (!isset($this->orderItems)) {
@@ -56,31 +67,18 @@ abstract class BannerFulfillment extends OrderFulfiller
         return $this->orderItems;
     }
 
-    private function applyBanner(OrderItem $orderItem)
-    {
-        $extraData = $orderItem->extra_data;
-        $user = $orderItem->order->user;
-        $user->profileBanners()->create([
-            'tournament_id' => $extraData->tournamentId,
-            'country_acronym' => $extraData->countryAcronym,
-        ]);
-    }
-
-    private function revokeBanner(OrderItem $orderItem)
+    protected function revokeBanner(OrderItem $orderItem)
     {
         $extraData = $orderItem->extra_data;
         $user = $orderItem->order->user;
 
         // just any matching banner
-        $banner = $user
+        $user
             ->profileBanners()
             ->where('tournament_id', $extraData->tournamentId)
             ->where('country_acronym', $extraData->countryAcronym)
-            ->first();
-
-        if ($banner) {
-            $banner->delete();
-        }
+            ->first()
+            ?->delete();
     }
 
     //================

--- a/app/Libraries/Fulfillments/PlayerSupporterFulfillment.php
+++ b/app/Libraries/Fulfillments/PlayerSupporterFulfillment.php
@@ -1,0 +1,36 @@
+<?php
+
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
+namespace App\Libraries\Fulfillments;
+
+use App\Models\Store\OrderItem;
+
+class PlayerSupporterFulfillment extends BannerFulfillment
+{
+    const TAGGED_NAME = 'player-supporter';
+
+    protected function applyBanner(OrderItem $orderItem)
+    {
+        $product = $orderItem->product;
+        $data = $product->typeMappings()[$product->getKey()];
+        $orderItem->order->user->profileBanners()->create([
+            'tournament_id' => $data['tournament_id'],
+            'country_acronym' => $data['player'],
+        ]);
+    }
+
+    protected function revokeBanner(OrderItem $orderItem)
+    {
+        $product = $orderItem->product;
+        $data = $product->typeMappings()[$product->getKey()];
+        // just any matching banner
+        $orderItem->order->user
+            ->profileBanners()
+            ->where('tournament_id', $data['tournament_id'])
+            ->where('country_acronym', $data['player'])
+            ->first()
+            ?->delete();
+    }
+}

--- a/database/migrations/2026_05_19_000000_change_banner_country_acronyms_to_varchar.php
+++ b/database/migrations/2026_05_19_000000_change_banner_country_acronyms_to_varchar.php
@@ -1,0 +1,35 @@
+<?php
+
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('osu_profile_banners', function (Blueprint $table) {
+            $table->string('country_acronym', 255)->change();
+        });
+
+        Schema::table('tournament_banners', function (Blueprint $table) {
+            $table->string('winner_country_acronym', 255)->change();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('osu_profile_banners', function (Blueprint $table) {
+            $table->char('country_acronym', 2)->change();
+        });
+
+        Schema::table('tournament_banners', function (Blueprint $table) {
+            $table->char('winner_country_acronym', 2)->change();
+        });
+    }
+};


### PR DESCRIPTION
Called it player supporter because that's what the data is keyed as.
Other clean ups can come later, including remapping the type mapping field name into something more generic...

- [x] change `custom_class` values on production to `player-supporter` 