### PR TITLE
Preload difficulty ratings for user score api

### DIFF
--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -19,6 +19,7 @@ use App\Models\Beatmap;
 use App\Models\BeatmapDiscussion;
 use App\Models\IpBan;
 use App\Models\Log;
+use App\Models\Solo\Score;
 use App\Models\User;
 use App\Models\UserAccountHistory;
 use App\Models\UserAchievement;
@@ -847,6 +848,7 @@ class UsersController extends Controller
                     $offset,
                     ScoreTransformer::USER_PROFILE_INCLUDES_PRELOAD
                 );
+                Score::preloadDifficultyRatings($collection, $this->mode);
                 $userRelationColumn = 'user';
                 break;
             case 'scoresFirsts':
@@ -858,7 +860,7 @@ class UsersController extends Controller
                     ->with(prefix_strings('score.', ScoreTransformer::USER_PROFILE_INCLUDES_PRELOAD))
                     ->orderByDesc('score_id');
                 $userRelationColumn = 'user';
-                $collectionFn = fn ($scoreFirst) => $scoreFirst->map->score;
+                $collectionFn = fn ($scoreFirst) => Score::preloadDifficultyRatings($scoreFirst->map->score, $this->mode);
                 break;
             case 'scoresPinned':
                 $transformer = new ScoreTransformer();
@@ -869,7 +871,7 @@ class UsersController extends Controller
                     ->withVisibleScore()
                     ->with(array_map(fn ($include) => "score.{$include}", ScoreTransformer::USER_PROFILE_INCLUDES_PRELOAD))
                     ->reorderBy('display_order', 'asc');
-                $collectionFn = fn ($pins) => $pins->map->score;
+                $collectionFn = fn ($pins) => Score::preloadDifficultyRatings($pins->map->score, $this->mode);
                 $userRelationColumn = 'user';
                 break;
             case 'scoresRecent':
@@ -880,6 +882,7 @@ class UsersController extends Controller
                     ->reorderBy('ended_at', 'desc')
                     ->with(ScoreTransformer::USER_PROFILE_INCLUDES_PRELOAD);
                 $userRelationColumn = 'user';
+                $collectionFn = fn ($scores) => Score::preloadDifficultyRatings($scores, $this->mode);
                 break;
         }
 

--- a/app/Models/Solo/Score.php
+++ b/app/Models/Solo/Score.php
@@ -28,6 +28,7 @@ use App\Models\Traits;
 use App\Models\User;
 use Carbon\CarbonImmutable;
 use Illuminate\Database\Eloquent\Builder;
+use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Relations\MorphTo;
 use LaravelRedis;
 
@@ -143,6 +144,30 @@ class Score extends Model implements Traits\ReportableInterface
         $params['ranked'] = $params['passed'] && $beatmap !== null && $beatmap->approved > 0;
 
         return $params;
+    }
+
+    public static function preloadDifficultyRatings(Collection $scores, string $rulesetName): Collection
+    {
+        // Technically the ruleset can be derived from the scores but the
+        // parameter should imply that the scores must have uniform ruleset.
+        $rulesetId = Beatmap::MODES[$rulesetName];
+
+        if ($rulesetId !== 0) {
+            $preload = false;
+            foreach ($scores as $score) {
+                if ($score->beatmap->playmode !== $rulesetId) {
+                    $preload = true;
+                    break;
+                }
+            }
+            if ($preload) {
+                $scores->loadMissing([
+                    'beatmap.baseDifficultyRatings' => fn ($q) => $q->where('mode', $rulesetId),
+                ]);
+            }
+        }
+
+        return $scores;
     }
 
     public function beatmap()


### PR DESCRIPTION
The score transformer automatically sets `convert` field for beatmap transformer accordingly. The beatmap transformer contains `difficulty_rating` field which creates an extra query to beatmap difficulty table when the `convert` field is set to true.

<sub>and the value isn't even used for display in osu-web ha ha ha... &lt;_&lt;</sub>