### PR TITLE
Fix datadog key for screenshots

### DIFF
--- a/app/Http/Controllers/ScreenshotsController.php
+++ b/app/Http/Controllers/ScreenshotsController.php
@@ -24,7 +24,7 @@ class ScreenshotsController extends Controller
             ],
         ]);
 
-        datadog_increment('osu.screenshots');
+        \Datadog::increment('osu.screenshots');
 
         $screenshot = Screenshot::create(['user_id' => \Auth::user()->getKey()]);
         $screenshot->store($validated['screenshot']);


### PR DESCRIPTION
This should be the same as in legacy system and not have the osu web prefix.