### PR TITLE
Fix rank value on user profile's ranked play

### DIFF
--- a/app/Models/MatchmakingUserStats.php
+++ b/app/Models/MatchmakingUserStats.php
@@ -57,6 +57,7 @@ class MatchmakingUserStats extends Model
             ->newQuery()
             ->from($this->tableName(true), 'mus')
             ->selectRaw('COUNT(*) + 1')
+            ->where('plays', '>', 0)
             ->whereColumn('rating', '>', $query->qualifyColumn('rating'))
             ->whereColumn('pool_id', '=', $query->qualifyColumn('pool_id'));
 


### PR DESCRIPTION
The `plays > 0` check is required because the rating doesn't start from 0 and thus it affects the rank value if not filtered out.