### PR TITLE
Update Polish translations

### DIFF
--- a/resources/lang/pl/rankings.php
+++ b/resources/lang/pl/rankings.php
@@ -66,7 +66,7 @@ return [
         'daily_challenge' => 'wyzwanie dnia',
         'global' => 'globalny',
         'kudosu' => 'kudosu',
-        'matchmaking' => 'szybka gra',
+        'matchmaking' => 'gra rankingowa',
         'playlists' => 'playlisty',
         'team' => 'zespołów',
         'top_plays' => 'najlepsze wyniki',

--- a/resources/lang/pl/users.php
+++ b/resources/lang/pl/users.php
@@ -475,7 +475,7 @@ return [
         ],
 
         'matchmaking' => [
-            'title' => 'Szybka Gra',
+            'title' => 'Gra Rankingowa',
         ],
 
         'not_found' => [


### PR DESCRIPTION
This PR changes the translations to ranked play in Polish, as it's currently quick play (and quick play doesn't exist anymore)
The translation is present in the client, but the website still says quick play.