### PR TITLE
Fix User indexing with duplicate previous_username entries

### DIFF
--- a/app/Models/Traits/Es/UserSearch.php
+++ b/app/Models/Traits/Es/UserSearch.php
@@ -31,7 +31,7 @@ trait UserSearch
         return match ($field) {
             'id' => $this->getKey(),
             'is_old' => $this->isOld(),
-            'previous_usernames' => $this->previousUsernames(true)->unique()->all(),
+            'previous_usernames' => $this->previousUsernames(true)->unique()->values()->all(),
             'user_lastvisit' => $this->displayed_last_visit,
             'groups' => $this->userGroups->pluck('group_id')->all(),
             default => $this->$field,


### PR DESCRIPTION
`['a', 'b', 'c', 'c']->unique() = ['a', 'b', 'c']`
`['a', 'b', 'b', 'c']->unique() = [0 => 'a', 1 => 'b', 3 => 'c']` the associative array is not valid for indexing
