### PR TITLE
Send notifications to participants of a Beatmap Discussion on replies

### DIFF
--- a/app/Jobs/Notifications/BeatmapsetDiscussionPostNew.php
+++ b/app/Jobs/Notifications/BeatmapsetDiscussionPostNew.php
@@ -15,9 +15,21 @@ class BeatmapsetDiscussionPostNew extends BeatmapsetDiscussionPostNotification
         $userIds = $this->beatmapsetDiscussionPost->beatmapset->watches()->pluck('user_id');
 
         $discussion = $this->beatmapsetDiscussionPost->beatmapDiscussion;
-        if ($discussion->canBeResolved() && $discussion->user_id !== null) {
-            if ($discussion->user?->notificationOptions()->where('name', static::NOTIFICATION_OPTION_NAME)->first()?->details[UserNotificationOption::BEATMAPSET_DISCUSSION_REPLY] ?? true) {
-                $userIds->push($discussion->user_id);
+        if ($discussion->canBeResolved()) {
+            // Avoid loading user models.
+            $participantIds = $discussion->beatmapDiscussionPosts->pluck('user_id');
+            $notificationOptionsByUserId = UserNotificationOption
+                ::where(['name' => static::NOTIFICATION_OPTION_NAME])
+                ->whereIn('user_id', $participantIds)
+                ->whereNotNull('details')
+                ->get()
+                ->keyBy('user_id');
+
+            foreach ($participantIds as $participantId) {
+                $option = $notificationOptionsByUserId[$participantId] ?? null;
+                if ($option?->details[UserNotificationOption::BEATMAPSET_DISCUSSION_REPLY] ?? true) {
+                    $userIds->push($participantId);
+                }
             }
         }
 

--- a/database/factories/BeatmapDiscussionFactory.php
+++ b/database/factories/BeatmapDiscussionFactory.php
@@ -7,6 +7,8 @@ namespace Database\Factories;
 
 use App\Models\BeatmapDiscussion;
 use App\Models\BeatmapDiscussionPost;
+use App\Models\Beatmapset;
+use App\Models\User;
 
 class BeatmapDiscussionFactory extends Factory
 {
@@ -28,11 +30,25 @@ class BeatmapDiscussionFactory extends Factory
 
     protected $model = BeatmapDiscussion::class;
 
+    public function configure(): static
+    {
+        return $this->afterCreating(
+            fn (BeatmapDiscussion $discussion) => $discussion->beatmapDiscussionPosts()->save(
+                BeatmapDiscussionPost::factory()->state(['user_id' => $discussion->user_id])->make()
+            )
+        );
+    }
+
     public function definition(): array
     {
-        return array_merge(array_rand_val(static::DEFAULTS), [
+
+
+        return [
+            ...array_rand_val(static::DEFAULTS),
+            'beatmapset_id' => Beatmapset::factory(),
             'resolved' => false,
-        ]);
+            'user_id' => User::factory(),
+        ];
     }
 
     public function general()
@@ -63,13 +79,5 @@ class BeatmapDiscussionFactory extends Factory
     public function timeline()
     {
         return $this->state(static::DEFAULTS['timeline']);
-    }
-
-    public function withStarter()
-    {
-        return $this->has(BeatmapDiscussionPost::factory()
-            ->state(fn (array $attr, BeatmapDiscussion $discussion) => [
-                'user_id' => $discussion->user_id,
-            ]));
     }
 }

--- a/database/factories/BeatmapDiscussionFactory.php
+++ b/database/factories/BeatmapDiscussionFactory.php
@@ -6,6 +6,7 @@
 namespace Database\Factories;
 
 use App\Models\BeatmapDiscussion;
+use App\Models\BeatmapDiscussionPost;
 
 class BeatmapDiscussionFactory extends Factory
 {
@@ -62,5 +63,13 @@ class BeatmapDiscussionFactory extends Factory
     public function timeline()
     {
         return $this->state(static::DEFAULTS['timeline']);
+    }
+
+    public function withStarter()
+    {
+        return $this->has(BeatmapDiscussionPost::factory()
+            ->state(fn (array $attr, BeatmapDiscussion $discussion) => [
+                'user_id' => $discussion->user_id,
+            ]));
     }
 }

--- a/tests/Libraries/BeatmapsetDiscussion/ReplyTest.php
+++ b/tests/Libraries/BeatmapsetDiscussion/ReplyTest.php
@@ -44,7 +44,7 @@ class ReplyTest extends TestCase
         ];
     }
 
-    public static function dataProviderForReplyQueuesNotificationToStarter(): array
+    public static function dataProviderForReplyQueuesNotification(): array
     {
         return [
             ['praise', false],
@@ -112,6 +112,7 @@ class ReplyTest extends TestCase
         ]);
         $discussion = BeatmapDiscussion::factory()
             ->general()
+            ->withStarter()
             ->for($this->beatmapsetFactory())
             ->create(['user_id' => $this->mapper]);
 
@@ -134,13 +135,64 @@ class ReplyTest extends TestCase
         );
     }
 
-    #[DataProvider('dataProviderForReplyQueuesNotificationToStarter')]
+    #[DataProvider('dataProviderForReplyQueuesNotification')]
+    public function testReplyParticipants(string $messageType, bool $includeOthers)
+    {
+        $user = User::factory()->create()->markSessionVerified();
+        $usersNotificationEnabled = User::factory()->count(3)->create();
+        $userNotificationDisabled = User::factory()->create();
+        $userNotificationDisabled->notificationOptions()->create([
+            'name' => UserNotificationOption::BEATMAPSET_MODDING,
+            'details' => ['push' => false],
+        ]);
+        $userReplyDisabled = User::factory()->create();
+        $userReplyDisabled->notificationOptions()->create([
+            'name' => UserNotificationOption::BEATMAPSET_MODDING,
+            'details' => ['push' => true, UserNotificationOption::BEATMAPSET_DISCUSSION_REPLY => false],
+        ]);
+        $participants = $listeners = [...$usersNotificationEnabled, $userNotificationDisabled, $userReplyDisabled];
+
+        $discussion = BeatmapDiscussion::factory()->general()->create([
+            'beatmapset_id' => $this->beatmapsetFactory(),
+            'message_type' => $messageType,
+            'user_id' => $participants[0]->getKey(),
+        ]);
+        foreach ($participants as $participant) {
+            $discussion->beatmapDiscussionPosts()->create([
+                'user_id' => $participant->getKey(),
+                'message' => static::TEST_MESSAGE,
+            ]);
+        }
+
+        new Reply($user, $discussion, static::TEST_MESSAGE)->handle();
+
+        $listeners = $includeOthers ? [...$usersNotificationEnabled, $userNotificationDisabled] : [];
+        Queue::assertPushed(
+            BeatmapsetDiscussionPostNew::class,
+            fn (BeatmapsetDiscussionPostNew $job) => $this->assertReceivers($job, $listeners)
+        );
+
+        $this->runFakeQueue();
+
+        if ($includeOthers) {
+            Event::assertDispatched(
+                NewPrivateNotificationEvent::class,
+                fn (NewPrivateNotificationEvent $event) =>
+                    $event->notification->name === Notification::BEATMAPSET_DISCUSSION_POST_NEW
+                    && $this->assertReceivers($event, $usersNotificationEnabled)
+            );
+        } else {
+            Event::assertNotDispatched(NewPrivateNotificationEvent::class);
+        }
+    }
+
+    #[DataProvider('dataProviderForReplyQueuesNotification')]
     public function testReplyQueuesNotificationToStarter(string $messageType, bool $includeStarter)
     {
         $user = User::factory()->create()->markSessionVerified();
         $starter = User::factory()->create();
 
-        $discussion = BeatmapDiscussion::factory()->general()->create([
+        $discussion = $this->discussionFactory()->general()->create([
             'beatmapset_id' => $this->beatmapsetFactory(),
             'message_type' => $messageType,
             'user_id' => $starter,
@@ -163,7 +215,7 @@ class ReplyTest extends TestCase
             'details' => [UserNotificationOption::BEATMAPSET_DISCUSSION_REPLY => false],
         ]);
 
-        $discussion = BeatmapDiscussion::factory()->general()->create([
+        $discussion = $this->discussionFactory()->general()->create([
             'beatmapset_id' => $this->beatmapsetFactory(),
             'message_type' => 'problem',
             'user_id' => $starter,
@@ -183,7 +235,7 @@ class ReplyTest extends TestCase
     public function testReplyResolvedDiscussion(?string $group)
     {
         $user = User::factory()->withGroup($group)->create()->markSessionVerified();
-        $discussion = BeatmapDiscussion::factory()->general()->problem()->create([
+        $discussion = $this->discussionFactory()->general()->problem()->create([
             'beatmapset_id' => $this->beatmapsetFactory(),
             'resolved' => true,
             'user_id' => User::factory(),
@@ -202,7 +254,7 @@ class ReplyTest extends TestCase
     public function testReplyUnresolvedDiscussion(?string $group)
     {
         $user = User::factory()->withGroup($group)->create()->markSessionVerified();
-        $discussion = BeatmapDiscussion::factory()->general()->problem()->create([
+        $discussion = $this->discussionFactory()->general()->problem()->create([
             'beatmapset_id' => $this->beatmapsetFactory(),
             'resolved' => false,
             'user_id' => User::factory(),
@@ -221,7 +273,7 @@ class ReplyTest extends TestCase
     public function testResolveDiscussionByStarter(string $messageType, bool $expected)
     {
         $user = User::factory()->create()->markSessionVerified();
-        $discussion = BeatmapDiscussion::factory()->general()->create([
+        $discussion = $this->discussionFactory()->general()->create([
             'beatmapset_id' => $this->beatmapsetFactory(),
             'message_type' => $messageType,
             'user_id' => $user,
@@ -244,7 +296,7 @@ class ReplyTest extends TestCase
     public function testResolveDiscussionByMapper(string $state, bool $expected)
     {
         $starter = User::factory()->create();
-        $discussion = BeatmapDiscussion::factory()->general()->problem()->create([
+        $discussion = $this->discussionFactory()->general()->problem()->create([
             'beatmapset_id' => $this->beatmapsetFactory()->$state(),
             'user_id' => $starter,
         ]);
@@ -268,7 +320,7 @@ class ReplyTest extends TestCase
         $user = User::factory()->create()->markSessionVerified();
         $beatmapset = $this->beatmapsetFactory()->$state()->create(['user_id' => $user]);
         $beatmap = $beatmapset->beatmaps->first();
-        $discussion = BeatmapDiscussion::factory()->general()->problem()->create([
+        $discussion = $this->discussionFactory()->general()->problem()->create([
             'beatmap_id' => $beatmap,
             'beatmapset_id' => $beatmapset,
             'user_id' => User::factory(),
@@ -291,7 +343,7 @@ class ReplyTest extends TestCase
     public function testResolveDiscussionByOtherUsers(?string $group, bool $expected)
     {
         $user = User::factory()->withGroup($group)->create()->markSessionVerified();
-        $discussion = BeatmapDiscussion::factory()->general()->problem()->create([
+        $discussion = $this->discussionFactory()->general()->problem()->create([
             'beatmapset_id' => $this->beatmapsetFactory(),
             'user_id' => User::factory(),
         ]);
@@ -319,7 +371,7 @@ class ReplyTest extends TestCase
             ->$state()
             ->create();
 
-        $discussion = BeatmapDiscussion::factory()->general()->problem()->create([
+        $discussion = $this->discussionFactory()->general()->problem()->create([
             'beatmapset_id' => $beatmapset,
             'resolved' => true,
             'user_id' => User::factory(),
@@ -339,7 +391,7 @@ class ReplyTest extends TestCase
     public function testReopenResolvedDiscussionByMapper()
     {
         $beatmapset = $this->beatmapsetFactory()->qualified()->create();
-        $discussion = BeatmapDiscussion::factory()->general()->problem()->create([
+        $discussion = $this->discussionFactory()->general()->problem()->create([
             'beatmapset_id' => $beatmapset,
             'resolved' => true,
             'user_id' => $this->mapper,
@@ -360,7 +412,7 @@ class ReplyTest extends TestCase
     {
         $user = User::factory()->create()->markSessionVerified();
         $beatmapset = $this->beatmapsetFactory()->qualified()->create();
-        $discussion = BeatmapDiscussion::factory()->general()->problem()->create([
+        $discussion = $this->discussionFactory()->general()->problem()->create([
             'beatmapset_id' => $beatmapset,
             'resolved' => true,
             'user_id' => $user,
@@ -382,7 +434,7 @@ class ReplyTest extends TestCase
     {
         $user = User::factory()->withGroup($group)->create()->markSessionVerified();
 
-        $discussion = BeatmapDiscussion::factory()->general()->mapperNote()->create([
+        $discussion = $this->discussionFactory()->general()->mapperNote()->create([
             'beatmapset_id' => $this->beatmapsetFactory(),
             'user_id' => $this->mapper,
         ]);
@@ -397,7 +449,7 @@ class ReplyTest extends TestCase
 
     public function testRequestingSameResolveStateDoesNotChangeResovled()
     {
-        $discussion = BeatmapDiscussion::factory()->general()->problem()->create([
+        $discussion = $this->discussionFactory()->general()->problem()->create([
             'beatmapset_id' => $this->beatmapsetFactory(),
             'resolved' => true,
             'user_id' => $this->mapper,
@@ -437,6 +489,11 @@ class ReplyTest extends TestCase
             ], $beatmapState)));
 
         return $factory;
+    }
+
+    private function discussionFactory()
+    {
+        return BeatmapDiscussion::factory()->withStarter();
     }
 
     private function getSystemPosts(array $posts, BeatmapDiscussion $discussion)

--- a/tests/Libraries/BeatmapsetDiscussion/ReplyTest.php
+++ b/tests/Libraries/BeatmapsetDiscussion/ReplyTest.php
@@ -112,7 +112,6 @@ class ReplyTest extends TestCase
         ]);
         $discussion = BeatmapDiscussion::factory()
             ->general()
-            ->withStarter()
             ->for($this->beatmapsetFactory())
             ->create(['user_id' => $this->mapper]);
 
@@ -192,7 +191,7 @@ class ReplyTest extends TestCase
         $user = User::factory()->create()->markSessionVerified();
         $starter = User::factory()->create();
 
-        $discussion = $this->discussionFactory()->general()->create([
+        $discussion = BeatmapDiscussion::factory()->general()->create([
             'beatmapset_id' => $this->beatmapsetFactory(),
             'message_type' => $messageType,
             'user_id' => $starter,
@@ -215,7 +214,7 @@ class ReplyTest extends TestCase
             'details' => [UserNotificationOption::BEATMAPSET_DISCUSSION_REPLY => false],
         ]);
 
-        $discussion = $this->discussionFactory()->general()->create([
+        $discussion = BeatmapDiscussion::factory()->general()->create([
             'beatmapset_id' => $this->beatmapsetFactory(),
             'message_type' => 'problem',
             'user_id' => $starter,
@@ -235,7 +234,7 @@ class ReplyTest extends TestCase
     public function testReplyResolvedDiscussion(?string $group)
     {
         $user = User::factory()->withGroup($group)->create()->markSessionVerified();
-        $discussion = $this->discussionFactory()->general()->problem()->create([
+        $discussion = BeatmapDiscussion::factory()->general()->problem()->create([
             'beatmapset_id' => $this->beatmapsetFactory(),
             'resolved' => true,
             'user_id' => User::factory(),
@@ -254,7 +253,7 @@ class ReplyTest extends TestCase
     public function testReplyUnresolvedDiscussion(?string $group)
     {
         $user = User::factory()->withGroup($group)->create()->markSessionVerified();
-        $discussion = $this->discussionFactory()->general()->problem()->create([
+        $discussion = BeatmapDiscussion::factory()->general()->problem()->create([
             'beatmapset_id' => $this->beatmapsetFactory(),
             'resolved' => false,
             'user_id' => User::factory(),
@@ -273,7 +272,7 @@ class ReplyTest extends TestCase
     public function testResolveDiscussionByStarter(string $messageType, bool $expected)
     {
         $user = User::factory()->create()->markSessionVerified();
-        $discussion = $this->discussionFactory()->general()->create([
+        $discussion = BeatmapDiscussion::factory()->general()->create([
             'beatmapset_id' => $this->beatmapsetFactory(),
             'message_type' => $messageType,
             'user_id' => $user,
@@ -296,7 +295,7 @@ class ReplyTest extends TestCase
     public function testResolveDiscussionByMapper(string $state, bool $expected)
     {
         $starter = User::factory()->create();
-        $discussion = $this->discussionFactory()->general()->problem()->create([
+        $discussion = BeatmapDiscussion::factory()->general()->problem()->create([
             'beatmapset_id' => $this->beatmapsetFactory()->$state(),
             'user_id' => $starter,
         ]);
@@ -320,7 +319,7 @@ class ReplyTest extends TestCase
         $user = User::factory()->create()->markSessionVerified();
         $beatmapset = $this->beatmapsetFactory()->$state()->create(['user_id' => $user]);
         $beatmap = $beatmapset->beatmaps->first();
-        $discussion = $this->discussionFactory()->general()->problem()->create([
+        $discussion = BeatmapDiscussion::factory()->general()->problem()->create([
             'beatmap_id' => $beatmap,
             'beatmapset_id' => $beatmapset,
             'user_id' => User::factory(),
@@ -343,7 +342,7 @@ class ReplyTest extends TestCase
     public function testResolveDiscussionByOtherUsers(?string $group, bool $expected)
     {
         $user = User::factory()->withGroup($group)->create()->markSessionVerified();
-        $discussion = $this->discussionFactory()->general()->problem()->create([
+        $discussion = BeatmapDiscussion::factory()->general()->problem()->create([
             'beatmapset_id' => $this->beatmapsetFactory(),
             'user_id' => User::factory(),
         ]);
@@ -371,7 +370,7 @@ class ReplyTest extends TestCase
             ->$state()
             ->create();
 
-        $discussion = $this->discussionFactory()->general()->problem()->create([
+        $discussion = BeatmapDiscussion::factory()->general()->problem()->create([
             'beatmapset_id' => $beatmapset,
             'resolved' => true,
             'user_id' => User::factory(),
@@ -391,7 +390,7 @@ class ReplyTest extends TestCase
     public function testReopenResolvedDiscussionByMapper()
     {
         $beatmapset = $this->beatmapsetFactory()->qualified()->create();
-        $discussion = $this->discussionFactory()->general()->problem()->create([
+        $discussion = BeatmapDiscussion::factory()->general()->problem()->create([
             'beatmapset_id' => $beatmapset,
             'resolved' => true,
             'user_id' => $this->mapper,
@@ -412,7 +411,7 @@ class ReplyTest extends TestCase
     {
         $user = User::factory()->create()->markSessionVerified();
         $beatmapset = $this->beatmapsetFactory()->qualified()->create();
-        $discussion = $this->discussionFactory()->general()->problem()->create([
+        $discussion = BeatmapDiscussion::factory()->general()->problem()->create([
             'beatmapset_id' => $beatmapset,
             'resolved' => true,
             'user_id' => $user,
@@ -434,7 +433,7 @@ class ReplyTest extends TestCase
     {
         $user = User::factory()->withGroup($group)->create()->markSessionVerified();
 
-        $discussion = $this->discussionFactory()->general()->mapperNote()->create([
+        $discussion = BeatmapDiscussion::factory()->general()->mapperNote()->create([
             'beatmapset_id' => $this->beatmapsetFactory(),
             'user_id' => $this->mapper,
         ]);
@@ -449,7 +448,7 @@ class ReplyTest extends TestCase
 
     public function testRequestingSameResolveStateDoesNotChangeResovled()
     {
-        $discussion = $this->discussionFactory()->general()->problem()->create([
+        $discussion = BeatmapDiscussion::factory()->general()->problem()->create([
             'beatmapset_id' => $this->beatmapsetFactory(),
             'resolved' => true,
             'user_id' => $this->mapper,
@@ -489,11 +488,6 @@ class ReplyTest extends TestCase
             ], $beatmapState)));
 
         return $factory;
-    }
-
-    private function discussionFactory()
-    {
-        return BeatmapDiscussion::factory()->withStarter();
     }
 
     private function getSystemPosts(array $posts, BeatmapDiscussion $discussion)


### PR DESCRIPTION
Sends notifications to all participants of problem or suggestion type Beatmap Discussions, not just the starter.
This is based on the reason the reasoning that if you are replying to a discussion, you are probably involved in it (and doesn't involve adding a watch toggle to every discussion).

~~Also made some of the tests more strict and give more information when the expected receiver ids don't match (because the `Event` and `Queue` assertions don't tell you much which makes find it out annoying...)~~ separated into #13044

closes #12885

- [x] #13057
