### PR TITLE
Add index for Passport's findValidToken

### DIFF
--- a/database/migrations/2026_05_29_000000_add_passport_find_valid_token_index.php
+++ b/database/migrations/2026_05_29_000000_add_passport_find_valid_token_index.php
@@ -1,0 +1,27 @@
+<?php
+
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('oauth_access_tokens', function (Blueprint $table) {
+            $table->index(['user_id', 'client_id', 'revoked', 'expires_at'], 'passport_find_valid_token_index');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('oauth_access_tokens', function (Blueprint $table) {
+            $table->dropIndex('passport_find_valid_token_index');
+        });
+    }
+};


### PR DESCRIPTION
this gets called via Passport during OAuth auth_code requests
```php
    public function findValidToken($user, $client)
    {
        return $client->tokens()
                      ->whereUserId($user->getAuthIdentifier())
                      ->where('revoked', 0)
                      ->where('expires_at', '>', Carbon::now())
                      ->latest('expires_at')
                      ->first();
    }
```