### PR TITLE
Adjust paddings of user ranking on profile page

### DIFF
--- a/resources/css/bem/rank-value.less
+++ b/resources/css/bem/rank-value.less
@@ -6,9 +6,6 @@
   --font-weight: bold;
   .fancy-text(var(--colour));
   font-weight: var(--font-weight);
-  // allow the fancy text to fill the characters overflowing to descender part
-  padding-bottom: 0.2em;
-  margin-bottom: -$padding-bottom;
 
   &--base {
     --font-weight: 400;

--- a/resources/css/bem/value-display.less
+++ b/resources/css/bem/value-display.less
@@ -9,6 +9,7 @@
   --value-color: hsl(var(--hsl-c1));
   --value-font-size-desktop: @font-size--title-small-4;
   --value-font-size: @font-size--title;
+  --value-margin-top: 0;
   display: flex;
   flex-direction: column;
   min-width: 60px;
@@ -43,6 +44,7 @@
     --value-color: hsl(var(--hsl-c2));
     --value-font-size-desktop: @font-size--new-header-title;
     --value-font-size: @font-size--large;
+    --value-margin-top: -0.1em;
 
     @media @desktop {
       flex: none;
@@ -85,5 +87,6 @@
     color: var(--value-color);
     font-size: var(--value-font-size);
     font-weight: 300;
+    margin-top: var(--value-margin-top);
   }
 }


### PR DESCRIPTION
The original margin/padding dance isn't relevant anymore with the line height being reverted back to 1.2 because of u-ellipsis-overflow being applied to the value container.

This also resulted in different text gradient display (not quite sure which one is more correct).

As an extra, add negative top margin for the value so it's not too far apart with the label. It's also kind of required for the new ranked play version.

before
![](https://s.kohaku.love/2026/06/firefox_2026-06-02_19-14-56.png)

after
![](https://s.kohaku.love/2026/06/firefox_2026-06-02_19-15-24.png)