### PR TITLE
Add missing preload for user modding history page

### DIFF
--- a/app/Http/Controllers/Users/ModdingHistoryController.php
+++ b/app/Http/Controllers/Users/ModdingHistoryController.php
@@ -92,7 +92,7 @@ class ModdingHistoryController extends Controller
             $search['query']->with([
                 'user',
                 'beatmapDiscussion',
-                'beatmapDiscussion.user',
+                'beatmapDiscussion.user.userGroups',
                 'beatmapDiscussion.beatmapset',
                 'beatmapDiscussion.startingPost',
             ])->get(),


### PR DESCRIPTION
The page itself isn't linked from anywhere 😬 (maybe a "show details" link in the relevant profile page's modding section?)