### PR TITLE
Fix `rank` function and attribute conflict

### DIFF
--- a/app/Models/MatchmakingUserStats.php
+++ b/app/Models/MatchmakingUserStats.php
@@ -74,9 +74,9 @@ class MatchmakingUserStats extends Model
         return $this->elo_data['approximate_posterior']['sig'] >= static::MIN_SIG_PROVISIONAL;
     }
 
-    public function rank(): int
+    public function getRank(): int
     {
-        return 1 + static::default()
+        return $this->attributes['rank'] ?? 1 + static::default()
             ->where('rating', '>', $this->rating)
             ->where('pool_id', $this->pool_id)
             ->count();

--- a/app/Transformers/MatchmakingUserStatsTransformer.php
+++ b/app/Transformers/MatchmakingUserStatsTransformer.php
@@ -23,7 +23,7 @@ class MatchmakingUserStatsTransformer extends TransformerAbstract
             'is_rating_provisional' => $stats->isRatingProvisional(),
             'plays' => $stats->plays,
             'pool_id' => $stats->pool_id,
-            'rank' => $stats->rank,
+            'rank' => $stats->getRank(),
             'rating' => $stats->rating,
             'total_points' => $stats->total_points,
             'user_id' => $stats->user_id,

--- a/resources/views/rankings/matchmaking.blade.php
+++ b/resources/views/rankings/matchmaking.blade.php
@@ -54,7 +54,7 @@
         @foreach ($scores as $index => $score)
             @php
                 $rank = $index === 0
-                    ? ($firstItem === 1 ? $firstItem : $score->rank())
+                    ? ($firstItem === 1 ? $firstItem : $score->getRank())
                     : ($score->rating === $prevRating ? $prevRank : $index + $firstItem);
                 $prevRank = $rank;
                 $prevRating = $score->rating;


### PR DESCRIPTION
I made a mistake in a branch I'm working of not querying with the scope for the attribute and laravel ended up very confused with the new function and attempted to use it as relation (because the attribute isn't in the attributes array).

So that's a bad idea. Rename the function so it handles both cases.