### PR TITLE
Use app url for the base url

### DIFF
--- a/resources/views/master.blade.php
+++ b/resources/views/master.blade.php
@@ -50,7 +50,7 @@
     <head>
         @include("layout.metadata")
         <title>{!! $title !!}</title>
-        <base href="{{ Request::getSchemeAndHttpHost().Request::getRequestUri() }}" />
+        <base href="{{ $GLOBALS['cfg']['app']['url'].Request::getRequestUri() }}" />
     </head>
 
     <body


### PR DESCRIPTION
It'll be very wrong if the app url is in a subdirectory but then again the assets path already assumes the app to be installed at root...

(for my own memo, it's to remove the need of specific headers from reverse proxy)