### PR TITLE
Update matchmaking.provisional i18n value

### DIFF
--- a/resources/lang/en/rankings.php
+++ b/resources/lang/en/rankings.php
@@ -36,7 +36,7 @@ return [
     'matchmaking' => [
         'plays' => 'Plays',
         'points' => 'Points',
-        'provisional' => 'Not enough matches played to accurately determine rating',
+        'provisional' => 'Provisional rating due to an insufficient number of recent matches',
         'rating' => 'Rating',
         'wins' => 'Wins',
     ],


### PR DESCRIPTION
As discussed on [discord](https://canary.discord.com/channels/188630481301012481/1440912440224120882/1513390186669674617)

The functionality has been updated with https://github.com/ppy/osu-web/pull/12979, but the tooltip wording has not