### PR TITLE
Restructure profile page stats value formatter

### DIFF
--- a/app/Transformers/UserStatisticsTransformer.php
+++ b/app/Transformers/UserStatisticsTransformer.php
@@ -44,7 +44,7 @@ class UserStatisticsTransformer extends TransformerAbstract
             'pp' => $stats->rank_score,
             'pp_exp' => 0,
             'ranked_score' => $stats->ranked_score,
-            'hit_accuracy' => $stats->hit_accuracy,
+            'hit_accuracy' => $stats->hit_accuracy, // deprecated. Use `accuracy` field instead
             'accuracy' => $stats->accuracy_normalised,
             'play_count' => $stats->playcount,
             'play_time' => $stats->total_seconds_played,

--- a/resources/js/interfaces/user-statistics-json.ts
+++ b/resources/js/interfaces/user-statistics-json.ts
@@ -25,7 +25,7 @@ interface UserStatisticsBaseJson {
   country_rank?: number | null;
   global_rank: number | null;
   grade_counts: Record<Grade, number>;
-  hit_accuracy: number;
+  // hit_accuracy: number; // deprecated
   is_ranked: boolean;
   level: {
     current: number;

--- a/resources/js/profile-page/stats.tsx
+++ b/resources/js/profile-page/stats.tsx
@@ -37,15 +37,16 @@ export default class Stats extends React.PureComponent<Props> {
   }
 
   private formatValue(key: EntryKey) {
-    const val = key === 'hits_per_play'
-      ? getHitsPerPlay(this.props.stats)
-      : this.props.stats[key];
+    switch (key) {
+      case 'hit_accuracy':
+        return formatNumber(this.props.stats.accuracy, 2, { style: 'percent' });
 
-    if (key === 'hit_accuracy') {
-      return formatNumber(this.props.stats.accuracy, 2, { style: 'percent' });
+      case 'hits_per_play':
+        return formatNumber(getHitsPerPlay(this.props.stats));
+
+      default:
+        return formatNumber(this.props.stats[key]);
     }
-
-    return formatNumber(val);
   }
 
   private readonly renderEntry = (key: EntryKey) => (


### PR DESCRIPTION
I was about to add the additional entries for the new design but noticed the format function is a bit funny. Using switch ends up a bit redundant in term of `formatNumber` call but I think it's easier to read?

And then there's the part we still have the deprecated `hit_accuracy` field in the stats json interface. I don't know if it's worth keeping the field commented though. Might as well just remove it?