### PR TITLE
Add lazer only flag on beatmaps

### DIFF
--- a/app/Models/Beatmap.php
+++ b/app/Models/Beatmap.php
@@ -37,6 +37,7 @@ use Illuminate\Database\Eloquent\SoftDeletes;
  * @property string|null $filename
  * @property int $hit_length
  * @property \Carbon\Carbon $last_update
+ * @property bool $lazer_only
  * @property int $max_combo
  * @property mixed $mode
  * @property int $osu_file_version
@@ -61,6 +62,7 @@ class Beatmap extends Model implements AfterCommit
     protected $primaryKey = 'beatmap_id';
 
     protected $casts = [
+        'lazer_only' => 'boolean',
         'last_update' => 'datetime',
     ];
 
@@ -278,6 +280,8 @@ class Beatmap extends Model implements AfterCommit
             'total_length',
             'user_id',
             'youtube_preview' => $this->getRawAttribute($key),
+
+            'lazer_only' => (bool) $this->getRawAttribute($key),
 
             'deleted_at',
             'last_update' => $this->getTimeFast($key),

--- a/app/Transformers/BeatmapCompactTransformer.php
+++ b/app/Transformers/BeatmapCompactTransformer.php
@@ -33,6 +33,7 @@ class BeatmapCompactTransformer extends TransformerAbstract
             'beatmapset_id' => $beatmap->beatmapset_id,
             'difficulty_rating' => $beatmap->difficultyrating,
             'id' => $beatmap->beatmap_id,
+            'lazer_only' => $beatmap->lazer_only,
             'mode' => $beatmap->mode,
             'status' => $beatmap->status(),
             'total_length' => $beatmap->total_length,

--- a/database/migrations/2026_06_18_080902_add_lazer_only_to_beatmaps.php
+++ b/database/migrations/2026_06_18_080902_add_lazer_only_to_beatmaps.php
@@ -1,0 +1,27 @@
+<?php
+
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('osu_beatmaps', function (Blueprint $table) {
+            $table->boolean('lazer_only')->default(false);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('osu_beatmaps', function (Blueprint $table) {
+            $table->dropColumn('lazer_only');
+        });
+    }
+};

--- a/resources/css/bem/beatmapset-status.less
+++ b/resources/css/bem/beatmapset-status.less
@@ -17,6 +17,11 @@
     background-color: @osu-colour-b3;
   }
 
+  &--lazer-only {
+    background-color: hsl(var(--hsl-pink-1));
+    color: hsl(var(--hsl-b4));
+  }
+
   &--list-view {
     background-color: hsla(var(--hsl-b6), 0.5);
     font-size: @font-size--small;

--- a/resources/js/beatmapsets-show/main.tsx
+++ b/resources/js/beatmapsets-show/main.tsx
@@ -5,12 +5,15 @@ import Comments from 'components/comments';
 import HeaderV4 from 'components/header-v4';
 import NotificationBanner from 'components/notification-banner';
 import PlaymodeTabs from 'components/playmode-tabs';
+import StringWithComponent from 'components/string-with-component';
 import Ruleset, { rulesets } from 'interfaces/ruleset';
-import { action, autorun, computed, IReactionDisposer, makeObservable, observable } from 'mobx';
+import { action, autorun, computed, IReactionDisposer, makeObservable, observable, untracked } from 'mobx';
 import { observer } from 'mobx-react';
+import core from 'osu-core-singleton';
 import * as React from 'react';
 import { generate, setHash } from 'utils/beatmapset-page-hash';
 import { trans } from 'utils/lang';
+import { reloadPage } from 'utils/turbolinks';
 import Controller from './controller';
 import Header from './header';
 import headerLinks from './header-links';
@@ -27,6 +30,12 @@ interface Props {
 export default class Main extends React.Component<Props> {
   @observable private readonly controller: Controller;
   private setHashDisposer?: IReactionDisposer;
+
+  @computed
+  private get showEnableLazerModeLink() {
+    // enabling lazer mode requires full page reload.
+    return this.controller.currentBeatmap.lazer_only && untracked(() => core.userPreferences.get('legacy_score_only'));
+  }
 
   @computed
   private get headerLinksAppend() {
@@ -85,6 +94,19 @@ export default class Main extends React.Component<Props> {
     );
   }
 
+
+  private handleEnableLazerMode(this: void, event: React.SyntheticEvent) {
+    event.preventDefault();
+    const request = core.userPreferences.set('legacy_score_only', false);
+
+    if (request == null) {
+      // the page is in weird state
+      reloadPage();
+    } else {
+      request.done(reloadPage);
+    }
+  }
+
   @action
   private readonly onClickPlaymode = (e: React.MouseEvent, mode: Ruleset) => {
     e.preventDefault();
@@ -111,6 +133,37 @@ export default class Main extends React.Component<Props> {
     );
   }
 
+  private renderLazerOnlyMessage() {
+    return (
+      <div className='beatmapset-hype'>
+        <div className='beatmapset-hype__box beatmapset-hype__box--description'>
+          <div className='beatmapset-hype__description-row beatmapset-hype__description-row--status'>
+            <div className='beatmapset-status beatmapset-status--lazer-only'>
+              {trans('beatmapsets.show.lazer_only.title')}
+            </div>
+          </div>
+          <p className='beatmapset-hype__description-row beatmapset-hype__description-row--current'>
+            {trans('beatmapsets.show.lazer_only.description')}
+          </p>
+          {this.showEnableLazerModeLink && (
+            <p className='beatmapset-hype__description-row'>
+              <StringWithComponent
+                mappings={{
+                  enable_link: (
+                    <a href='#' onClick={this.handleEnableLazerMode}>
+                      {trans('beatmapsets.show.lazer_only.scoreboard_switch_mode.enable_link')}
+                    </a>
+                  ),
+                }}
+                pattern={trans('beatmapsets.show.lazer_only.scoreboard_switch_mode._')}
+              />
+            </p>
+          )}
+        </div>
+      </div>
+    );
+  }
+
   private renderPage() {
     return (
       <>
@@ -125,7 +178,13 @@ export default class Main extends React.Component<Props> {
               </div>
             }
 
-            {this.controller.currentBeatmap.is_scoreable &&
+            {this.controller.currentBeatmap.lazer_only && (
+              <div className='page-extra page-extra--compact'>
+                {this.renderLazerOnlyMessage()}
+              </div>
+            )}
+
+            {this.controller.currentBeatmap.is_scoreable && !this.showEnableLazerModeLink &&
               <div className='page-extra'>
                 <ScoreboardMain
                   beatmap={this.controller.currentBeatmap}

--- a/resources/js/interfaces/beatmap-json.ts
+++ b/resources/js/interfaces/beatmap-json.ts
@@ -25,6 +25,7 @@ interface BeatmapJsonDefaultAttributes {
   beatmapset_id: number;
   difficulty_rating: number;
   id: number;
+  lazer_only: boolean;
   mode: Ruleset;
   status: string;
   total_length: number;
@@ -41,6 +42,7 @@ export function deletedBeatmap(mode: Ruleset): BeatmapJson {
     beatmapset_id: 0,
     difficulty_rating: 0,
     id: 0,
+    lazer_only: false,
     mode,
     status: '',
     total_length: 0,

--- a/resources/lang/en/beatmapsets.php
+++ b/resources/lang/en/beatmapsets.php
@@ -156,6 +156,16 @@ return [
             'video' => 'This beatmap contains video',
         ],
 
+        'lazer_only' => [
+            'title' => 'Lazer Only',
+            'description' => 'Due to specific mechanics, this beatmap can only be played on osu!lazer.',
+
+            'scoreboard_switch_mode' => [
+                '_' => ':enable_link to view scores set on this beatmap.',
+                'enable_link' => 'Enable lazer mode',
+            ],
+        ],
+
         'nsfw_warning' => [
             'details' => 'This beatmap contains explicit, offensive, or disturbing content. Would you like to view it anyway?',
             'title' => 'Explicit Content',


### PR DESCRIPTION
Dunno if the switch mode message should be in the box or in the scoreboard. And if the scoreboard should show the tabs and mods selector if the message is in scoreboard.

Switching lazer mode currently requires full page reload.

![](https://s.kohaku.love/2026/06/firefox_2026-06-19_15-04-06.png)