### PR TITLE
Add styled alerts to markdown

### DIFF
--- a/app/Libraries/Markdown/OsuMarkdown.php
+++ b/app/Libraries/Markdown/OsuMarkdown.php
@@ -379,7 +379,19 @@ class OsuMarkdown
                 'class' => "{$blockClass}__paragraph",
             ],
             StyleBlock\Element::class => [
-                'class' => static fn (StyleBlock\Element $node) => "{$blockClass}__{$node->getClassName()}",
+                'class' => static function (StyleBlock\Element $node) use ($blockClass) {
+                    $className = $node->getClassName();
+
+                    if (starts_with($className, 'alert-')) {
+                        $type = explode('-', $className)[1] ?? null;
+
+                        if ($type !== null) {
+                            return class_with_modifiers("{$blockClass}__alert", [$type]);
+                        }
+                    }
+
+                    return "{$blockClass}__{$className}";
+                },
             ],
             Table::class => [
                 'class' => "{$blockClass}__table",

--- a/app/Libraries/Markdown/OsuMarkdown.php
+++ b/app/Libraries/Markdown/OsuMarkdown.php
@@ -382,11 +382,11 @@ class OsuMarkdown
                 'class' => static function (StyleBlock\Element $node) use ($blockClass) {
                     $className = $node->getClassName();
 
-                    if (starts_with($className, 'alert-')) {
-                        $type = explode('-', $className)[1] ?? null;
+                    if (str_starts_with($className, 'alert-')) {
+                        $type = explode('-', $className, 2)[1] ?? null;
 
                         if ($type !== null) {
-                            return class_with_modifiers("{$blockClass}__alert", [$type]);
+                            return class_with_modifiers("{$blockClass}__alert", $type);
                         }
                     }
 

--- a/app/Libraries/Markdown/OsuMarkdown.php
+++ b/app/Libraries/Markdown/OsuMarkdown.php
@@ -30,7 +30,7 @@ class OsuMarkdown
 {
     use Memoizes;
 
-    const VERSION = 14;
+    const VERSION = 15;
 
     const DEFAULT_COMMONMARK_CONFIG = [
         'allow_unsafe_links' => false,
@@ -96,6 +96,13 @@ class OsuMarkdown
                 'fix_wiki_url' => true,
                 'generate_toc' => true,
                 'record_first_image' => true,
+                'style_block_allowed_classes' => [
+                    'alert-caution',
+                    'alert-note',
+                    'alert-notice',
+                    'alert-tip',
+                    'alert-warning',
+                ],
             ],
             'osu_markdown' => [
                 'block_modifiers' => ['news'],
@@ -125,7 +132,14 @@ class OsuMarkdown
                 'custom_container_inline' => true,
                 'fix_wiki_url' => true,
                 'generate_toc' => true,
-                'style_block_allowed_classes' => ['infobox'],
+                'style_block_allowed_classes' => [
+                    'alert-caution',
+                    'alert-note',
+                    'alert-notice',
+                    'alert-tip',
+                    'alert-warning',
+                    'infobox',
+                ],
                 'title_from_document' => true,
                 'with_gallery' => true,
             ],

--- a/app/Models/Wiki/Page.php
+++ b/app/Models/Wiki/Page.php
@@ -27,7 +27,7 @@ class Page implements WikiObject
     use Memoizes, Traits\Es\WikiPageSearch;
 
     const CACHE_DURATION = 5 * 60 * 60;
-    const VERSION = 9;
+    const VERSION = 10;
 
     const TEMPLATES = [
         'markdown_page' => 'wiki.show',

--- a/resources/css/bem/osu-md.less
+++ b/resources/css/bem/osu-md.less
@@ -295,73 +295,30 @@
     }
   }
 
-  @alert-title: ~"> .@{_top}__paragraph:first-child strong:first-of-type";
-  @alert-inline-p: ~"> .@{_top}__paragraph:only-child:not(:has(> br))";
-  @alert-inline-compact: ~":not(:has(> .@{_top}__paragraph > br)):has(> .@{_top}__paragraph:only-child)";
-
-  .osu-md-alert() {
-    padding: 10px 15px;
+  &__alert {
+    padding: 5px 15px;
     margin: var(--paragraph-space) 0;
     border-left: 4px solid;
+    border-left-color: var(--alert-colour);
 
-    > .@{_top}__paragraph {
-      margin: 0;
-
-      + .@{_top}__paragraph {
-        margin-top: var(--paragraph-space);
+    @alert-types: {
+      note: @fa-var-info-circle, --hsl-blue-2;
+      tip: @fa-var-lightbulb, --hsl-lime-2;
+      notice: @fa-var-bullhorn, --hsl-pink-2;
+      warning: @fa-var-exclamation, --hsl-red-2;
+      caution: @fa-var-exclamation-triangle, --hsl-orange-2;
+    };
+    each(@alert-types, {
+      &--@{key} {
+        --alert-icon: extract(@value, 1);
+        --alert-colour: hsla(var(extract(@value, 2)), 75%);
       }
-    }
+    });
 
-    @{alert-title} {
-      display: block;
-      padding-bottom: 8px;
-      font-weight: bold;
-
-      &::before {
-        .fas();
-        .fa-fw();
-        content: var(--alert-icon);
-        margin-right: 8px;
-      }
-    }
-
-    @{alert-title} + br {
-      display: none;
-    }
-
-    @{alert-inline-p} {
-      display: inline;
-
-      strong:first-of-type {
-        display: inline;
-        padding-bottom: 0;
-      }
-    }
-
-    &@{alert-inline-compact} {
-      padding: 5px 15px;
+    &:has(.@{_top}__paragraph:not(:only-child)), &:has(br) {
+      padding: 10px 15px;
     }
   }
-
-  @alert-types: {
-    note: @fa-var-info-circle, --hsl-blue-2;
-    tip: @fa-var-lightbulb, --hsl-lime-2;
-    notice: @fa-var-bullhorn, --hsl-pink-2;
-    warning: @fa-var-exclamation, --hsl-red-2;
-    caution: @fa-var-exclamation-triangle, --hsl-orange-2;
-  };
-
-  each(@alert-types, {
-    &__alert-@{key} {
-      .osu-md-alert();
-      --alert-icon: extract(@value, 1);
-      border-left-color: hsla(var(extract(@value, 2)), 75%);
-
-      @{alert-title} {
-        color: hsla(var(extract(@value, 2)), 75%);
-      }
-    }
-  });
 
   &__link {
     &--footnote-ref {
@@ -431,6 +388,28 @@
       flex: 1;
       min-width: 0;
       line-height: inherit;
+    }
+
+    .@{_top}__alert > & {
+      &:first-child strong:first-of-type {
+        display: inline-block;
+        color: var(--alert-colour);
+
+        &:has(+ br) {
+          margin-bottom: 5px;
+        }
+
+        &::before {
+          .fas();
+          .fa-fw();
+          content: var(--alert-icon);
+          margin-right: 5px;
+        }
+      }
+
+      &:last-child {
+        margin-bottom: 0;
+      }
     }
   }
 

--- a/resources/css/bem/osu-md.less
+++ b/resources/css/bem/osu-md.less
@@ -295,6 +295,74 @@
     }
   }
 
+  @alert-title: ~"> .@{_top}__paragraph:first-child strong:first-of-type";
+  @alert-inline-p: ~"> .@{_top}__paragraph:only-child:not(:has(> br))";
+  @alert-inline-compact: ~":not(:has(> .@{_top}__paragraph > br)):has(> .@{_top}__paragraph:only-child)";
+
+  .osu-md-alert() {
+    padding: 10px 15px;
+    margin: var(--paragraph-space) 0;
+    border-left: 4px solid;
+
+    > .@{_top}__paragraph {
+      margin: 0;
+
+      + .@{_top}__paragraph {
+        margin-top: var(--paragraph-space);
+      }
+    }
+
+    @{alert-title} {
+      display: block;
+      padding-bottom: 8px;
+      font-weight: bold;
+
+      &::before {
+        .fas();
+        .fa-fw();
+        content: var(--alert-icon);
+        margin-right: 8px;
+      }
+    }
+
+    @{alert-title} + br {
+      display: none;
+    }
+
+    @{alert-inline-p} {
+      display: inline;
+
+      strong:first-of-type {
+        display: inline;
+        padding-bottom: 0;
+      }
+    }
+
+    &@{alert-inline-compact} {
+      padding: 5px 15px;
+    }
+  }
+
+  @alert-types: {
+    note: @fa-var-info-circle, --hsl-blue-2;
+    tip: @fa-var-lightbulb, --hsl-lime-2;
+    notice: @fa-var-bullhorn, --hsl-pink-2;
+    warning: @fa-var-exclamation, --hsl-red-2;
+    caution: @fa-var-exclamation-triangle, --hsl-orange-2;
+  };
+
+  each(@alert-types, {
+    &__alert-@{key} {
+      .osu-md-alert();
+      --alert-icon: extract(@value, 1);
+      border-left-color: hsla(var(extract(@value, 2)), 75%);
+
+      @{alert-title} {
+        color: hsla(var(extract(@value, 2)), 75%);
+      }
+    }
+  });
+
   &__link {
     &--footnote-ref {
       font-size: @font-size--small-2;

--- a/resources/css/bem/osu-md.less
+++ b/resources/css/bem/osu-md.less
@@ -392,7 +392,7 @@
     }
 
     .@{_top}__alert > & {
-      &:first-child strong:first-of-type {
+      &:first-child > strong:first-of-type {
         display: inline-block;
         color: var(--alert-colour);
 

--- a/resources/css/bem/osu-md.less
+++ b/resources/css/bem/osu-md.less
@@ -315,7 +315,8 @@
       }
     });
 
-    &:has(.@{_top}__paragraph:not(:only-child)), &:has(br) {
+    &:has(.@{_top}__paragraph:not(:only-child)),
+    &:has(br) {
       padding: 10px 15px;
     }
   }

--- a/tests/Libraries/Markdown/ProcessorTest.php
+++ b/tests/Libraries/Markdown/ProcessorTest.php
@@ -73,7 +73,14 @@ class ProcessorTest extends TestCase
                 osuExtensionConfig: [
                     'attributes_allowed' => ['flag', 'id'],
                     'custom_container_inline' => true,
-                    'style_block_allowed_classes' => ['class-name'],
+                    'style_block_allowed_classes' => [
+                        'alert-caution',
+                        'alert-note',
+                        'alert-notice',
+                        'alert-tip',
+                        'alert-warning',
+                        'class-name',
+                    ],
                 ],
                 osuMarkdownConfig: [
                     'enable_footnote' => true,

--- a/tests/Libraries/Markdown/html_markdown_examples/alert.html
+++ b/tests/Libraries/Markdown/html_markdown_examples/alert.html
@@ -1,23 +1,23 @@
-<div class="osu-md__alert-note">
+<div class="osu-md__alert osu-md__alert--note">
   <p class="osu-md__paragraph"><strong>Note</strong><br />Note body text.</p>
 </div>
 
-<div class="osu-md__alert-tip">
+<div class="osu-md__alert osu-md__alert--tip">
   <p class="osu-md__paragraph"><strong>Tip</strong><br />Tip body text.</p>
 </div>
 
-<div class="osu-md__alert-notice">
+<div class="osu-md__alert osu-md__alert--notice">
   <p class="osu-md__paragraph"><strong>Notice</strong><br />Notice body text.</p>
 </div>
 
-<div class="osu-md__alert-warning">
+<div class="osu-md__alert osu-md__alert--warning">
   <p class="osu-md__paragraph"><strong>Warning</strong><br />Warning body text.</p>
 </div>
 
-<div class="osu-md__alert-caution">
+<div class="osu-md__alert osu-md__alert--caution">
   <p class="osu-md__paragraph"><strong>Caution</strong><br />Caution body text.</p>
 </div>
 
-<div class="osu-md__alert-note">
+<div class="osu-md__alert osu-md__alert--note">
   <p class="osu-md__paragraph"><strong>Good to know</strong><br />Custom title body text.</p>
 </div>

--- a/tests/Libraries/Markdown/html_markdown_examples/alert.html
+++ b/tests/Libraries/Markdown/html_markdown_examples/alert.html
@@ -1,0 +1,23 @@
+<div class="osu-md__alert-note">
+  <p class="osu-md__paragraph"><strong>Note</strong><br />Note body text.</p>
+</div>
+
+<div class="osu-md__alert-tip">
+  <p class="osu-md__paragraph"><strong>Tip</strong><br />Tip body text.</p>
+</div>
+
+<div class="osu-md__alert-notice">
+  <p class="osu-md__paragraph"><strong>Notice</strong><br />Notice body text.</p>
+</div>
+
+<div class="osu-md__alert-warning">
+  <p class="osu-md__paragraph"><strong>Warning</strong><br />Warning body text.</p>
+</div>
+
+<div class="osu-md__alert-caution">
+  <p class="osu-md__paragraph"><strong>Caution</strong><br />Caution body text.</p>
+</div>
+
+<div class="osu-md__alert-note">
+  <p class="osu-md__paragraph"><strong>Good to know</strong><br />Custom title body text.</p>
+</div>

--- a/tests/Libraries/Markdown/html_markdown_examples/alert.md
+++ b/tests/Libraries/Markdown/html_markdown_examples/alert.md
@@ -1,0 +1,29 @@
+::: alert-note
+**Note**
+Note body text.
+:::
+
+::: alert-tip
+**Tip**
+Tip body text.
+:::
+
+::: alert-notice
+**Notice**
+Notice body text.
+:::
+
+::: alert-warning
+**Warning**
+Warning body text.
+:::
+
+::: alert-caution
+**Caution**
+Caution body text.
+:::
+
+::: alert-note
+**Good to know**
+Custom title body text.
+:::

--- a/tests/Libraries/Markdown/html_markdown_examples/alert_inline.html
+++ b/tests/Libraries/Markdown/html_markdown_examples/alert_inline.html
@@ -1,0 +1,11 @@
+<div class="osu-md__alert-note">
+  <p class="osu-md__paragraph"><strong>See also</strong> <a class="osu-md__link" href="/link">foo</a> and <a class="osu-md__link" href="/link2">bar</a>.</p>
+</div>
+
+<div class="osu-md__alert-note">
+  <p class="osu-md__paragraph"><strong>Main page</strong> <a class="osu-md__link" href="/wiki/Main">Index</a></p>
+</div>
+
+<div class="osu-md__alert-note">
+  <p class="osu-md__paragraph"><strong>Note:</strong> For other uses, see: <a class="osu-md__link" href="/wiki/other">other</a>.</p>
+</div>

--- a/tests/Libraries/Markdown/html_markdown_examples/alert_inline.html
+++ b/tests/Libraries/Markdown/html_markdown_examples/alert_inline.html
@@ -1,11 +1,11 @@
-<div class="osu-md__alert-note">
+<div class="osu-md__alert osu-md__alert--note">
   <p class="osu-md__paragraph"><strong>See also</strong> <a class="osu-md__link" href="/link">foo</a> and <a class="osu-md__link" href="/link2">bar</a>.</p>
 </div>
 
-<div class="osu-md__alert-note">
+<div class="osu-md__alert osu-md__alert--note">
   <p class="osu-md__paragraph"><strong>Main page</strong> <a class="osu-md__link" href="/wiki/Main">Index</a></p>
 </div>
 
-<div class="osu-md__alert-note">
+<div class="osu-md__alert osu-md__alert--note">
   <p class="osu-md__paragraph"><strong>Note:</strong> For other uses, see: <a class="osu-md__link" href="/wiki/other">other</a>.</p>
 </div>

--- a/tests/Libraries/Markdown/html_markdown_examples/alert_inline.md
+++ b/tests/Libraries/Markdown/html_markdown_examples/alert_inline.md
@@ -1,0 +1,11 @@
+::: alert-note
+**See also** [foo](/link) and [bar](/link2).
+:::
+
+::: alert-note
+**Main page** [Index](/wiki/Main)
+:::
+
+::: alert-note
+**Note:** For other uses, see: [other](/wiki/other).
+:::

--- a/tests/Libraries/Markdown/html_markdown_examples/alert_invalid.html
+++ b/tests/Libraries/Markdown/html_markdown_examples/alert_invalid.html
@@ -1,0 +1,1 @@
+<p class="osu-md__paragraph"><strong>Example</strong><br />Should render without alert styling.</p>

--- a/tests/Libraries/Markdown/html_markdown_examples/alert_invalid.md
+++ b/tests/Libraries/Markdown/html_markdown_examples/alert_invalid.md
@@ -1,0 +1,4 @@
+::: alert-notreal
+**Example**
+Should render without alert styling.
+:::

--- a/tests/Libraries/Markdown/indexable_markdown_examples/alert.md
+++ b/tests/Libraries/Markdown/indexable_markdown_examples/alert.md
@@ -1,0 +1,9 @@
+::: alert-note
+**Note**
+Searchable note body.
+:::
+
+::: alert-warning
+**Watch out**
+Searchable warning body.
+:::

--- a/tests/Libraries/Markdown/indexable_markdown_examples/alert.txt
+++ b/tests/Libraries/Markdown/indexable_markdown_examples/alert.txt
@@ -1,0 +1,5 @@
+Note Searchable note body.
+
+Watch out Searchable warning body.
+
+

--- a/tests/Libraries/Markdown/indexable_markdown_examples/alert_inline.md
+++ b/tests/Libraries/Markdown/indexable_markdown_examples/alert_inline.md
@@ -1,0 +1,11 @@
+::: alert-note
+**See also** [foo](/link) and [bar](/link2).
+:::
+
+::: alert-note
+**Main page** [Index](/wiki/Main)
+:::
+
+::: alert-note
+**Note:** For other uses, see: [other](/wiki/other).
+:::

--- a/tests/Libraries/Markdown/indexable_markdown_examples/alert_inline.txt
+++ b/tests/Libraries/Markdown/indexable_markdown_examples/alert_inline.txt
@@ -1,0 +1,7 @@
+See also foo and bar.
+
+Main page Index
+
+Note: For other uses, see: other.
+
+


### PR DESCRIPTION
Resolves https://github.com/ppy/osu-web/issues/13064 (with applied feedback from `#osu-wiki`)

Enabled for wiki and news.

Also supports an inline variant per wiki maintainer request.

<details>
<summary>Preview</summary>

<img width="725" height="736" alt="image" src="https://github.com/user-attachments/assets/8e357bb5-b112-458d-9430-8f70fb352748" />

</details>

<details>
<summary>Initial implementation commentary</summary>

initial implementation used the GitHub custom syntax detailed in the linked issue via a custom parser. after a conversation with clayton and Wala in `#osu-wiki` ([link](https://discord.com/channels/188630481301012481/218677502141399041/1517256350034559177)), we decided it would be best to rework this using existing syntax of `CustomContainerInline` (similar to flags), and let CSS selectors do the heavy lifting, which eliminates the need of custom parsers altogether.

finalized syntax is the following:

```md
> ::{alert=caution}:: **Caution**
> This is *critical* content demanding of the user's attention.
```
this results in an alert.
<img width="446" height="92" alt="image" src="https://github.com/user-attachments/assets/e3f58e1a-96a3-427d-add3-6307926701b3" />

```md
> ::{alert=note}:: **See also:** [Ranking criteria](/wiki/Ranking_criteria) and [Beatmap ranking procedure](/wiki/Beatmap_ranking_procedure)
```
this results in an inline alert.
<img width="452" height="52" alt="image" src="https://github.com/user-attachments/assets/635c0f23-f8bb-4eba-bad5-64cb955546a7" />

</details>

---

Available styleblock attributes are:

- `::: alert-note`
- `::: alert-tip`
- `::: alert-notice` 
- `::: alert-warning`
- `::: alert-caution`

Syntax is the following:

```md
::: alert-note
**See also:** [Ranking criteria](/wiki/Ranking_criteria)
:::
```

This results in an inline/compact alert.
<img width="242" height="61" alt="image" src="https://github.com/user-attachments/assets/859807dc-9b89-44e8-a552-1f435073b4e1" />

```md
::: alert-caution
**Caution**
This is *critical* content demanding of the user's attention.
:::
```
This results in a regular alert.
<img width="410" height="86" alt="image" src="https://github.com/user-attachments/assets/0b2fc329-3b7b-480c-804c-d199e445ebee" />






