### PR TITLE
Ensure mod acronym is a string

### DIFF
--- a/app/Singletons/Mods.php
+++ b/app/Singletons/Mods.php
@@ -228,7 +228,7 @@ class Mods
         $filteredMods = [];
 
         foreach ($mods as $mod) {
-            if (!present($mod['acronym'] ?? null)) {
+            if (!is_string(presence($mod['acronym'] ?? null))) {
                 throw new InvariantException('invalid mod array');
             }
 

--- a/tests/Singletons/ModsTest.php
+++ b/tests/Singletons/ModsTest.php
@@ -34,6 +34,14 @@ class ModsTest extends TestCase
         $this->assertSame('WU', $parsed[0]->acronym);
     }
 
+    public function testParseInputArrayInvalidAcronymType()
+    {
+        $input = [['acronym' => ['WU'], 'settings' => []]];
+
+        $this->expectException(InvariantException::class);
+        app('mods')->parseInputArray(Ruleset::osu->value, $input);
+    }
+
     public function testParseInputArrayInvalidMod()
     {
         $input = [['acronym' => 'XYZ', 'settings' => []]];


### PR DESCRIPTION
`present` doesn't check that the value is a string.