### PR TITLE
Clean up profile rank count styles

### DIFF
--- a/resources/css/bem/profile-detail-stats.less
+++ b/resources/css/bem/profile-detail-stats.less
@@ -60,6 +60,7 @@
     &--grid {
       display: grid;
       grid-template-columns: repeat(4, 1fr);
+      flex: 1;
     }
   }
 }

--- a/resources/css/bem/profile-rank-count.less
+++ b/resources/css/bem/profile-rank-count.less
@@ -2,22 +2,27 @@
 // See the LICENCE file in the repository root for full licence text.
 
 .profile-rank-count {
-  display: flex;
-  text-align: center;
+  --rank-size: 22px;
+  display: grid;
+  grid-template-columns: repeat(5, 1fr);
   font-weight: bold;
   font-size: @font-size--normal;
   gap: 4px;
-  flex-wrap: wrap;
   justify-content: center;
   margin: auto;
-
-  @media @desktop {
-    font-size: @font-size--normal;
-    margin: 0;
-  }
 
   &--team {
     gap: 10px;
     padding-top: 10px;
+  }
+
+  &__item {
+    display: grid;
+    justify-items: center;
+  }
+
+  &__rank {
+    display: contents;
+    font-size: var(--rank-size);
   }
 }

--- a/resources/css/bem/value-display.less
+++ b/resources/css/bem/value-display.less
@@ -31,6 +31,7 @@
     --value-color: hsl(var(--hsl-c2));
     --value-font-size-desktop: @font-size--title-small-3;
     --value-font-size: @font-size--title-small-3;
+    min-width: auto;
   }
 
   &--plain-wide {

--- a/resources/js/profile-page/rank-count.tsx
+++ b/resources/js/profile-page/rank-count.tsx
@@ -14,8 +14,10 @@ export default function RankCount({ stats }: Props) {
   return (
     <div className='profile-rank-count'>
       {grades.map((grade) => (
-        <div key={grade}>
-          <div className={classWithModifiers('score-rank', `rank-${grade}`, 'profile-page')} />
+        <div key={grade} className='profile-rank-count__item'>
+          <div className='profile-rank-count__rank'>
+            <div className={classWithModifiers('score-rank', `rank-${grade}`)} />
+          </div>
           {formatNumber(stats.grade_counts[grade])}
         </div>
       ))}

--- a/resources/views/teams/show.blade.php
+++ b/resources/views/teams/show.blade.php
@@ -299,26 +299,14 @@
                         @endif
                         <div class="team-info-entry">
                             <div class="profile-rank-count profile-rank-count--team">
-                                <div>
-                                    <div class="score-rank score-rank--XH score-rank--profile-page"></div>
-                                    {{ i18n_number_format($extraStatistics['xh_rank_count']) }}
-                                </div>
-                                <div>
-                                    <div class="score-rank score-rank--X score-rank--profile-page"></div>
-                                    {{ i18n_number_format($extraStatistics['x_rank_count']) }}
-                                </div>
-                                <div>
-                                    <div class="score-rank score-rank--SH score-rank--profile-page"></div>
-                                    {{ i18n_number_format($extraStatistics['sh_rank_count']) }}
-                                </div>
-                                <div>
-                                    <div class="score-rank score-rank--S score-rank--profile-page"></div>
-                                    {{ i18n_number_format($extraStatistics['s_rank_count']) }}
-                                </div>
-                                <div>
-                                    <div class="score-rank score-rank--A score-rank--profile-page"></div>
-                                    {{ i18n_number_format($extraStatistics['a_rank_count']) }}
-                                </div>
+                                @foreach (['xh', 'x', 'sh', 's', 'a'] as $grade)
+                                    <div class="profile-rank-count__item">
+                                        <div class="profile-rank-count__rank">
+                                            <div class="score-rank score-rank--{{ strtoupper($grade) }}"></div>
+                                        </div>
+                                        {{ i18n_number_format($extraStatistics["{$grade}_rank_count"]) }}
+                                    </div>
+                                @endforeach
                             </div>
                         </div>
                     </div>


### PR DESCRIPTION
- remove unused desktop specific styling
- move icon sizing to profile rank count class
- ensure centered and equal sized items when the text is longer than the icon

Also fixed the stats values not squished enough when the desktop screen is narrow