### PR TITLE
change beatmap list component to be more general

### DIFF
--- a/resources/js/beatmap-discussions/header.tsx
+++ b/resources/js/beatmap-discussions/header.tsx
@@ -12,6 +12,7 @@ import HeaderV4 from 'components/header-v4';
 import NotificationBanner from 'components/notification-banner';
 import PlaymodeTabs from 'components/playmode-tabs';
 import StringWithComponent from 'components/string-with-component';
+import BeatmapExtendedJson from 'interfaces/beatmap-extended-json';
 import BeatmapsetDiscussionsStore from 'interfaces/beatmapset-discussions-store';
 import Ruleset, { rulesets } from 'interfaces/ruleset';
 import { route } from 'laroute';
@@ -19,6 +20,7 @@ import { action, computed, makeObservable } from 'mobx';
 import { observer } from 'mobx-react';
 import * as React from 'react';
 import { hasGuestOwners } from 'utils/beatmap-helper';
+import { makeUrl } from 'utils/beatmapset-discussion-helper';
 import { getArtist, getTitle } from 'utils/beatmapset-helper';
 import { trans, transChoice } from 'utils/lang';
 import Chart from './chart';
@@ -34,6 +36,11 @@ interface Props {
 
 @observer
 export class Header extends React.Component<Props> {
+  @computed
+  private get beatmaps() {
+    return this.discussionsState.groupedBeatmaps.get(this.discussionsState.currentBeatmap.mode) ?? [];
+  }
+
   private get beatmapset() {
     return this.discussionsState.beatmapset;
   }
@@ -93,10 +100,19 @@ export class Header extends React.Component<Props> {
     );
   }
 
+  private readonly getCount = (beatmap: BeatmapExtendedJson) => this.discussionsState.unresolvedDiscussionCounts.byBeatmap[beatmap.id];
+
+  private readonly makeBeatmapUrl = (beatmap: BeatmapExtendedJson) => makeUrl({ beatmap, filter: this.discussionsState.currentFilter });
+
   @action
   private readonly onClickMode = (event: React.MouseEvent<HTMLAnchorElement>, mode: Ruleset) => {
     event.preventDefault();
     this.discussionsState.changeGameMode(mode);
+  };
+
+  private readonly onSelectBeatmap = (beatmapId: number) => {
+    this.discussionsState.currentBeatmapId = beatmapId;
+    this.discussionsState.changeDiscussionPage('timeline');
   };
 
   private renderHeaderBottom() {
@@ -166,8 +182,12 @@ export class Header extends React.Component<Props> {
           <div className={`${bn}__filters`}>
             <div className={`${bn}__filter-group`}>
               <BeatmapList
-                discussionsState={this.discussionsState}
-                users={this.users}
+                beatmaps={this.beatmaps}
+                beatmapset={this.beatmapset}
+                currentBeatmap={this.currentBeatmap}
+                getCount={this.getCount}
+                makeBeatmapUrl={this.makeBeatmapUrl}
+                onSelectBeatmap={this.onSelectBeatmap}
               />
             </div>
           </div>

--- a/resources/js/beatmap-discussions/header.tsx
+++ b/resources/js/beatmap-discussions/header.tsx
@@ -3,6 +3,7 @@
 
 import headerLinks from 'beatmapsets-show/header-links';
 import BeatmapBasicStats from 'components/beatmap-basic-stats';
+import BeatmapList from 'components/beatmap-list';
 import BeatmapsetBadge from 'components/beatmapset-badge';
 import BeatmapsetCover from 'components/beatmapset-cover';
 import BeatmapsetMapping from 'components/beatmapset-mapping';
@@ -20,7 +21,6 @@ import * as React from 'react';
 import { hasGuestOwners } from 'utils/beatmap-helper';
 import { getArtist, getTitle } from 'utils/beatmapset-helper';
 import { trans, transChoice } from 'utils/lang';
-import BeatmapList from './beatmap-list';
 import Chart from './chart';
 import DiscussionsState from './discussions-state';
 import { Nominations } from './nominations';

--- a/resources/js/components/beatmap-list.tsx
+++ b/resources/js/components/beatmap-list.tsx
@@ -3,31 +3,28 @@
 
 import BeatmapListItem from 'components/beatmap-list-item';
 import BeatmapExtendedJson from 'interfaces/beatmap-extended-json';
-import UserJson from 'interfaces/user-json';
-import { action, autorun, computed, makeObservable, observable } from 'mobx';
+import BeatmapsetExtendedJson from 'interfaces/beatmapset-extended-json';
+import { action, autorun, makeObservable, observable } from 'mobx';
 import { disposeOnUnmount, observer } from 'mobx-react';
 import * as React from 'react';
-import { makeUrl } from 'utils/beatmapset-discussion-helper';
 import { blackoutToggle } from 'utils/blackout';
 import { classWithModifiers } from 'utils/css';
 import { formatNumber } from 'utils/html';
 import { nextVal } from 'utils/seq';
-import DiscussionsState from '../beatmap-discussions/discussions-state';
 
 interface Props {
-  discussionsState: DiscussionsState;
-  users: Map<number | null | undefined, UserJson>;
+  beatmaps: BeatmapExtendedJson[];
+  beatmapset: BeatmapsetExtendedJson;
+  currentBeatmap: BeatmapExtendedJson;
+  getCount?: (beatmap: BeatmapExtendedJson) => number | undefined;
+  makeBeatmapUrl: (beatmap: BeatmapExtendedJson) => string;
+  onSelectBeatmap: (beatmapId: number) => void;
 }
 
 @observer
 export default class BeatmapList extends React.Component<Props> {
-  private readonly eventId = `beatmapset-discussions-show-beatmap-list-${nextVal()}`;
+  private readonly eventId = `beatmap-list-${nextVal()}`;
   @observable private showingSelector = false;
-
-  @computed
-  private get beatmaps() {
-    return this.props.discussionsState.groupedBeatmaps.get(this.props.discussionsState.currentBeatmap.mode) ?? [];
-  }
 
   constructor(props: Props) {
     super(props);
@@ -54,10 +51,10 @@ export default class BeatmapList extends React.Component<Props> {
         <div className='beatmap-list__body'>
           <a
             className='beatmap-list__item beatmap-list__item--selected beatmap-list__item--large js-beatmap-list-selector'
-            href={makeUrl({ beatmap: this.props.discussionsState.currentBeatmap })}
+            href={this.props.makeBeatmapUrl(this.props.currentBeatmap)}
             onClick={this.toggleSelector}
           >
-            <BeatmapListItem beatmap={this.props.discussionsState.currentBeatmap} modifiers='large' showOwners={false} />
+            <BeatmapListItem beatmap={this.props.currentBeatmap} modifiers='large' showOwners={false} />
             <div className='beatmap-list__item-selector-button'>
               <span className='fas fa-chevron-down' />
             </div>
@@ -65,7 +62,7 @@ export default class BeatmapList extends React.Component<Props> {
 
           <div className='beatmap-list__selector-container'>
             <div className='beatmap-list__selector'>
-              {this.beatmaps.map(this.beatmapListItem)}
+              {this.props.beatmaps.map(this.beatmapListItem)}
             </div>
           </div>
         </div>
@@ -74,19 +71,19 @@ export default class BeatmapList extends React.Component<Props> {
   }
 
   private readonly beatmapListItem = (beatmap: BeatmapExtendedJson) => {
-    const count = this.props.discussionsState.unresolvedDiscussionCounts.byBeatmap[beatmap.id];
+    const count = this.props.getCount?.(beatmap);
 
     return (
       <div
         key={beatmap.id}
-        className={classWithModifiers('beatmap-list__item', { current: beatmap.id === this.props.discussionsState.currentBeatmap.id })}
+        className={classWithModifiers('beatmap-list__item', { current: beatmap.id === this.props.currentBeatmap.id })}
         data-id={beatmap.id}
         onClick={this.selectBeatmap}
       >
         <BeatmapListItem
           beatmap={beatmap}
-          beatmapUrl={makeUrl({ beatmap, filter: this.props.discussionsState.currentFilter })}
-          beatmapset={this.props.discussionsState.beatmapset}
+          beatmapUrl={this.props.makeBeatmapUrl(beatmap)}
+          beatmapset={this.props.beatmapset}
           showNonGuestOwner={false}
           showOwners
         />
@@ -121,9 +118,7 @@ export default class BeatmapList extends React.Component<Props> {
     e.preventDefault();
 
     const beatmapId = parseInt(e.currentTarget.dataset.id ?? '', 10);
-
-    this.props.discussionsState.currentBeatmapId = beatmapId;
-    this.props.discussionsState.changeDiscussionPage('timeline');
+    this.props.onSelectBeatmap(beatmapId);
   };
 
   @action

--- a/resources/js/components/beatmap-list.tsx
+++ b/resources/js/components/beatmap-list.tsx
@@ -12,7 +12,7 @@ import { blackoutToggle } from 'utils/blackout';
 import { classWithModifiers } from 'utils/css';
 import { formatNumber } from 'utils/html';
 import { nextVal } from 'utils/seq';
-import DiscussionsState from './discussions-state';
+import DiscussionsState from '../beatmap-discussions/discussions-state';
 
 interface Props {
   discussionsState: DiscussionsState;


### PR DESCRIPTION
While working on rebasing #7899, I notice that beatmap list component now only accept discussion state as its props.

Because I want to reuse this component in new beatmapset show header, I decided to generalize this component and move it to general component folder.