### PR TITLE
Support React elements as label for InputContainer

### DIFF
--- a/resources/js/components/input-container.tsx
+++ b/resources/js/components/input-container.tsx
@@ -10,6 +10,7 @@ import MessageLengthCounter from './message-length-counter';
 interface CommonProps {
   for?: string;
   hasError?: boolean;
+  label?: React.ReactNode;
   labelKey?: string;
   modifiers?: Modifiers;
   showError?: boolean;
@@ -27,12 +28,13 @@ type Props = CommonProps & ({
 // TODO: show error message
 const InputContainer = observer((props: React.PropsWithChildren<Props>) => {
   const error = props.hasError && props.showError;
+  const labelText = props.label ?? (props.labelKey != null ? trans(props.labelKey) : null);
 
   return (
     <label className={classWithModifiers('input-container', { error }, props.modifiers)} htmlFor={props.for}>
-      {props.labelKey != null && (
+      {(labelText != null || props.maxLength != null) && (
         <div className='input-container__label'>
-          {trans(props.labelKey)}
+          {labelText}
           {props.maxLength != null && (
             <MessageLengthCounter
               maxLength={props.maxLength}

--- a/resources/js/components/input-container.tsx
+++ b/resources/js/components/input-container.tsx
@@ -32,17 +32,15 @@ const InputContainer = observer((props: React.PropsWithChildren<Props>) => {
 
   return (
     <label className={classWithModifiers('input-container', { error }, props.modifiers)} htmlFor={props.for}>
-      {(labelText != null || props.maxLength != null) && (
-        <div className='input-container__label'>
-          {labelText ?? <span />}
-          {props.maxLength != null && (
-            <MessageLengthCounter
-              maxLength={props.maxLength}
-              message={props.input}
-            />
-          )}
-        </div>
-      )}
+      <div className='input-container__label'>
+        {labelText ?? <span />}
+        {props.maxLength != null && (
+          <MessageLengthCounter
+            maxLength={props.maxLength}
+            message={props.input}
+          />
+        )}
+      </div>
       {props.children}
     </label>
   );

--- a/resources/js/components/input-container.tsx
+++ b/resources/js/components/input-container.tsx
@@ -34,7 +34,7 @@ const InputContainer = observer((props: React.PropsWithChildren<Props>) => {
     <label className={classWithModifiers('input-container', { error }, props.modifiers)} htmlFor={props.for}>
       {(labelText != null || props.maxLength != null) && (
         <div className='input-container__label'>
-          {labelText}
+          {labelText ?? <span />}
           {props.maxLength != null && (
             <MessageLengthCounter
               maxLength={props.maxLength}


### PR DESCRIPTION
More flexibility beyond translation keys.
Also, allow showing length counter without label text.