### PR TITLE
Fix incorrect casting for account option parameters

### DIFF
--- a/app/Http/Controllers/AccountController.php
+++ b/app/Http/Controllers/AccountController.php
@@ -258,7 +258,7 @@ class AccountController extends Controller
             $params,
             'user_profile_customization',
             // type validation is done by each setters
-            array_keys(UserProfileCustomization::DEFAULTS),
+            array_map(fn ($key) => $key.':any', array_keys(UserProfileCustomization::DEFAULTS)),
         );
 
         $profileCustomization = $user->userProfileCustomization()->createOrFirst();


### PR DESCRIPTION
Namely `extra_options` shouldn't be casted to string by the default param value handler.

I forgot the default isn't a passthrough/simple null check 🙃 