### PR TITLE
Add tier colour to ranked play ranking

### DIFF
--- a/app/Models/MatchmakingUserStats.php
+++ b/app/Models/MatchmakingUserStats.php
@@ -81,4 +81,21 @@ class MatchmakingUserStats extends Model
             ->where('pool_id', $this->pool_id)
             ->count();
     }
+
+    public function getRankPercent(?int $rank = null): float
+    {
+        $rank ??= $this->getRank();
+
+        $count = cache_remember_mutexed(
+            "matchmaking_user_count:{$this->pool_id}",
+            600,
+            1,
+            fn () => static
+                ::where('pool_id', $this->pool_id)
+                ->where('plays', '>', 0)
+                ->count(),
+        );
+
+        return min(1, $rank / max(1, $count ?? 1));
+    }
 }

--- a/app/Transformers/MatchmakingUserStatsTransformer.php
+++ b/app/Transformers/MatchmakingUserStatsTransformer.php
@@ -18,12 +18,15 @@ class MatchmakingUserStatsTransformer extends TransformerAbstract
 
     public function transform(MatchmakingUserStats $stats): array
     {
+        $rank = $stats->getRank();
+
         return [
             'first_placements' => $stats->first_placements,
             'is_rating_provisional' => $stats->isRatingProvisional(),
             'plays' => $stats->plays,
             'pool_id' => $stats->pool_id,
-            'rank' => $stats->getRank(),
+            'rank' => $rank,
+            'rank_percent' => $stats->getRankPercent($rank),
             'rating' => $stats->rating,
             'total_points' => $stats->total_points,
             'user_id' => $stats->user_id,

--- a/resources/css/bem/daily-challenge.less
+++ b/resources/css/bem/daily-challenge.less
@@ -39,6 +39,11 @@
   &__value {
     .fancy-text(var(--colour));
     --colour: hsl(var(--hsl-c2));
+
+    &--plain {
+      background: initial;
+      color: var(--colour);
+    }
   }
 
   &__value-box {

--- a/resources/css/utilities.less
+++ b/resources/css/utilities.less
@@ -62,6 +62,10 @@
   .fancy-scrollbar();
 }
 
+.u-fancy-text {
+  .fancy-text(var(--colour));
+}
+
 .u-focus-hides-placeholder {
   &:focus::placeholder {
     opacity: 0;

--- a/resources/js/interfaces/matchmaking-user-stats-json.ts
+++ b/resources/js/interfaces/matchmaking-user-stats-json.ts
@@ -12,7 +12,8 @@ interface MatchmakingUserStatsJsonDefaultAttributes {
   is_rating_provisional: boolean;
   plays: number;
   pool_id: number;
-  rank: null | number;
+  rank: number;
+  rank_percent: number;
   rating: number;
   total_points: number;
   user_id: number;

--- a/resources/js/profile-page/matchmaking.tsx
+++ b/resources/js/profile-page/matchmaking.tsx
@@ -12,6 +12,27 @@ import { trans } from 'utils/lang';
 import { qtipPosition } from 'utils/qtip-helper';
 import { ProfilePageMatchmakingStatsJson } from './extra-page-props';
 
+function tier(stats: ProfilePageMatchmakingStatsJson) {
+  const rank = stats.rank;
+  const percent = stats.rank_percent;
+
+  if (rank <= 100) {
+    return 'lustrous';
+  }
+
+  return percent < 0.05
+    ? 'radiant'
+    : percent < 0.2
+      ? 'rhodium'
+      : percent < 0.5
+        ? 'platinum'
+        : percent < 0.75
+          ? 'gold'
+          : percent < 0.95
+            ? 'silver'
+            : 'bronze';
+}
+
 function poolDisplayName(pool: MatchmakingPoolJson) {
   const variantName = rulesetVariantIdToName[pool.variant_id];
 
@@ -22,8 +43,19 @@ function poolDisplayName(pool: MatchmakingPoolJson) {
   return `${prefix}${pool.name}`;
 }
 
-function rankText(rank: null | number) {
-  return rank == null ? '-' : `#${formatNumber(rank)}`;
+function rankText(stats: null | ProfilePageMatchmakingStatsJson) {
+  return stats == null
+    ? '-'
+    : (
+      <span
+        className='u-fancy-text'
+        style={{
+          '--colour': `var(--level-tier-${tier(stats)})`,
+        } as React.CSSProperties}
+      >
+        #{formatNumber(stats.rank)}
+      </span>
+    );
 }
 
 function popup(allStats: ProfilePageMatchmakingStatsJson[]) {
@@ -50,7 +82,7 @@ function popup(allStats: ProfilePageMatchmakingStatsJson[]) {
             {poolDisplayName(stats.pool)}
           </div>
           <div className='matchmaking-popup__value'>
-            {rankText(stats.rank)}
+            {rankText(stats)}
           </div>
           <div className='matchmaking-popup__value'>
             {formatNumber(stats.first_placements)}
@@ -84,16 +116,12 @@ export default class Matchmaking extends React.Component<Props> {
     if (this.props.allStats.length === 0) {
       return null;
     }
-    let highestRank: null | number = null;
+
+    let highestRankStats: null | ProfilePageMatchmakingStatsJson = null;
     for (const stats of this.props.allStats) {
-      const rank = stats.rank;
       // only show active stats for profile page
-      if (stats.pool.active && rank != null) {
-        if (highestRank == null) {
-          highestRank = rank;
-        } else if (rank < highestRank) {
-          highestRank = rank;
-        }
+      if (stats.pool.active && (highestRankStats == null || stats.rank < highestRankStats.rank)) {
+        highestRankStats = stats;
       }
     }
 
@@ -107,8 +135,8 @@ export default class Matchmaking extends React.Component<Props> {
           {trans('users.show.matchmaking.title')}
         </div>
         <div className='daily-challenge__value-box'>
-          <div className='daily-challenge__value'>
-            {rankText(highestRank)}
+          <div className='daily-challenge__value daily-challenge__value--plain'>
+            {rankText(highestRankStats)}
           </div>
         </div>
       </div>


### PR DESCRIPTION
Fun 🤷 [Tiers reference](https://discord.com/channels/90072389919997952/1458132886946451497/1520020010842591232)

`daily-challenge__value` and the new span have sort of overlapping style but with the `u-fancy-text` thing I can use the same formatter for both the page and popup.

Also the rank is always given after the removal of the non-provisional requirement a while ago.

<sub>As usual, the tiers are subject to change</sub>

![](https://s.kohaku.love/2026/06/firefox_2026-06-26_20-54-45.png)