### PR TITLE
Always flush loading overlay calls when using immediate version

### DIFF
--- a/resources/js/utils/loading-overlay.ts
+++ b/resources/js/utils/loading-overlay.ts
@@ -23,9 +23,5 @@ export const showLoadingOverlay = debounce(() => {
 export function hideLoadingOverlay() {
   showLoadingOverlay.cancel();
 
-  const el = getOverlayElement();
-
-  if (el == null) return;
-
-  el.classList.remove('loading-overlay--visible');
+  getOverlayElement()?.classList.remove('loading-overlay--visible');
 }

--- a/resources/js/utils/loading-overlay.ts
+++ b/resources/js/utils/loading-overlay.ts
@@ -12,14 +12,13 @@ function getOverlayElement() {
 }
 
 export function showImmediateLoadingOverlay() {
-  const el = getOverlayElement();
-
-  if (el == null) return;
-
-  el.classList.add('loading-overlay--visible');
+  showLoadingOverlay();
+  showLoadingOverlay.flush();
 }
 
-export const showLoadingOverlay = debounce(showImmediateLoadingOverlay, 5000, { maxWait: 5000 });
+export const showLoadingOverlay = debounce(() => {
+  getOverlayElement()?.classList.add('loading-overlay--visible');
+}, 5000, { maxWait: 5000 });
 
 export function hideLoadingOverlay() {
   showLoadingOverlay.cancel();


### PR DESCRIPTION
Makes more sense maybe? 🤔 

Also simplified the function itself. Although the class name isn't quite right...