### PR TITLE
Use the more general react element type

### DIFF
--- a/resources/js/beatmap-discussions/review-post.tsx
+++ b/resources/js/beatmap-discussions/review-post.tsx
@@ -15,7 +15,7 @@ interface Props {
 
 export class ReviewPost extends React.Component<Props> {
   render() {
-    const docBlocks: JSX.Element[] = [];
+    const docBlocks: React.ReactNode[] = [];
 
     try {
       const doc = JSON.parse(this.props.post.message) as PersistedBeatmapDiscussionReview;

--- a/resources/js/chat/conversation-view.tsx
+++ b/resources/js/chat/conversation-view.tsx
@@ -42,7 +42,7 @@ export default class ConversationView extends React.Component<Props> {
     const channel = this.currentChannel;
     if (channel == null) return [];
 
-    const conversationStack: JSX.Element[] = [];
+    const conversationStack: React.ReactNode[] = [];
     let currentGroup: Message[] = [];
     let unreadMarkerShown = false;
     let currentDay: string;

--- a/resources/js/components/value-display.tsx
+++ b/resources/js/components/value-display.tsx
@@ -7,10 +7,10 @@ import { Modifiers, classWithModifiers } from 'utils/css';
 const bn = 'value-display';
 
 interface Props {
-  description?: JSX.Element;
+  description?: React.ReactNode;
   label: string;
   modifiers?: Modifiers;
-  value: string | number | JSX.Element;
+  value: React.ReactNode;
 }
 
 export default function ValueDisplay({ description, label, modifiers, value }: Props) {

--- a/resources/js/profile-page/account-standing.tsx
+++ b/resources/js/profile-page/account-standing.tsx
@@ -70,7 +70,7 @@ const ColumnLength = ({ history }: ColumnProps) => {
   return <>{moment.duration(history.length, 'seconds').humanize()}</>;
 };
 
-const content: Record<Column, (props: ColumnProps) => JSX.Element | null> = {
+const content: Record<Column, React.FunctionComponent<ColumnProps>> = {
   action: ColumnAction,
   date: ColumnDate,
   description: ColumnDescription,

--- a/resources/js/profile-page/cover.tsx
+++ b/resources/js/profile-page/cover.tsx
@@ -21,7 +21,7 @@ import SeasonStats from './season-stats';
 interface Props {
   coverUrl: string | null;
   currentMode: Ruleset;
-  editor?: JSX.Element;
+  editor?: React.ReactNode;
   isUpdatingCover?: boolean;
   modifiers?: Modifiers;
   user: UserExtendedJson;


### PR DESCRIPTION
Maybe? Mainly just for the `ValueDisplay` so I don't need to type `let someElement: string | JSX.Element` ( ﾟ ヮﾟ)a