### PR TITLE
Hide loading overlay when loading from back/forward cache

### DIFF
--- a/resources/js/setup-turbo.ts
+++ b/resources/js/setup-turbo.ts
@@ -8,6 +8,11 @@ import { reloadPage } from 'utils/turbolinks';
 Turbo.config.drive.progressBarDelay = 0;
 
 // loading animation overlay
+window.addEventListener('pageshow', (event) => {
+  if (event.persisted) {
+    hideLoadingOverlay();
+  }
+});
 document.addEventListener('turbo:visit', showLoadingOverlay);
 document.addEventListener('turbo:before-cache', hideLoadingOverlay);
 document.addEventListener('turbo:load', hideLoadingOverlay);


### PR DESCRIPTION
Apparently this is a thing that we never noticed because we're using Turbo for internal urls, and the previous behaviour of the bfcache was not to cache the page if it had an existing websocket connection, but the new behaviour for Chrome, at least, is to add the page even if there is an open websocket connection (causing any loading overlay to stick when navigating back). https://chromestatus.com/feature/5068439115923456

I'm not sure if it should just go with setup-turbo or somewhere else 🤷 