### PR TITLE
Simplify handling of token parsing failure

### DIFF
--- a/app/Http/Controllers/Beatmapsets/BeatmapsetRatingsController.php
+++ b/app/Http/Controllers/Beatmapsets/BeatmapsetRatingsController.php
@@ -12,7 +12,6 @@ use App\Http\Controllers\Controller;
 use App\Libraries\ClientCheck;
 use App\Models\Beatmapset;
 use App\Models\BeatmapsetUserRating;
-use Symfony\Component\HttpKernel\Exception\HttpException;
 
 class BeatmapsetRatingsController extends Controller
 {
@@ -44,11 +43,7 @@ class BeatmapsetRatingsController extends Controller
     {
         $request = \Request::instance();
 
-        try {
-            ClientCheck::parseToken($request);
-        } catch (HttpException $e) {
-            abort(403);
-        }
+        ClientCheck::parseToken($request);
 
         $rating = get_int($request['rating'] ?? null);
         if ($rating === null || $rating < 1 || $rating > 10) {

--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -39,7 +39,6 @@ use Illuminate\Database\Eloquent\Relations\MorphTo;
 use Request;
 use romanzipp\Turnstile\Validator as TurnstileValidator;
 use Sentry\State\Scope;
-use Symfony\Component\HttpKernel\Exception\HttpException;
 
 /**
  * @group Users
@@ -111,14 +110,6 @@ class UsersController extends Controller
         ]);
 
         parent::__construct();
-    }
-
-    private static function storeClientDisabledError()
-    {
-        return response([
-            'error' => osu_trans('users.store.from_web'),
-            'url' => route('users.create'),
-        ], 403);
     }
 
     public function create()
@@ -198,7 +189,10 @@ class UsersController extends Controller
     public function store()
     {
         if (!$GLOBALS['cfg']['osu']['user']['registration_mode']['client']) {
-            return static::storeClientDisabledError();
+            return response([
+                'error' => osu_trans('users.store.from_web'),
+                'url' => route('users.create'),
+            ], 403);
         }
 
         $request = \Request::instance();
@@ -207,13 +201,7 @@ class UsersController extends Controller
             return error_popup(osu_trans('users.store.from_client'), 403);
         }
 
-        try {
-            $clientTokenData = ClientCheck::parseToken($request);
-        } catch (HttpException $e) {
-            return static::storeClientDisabledError();
-        }
-
-        return $this->storeUser($request->all(), $clientTokenData);
+        return $this->storeUser($request->all(), ClientCheck::parseToken($request));
     }
 
     public function storeWeb()
@@ -698,11 +686,7 @@ class UsersController extends Controller
 
         abort_unless($achievement->client_side, 422, 'achievement cannot be unlocked');
 
-        try {
-            ClientCheck::parseToken($request);
-        } catch (HttpException $e) {
-            abort(403);
-        }
+        ClientCheck::parseToken($request);
 
         $unlocked = UserAchievement::unlock($user, $achievement);
         abort_unless($unlocked, 422, 'user already unlocked the specified achievement');


### PR DESCRIPTION
The beatmap rating and client side medal are fine with 422 according to @bdach (well the former isn't implemented yet iiuc)

The registration endpoint already contains token validation down the path and returning 422 on failure. I'm not quite sure why it's returning the use-the-web response instead. Or maybe it made sense before the additional token validation thing was added (something with the older client not sending the token maybe?).