### PR TITLE
Hide score notice on bot profiles

### DIFF
--- a/resources/css/bem/wiki-notice.less
+++ b/resources/css/bem/wiki-notice.less
@@ -30,7 +30,7 @@
   &--profile-page-extra {
     border-radius: @border-radius-large;
     background-color: hsl(var(--hsl-b4));
-    margin: 0 var(--page-gutter) 10px;
+    margin: 10px 0;
     width: auto;
     font-size: @font-size--title-small;
   }

--- a/resources/js/profile-page/detail.tsx
+++ b/resources/js/profile-page/detail.tsx
@@ -42,10 +42,10 @@ export default class Detail extends React.Component<Props> {
         {!user.is_bot && (
           <div className='profile-detail'>
             <DetailStats user={user} />
+
+            {this.renderScoresNotice()}
           </div>
         )}
-
-        {this.renderScoresNotice()}
 
         <DetailBar user={user} />
 


### PR DESCRIPTION
It's unnecessary since bots don't have ranks or scores, also it looks kinda bad:

<img width="1000" height="263" alt="image" src="https://github.com/user-attachments/assets/b8f70f3f-5f7d-4ef0-8803-cafbfd72dbac" />
