### PR TITLE
Add support for style block with more than 3 fence character

### DIFF
--- a/app/Libraries/Markdown/StyleBlock/Parser.php
+++ b/app/Libraries/Markdown/StyleBlock/Parser.php
@@ -14,10 +14,12 @@ use League\CommonMark\Parser\Cursor;
 class Parser extends AbstractBlockContinueParser
 {
     private Element $block;
+    private int $fenceLength;
 
-    public function __construct(string $className)
+    public function __construct(string $className, int $fenceLength)
     {
         $this->block = new Element($className);
+        $this->fenceLength = $fenceLength;
     }
 
     public function getBlock(): AbstractBlock
@@ -39,9 +41,7 @@ class Parser extends AbstractBlockContinueParser
     {
         $currentLine = $cursor->getLine();
 
-        // TODO: closing block length is supposed to match opening block length which can be > 3;
-        // what's supposed to happen when they don't match currently is undefined.
-        if ($currentLine === ':::') {
+        if ($currentLine === str_repeat(':', $this->fenceLength)) {
             return BlockContinue::finished();
         }
 

--- a/app/Libraries/Markdown/StyleBlock/StartParser.php
+++ b/app/Libraries/Markdown/StyleBlock/StartParser.php
@@ -28,8 +28,10 @@ class StartParser implements BlockStartParserInterface
             return BlockStart::none();
         }
 
+        $fence = $cursor->match('/^:{3,}/');
+
         $cursor->advanceToEnd();
 
-        return BlockStart::of(new Parser($className))->at($cursor);
+        return BlockStart::of(new Parser($className, strlen($fence)))->at($cursor);
     }
 }

--- a/tests/Libraries/Markdown/html_markdown_examples/style_block.html
+++ b/tests/Libraries/Markdown/html_markdown_examples/style_block.html
@@ -11,3 +11,11 @@
     <a class="osu-md__link" href="/link">link</a><strong>bold</strong><em>italic</em>
   </p>
 </div>
+
+<div class="osu-md__class-name">
+  <p class="osu-md__paragraph">4 character fence</p>
+</div>
+
+<div class="osu-md__class-name">
+  <p class="osu-md__paragraph">5 character fence</p>
+</div>

--- a/tests/Libraries/Markdown/html_markdown_examples/style_block.md
+++ b/tests/Libraries/Markdown/html_markdown_examples/style_block.md
@@ -15,3 +15,15 @@ Paragraph block
 [link](/link) **bold** *italic*
 
 :::
+
+:::: class-name
+
+4 character fence
+
+::::
+
+:::: class-name
+
+5 character fence
+
+::::

--- a/tests/Libraries/Markdown/html_markdown_examples/style_block_nested.html
+++ b/tests/Libraries/Markdown/html_markdown_examples/style_block_nested.html
@@ -1,0 +1,9 @@
+<div class="osu-md__class-name">
+  <p class="osu-md__paragraph">First paragraph</p>
+
+  <div class="osu-md__class-name">
+    <p class="osu-md__paragraph">Inner paragraph</p>
+  </div>
+
+  <p class="osu-md__paragraph">Last paragraph</p>
+</div>

--- a/tests/Libraries/Markdown/html_markdown_examples/style_block_nested.md
+++ b/tests/Libraries/Markdown/html_markdown_examples/style_block_nested.md
@@ -1,0 +1,13 @@
+::: class-name
+
+First paragraph
+
+:::: class-name
+
+Inner paragraph
+
+::::
+
+Last paragraph
+
+:::

--- a/tests/Libraries/Markdown/indexable_markdown_examples/style_block.md
+++ b/tests/Libraries/Markdown/indexable_markdown_examples/style_block.md
@@ -1,5 +1,29 @@
 ::: Class Name
 
-paragraph
+## Heading block
 
 :::
+
+:::class name
+
+Paragraph block
+
+:::
+
+:::class-name
+
+[link](/link) **bold** *italic*
+
+:::
+
+:::: class-name
+
+4 character fence
+
+::::
+
+:::: class-name
+
+5 character fence
+
+::::

--- a/tests/Libraries/Markdown/indexable_markdown_examples/style_block.txt
+++ b/tests/Libraries/Markdown/indexable_markdown_examples/style_block.txt
@@ -1,3 +1,11 @@
-paragraph
+Heading block
+
+Paragraph block
+
+link bold italic
+
+4 character fence
+
+5 character fence
 
 

--- a/tests/Libraries/Markdown/indexable_markdown_examples/style_block_nested.md
+++ b/tests/Libraries/Markdown/indexable_markdown_examples/style_block_nested.md
@@ -1,0 +1,13 @@
+::: class-name
+
+First paragraph
+
+:::: class-name
+
+Inner paragraph
+
+::::
+
+Last paragraph
+
+:::

--- a/tests/Libraries/Markdown/indexable_markdown_examples/style_block_nested.txt
+++ b/tests/Libraries/Markdown/indexable_markdown_examples/style_block_nested.txt
@@ -1,0 +1,6 @@
+First paragraph
+Inner paragraph
+
+Last paragraph
+
+


### PR DESCRIPTION
I noticed this comment while discussing something is `#osu-wiki` discord.

https://github.com/ppy/osu-web/blob/b6cd03f95a4dd66f39d812659001a7ff0ad78d09/app/Libraries/Markdown/StyleBlock/Parser.php#L42-L46

Now style block can use more than 3 fence character and also automatically can support nested style block by using different length of fence chars.