### PR TITLE
Add endpoint to generate one time key thing

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -319,6 +319,8 @@ CLIENT_CHECK_VERSION=false
 
 # IS_DEVELOPMENT_DEPLOY=true
 
+# OSU_ONE_TIME_KEY=false
+
 # OSU_URL_DOWNLOAD_VIDEO='https://assets.ppy.sh/media/festive.mp4'
 # OSU_URL_LAZER_ANDROID='https://github.com/ppy/osu/releases/latest/download/sh.ppy.osulazer.apk'
 # OSU_URL_LAZER_IOS='/home/testflight'

--- a/app/Http/Controllers/OneTimeKeyController.php
+++ b/app/Http/Controllers/OneTimeKeyController.php
@@ -1,0 +1,80 @@
+<?php
+
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
+declare(strict_types=1);
+
+namespace App\Http\Controllers;
+
+use App\Libraries\OneTimeKey;
+use App\Models\Beatmap;
+use App\Models\User;
+use App\Transformers\UserCompactTransformer;
+
+class OneTimeKeyController extends Controller
+{
+    public function __construct()
+    {
+        $this->middleware('auth', ['except' => ['check']]);
+        $this->middleware('verify-user', ['except' => ['check']]);
+    }
+
+    public function check()
+    {
+        $userId = OneTimeKey::retrieve(get_string(request('key'))) ?? abort(422);
+        $user = User::findOrFail($userId);
+        $matchmakingUserStats = $user
+            ->matchmakingStats()
+            ->whereHas('pool', fn ($q) => $q->where('active', true))
+            ->with('pool')
+            ->get();
+
+        // TODO: actual transformer json after moving out the rank
+        // attributes somewhere else
+        $matchmakingUserStatsJson = [];
+        foreach ($matchmakingUserStats as $entry) {
+            $matchmakingUserStatsJson[] = [
+                'pool_id' => $entry->pool_id,
+                'rating' => $entry->rating,
+                'ruleset_id' => $entry->pool->ruleset_id,
+                'variant_id' => $entry->pool->variant_id,
+            ];
+        }
+
+        $pp = [];
+        foreach (Beatmap::VARIANT_BY_ID as $rulesetId => $variants) {
+            foreach ($variants as $variantId => $variantName) {
+                $statistics = $user->statistics(Beatmap::modeStr($rulesetId), variant: presence($variantName));
+
+                if ($statistics !== null) {
+                    $pp[] = [
+                        'pp' => $statistics->rank_score,
+                        'ruleset_id' => $rulesetId,
+                        'variant_id' => $variantId,
+                    ];
+                }
+            }
+        }
+
+        return [
+            'matchmaking_user_stats' => $matchmakingUserStatsJson,
+            'stats' => $pp,
+            'user' => json_item($user, new UserCompactTransformer(), UserCompactTransformer::CARD_INCLUDES),
+        ];
+    }
+
+    public function create()
+    {
+        $key = OneTimeKey::currentKey(\Auth::user());
+
+        return ext_view('one_time_key.create', compact('key'));
+    }
+
+    public function store()
+    {
+        $key = OneTimeKey::generate(\Auth::user());
+
+        return ujs_redirect(route('one-time-key'));
+    }
+}

--- a/app/Http/Middleware/VerifyCsrfToken.php
+++ b/app/Http/Middleware/VerifyCsrfToken.php
@@ -16,6 +16,7 @@ class VerifyCsrfToken extends BaseVerifier
     protected $except = [
         'home/changelog/github',
         'oauth/authorize',
+        'one-time-key/check',
         'payments/paypal/ipn',
         'payments/shopify/callback',
         'payments/xsolla/callback',

--- a/app/Libraries/OneTimeKey.php
+++ b/app/Libraries/OneTimeKey.php
@@ -1,0 +1,67 @@
+<?php
+
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
+declare(strict_types=1);
+
+namespace App\Libraries;
+
+use App\Models\User;
+
+class OneTimeKey
+{
+    const VALID_SECONDS = 180;
+
+    public static function currentKey(User $user): ?string
+    {
+        return \Cache::get(static::lookupKey($user->getKey()));
+    }
+
+    public static function generate(User $user): string
+    {
+        $currentKey = static::currentKey($user);
+
+        if ($currentKey !== null) {
+            return $currentKey;
+        }
+
+        $key = bin2hex(random_bytes(4));
+
+        \Cache::put(static::redisKey($key), [
+            'user_id' => $user->getKey(),
+        ], static::VALID_SECONDS);
+        \Cache::put(static::lookupKey($user->getKey()), $key, static::VALID_SECONDS);
+
+        return $key;
+    }
+
+    public static function retrieve(?string $key): ?int
+    {
+        if ($key === null || strlen($key) !== 8 || !ctype_xdigit($key)) {
+            return null;
+        }
+
+        $redisKey = static::redisKey($key);
+        $data = \Cache::get($redisKey);
+
+        if ($data === null) {
+            return null;
+        }
+
+        \Cache::delete($redisKey);
+        \Cache::delete(static::lookupKey($data['user_id']));
+
+        return $data['user_id'];
+    }
+
+    private static function lookupKey(int $userId): string
+    {
+        return "one_time_key_for:{$userId}";
+    }
+
+    private static function redisKey(string $key): string
+    {
+        return "one_time_key:{$key}";
+    }
+}

--- a/config/osu.php
+++ b/config/osu.php
@@ -23,6 +23,7 @@ $sentryLogSampleRateInversed = $sentryLogSampleRate <= 0 ? null : (int) (100 / $
 
 // osu config~
 return [
+    'one_time_key' => get_bool(env('OSU_ONE_TIME_KEY')) ?? false,
     'achievement' => [
         'icon_prefix' => env('USER_ACHIEVEMENT_ICON_PREFIX', 'https://assets.ppy.sh/user-achievements/'),
     ],

--- a/resources/css/bem/dialog-form.less
+++ b/resources/css/bem/dialog-form.less
@@ -120,6 +120,12 @@
       flex-wrap: wrap;
     }
 
+    &--centered {
+      display: block;
+      text-align: center;
+      margin-bottom: 30px;
+    }
+
     &--client-verification-completed {
       display: block;
       margin-top: -20px; // undo --title

--- a/resources/views/one_time_key/create.blade.php
+++ b/resources/views/one_time_key/create.blade.php
@@ -1,0 +1,70 @@
+{{--
+    Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+    See the LICENCE file in the repository root for full licence text.
+--}}
+@php
+    $user = Auth::user();
+@endphp
+
+@extends('master', [
+    'blank' => true,
+    'titleOverride' => 'One Time Key',
+])
+
+@section('content')
+    <div class="dialog-form">
+        <div class="dialog-form__dialog">
+            <div
+                class="dialog-form__row dialog-form__row--header"
+                style="background-image: url('{{ $user->cover()->url() }}')"
+            >
+                <div class="dialog-form__header-overlay"></div>
+                <a
+                    class="dialog-form__user-header"
+                    href="{{ route('users.show', ['user' => $user->getKey()]) }}"
+                >
+                    <div class="dialog-form__user-avatar">
+                        <div
+                            class="avatar avatar--full-circle"
+                            style="background-image: url('{{ $user->user_avatar }}')"
+                        ></div>
+                    </div>
+
+                    {{ $user->username }}
+                </a>
+            </div>
+
+            <div class="dialog-form__row dialog-form__row--title">
+                <div class="dialog-form__logo"></div>
+                <h1 class="dialog-form__title">
+                    @if ($key === null)
+                        Generate login key for the event
+                    @else
+                        Here's your one time key!
+                    @endif
+                </h1>
+            </div>
+
+            <div class="dialog-form__row dialog-form__row--centered">
+                @if ($key === null)
+                    <form
+                        action="{{ route('one-time-key') }}"
+                        method="POST"
+                    >
+                        @csrf
+                        <button class="dialog-form__button">
+                            Generate Key
+                        </button>
+                    </form>
+                @else
+                    <h2 class="dialog-form__client-name">
+                        <code>{{ $key }}</code>
+                    </h2>
+                    <p><small>
+                        The key is valid for {{ App\Libraries\OneTimeKey::VALID_SECONDS / 60 }} minutes.
+                    </small></p>
+                @endif
+            </div>
+        </div>
+    </div>
+@endsection

--- a/routes/web.php
+++ b/routes/web.php
@@ -305,6 +305,12 @@ Route::group(['middleware' => ['web']], function () {
         Route::post('clients/{client}/reset-secret', 'ClientsController@resetSecret')->name('clients.reset-secret');
     });
 
+    if ($GLOBALS['cfg']['osu']['one_time_key']) {
+        Route::get('one-time-key', 'OneTimeKeyController@create')->name('one-time-key');
+        Route::post('one-time-key', 'OneTimeKeyController@store');
+        Route::post('one-time-key/check', 'OneTimeKeyController@check');
+    }
+
     Route::get('rankings/kudosu', 'RankingController@kudosu')->name('rankings.kudosu');
     Route::resource('rankings/daily-challenge', 'Ranking\DailyChallengeController', ['only' => ['index', 'show']]);
     Route::get('rankings/ranked-play/{mode?}/{pool?}', 'Ranking\MatchmakingController@show')->name('rankings.matchmaking');


### PR DESCRIPTION
Something event something. Only to link a string with user id.

https://discord.com/channels/90072389919997952/1458132886946451497/1526427566313967686

The endpoints and return format have since been changed.

```
GET /one-time-key -> create the key (now with button and existing key lookup)
POST /one-time-key/check (parameter: key (string)) -> obtain user id
```

toggle env:
```
OSU_ONE_TIME_KEY=false
```

Removed the key splitting because I miscounted the available bits 🙃 