### PR TITLE
Fix more deprecation warnings

### DIFF
--- a/app/helpers.php
+++ b/app/helpers.php
@@ -877,7 +877,7 @@ function from_app_url(?HttpRequest $request = null)
     // https://osu.web.domain.com.
     // This assumes app.url doesn't contain trailing slash.
     return $headers->get('origin') === $appUrl
-        || str_starts_with($headers->get('referer'), "{$appUrl}/");
+        || str_starts_with($headers->get('referer', ''), "{$appUrl}/");
 }
 
 function forum_user_link(int $id, string $username, string|null $colour, int|null $currentUserId): string


### PR DESCRIPTION
passing `null` to `str_starts_with` is deprecated