### PR TITLE
Add API endpoints for retrieving and modifying user preferences

### DIFF
--- a/app/Http/Controllers/UsersController.php
+++ b/app/Http/Controllers/UsersController.php
@@ -574,6 +574,7 @@ class UsersController extends Controller
                 'score_processing_notice_url',
                 'session_verification_method',
                 'session_verified',
+                'user_preferences',
                 ...$this->showUserIncludes(),
                 ...array_map(
                     fn (string $ruleset) => "statistics_rulesets.{$ruleset}",

--- a/routes/web.php
+++ b/routes/web.php
@@ -604,6 +604,8 @@ Route::group(['as' => 'api.', 'prefix' => 'api', 'middleware' => ['api', Throttl
         Route::get('me/download-quota-check', 'HomeController@downloadQuotaCheck')->name('download-quota-check');
         //  GET /api/v2/me
         Route::get('me/{mode?}', 'UsersController@me')->name('me');
+        //  PUT /api/v2/me/options
+        Route::put('me/options', 'AccountController@updateOptions')->name('me.options');
         //  PUT /api/v2/me/achievements/:achievementId
         Route::put('me/achievements/{achievementId}', 'UsersController@unlockClientSideAchievement')->name('unlock-client-side-achievement');
 

--- a/tests/Controllers/AccountControllerTest.php
+++ b/tests/Controllers/AccountControllerTest.php
@@ -145,6 +145,46 @@ class AccountControllerTest extends TestCase
             ->assertStatus(422);
     }
 
+    public function testOptionsViaApi()
+    {
+        $user = User::factory()->create();
+
+        $this->actAsScopedUser($user)
+            ->putJson(route('api.me.options'), [
+                'user_profile_customization' => [
+                    'beatmapset_show_anime_cover' => false,
+                ]
+            ])
+            ->assertSuccessful()
+            ->assertJson(['user_preferences' => [
+                'beatmapset_show_anime_cover' => false,
+            ]]);
+    }
+
+    public function testOptionsViaApiFailsWhenIncorrectScopes()
+    {
+        $user = User::factory()->create();
+
+        $this->actAsScopedUser($user, ['public', 'identify'])
+            ->putJson(route('api.me.options'), [
+            'user_profile_customization' => [
+                'beatmapset_show_anime_cover' => false,
+            ]
+        ])
+            ->assertStatus(403);
+    }
+
+    public function testOptionsViaApiFailsWhenUnauthorised()
+    {
+        $this->putJson(route('api.me.options'), [
+            'user_profile_customization' => [
+                'beatmapset_show_anime_cover' => false,
+            ]
+        ])
+            ->assertStatus(401);
+    }
+
+
     public function testUpdatePassword()
     {
         $newPassword = 'newpassword';

--- a/tests/Controllers/AccountControllerTest.php
+++ b/tests/Controllers/AccountControllerTest.php
@@ -153,7 +153,7 @@ class AccountControllerTest extends TestCase
             ->putJson(route('api.me.options'), [
                 'user_profile_customization' => [
                     'beatmapset_show_anime_cover' => false,
-                ]
+                ],
             ])
             ->assertSuccessful()
             ->assertJson(['user_preferences' => [
@@ -169,7 +169,7 @@ class AccountControllerTest extends TestCase
             ->putJson(route('api.me.options'), [
             'user_profile_customization' => [
                 'beatmapset_show_anime_cover' => false,
-            ]
+            ],
         ])
             ->assertStatus(403);
     }
@@ -179,7 +179,7 @@ class AccountControllerTest extends TestCase
         $this->putJson(route('api.me.options'), [
             'user_profile_customization' => [
                 'beatmapset_show_anime_cover' => false,
-            ]
+            ],
         ])
             ->assertStatus(401);
     }

--- a/tests/api_routes.json
+++ b/tests/api_routes.json
@@ -1573,6 +1573,19 @@
         ]
     },
     {
+        "uri": "api/v2/me/options",
+        "methods": [
+            "PUT"
+        ],
+        "controller": "App\\Http\\Controllers\\AccountController@updateOptions",
+        "middlewares": [
+            "App\\Http\\Middleware\\ThrottleRequests:1200,1,api:",
+            "App\\Http\\Middleware\\RequireScopes",
+            "Illuminate\\Auth\\Middleware\\Authenticate"
+        ],
+        "scopes": []
+    },
+    {
         "uri": "api/v2/me/achievements/{achievementId}",
         "methods": [
             "PUT"


### PR DESCRIPTION
The use case for this is coming from https://github.com/ppy/osu/issues/36527:

> Optimally, sync the setting from osu-web (and other settings using a combined api?)

My starting proposition was https://github.com/ppy/osu/issues/36527#issuecomment-4968547055. As it turns out most of the work was already done. This PR is mostly exposing one extra attribute on `GET /api/v2/me` and exposing an existing website endpoint to also work via `PUT /api/v2/me/options`. I could not see any reason preventing just reusing it - it doesn't seem like that endpoint allows doing something that shouldn't be done by client - but that does not mean there isn't one, so reviewer beware.

I've briefly tested this full-stack with a hastily-written client-side diff and it seems to be enough to make work.

The test is very paranoid and probably unnecessary, I just *really* wanted to make sure I'm not accidentally exposing stuff too widely.