### PR TITLE
Update vertical alignment in diff badge

### DIFF
--- a/resources/css/bem/difficulty-badge.less
+++ b/resources/css/bem/difficulty-badge.less
@@ -16,7 +16,7 @@
   &--beatmapset {
     display: inline-flex;
     height: auto;
-    vertical-align: bottom;
+    vertical-align: middle;
     margin-bottom: 3px;
     padding-top: 1px;
     padding-bottom: $padding-top;
@@ -34,5 +34,6 @@
     // Font width is at most 0.67em for the numbers.
     // Lastly add 0.25em for decimal separator.
     min-width: 0.67em * 3 + 0.25em;
+    transform: translateY(-0.5px);
   }
 }


### PR DESCRIPTION
Sort of adresses #13170.  

<img width="400" height="300" alt="before & after - diff badge is now more centered with diff name, showcased on osu.ppy.sh/b/782310" title="diff badge is now more centered with diff name, showcased on osu.ppy.sh/b/782310" src="https://github.com/user-attachments/assets/dfa17e62-299d-4741-a3b1-7468ae83739c" />
