### PR TITLE
Adjust spacing and sizing in details on beatmapset page

### DIFF
--- a/resources/css/bem-index.less
+++ b/resources/css/bem-index.less
@@ -72,6 +72,7 @@
 @import "bem/beatmapset-beatmap-picker";
 @import "bem/beatmapset-cover";
 @import "bem/beatmapset-cover-admin";
+@import "bem/beatmapset-diff-details";
 @import "bem/beatmapset-discussion-image-link";
 @import "bem/beatmapset-discussions-chart";
 @import "bem/beatmapset-discussions-toolbar";

--- a/resources/css/bem/beatmapset-diff-details.less
+++ b/resources/css/bem/beatmapset-diff-details.less
@@ -2,21 +2,30 @@
 // See the LICENCE file in the repository root for full licence text.
 
 .beatmapset-diff-details {
-  margin-bottom: 1px;
+  display: flex;
+  flex: 0 0 0;
+  flex-direction: row;
+  justify-content: left;
+  align-items: center;
+  vertical-align: bottom;
 
-    &__extra {
-      margin-left: 5px;
-      font-size: @font-size--small-2;
-      font-weight: 600;
-    }
+    &__text {
+      font-size: @font-size--title-small-3;
+      margin-left: 0.3em; // space
+      margin-bottom: 2px;
+        .default-text-shadow();
 
-    &__name {
-      font-size: 17px;
-      font-weight: 600;
-      overflow-wrap: anywhere;
+      &--extra {
+        margin-left: 5px;
+        font-size: @font-size--small-2;
+        font-weight: 600;
+      }
+      &--name {
+        font-weight: 600;
+        overflow-wrap: anywhere;
 
-      color: hsl(var(--hsl-c1));
+        color: hsl(var(--hsl-c1));
 
-      .default-text-shadow();
+      }
     }
 }

--- a/resources/css/bem/beatmapset-diff-details.less
+++ b/resources/css/bem/beatmapset-diff-details.less
@@ -1,0 +1,22 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
+.beatmapset-diff-details {
+  margin-bottom: 1px;
+
+    &__extra {
+      margin-left: 5px;
+      font-size: @font-size--small-2;
+      font-weight: 600;
+    }
+
+    &__name {
+      font-size: 17px;
+      font-weight: 600;
+      overflow-wrap: anywhere;
+
+      color: hsl(var(--hsl-c1));
+
+      .default-text-shadow();
+    }
+}

--- a/resources/css/bem/beatmapset-header.less
+++ b/resources/css/bem/beatmapset-header.less
@@ -84,22 +84,6 @@
     .link-plain();
   }
 
-  &__diff-extra {
-    margin-left: 5px;
-    font-size: @font-size--small-2;
-    font-weight: 600;
-  }
-
-  &__diff-name {
-    font-size: 17px;
-    font-weight: 600;
-    overflow-wrap: anywhere;
-
-    color: hsl(var(--hsl-c1));
-
-    .default-text-shadow();
-  }
-
   &__more {
     display: inline-flex;
     justify-content: center;

--- a/resources/css/bem/difficulty-badge.less
+++ b/resources/css/bem/difficulty-badge.less
@@ -14,11 +14,7 @@
   height: 100%;
 
   &--beatmapset {
-    display: inline-flex;
     height: auto;
-    vertical-align: bottom;
-    padding-top: 1px;
-    padding-bottom: $padding-top;
     font-size: 13px; // the default size (13.94px or 14px) has weird geometry
   }
 

--- a/resources/css/bem/difficulty-badge.less
+++ b/resources/css/bem/difficulty-badge.less
@@ -17,7 +17,6 @@
     display: inline-flex;
     height: auto;
     vertical-align: bottom;
-    margin-bottom: 3px;
     padding-top: 1px;
     padding-bottom: $padding-top;
     font-size: 13px; // the default size (13.94px or 14px) has weird geometry

--- a/resources/js/beatmapsets-show/header.tsx
+++ b/resources/js/beatmapsets-show/header.tsx
@@ -285,12 +285,12 @@ export default class Header extends React.Component<Props> {
     return (
       <div className="beatmapset-diff-details">
         <DifficultyBadge modifiers='beatmapset' rating={beatmap.difficulty_rating} />
-        <span className='beatmapset-diff-details__name'>
-          {' '}
+        <div className='beatmapset-diff-details__text'>
+          <span className='beatmapset-diff-details__text--name'>
           {beatmap.version}
-        </span>
-        {hasGuestOwners(beatmap, this.controller.beatmapset) && (
-            <span className='beatmapset-diff-details__extra'>
+          </span>
+          {hasGuestOwners(beatmap, this.controller.beatmapset) && (
+            <span className='beatmapset-diff-details__text--extra'>
               <StringWithComponent
                 mappings={{
                   mapper: <UserLinkList users={this.controller.owners(beatmap)} />,
@@ -299,6 +299,8 @@ export default class Header extends React.Component<Props> {
               />
             </span>
           )}
+        </div>
+
       </div>
     );
   }

--- a/resources/js/beatmapsets-show/header.tsx
+++ b/resources/js/beatmapsets-show/header.tsx
@@ -283,22 +283,23 @@ export default class Header extends React.Component<Props> {
     const beatmap = this.controller.hoveredBeatmap ?? this.controller.currentBeatmap;
 
     return (
-      <span className='beatmapset-header__diff-name'>
+      <div className="beatmapset-diff-details">
         <DifficultyBadge modifiers='beatmapset' rating={beatmap.difficulty_rating} />
-        {' '}
-        {beatmap.version}
-
+        <span className='beatmapset-diff-details__name'>
+          {' '}
+          {beatmap.version}
+        </span>
         {hasGuestOwners(beatmap, this.controller.beatmapset) && (
-          <span className='beatmapset-header__diff-extra'>
-            <StringWithComponent
-              mappings={{
-                mapper: <UserLinkList users={this.controller.owners(beatmap)} />,
-              }}
-              pattern={trans('beatmapsets.show.details.mapped_by')}
-            />
-          </span>
-        )}
-      </span>
+            <span className='beatmapset-diff-details__extra'>
+              <StringWithComponent
+                mappings={{
+                  mapper: <UserLinkList users={this.controller.owners(beatmap)} />,
+                }}
+                pattern={trans('beatmapsets.show.details.mapped_by')}
+              />
+            </span>
+          )}
+      </div>
     );
   }
 


### PR DESCRIPTION
 master
<img width="686" height="413" alt="2026-07-22_17-58" src="https://github.com/user-attachments/assets/81ecff56-d22d-4702-b39b-e766de5cf2c3" />
 PR
<img width="678" height="408" alt="image" src="https://github.com/user-attachments/assets/10442795-d527-4cdb-9057-8737c3833cea" />
</table>

I'm a first time contributor. No AI was used for this.

Wrapped the badge, name and diff owner in a container to make it easier to distance the whole box from everything. also wrapped the text components in a div to more easily margin them closer.
Resizes diff name from 17px to 16px to be able to center the badge