### PR TITLE
The difficulty name isn't aligned with the star badge.

### DIFF
--- a/resources/css/bem/difficulty-badge.less
+++ b/resources/css/bem/difficulty-badge.less
@@ -17,7 +17,6 @@
     display: inline-flex;
     height: auto;
     vertical-align: bottom;
-    margin-bottom: 3px;
     padding-top: 1px;
     padding-bottom: $padding-top;
     font-size: 13px; // the default size (13.94px or 14px) has weird geometry


### PR DESCRIPTION
Before:
<img width="194" height="123" alt="Before" src="https://github.com/user-attachments/assets/63289601-8910-490e-992a-7e27c79ba48b" />

After:
<img width="204" height="116" alt="After" src="https://github.com/user-attachments/assets/6e70ea38-8c8f-4db5-a304-d982b5e82d71" />
