### PR TITLE
Add kudosu rank to modding profile

### DIFF
--- a/app/Http/Controllers/RankingController.php
+++ b/app/Http/Controllers/RankingController.php
@@ -28,6 +28,7 @@ use Illuminate\Pagination\LengthAwarePaginator;
  */
 class RankingController extends Controller
 {
+    const KUDOSU_MAX_RESULTS = 1000;
     const MAX_RESULTS = 10000;
     const PAGE_SIZE = Model::PER_PAGE;
     // in display order
@@ -358,15 +359,13 @@ class RankingController extends Controller
      */
     public function kudosu()
     {
-        static $maxResults = 1000;
-
-        $maxPage = $maxResults / static::PAGE_SIZE;
+        $maxPage = static::KUDOSU_MAX_RESULTS / static::PAGE_SIZE;
         $page = min(get_int(request('page')) ?? 1, $maxPage);
 
         $scores = User::default()
             ->with('team')
             ->orderBy('osu_kudostotal', 'desc')
-            ->paginate(static::PAGE_SIZE, ['*'], 'page', $page, $maxResults);
+            ->paginate(static::PAGE_SIZE, ['*'], 'page', $page, static::KUDOSU_MAX_RESULTS);
 
         if (is_json_request()) {
             return ['ranking' => json_collection(

--- a/app/Libraries/ModdingHistoryEventsBundle.php
+++ b/app/Libraries/ModdingHistoryEventsBundle.php
@@ -160,7 +160,11 @@ class ModdingHistoryEventsBundle
                         [
                             ...UserTransformer::PROFILE_HEADER_INCLUDES,
                             'graveyard_beatmapset_count',
+                            'guest_beatmapset_count',
+                            'kudosu',
+                            'kudosu.rank',
                             'loved_beatmapset_count',
+                            'nominated_beatmapset_count',
                             'pending_beatmapset_count',
                             'ranked_beatmapset_count',
                             'statistics',

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -8,6 +8,7 @@ namespace App\Models;
 use App\Exceptions\ChangeUsernameException;
 use App\Exceptions\InvariantException;
 use App\Exceptions\ModelNotSavedException;
+use App\Http\Controllers\RankingController;
 use App\Jobs\EsDocument;
 use App\Libraries\BBCodeForDB;
 use App\Libraries\ChangeUsername;
@@ -1648,6 +1649,37 @@ class User extends Model implements AfterCommit, AuthenticatableContract, HasLoc
     public function receivedKudosu()
     {
         return $this->hasMany(KudosuHistory::class, 'receiver_id');
+    }
+
+    public function kudosuRank(): ?int
+    {
+        if ($this->osu_kudostotal === 0) {
+            return null;
+        }
+
+        return $this->memoize(__FUNCTION__, function () {
+            $threshold = static::kudosuRankThreshold();
+            if ($threshold !== null && $this->osu_kudostotal < $threshold) {
+                return null;
+            }
+
+            return static::default()
+                ->where('osu_kudostotal', '>', $this->osu_kudostotal)
+                ->count() + 1;
+        });
+    }
+
+    private static function kudosuRankThreshold(): ?int
+    {
+        $cacheDuration = 43200; // 12 hours
+
+        return Cache::remember('kudosu_rank_threshold:v1', $cacheDuration, function () {
+            return static::default()
+                ->where('osu_kudostotal', '>', 0)
+                ->orderByDesc('osu_kudostotal')
+                ->offset(RankingController::KUDOSU_MAX_RESULTS - 1)
+                ->value('osu_kudostotal');
+        });
     }
 
     public function supporterTags()

--- a/app/Transformers/UserCompactTransformer.php
+++ b/app/Transformers/UserCompactTransformer.php
@@ -360,10 +360,7 @@ class UserCompactTransformer extends TransformerAbstract
 
     public function includeKudosu(User $user): ResourceInterface
     {
-        return $this->primitive([
-            'available' => $user->osu_kudosavailable,
-            'total' => $user->osu_kudostotal,
-        ]);
+        return $this->item($user, new UserKudosuTransformer());
     }
 
     public function includeLovedBeatmapsetCount(User $user)

--- a/app/Transformers/UserKudosuTransformer.php
+++ b/app/Transformers/UserKudosuTransformer.php
@@ -1,0 +1,29 @@
+<?php
+
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
+namespace App\Transformers;
+
+use App\Models\User;
+use League\Fractal\Resource\ResourceInterface;
+
+class UserKudosuTransformer extends TransformerAbstract
+{
+    protected array $availableIncludes = [
+        'rank',
+    ];
+
+    public function transform(User $user): array
+    {
+        return [
+            'available' => $user->osu_kudosavailable,
+            'total' => $user->osu_kudostotal,
+        ];
+    }
+
+    public function includeRank(User $user): ResourceInterface
+    {
+        return $this->primitive($user->kudosuRank());
+    }
+}

--- a/resources/js/interfaces/user-extended-json.ts
+++ b/resources/js/interfaces/user-extended-json.ts
@@ -37,6 +37,7 @@ interface UserExtendedAdditionalAttributes {
   join_date: string;
   kudosu: {
     available: number;
+    rank?: number | null;
     total: number;
   };
   location: string | null;

--- a/resources/js/interfaces/user-modding-profile-json.ts
+++ b/resources/js/interfaces/user-modding-profile-json.ts
@@ -7,11 +7,16 @@ import { ProfileHeaderIncludes } from './user-json';
 type ModdingProfileIncludes =
   ProfileHeaderIncludes
   | 'graveyard_beatmapset_count'
+  | 'guest_beatmapset_count'
+  | 'kudosu'
   | 'loved_beatmapset_count'
+  | 'nominated_beatmapset_count'
   | 'pending_beatmapset_count'
   | 'ranked_beatmapset_count'
   | 'statistics';
 
-type UserModdingProfileJson = UserExtendedJson & Required<Pick<UserExtendedJson, ModdingProfileIncludes>>;
+type UserModdingProfileJson = UserExtendedJson & Required<Pick<UserExtendedJson, ModdingProfileIncludes>> & {
+  kudosu: UserExtendedJson['kudosu'] & { rank: number | null };
+};
 
 export default UserModdingProfileJson;

--- a/resources/js/modding-profile/stats.tsx
+++ b/resources/js/modding-profile/stats.tsx
@@ -1,7 +1,8 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
-import UserJson from 'interfaces/user-extended-json';
+import ValueDisplay from 'components/value-display';
+import UserModdingProfileJson from 'interfaces/user-modding-profile-json';
 import * as React from 'react';
 import { classWithModifiers } from 'utils/css';
 import { formatNumber } from 'utils/html';
@@ -12,19 +13,43 @@ const entries = [
   'loved_beatmapset_count',
   'pending_beatmapset_count',
   'graveyard_beatmapset_count',
+  'guest_beatmapset_count',
+  'nominated_beatmapset_count',
 ] as const;
 type UserBeatmapsetCount = typeof entries[number];
 
 interface Props {
-  // TODO: add actual typing for modding profile user json
-  user: UserJson & Required<Pick<UserJson, UserBeatmapsetCount>>;
+  user: UserModdingProfileJson;
 }
 
 export default class Stats extends React.PureComponent<Props> {
   render() {
+    const rank = this.props.user.kudosu.rank;
+
     return (
-      <div className={classWithModifiers('profile-stats', 'modding')}>
-        {entries.map(this.renderEntry)}
+      <div className='profile-detail-stats'>
+        <div className='profile-detail-stats__values'>
+          <ValueDisplay
+            label={trans('users.show.rank.kudosu_simple')}
+            modifiers='rank'
+            value={
+              <div
+                className='rank-value rank-value--base'
+                data-html-title={rank == null ? trans('users.show.rank.kudosu_outside_top_1000') : undefined}
+                data-tooltip-position='bottom left'
+                title=''
+              >
+                {rank != null ? `#${formatNumber(rank)}` : '-'}
+              </div>
+            }
+          />
+        </div>
+
+        <div className='profile-detail-stats__separator' />
+
+        <div className={classWithModifiers('profile-stats', 'modding')}>
+          {entries.map(this.renderEntry)}
+        </div>
       </div>
     );
   }

--- a/resources/lang/en/users.php
+++ b/resources/lang/en/users.php
@@ -506,6 +506,8 @@ return [
             'global' => 'Global rank for :mode',
             'global_simple' => 'Global Ranking',
             'highest' => 'Highest rank: :rank on :date',
+            'kudosu_outside_top_1000' => 'Rank is only shown after entering the top 1,000',
+            'kudosu_simple' => 'Kudosu Ranking',
         ],
         'score_processing' => [
             'title' => 'A new Star Rating / PP algorithm is :link.',
@@ -532,7 +534,9 @@ return [
             'total_score' => 'Total Score',
             // modding stats
             'graveyard_beatmapset_count' => 'Graveyarded Beatmaps',
+            'guest_beatmapset_count' => 'Guest Participation Beatmaps',
             'loved_beatmapset_count' => 'Loved Beatmaps',
+            'nominated_beatmapset_count' => 'Nominated Ranked Beatmaps',
             'pending_beatmapset_count' => 'Pending Beatmaps',
             'ranked_beatmapset_count' => 'Ranked Beatmaps',
         ],

--- a/resources/views/docs/_structures/user.md
+++ b/resources/views/docs/_structures/user.md
@@ -88,6 +88,12 @@ Field     | Type
 available | integer
 total     | integer
 
+### Optional attributes
+
+Field | Type     | Description
+------|----------|------------
+rank  | integer? | Global kudosu rank. `null` if the user has no kudosu or is outside the top 1,000.
+
 <div id="user-profilebanner" data-unique="user-profilebanner"></div>
 
 ### ProfileBanner

--- a/tests/Models/UserTest.php
+++ b/tests/Models/UserTest.php
@@ -11,6 +11,7 @@ use App\Libraries\Session\Store;
 use App\Models\OAuth\Token;
 use App\Models\User;
 use App\Models\UsernameChangeHistory;
+use Cache;
 use Carbon\CarbonImmutable;
 use Database\Factories\OAuth\RefreshTokenFactory;
 use Tests\TestCase;
@@ -268,5 +269,34 @@ class UserTest extends TestCase
         if (!$valid) {
             $this->assertArrayHasKey('user_discord', $user->validationErrors()->all());
         }
+    }
+
+    public function testKudosuRankReturnsNullForZeroTotal()
+    {
+        Cache::forget('kudosu_rank_threshold:v1');
+        $user = User::factory()->create(['osu_kudostotal' => 0]);
+
+        $this->assertNull($user->kudosuRank());
+    }
+
+    public function testKudosuRankReturnsNullBelowThreshold()
+    {
+        Cache::put('kudosu_rank_threshold:v1', 50, 60);
+        $user = User::factory()->create(['osu_kudostotal' => 10]);
+
+        $this->assertNull($user->kudosuRank());
+    }
+
+    public function testKudosuRank()
+    {
+        Cache::forget('kudosu_rank_threshold:v1');
+        $topUser = User::factory()->create(['osu_kudostotal' => 30_000]);
+        $middleUser = User::factory()->create(['osu_kudostotal' => 20_000]);
+        $tiedUser = User::factory()->create(['osu_kudostotal' => 20_000]);
+        User::factory()->create(['osu_kudostotal' => 10_000]);
+
+        $this->assertSame(1, $topUser->fresh()->kudosuRank());
+        $this->assertSame(2, $middleUser->fresh()->kudosuRank());
+        $this->assertSame(2, $tiedUser->fresh()->kudosuRank());
     }
 }


### PR DESCRIPTION
Resolves #10391

In an attempt to make the modding page slightly less barebones, I've added kudosu ranking and a few missing beatmap stats.

Sure, may still feel somewhat empty, but it's definitely not worse than what we have right now. There's definitely room to add more things based on community feedback so consider this as some sort of starting point too.

<table>
<tr>
 <td> master
 <td> <img width="1001" height="269" alt="image" src="https://github.com/user-attachments/assets/90377c88-880e-40ff-b54c-e4dacc12d24d" />
<tr>
 <td> PR
 <td> <img width="999" height="307" alt="image" src="https://github.com/user-attachments/assets/db6e5c53-6e08-4b7a-9904-11265cbb6efa" />
</table>