### PR TITLE
Remove computed wrapping around non-observables in Comment model

### DIFF
--- a/resources/js/models/comment.ts
+++ b/resources/js/models/comment.ts
@@ -82,7 +82,6 @@ export default class Comment {
     return !meta.locked;
   }
 
-  @computed
   get canHaveVote() {
     return !this.isDeleted;
   }
@@ -137,12 +136,10 @@ export default class Comment {
     return !this.isOwner;
   }
 
-  @computed
   get isDeleted() {
     return this.deletedAt != null;
   }
 
-  @computed
   get isEdited() {
     return this.editedAt != null;
   }


### PR DESCRIPTION
Noticed while investigating something else.

Fixes `xx is being read outside a reactive context. Doing a full recompute`  warnings when posting a new comment.
The fields on `Comment` are `observable` when accessed via `state` in the controller, but not directly `observable` themselves.