### PR TITLE
Fix mods tooltip not showing on most watched replays

### DIFF
--- a/resources/js/profile-page/score-replay-stats-entry.tsx
+++ b/resources/js/profile-page/score-replay-stats-entry.tsx
@@ -93,7 +93,9 @@ export default function ScoreReplayStatsEntry(props: Props) {
 
         <div className='play-detail__mods-pp'>
           <div className='play-detail__mods'>
-            {displayMods(score, false).map((mod) => <Mod key={mod.acronym} mod={mod} />)}
+            <div className='u-contents u-hover'>
+              {displayMods(score, false).map((mod) => <Mod key={mod.acronym} mod={mod} />)}
+            </div>
           </div>
 
           <div className='play-detail__pp play-detail__pp--watch-count'>


### PR DESCRIPTION
I missed this when updating it last time.