### PR TITLE
Return transformed version of tags for Beatmapset related_tags response

### DIFF
--- a/app/Singletons/Tags.php
+++ b/app/Singletons/Tags.php
@@ -10,6 +10,7 @@ namespace App\Singletons;
 use App\Models\Tag;
 use App\Traits\Memoizes;
 use App\Transformers\TagTransformer;
+use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
 
 class Tags
@@ -29,6 +30,16 @@ class Tags
         $allById = $this->memoize(
             'allById',
             fn () => $this->all()->keyBy('id'),
+        );
+
+        return $allById[$id] ?? null;
+    }
+
+    public function getJson(int $id): ?array
+    {
+        $allById = $this->memoize(
+            'allByIdJson',
+            fn () => Arr::keyBy($this->json(), 'id'),
         );
 
         return $allById[$id] ?? null;

--- a/app/Transformers/BeatmapsetCompactTransformer.php
+++ b/app/Transformers/BeatmapsetCompactTransformer.php
@@ -313,7 +313,7 @@ class BeatmapsetCompactTransformer extends TransformerAbstract
         $json = [];
 
         foreach ($tagIdSet as $tagId) {
-            $tag = $cachedTags->get($tagId);
+            $tag = $cachedTags->getJson($tagId);
             if ($tag !== null) {
                 $json[] = $tag;
             }


### PR DESCRIPTION
Not sure how useful caching and using the already transformed version is, though.

closes #13122