### PR TITLE
Show pp value of non-preserved scores

### DIFF
--- a/resources/css/bem-index.less
+++ b/resources/css/bem-index.less
@@ -307,6 +307,7 @@
 @import "bem/popup-menu";
 @import "bem/popup-menu-float";
 @import "bem/post-box";
+@import "bem/pp-value";
 @import "bem/product-box";
 @import "bem/profile-badges";
 @import "bem/profile-cover-change-popup";

--- a/resources/css/bem/pp-value.less
+++ b/resources/css/bem/pp-value.less
@@ -1,3 +1,6 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
 .pp-value {
   &--non-preserved {
     opacity: 0.7;

--- a/resources/css/bem/pp-value.less
+++ b/resources/css/bem/pp-value.less
@@ -1,0 +1,5 @@
+.pp-value {
+  &--non-preserved {
+    opacity: 0.7;
+  }
+}

--- a/resources/js/scores/pp-value.tsx
+++ b/resources/js/scores/pp-value.tsx
@@ -5,6 +5,7 @@ import ScoreJson from 'interfaces/score-json';
 import * as React from 'react';
 import { formatNumber } from 'utils/html';
 import { trans } from 'utils/lang';
+import { classWithModifiers } from "../utils/css";
 
 interface Props {
   score: ScoreJson;
@@ -18,7 +19,7 @@ export default function PpValue({ score, suffix }: Props) {
 
   if (
     score.type === 'solo_score' &&
-    (!score.preserve || !score.ranked || (score.pp == null && score.processed))
+    (!score.ranked || (score.pp == null && score.processed))
   ) {
     return <span title={trans('scores.status.no_pp')}>-</span>;
   }
@@ -31,8 +32,11 @@ export default function PpValue({ score, suffix }: Props) {
     );
   }
 
+  const nonPreserved = score.type === 'solo_score' && !score.preserve;
   return (
-    <span title={formatNumber(score.pp)}>
+    <span
+      className={classWithModifiers('pp-value', { 'non-preserved': nonPreserved })}
+      title={nonPreserved ? trans('scores.status.non_best') : formatNumber(score.pp)}>
       {formatNumber(Math.round(score.pp))}
       {suffix}
     </span>

--- a/resources/js/scores/pp-value.tsx
+++ b/resources/js/scores/pp-value.tsx
@@ -5,7 +5,7 @@ import ScoreJson from 'interfaces/score-json';
 import * as React from 'react';
 import { formatNumber } from 'utils/html';
 import { trans } from 'utils/lang';
-import { classWithModifiers } from "../utils/css";
+import { classWithModifiers } from '../utils/css';
 
 interface Props {
   score: ScoreJson;


### PR DESCRIPTION
With the recent roll-out of https://github.com/ppy/osu-queue-score-statistics/pull/392, scores have started getting marked as `preserve=0` much more aggressively, meaning that they started up showing on user profiles in the "recent" section in that state. When they do, the pp value is not displayed which has been noticed pretty much instantly. See [this forum thread](https://osu.ppy.sh/community/forums/topics/2229803?n=1) for an example of a user confused about this.

Now, this is how things worked on the old tables - if a score wasn't the user's best, its pp value would not show anywhere, including the recent scores list. See 3778dec3c3ae26037c331be0c3ca4e7f79bf719e, which is preserved to this day as

https://github.com/ppy/osu-web/blob/ad92032fd45eaf9bef748fd37ebde2eeb0a17370/resources/js/scores/pp-value.tsx#L15-L17

In ade9f0aad4853f0bfc3c46fc0d60b7dfabbfc2fb, seeking parity, I made the treatment of `preserve=0` match the above. However I am told that it is more desirable to keep this value visible as it prevents users wanting to see these values from deploying browser extensions of dubious quality that tend to incur disproportionate load on the API.

This change will affect all places where this component is used, namely:

- beatmap leaderboards (which I would hope to be a dead case anyway, as non-preserved scores should never be on a beatmap leaderboard),
- profile page, both "recent" and "most watched replays" sections,
- individual score pages.

While the scope of the above is somewhat larger than the single place this change was desired (the "recent" profile section), I do not see any particular value in constraining this change to that particular usage site.

| before | after |
| :-: | :-: |
| <img width="966" height="303" alt="Screenshot 2026-07-29 at 14 11 47" src="https://github.com/user-attachments/assets/48f812db-b41b-49ea-bdd9-2c9661a6be84" /> | <img width="1005" height="315" alt="Screenshot 2026-07-29 at 14 12 33" src="https://github.com/user-attachments/assets/68d78ec2-a281-498f-ac64-dd2e9423a557" /> |
| <img width="1033" height="640" alt="Screenshot 2026-07-29 at 14 12 15" src="https://github.com/user-attachments/assets/49d12674-babe-4cbc-a419-647f80ae52da" /> | <img width="1037" height="636" alt="Screenshot 2026-07-29 at 14 12 46" src="https://github.com/user-attachments/assets/be2410d7-fda1-4c3c-aca2-0610071c1035" /> |
