### PR TITLE
Lazy load user avatar in chat channel list

### DIFF
--- a/resources/css/bem-index.less
+++ b/resources/css/bem-index.less
@@ -425,6 +425,7 @@
 @import "bem/turbo-progress-bar";
 @import "bem/update-streams-v2";
 @import "bem/user-action-button";
+@import "bem/user-avatar";
 @import "bem/user-card";
 @import "bem/user-card-brick";
 @import "bem/user-cards";

--- a/resources/css/bem/user-avatar.less
+++ b/resources/css/bem/user-avatar.less
@@ -1,0 +1,53 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
+.user-avatar {
+  @transition: opacity ease-in-out 220ms;
+  --avatar-border-radius: 6px;
+  --avatar-size: 60px;
+
+  width: var(--avatar-size);
+  height: var(--avatar-size);
+  flex: none;
+  position: relative;
+
+  &--full-circle {
+    --avatar-size: 100%;
+    --avatar-border-radius: 50%;
+  }
+
+  &--list {
+    --avatar-border-radius: 6px 0 0 6px;
+    --avatar-size: 40px;
+  }
+
+  &__image {
+    .full-size();
+    border-radius: var(--avatar-border-radius);
+    object-fit: contain;
+    background-color: var(--hsl-b4);
+    transition: @transition;
+    opacity: 0;
+
+    &--loaded {
+      opacity: 1;
+    }
+  }
+
+  &__spinner {
+    .full-size();
+    .center-content();
+    border-radius: var(--avatar-border-radius);
+    color: #fff;
+    font-size: 14px;
+    background: fade(#fff, 10%);
+    transition: @transition;
+    opacity: 0.25;
+
+    &--loaded {
+      // needs display: none or element to be removed to remove the layer in Safari
+      // but can't transition a display change...
+      opacity: 0;
+    }
+  }
+}

--- a/resources/css/bem/user-avatar.less
+++ b/resources/css/bem/user-avatar.less
@@ -3,17 +3,26 @@
 
 .user-avatar {
   @transition: opacity ease-in-out 220ms;
-  --avatar-border-radius: 6px;
-  --avatar-size: 60px;
+  --avatar-border-radius: @border-radius-base;
+  --avatar-size: 70px;
 
   width: var(--avatar-size);
   height: var(--avatar-size);
   flex: none;
   position: relative;
 
+  &--card {
+    --avatar-border-radius: 6px;
+    --avatar-size: 60px;
+  }
+
   &--full-circle {
     --avatar-size: 100%;
     --avatar-border-radius: 50%;
+  }
+
+  &--has-box-shadow {
+    .default-box-shadow();
   }
 
   &--list {

--- a/resources/css/bem/user-card.less
+++ b/resources/css/bem/user-card.less
@@ -68,47 +68,6 @@
     }
   }
 
-  &__avatar {
-    .full-size();
-    border-radius: @avatar-border-radius;
-    object-fit: contain;
-    background-color: @background-color;
-    transition: opacity ease-in-out @fade-duration;
-    opacity: 0;
-
-    &--loaded {
-      opacity: 1;
-    }
-
-    .@{top}--list & {
-      border-radius: @avatar-border-radius 0 0 @avatar-border-radius;
-    }
-  }
-
-  &__avatar-space {
-    width: var(--avatar-size);
-    height: var(--avatar-size);
-    flex: none;
-    position: relative;
-  }
-
-  &__avatar-spinner {
-    .full-size();
-    .center-content();
-    border-radius: @avatar-border-radius;
-    color: #fff;
-    font-size: 14px;
-    background: fade(#fff, 10%);
-    transition: opacity ease-in-out @fade-duration;
-    opacity: 0.25;
-
-    &--loaded {
-      // needs display: none or element to be removed to remove the layer in Safari
-      // but can't transition a display change...
-      opacity: 0;
-    }
-  }
-
   &__background {
     // to prevent annoying white-pixel artefacts appearing due to
     // browsers not handling 'overflow: hidden' properly

--- a/resources/js/chat/conversation-list-item.tsx
+++ b/resources/js/chat/conversation-list-item.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
-import UserAvatar from 'components/user-avatar';
+import UserAvatarImg from 'components/user-avatar-img';
 import { computed, makeObservable } from 'mobx';
 import { observer } from 'mobx-react';
 import Channel from 'models/chat/channel';
@@ -60,7 +60,7 @@ export default class ConversationListItem extends React.Component<Props> {
 
         <button className={`${baseClassName}__tile`} onClick={this.switch}>
           <div className={`${baseClassName}__avatar`}>
-            <UserAvatar modifiers='full-circle' user={{ avatar_url: this.props.channel.icon }} />
+            <UserAvatarImg modifiers='full-circle' user={{ avatar_url: this.props.channel.icon }} />
           </div>
           <div className={`${baseClassName}__name u-ellipsis-overflow`}>{this.props.channel.name}</div>
           <div className={`${baseClassName}__chevron`}>

--- a/resources/js/chat/conversation-view.tsx
+++ b/resources/js/chat/conversation-view.tsx
@@ -4,7 +4,7 @@
 import ShowMoreLink from 'components/show-more-link';
 import { Spinner } from 'components/spinner';
 import StringWithComponent from 'components/string-with-component';
-import UserAvatar from 'components/user-avatar';
+import UserAvatarImg from 'components/user-avatar-img';
 import UserCardBrick from 'components/user-card-brick';
 import UserLink from 'components/user-link';
 import { each, isEmpty, last, throttle } from 'lodash';
@@ -216,10 +216,10 @@ export default class ConversationView extends React.Component<Props> {
         <div ref={this.chatViewRef} className={className} onScroll={this.handleOnScroll}>
           <div className='chat-conversation__new-chat-avatar'>
             {pmTargetJson == null ? (
-              <UserAvatar user={{ avatar_url: channel.icon }} />
+              <UserAvatarImg modifiers='has-box-shadow' user={{ avatar_url: channel.icon }} />
             ) : (
               <UserLink user={pmTargetJson}>
-                <UserAvatar user={pmTargetJson} />
+                <UserAvatarImg modifiers='has-box-shadow' user={pmTargetJson} />
               </UserLink>
             )}
           </div>

--- a/resources/js/chat/message-group.tsx
+++ b/resources/js/chat/message-group.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
-import UserAvatar from 'components/user-avatar';
+import UserAvatarImg from 'components/user-avatar-img';
 import UserLink from 'components/user-link';
 import Reportable from 'interfaces/reportable';
 import { last } from 'lodash';
@@ -54,7 +54,7 @@ export default class MessageGroup extends React.Component<Props> {
             user={sender}
           >
             <div className='chat-message-group__avatar'>
-              <UserAvatar modifiers='full-circle' user={{ avatar_url: sender.avatarUrl }} />
+              <UserAvatarImg modifiers='full-circle' user={{ avatar_url: sender.avatarUrl }} />
             </div>
           </UserLink>
           <div className='chat-message-group__username u-ellipsis-overflow'>

--- a/resources/js/components/user-avatar-img.tsx
+++ b/resources/js/components/user-avatar-img.tsx
@@ -18,14 +18,30 @@ interface Props {
 export default class UserAvatarImg extends React.PureComponent<Props> {
   @observable private avatarLoaded = false;
 
+  private get url() {
+    return presence(this.props.user.avatar_url); // assumes loading user has empty avatar_url.
+  }
+
   constructor(props: Props) {
     super(props);
+
+    // Check if image is already loaded from cache to avoid showing the spinner and transitions, especially in back/forward navigation.
+    const url = this.url;
+    if (url != null) {
+      const image = new Image();
+      image.loading = 'lazy';
+      image.src = url;
+      if (image.complete && image.naturalWidth > 0) {
+        this.avatarLoaded = true;
+      }
+    }
+
     makeObservable(this);
   }
 
   render() {
     const extraModifiers = this.avatarLoaded ? 'loaded' : null;
-    const url = presence(this.props.user.avatar_url); // assumes loading user has empty avatar_url.
+    const url = this.url;
 
     return (
       <div className={classWithModifiers('user-avatar', this.props.modifiers)}>

--- a/resources/js/components/user-avatar-img.tsx
+++ b/resources/js/components/user-avatar-img.tsx
@@ -1,0 +1,52 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
+import UserJson from 'interfaces/user-json';
+import { action, makeObservable, observable } from 'mobx';
+import { observer } from 'mobx-react';
+import * as React from 'react';
+import { classWithModifiers, Modifiers } from 'utils/css';
+import { presence } from 'utils/string';
+import { Spinner } from './spinner';
+
+interface Props {
+  modifiers?: Modifiers;
+  user: Pick<UserJson, 'avatar_url'>;
+}
+
+@observer
+export default class UserAvatarImg extends React.PureComponent<Props> {
+  @observable private avatarLoaded = false;
+
+  constructor(props: Props) {
+    super(props);
+    makeObservable(this);
+  }
+
+  render() {
+    const extraModifiers = this.avatarLoaded ? 'loaded' : null;
+    const url = presence(this.props.user.avatar_url); // assumes loading user has empty avatar_url.
+
+    return (
+      <div className={classWithModifiers('user-avatar', this.props.modifiers)}>
+        <div className={classWithModifiers('user-avatar__spinner', this.props.modifiers, extraModifiers)}>
+          {url != null && <Spinner modifiers={extraModifiers} />}
+        </div>
+        {url != null && (
+          <img
+            className={classWithModifiers('user-avatar__image', this.props.modifiers, extraModifiers)}
+            loading='lazy'
+            onError={this.onAvatarLoad} // remove spinner if error
+            onLoad={this.onAvatarLoad}
+            src={url}
+          />
+        )}
+      </div>
+    );
+  }
+
+  @action
+  private readonly onAvatarLoad = () => {
+    this.avatarLoaded = true;
+  };
+}

--- a/resources/js/components/user-card.tsx
+++ b/resources/js/components/user-card.tsx
@@ -12,7 +12,6 @@ import core from 'osu-core-singleton';
 import * as React from 'react';
 import { classWithModifiers, Modifiers } from 'utils/css';
 import { trans } from 'utils/lang';
-import { present } from 'utils/string';
 import { giftSupporterTagUrl } from 'utils/url';
 import FlagCountry from './flag-country';
 import FlagTeam from './flag-team';
@@ -20,10 +19,10 @@ import FollowUserMappingButton from './follow-user-mapping-button';
 import { PopupMenuPersistent } from './popup-menu-persistent';
 import PopupMenuState from './popup-menu-state';
 import { ReportReportable } from './report-reportable';
-import { Spinner } from './spinner';
 import StringWithComponent from './string-with-component';
 import SupporterIcon from './supporter-icon';
 import TimeWithTooltip from './time-with-tooltip';
+import UserAvatarImg from './user-avatar-img';
 import UserCardBrick from './user-card-brick';
 import UserGroupBadges from './user-group-badges';
 
@@ -67,7 +66,6 @@ export class UserCard extends React.PureComponent<Props, State> {
     username: trans('users.card.loading'),
   };
 
-  @observable private avatarLoaded = false;
   @observable private backgroundLoaded = false;
   private readonly popupMenuState = new PopupMenuState();
   private url?: string;
@@ -89,16 +87,12 @@ export class UserCard extends React.PureComponent<Props, State> {
     return Number.isFinite(this.user.id) && this.user.id > 0;
   }
 
-  private get isUserNotFound() {
-    return this.user.id === -1;
-  }
-
   private get isUserVisible() {
     return this.isUserLoaded && !this.user.is_deleted;
   }
 
   private get user() {
-    return this.props.user || UserCard.userLoading;
+    return this.props.user ?? UserCard.userLoading;
   }
 
   constructor(props: Props) {
@@ -132,7 +126,7 @@ export class UserCard extends React.PureComponent<Props, State> {
         <div className='user-card__card'>
           <div className='user-card__content user-card__content--details'>
             <div className='user-card__user'>
-              {this.renderAvatar()}
+              <UserAvatarImg modifiers={this.props.mode} user={this.user} />
             </div>
             <div className='user-card__details'>
               {this.renderIcons()}
@@ -145,27 +139,6 @@ export class UserCard extends React.PureComponent<Props, State> {
           </div>
           {this.renderStatusBar()}
         </div>
-      </div>
-    );
-  }
-
-  renderAvatar() {
-    const modifiers = this.avatarLoaded ? 'loaded' : null;
-    const hasAvatar = present(this.user.avatar_url) && !this.isUserNotFound;
-
-    return (
-      <div className='user-card__avatar-space'>
-        <div className={classWithModifiers('user-card__avatar-spinner', modifiers)}>
-          {hasAvatar && <Spinner modifiers={modifiers} />}
-        </div>
-        {this.isUserLoaded && hasAvatar && (
-          <img
-            className={classWithModifiers('user-card__avatar', modifiers)}
-            onError={this.onAvatarLoad} // remove spinner if error
-            onLoad={this.onAvatarLoad}
-            src={this.user.avatar_url}
-          />
-        )}
       </div>
     );
   }
@@ -322,11 +295,6 @@ export class UserCard extends React.PureComponent<Props, State> {
       </div>
     );
   }
-
-  @action
-  private readonly onAvatarLoad = () => {
-    this.avatarLoaded = true;
-  };
 
   @action
   private readonly onBackgroundLoad = () => {

--- a/resources/js/models/chat/channel.ts
+++ b/resources/js/models/chat/channel.ts
@@ -13,6 +13,7 @@ import Message from './message';
 
 const hideableChannelTypes: Set<ChannelType> = new Set(['ANNOUNCE', 'PM']);
 
+const defaultChannelIcon = '/images/layout/chat/channel-default.png';
 export const maxMessageLength = 1024;
 
 // TODO: rename minMessageId and also check firstMessageId
@@ -28,14 +29,12 @@ function getMinMessageIdFrom(messages: Message[]) {
 }
 
 export default class Channel {
-  private static readonly defaultIcon = '/images/layout/chat/channel-default.png'; // TODO: update with channel-specific icons?
-
   @observable canListUsers: boolean = false;
   @observable canMessageError: string | null = null;
   @observable channelId: number;
   @observable description?: string;
   @observable firstMessageId = -1;
-  @observable icon?: string;
+  @observable icon = defaultChannelIcon;
   @observable inputText = '';
   @observable lastReadId?: number;
   @observable loadingEarlierMessages = false;
@@ -286,7 +285,7 @@ export default class Channel {
     this.name = json.name;
     this.description = json.description;
     this.type = json.type;
-    this.icon = json.icon ?? Channel.defaultIcon;
+    this.icon = json.icon ?? defaultChannelIcon;
     this.messageLengthLimit = json.message_length_limit;
     this.userIds = json.users ?? this.userIds;
 


### PR DESCRIPTION
Replaces the use of `background-image` with actual lazy loaded `img` (although, Safari appears to have a very liberal range of what is lazy loaded...)

Includes a workaround to avoid showing the spinner and fade-in for images that are already loaded in cache, most noticeable during browser back/forward navigations.

The component name could use an improvement but I don't want to just blindly replace all the existing `UserAvatar` usages either and find out the layout on something is different 👀  

maybe fixes #13181
