### PR TITLE
Use the more general error class

### DIFF
--- a/app/Models/Forum/TopicCover.php
+++ b/app/Models/Forum/TopicCover.php
@@ -9,7 +9,6 @@ use App\Casts\LegacyFilename;
 use App\Libraries\Uploader;
 use App\Models\User;
 use DB;
-use Exception;
 
 /**
  * @property \Carbon\Carbon|null $created_at
@@ -107,7 +106,7 @@ class TopicCover extends Model
     {
         try {
             return $this->topic->forum->cover->defaultTopicCover->url();
-        } catch (Exception $_e) {
+        } catch (\Throwable) {
             // do nothing
         }
     }


### PR DESCRIPTION
It throws different error when laravel specific error handling is removed (like when testing updated phpunit and trying to get rid of "risky test" warning).

Removed the variable while at it.