### PR TITLE
Allow specifying max filesize in contest extra options

### DIFF
--- a/app/Models/Contest.php
+++ b/app/Models/Contest.php
@@ -451,7 +451,7 @@ class Contest extends Model
 
     public function getMaxFilesize(): int
     {
-        return self::MAX_FILESIZE[$this->type] ?? 0;
+        return $this->getExtraOptions()['max_filesize'] ?? self::MAX_FILESIZE[$this->type] ?? 0;
     }
 
     public function showEntryUser(): bool

--- a/tests/Models/ContestTest.php
+++ b/tests/Models/ContestTest.php
@@ -92,9 +92,12 @@ class ContestTest extends TestCase
     public static function dataProviderForTestMaxFilesize(): array
     {
         return [
-            ['art', 8 * 1024 * 1024],
-            ['beatmap', 32 * 1024 * 1024],
-            ['music', 16 * 1024 * 1024],
+            ['art', null, 8 * 1024 * 1024],
+            ['beatmap', null, 32 * 1024 * 1024],
+            ['music', null, 16 * 1024 * 1024],
+            ['art', 4 * 1024 * 1024, 4 * 1024 * 1024],
+            ['beatmap', 64 * 1024 * 1024, 64 * 1024 * 1024],
+            ['music', 2 * 1024 * 1024, 2 * 1024 * 1024],
         ];
     }
 
@@ -270,10 +273,14 @@ class ContestTest extends TestCase
     /**
      * @dataProvider dataProviderForTestMaxFilesize
      */
-    public function testMaxFilesize(string $type, int $expectedResult): void
+    public function testMaxFilesize(string $type, ?int $maxFilesize, int $expectedResult): void
     {
+        $extraOptions = $maxFilesize === null
+            ? null
+            : ['max_filesize' => $maxFilesize];
         $contest = Contest::factory()->create([
             'type' => $type,
+            'extra_options' => $extraOptions,
         ]);
         $this->assertSame($expectedResult, $contest->getMaxFilesize());
     }


### PR DESCRIPTION
value is in bytes

a bit time-sensitive for Aspire-related reasons