### PR TITLE
Improve beatmapset/news/contest opengraph

### DIFF
--- a/app/Libraries/Opengraph/BeatmapsetOpengraph.php
+++ b/app/Libraries/Opengraph/BeatmapsetOpengraph.php
@@ -17,13 +17,39 @@ class BeatmapsetOpengraph implements OpengraphInterface
 
     public function get(): array
     {
-        $section = osu_trans('layout.menu.beatmaps._');
         $title = "{$this->beatmapset->artist} - {$this->beatmapset->title}"; // opengraph header always intended for guest.
 
         return [
-            'description' => "osu! » {$section} » {$title}",
+            'description' => $this->description(),
             'image' => $this->beatmapset->coverURL('list'),
             'title' => $title,
         ];
+    }
+
+    private function description(): string
+    {
+        return implode(' | ', [
+            osu_trans('beatmapsets.show.details.mapped_by', [
+                'mapper' => $this->beatmapset->creator,
+            ]),
+            $this->statusText(),
+            osu_trans_choice('beatmapsets.ogp.playcount', $this->beatmapset->play_count),
+            osu_trans_choice('beatmapsets.ogp.favourites', $this->beatmapset->favourite_count),
+        ]);
+    }
+
+    private function statusText(): string
+    {
+        if ($this->beatmapset->approved > 0) {
+            $key = $this->beatmapset->status();
+            $date = $this->beatmapset->approved_date;
+        } else {
+            $key = 'updated';
+            $date = $this->beatmapset->last_update;
+        }
+
+        return osu_trans("beatmapsets.show.details_date.{$key}", [
+            'timeago' => $date?->diffForHumans() ?? '',
+        ]);
     }
 }

--- a/app/Libraries/Opengraph/ContestOpengraph.php
+++ b/app/Libraries/Opengraph/ContestOpengraph.php
@@ -18,6 +18,7 @@ class ContestOpengraph implements OpengraphInterface
     public function get(): array
     {
         return [
+            'card' => 'summary_large_image',
             'description' => strip_tags(markdown($this->contest->currentDescription())),
             'image' => $this->contest->header_url,
             'title' => $this->contest->name,

--- a/app/Libraries/Opengraph/NewsPostOpengraph.php
+++ b/app/Libraries/Opengraph/NewsPostOpengraph.php
@@ -18,6 +18,7 @@ class NewsPostOpengraph implements OpengraphInterface
     public function get(): array
     {
         return [
+            'card' => 'summary_large_image',
             'description' => $this->post->previewText(),
             'image' => $this->post->firstImage(true),
             'title' => $this->post->title(),

--- a/resources/lang/en/beatmapsets.php
+++ b/resources/lang/en/beatmapsets.php
@@ -29,6 +29,11 @@ return [
         'guest_title' => 'Beatmaps',
     ],
 
+    'ogp' => [
+        'favourites' => ':count_delimited favourite|:count_delimited favourites',
+        'playcount' => ':count_delimited play|:count_delimited plays',
+    ],
+
     'panel' => [
         'empty' => 'no beatmaps',
 

--- a/resources/views/layout/metadata.blade.php
+++ b/resources/views/layout/metadata.blade.php
@@ -37,7 +37,9 @@
 
 @foreach ($opengraph as $key => $value)
     @if (present($value))
-        @if ($key === 'title')
+        @if ($key === 'card')
+            <meta name="twitter:card" content="{{ $value }}">
+        @elseif ($key === 'title')
             <meta property="og:{{ $key }}" content="{{ $value }} · {{ page_title() }}">
         @else
             <meta property="og:{{ $key }}" content="{{ $value }}">


### PR DESCRIPTION
maps now show basic info similar to players og

contests and news specify a wide image layout for discord/twitter which looks more fitting that current layout

<table>
<tr>
 <td>before
 <td>after
<tr>
 <td> <img width="387" height="107" alt="image" src="https://github.com/user-attachments/assets/44abea19-0baf-4443-8339-9c7b7bf1655d" />
 <td> <img width="451" height="208" alt="image" src="https://github.com/user-attachments/assets/ea4df0fc-7eef-490f-be03-01354ae55eab" />
</table>