### PR TITLE
Fix some php deprecations

### DIFF
--- a/app/Libraries/BBCodeForDB.php
+++ b/app/Libraries/BBCodeForDB.php
@@ -18,7 +18,7 @@ class BBCodeForDB
         '@' => '&#64;',
     ];
 
-    public $text;
+    public string $text;
     public $uid;
 
     // "11111111111111111111111111111"
@@ -39,9 +39,9 @@ class BBCodeForDB
         return strtr($text, $mapping);
     }
 
-    public function __construct($text = '')
+    public function __construct(?string $text = '')
     {
-        $this->text = $text;
+        $this->text = $text ?? '';
         $this->uid = $GLOBALS['cfg']['osu']['bbcode']['uid'];
     }
 

--- a/app/Libraries/BBCodeFromDB.php
+++ b/app/Libraries/BBCodeFromDB.php
@@ -457,7 +457,7 @@ class BBCodeFromDB
 
         static $pattern = '#\[/?(\*|\*:m|audio|b|box|color|spoilerbox|centre|code|email|heading|i|img|left|list|list:o|list:u|notice|profile|quote|right|s|strike|u|spoiler|size|url|youtube)(=.*?(?=:))?(:[a-zA-Z0-9]{1,5})?\]#';
 
-        return preg_replace($pattern, '', $text);
+        return preg_replace($pattern, '', $text ?? '');
     }
 
     public static function removeBlockQuotes($text)

--- a/app/Libraries/Payments/XsollaSignature.php
+++ b/app/Libraries/Payments/XsollaSignature.php
@@ -36,7 +36,7 @@ class XsollaSignature implements PaymentSignature
 
     private function receivedSignature()
     {
-        preg_match('~^Signature (?<signature>[0-9a-f]{40})$~', $this->request->header('Authorization'), $matches);
+        preg_match('~^Signature (?<signature>[0-9a-f]{40})$~', $this->request->header('Authorization') ?? '', $matches);
 
         return $matches['signature'] ?? null;
     }

--- a/app/Models/Forum/Forum.php
+++ b/app/Models/Forum/Forum.php
@@ -238,8 +238,7 @@ class Forum extends Model
 
     public function setForumLastPosterColourAttribute($value)
     {
-        // also functions for casting null to string
-        $this->attributes['forum_last_poster_colour'] = ltrim($value, '#');
+        $this->attributes['forum_last_poster_colour'] = ltrim($value ?? '', '#');
     }
 
     // feature forum shall have extra features like sorting and voting

--- a/app/Models/Forum/Topic.php
+++ b/app/Models/Forum/Topic.php
@@ -283,8 +283,7 @@ class Topic extends Model implements AfterCommit
 
     public function setTopicFirstPosterColourAttribute($value)
     {
-        // also functions for casting null to string
-        $this->attributes['topic_first_poster_colour'] = ltrim($value, '#');
+        $this->attributes['topic_first_poster_colour'] = ltrim($value ?? '', '#');
     }
 
     public function getTopicLastPosterColourAttribute($value)
@@ -296,8 +295,7 @@ class Topic extends Model implements AfterCommit
 
     public function setTopicLastPosterColourAttribute($value)
     {
-        // also functions for casting null to string
-        $this->attributes['topic_last_poster_colour'] = ltrim($value, '#');
+        $this->attributes['topic_last_poster_colour'] = ltrim($value ?? '', '#');
     }
 
     public function setTopicTitleAttribute($value)

--- a/app/Models/OAuth/Client.php
+++ b/app/Models/OAuth/Client.php
@@ -92,7 +92,7 @@ class Client extends PassportClient
             }
         }
 
-        if (mb_strlen(trim($this->name)) === 0) {
+        if (mb_strlen(trim($this->name ?? '')) === 0) {
             $this->validationErrors()->add('name', 'required');
         }
 

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -428,7 +428,7 @@ class User extends Model implements AfterCommit, AuthenticatableContract, HasLoc
 
     public static function cleanUsername($username)
     {
-        return strtolower($username);
+        return strtolower($username ?? '');
     }
 
     public static function findAndRenameUserForInactive($username): ?self
@@ -768,7 +768,7 @@ class User extends Model implements AfterCommit, AuthenticatableContract, HasLoc
 
     public function setUserTwitterAttribute($value)
     {
-        $this->attributes['user_twitter'] = trim(ltrim($value, '@'));
+        $this->attributes['user_twitter'] = trim(ltrim($value ?? '', '@'));
     }
 
     public function setUserDiscordAttribute($value)
@@ -778,8 +778,7 @@ class User extends Model implements AfterCommit, AuthenticatableContract, HasLoc
 
     public function setUserColourAttribute($value)
     {
-        // also functions for casting null to string
-        $this->attributes['user_colour'] = ltrim($value, '#');
+        $this->attributes['user_colour'] = ltrim($value ?? '', '#');
     }
 
     public function getAttribute($key)

--- a/app/Models/UserClient.php
+++ b/app/Models/UserClient.php
@@ -63,9 +63,9 @@ class UserClient extends Model
         }
     }
 
-    public static function splitHash($hash)
+    public static function splitHash(?string $hash)
     {
-        $hashes = explode(':', $hash);
+        $hashes = explode(':', $hash ?? '');
 
         if (count($hashes) < 5) {
             throw new InvariantException('invalid client hash format');

--- a/app/Models/UserStatistics/VariantModel.php
+++ b/app/Models/UserStatistics/VariantModel.php
@@ -92,7 +92,7 @@ abstract class VariantModel extends Model
 
     public function setTotalScoreAttribute($value)
     {
-        $this->total_score = $value;
+        $this->total_score = (int) $value;
     }
 
     public function setTotalSecondsPlayedAttribute($value)

--- a/app/helpers.php
+++ b/app/helpers.php
@@ -518,7 +518,7 @@ function storage_disk(string $type): Illuminate\Contracts\Filesystem\Filesystem
 
 function trim_unicode(?string $value)
 {
-    return preg_replace('/(^\s+|\s+$)/u', '', $value);
+    return preg_replace('/(^\s+|\s+$)/u', '', $value ?? '');
 }
 
 function truncate(string $text, $limit = 100, $ellipsis = '...')
@@ -1984,7 +1984,12 @@ function check_url(string $url): bool
 
 function mini_asset(string $url): string
 {
-    return str_replace($GLOBALS['cfg']['filesystems']['disks']['s3']['base_url'], $GLOBALS['cfg']['filesystems']['disks']['s3']['mini_url'], $url);
+    $baseUrl = $GLOBALS['cfg']['filesystems']['disks']['s3']['base_url'];
+    $miniUrl = $GLOBALS['cfg']['filesystems']['disks']['s3']['mini_url'];
+
+    return isset($baseUrl, $miniUrl)
+        ? preg_replace('#^'.preg_quote($baseUrl, '#').'#', $miniUrl, $url)
+        : $url;
 }
 
 function section_to_hue_map($section): int

--- a/tests/Controllers/Chat/Channels/MessagesControllerTest.php
+++ b/tests/Controllers/Chat/Channels/MessagesControllerTest.php
@@ -26,6 +26,7 @@ class MessagesControllerTest extends TestCase
     private User $silencedUser;
     private Channel $tourneyChannel;
     private User $user;
+    private UserChannel $userChannel;
 
     public static function setUpBeforeClass(): void
     {

--- a/tests/Libraries/Fulfillments/BannerFulfillmentTest.php
+++ b/tests/Libraries/Fulfillments/BannerFulfillmentTest.php
@@ -20,6 +20,12 @@ use Tests\TestCase;
 
 class BannerFulfillmentTest extends TestCase
 {
+    private Country $country;
+    private Order $order;
+    private ?Product $product;
+    private Tournament $tournament;
+    private User $user;
+
     private function findOrSeed()
     {
         // TODO: factory that creates related items properly? or just use fixtures.

--- a/tests/Libraries/Fulfillments/UsernameChangeFulfillmentTest.php
+++ b/tests/Libraries/Fulfillments/UsernameChangeFulfillmentTest.php
@@ -16,6 +16,9 @@ use Tests\TestCase;
 
 class UsernameChangeFulfillmentTest extends TestCase
 {
+    private Order $order;
+    private User $user;
+
     public function testRun()
     {
         $oldUsername = $this->user->username;


### PR DESCRIPTION
- don't pass null to various string functions
- declare class property
- explicitly cast float to int

Discovered by updating to phpunit 11 (with a bit of "fix"es)