### PR TITLE
Update tests to use the attribute syntax for data provider

### DIFF
--- a/tests/BeatmapsetDisqualifyNotificationsTest.php
+++ b/tests/BeatmapsetDisqualifyNotificationsTest.php
@@ -13,6 +13,7 @@ use App\Models\Notification;
 use App\Models\User;
 use App\Models\UserNotificationOption;
 use Event;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Queue;
 
 class BeatmapsetDisqualifyNotificationsTest extends TestCase
@@ -65,9 +66,7 @@ class BeatmapsetDisqualifyNotificationsTest extends TestCase
             $event->notification->name === Notification::BEATMAPSET_DISQUALIFY && $this->assertReceivers($event, $this->user));
     }
 
-    /**
-     * @dataProvider booleanDataProvider
-     */
+    #[DataProvider('booleanDataProvider')]
     public function testNotificationSentWithPushNotificationDeliveryOption($pushEnabled)
     {
         $this->beatmapset->watches()->create(['user_id' => $this->user->getKey()]);

--- a/tests/BroadcastNotificationTest.php
+++ b/tests/BroadcastNotificationTest.php
@@ -16,6 +16,7 @@ use App\Models\User;
 use App\Models\UserNotificationOption;
 use Event;
 use Mail;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Queue;
 use ReflectionClass;
 use ReflectionClassConstant;
@@ -40,17 +41,13 @@ class BroadcastNotificationTest extends TestCase
         Event::assertNotDispatched(NewPrivateNotificationEvent::class);
     }
 
-    /**
-     * @dataProvider notificationNamesDataProvider
-     */
+    #[DataProvider('notificationNamesDataProvider')]
     public function testAllNotificationNamesHaveNotificationClasses($name)
     {
         $this->assertNotNull(BroadcastNotificationBase::getNotificationClass($name));
     }
 
-    /**
-     * @dataProvider notificationJobClassesDataProvider
-     */
+    #[DataProvider('notificationJobClassesDataProvider')]
     public function testNotificationOptionNameHasDeliveryModes($class)
     {
         $predicate = $class::NOTIFICATION_OPTION_NAME === null
@@ -59,9 +56,7 @@ class BroadcastNotificationTest extends TestCase
         $this->assertTrue($predicate, "NOTIFICATION_OPTION_NAME for {$class} must be null or in UserNotificationOption::HAS_DELIVERY_MODES");
     }
 
-    /**
-     * @dataProvider userNotificationDetailsDataProvider
-     */
+    #[DataProvider('userNotificationDetailsDataProvider')]
     public function testSendNotificationWithOptions($details)
     {
         $user = User::factory()->create();

--- a/tests/Browser/SanityTest.php
+++ b/tests/Browser/SanityTest.php
@@ -60,6 +60,7 @@ use App\Models\UserStatistics;
 use Exception;
 use Illuminate\Routing\Route as LaravelRoute;
 use Laravel\Dusk\Browser;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Tests\DuskTestCase;
 
 class SanityTest extends DuskTestCase
@@ -381,9 +382,7 @@ class SanityTest extends DuskTestCase
         return $data;
     }
 
-    /**
-     * @dataProvider routesDataProvider
-     */
+    #[DataProvider('routesDataProvider')]
     public function testPageLoadCheck($type, $uri)
     {
         $route = app()->routes->get('GET')[$uri];

--- a/tests/Commands/EsIndexScoresQueueTest.php
+++ b/tests/Commands/EsIndexScoresQueueTest.php
@@ -9,6 +9,7 @@ use App\Exceptions\InvariantException;
 use App\Models\Solo\Score;
 use Artisan;
 use LaravelRedis;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Tests\TestCase;
 
 class EsIndexScoresQueueTest extends TestCase
@@ -30,9 +31,7 @@ class EsIndexScoresQueueTest extends TestCase
         return LaravelRedis::llen(static::queueKey());
     }
 
-    /**
-     * @dataProvider dataProviderForTestParameterValidity
-     */
+    #[DataProvider('dataProviderForTestParameterValidity')]
     public function testParameterValidity(array $params, bool $isValid)
     {
         if (!$isValid) {
@@ -46,9 +45,7 @@ class EsIndexScoresQueueTest extends TestCase
         }
     }
 
-    /**
-     * @dataProvider dataProviderForTestQueueScores
-     */
+    #[DataProvider('dataProviderForTestQueueScores')]
     public function testQueueScores(callable $setUp, array|callable $params, int $change): void
     {
         $setUp();

--- a/tests/Commands/ModdingRankCommandTest.php
+++ b/tests/Commands/ModdingRankCommandTest.php
@@ -16,6 +16,7 @@ use App\Models\BeatmapDiscussion;
 use App\Models\Beatmapset;
 use Bus;
 use Database\Factories\BeatmapsetFactory;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Tests\TestCase;
 
 class ModdingRankCommandTest extends TestCase
@@ -32,9 +33,7 @@ class ModdingRankCommandTest extends TestCase
         Bus::assertNotDispatched(BeatmapsetRank::class);
     }
 
-    /**
-     * @dataProvider rankDataProvider
-     */
+    #[DataProvider('rankDataProvider')]
     public function testRank(int $qualifiedDaysAgo, int $expected): void
     {
         $this->beatmapset([Ruleset::osu], $qualifiedDaysAgo)->create();
@@ -47,9 +46,7 @@ class ModdingRankCommandTest extends TestCase
         Bus::assertDispatchedTimes(BeatmapsetRank::class, $expected);
     }
 
-    /**
-     * @dataProvider rankHybridDataProvider
-     */
+    #[DataProvider('rankHybridDataProvider')]
     public function testRankHybrid(array $beatmapsetRulesets, array $expectedCounts): void
     {
         foreach ($beatmapsetRulesets as $rulesets) {

--- a/tests/Controllers/AccountControllerTest.php
+++ b/tests/Controllers/AccountControllerTest.php
@@ -16,6 +16,8 @@ use App\Models\WeakPassword;
 use Database\Factories\UserFactory;
 use Hash;
 use Mail;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 use Tests\TestCase;
 
 class AccountControllerTest extends TestCase
@@ -67,11 +69,10 @@ class AccountControllerTest extends TestCase
     }
 
     /**
-     * @dataProvider dataProviderForUpdateCountry
-     * @group RequiresScoreIndexer
-     *
      * More complete tests are done through CountryChange and CountryChangeTarget.
      */
+    #[DataProvider('dataProviderForUpdateCountry')]
+    #[Group('RequiresScoreIndexer')]
     public function testUpdateCountry(?string $historyCountry, ?string $targetCountry, bool $success): void
     {
         $user = $this->user();

--- a/tests/Controllers/BeatmapDiscussionsControllerTest.php
+++ b/tests/Controllers/BeatmapDiscussionsControllerTest.php
@@ -12,6 +12,7 @@ use App\Models\BeatmapDiscussionVote;
 use App\Models\Beatmapset;
 use App\Models\User;
 use Faker;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Tests\TestCase;
 
 class BeatmapDiscussionsControllerTest extends TestCase
@@ -25,9 +26,7 @@ class BeatmapDiscussionsControllerTest extends TestCase
         self::$faker = Faker\Factory::create();
     }
 
-    /**
-     * @dataProvider putVoteDataProvider
-     */
+    #[DataProvider('putVoteDataProvider')]
     public function testPutVote(string $beatmapState, int $status, int $change)
     {
         $this->discussion->beatmapset->update(['approved' => Beatmapset::STATES[$beatmapState]]);
@@ -44,9 +43,7 @@ class BeatmapDiscussionsControllerTest extends TestCase
         $this->assertSame($currentScore + $change, $this->currentScore());
     }
 
-    /**
-     * @dataProvider putVoteAgainDataProvider
-     */
+    #[DataProvider('putVoteAgainDataProvider')]
     public function testPutVoteAgain(string $score, int $change)
     {
         $user = User::factory()->create();
@@ -80,9 +77,7 @@ class BeatmapDiscussionsControllerTest extends TestCase
         $this->assertSame($currentScore, $this->currentScore());
     }
 
-    /**
-     * @dataProvider putVoteChangeToDownDataProvider
-     */
+    #[DataProvider('putVoteChangeToDownDataProvider')]
     public function testPutVoteChangeToDown(?string $group, int $status, int $scoreChange)
     {
         $user = User::factory()->withGroup($group)->create();
@@ -103,9 +98,7 @@ class BeatmapDiscussionsControllerTest extends TestCase
         $this->assertSame($currentScore + $scoreChange, $this->currentScore());
     }
 
-    /**
-     * @dataProvider putVoteDownDataProvider
-     */
+    #[DataProvider('putVoteDownDataProvider')]
     public function testPutVoteDown(?string $group, int $status, int $voteChange, int $scoreChange)
     {
         $user = User::factory()->withGroup($group)->create();

--- a/tests/Controllers/BeatmapTagsControllerTest.php
+++ b/tests/Controllers/BeatmapTagsControllerTest.php
@@ -12,6 +12,7 @@ use App\Models\BeatmapTag;
 use App\Models\Solo\Score;
 use App\Models\Tag;
 use App\Models\User;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Tests\TestCase;
 
 class BeatmapTagsControllerTest extends TestCase
@@ -37,9 +38,7 @@ class BeatmapTagsControllerTest extends TestCase
             ->assertSuccessful();
     }
 
-     /**
-      * @dataProvider dataProviderForUpdate
-      */
+    #[DataProvider('dataProviderForUpdate')]
     public function testUpdate(int $beatmapRulesetId, ?int $tagRulesetId, bool $successful): void
     {
         $tag = Tag::factory()->state(['ruleset_id' => $tagRulesetId])->create();

--- a/tests/Controllers/BeatmapsControllerSoloScoresTest.php
+++ b/tests/Controllers/BeatmapsControllerSoloScoresTest.php
@@ -12,7 +12,6 @@ use App\Models\Beatmap;
 use App\Models\Beatmapset;
 use App\Models\Country;
 use App\Models\Genre;
-use App\Models\Group;
 use App\Models\Language;
 use App\Models\OAuth;
 use App\Models\Solo\Score as SoloScore;
@@ -20,8 +19,11 @@ use App\Models\User;
 use App\Models\UserGroup;
 use App\Models\UserGroupEvent;
 use App\Models\UserRelation;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 use Tests\TestCase;
 
+#[Group('RequiresScoreIndexer')]
 class BeatmapsControllerSoloScoresTest extends TestCase
 {
     protected $connectionsToTransact = [];
@@ -199,10 +201,7 @@ class BeatmapsControllerSoloScoresTest extends TestCase
         });
     }
 
-    /**
-     * @dataProvider dataProviderForTestQuery
-     * @group RequiresScoreIndexer
-     */
+    #[DataProvider('dataProviderForTestQuery')]
     public function testQuery(array $scoreKeys, array $params, string $route)
     {
         $resp = $this->actingAs(static::$user)
@@ -216,9 +215,6 @@ class BeatmapsControllerSoloScoresTest extends TestCase
         }
     }
 
-    /**
-     * @group RequiresScoreIndexer
-     */
     public function testUserScore()
     {
         $url = route('api.beatmaps.user.score', [
@@ -233,9 +229,6 @@ class BeatmapsControllerSoloScoresTest extends TestCase
             ->assertJsonPath('score.id', static::$scores['legacy:userMods']->legacy_score_id);
     }
 
-    /**
-     * @group RequiresScoreIndexer
-     */
     public function testUserScoreInvalidRulesetName()
     {
         $url = route('api.beatmaps.user.score', [
@@ -251,9 +244,6 @@ class BeatmapsControllerSoloScoresTest extends TestCase
             ->assertStatus(422);
     }
 
-    /**
-     * @group RequiresScoreIndexer
-     */
     public function testUserScoreAll()
     {
         $url = route('api.beatmaps.user.scores', [

--- a/tests/Controllers/BeatmapsControllerTest.php
+++ b/tests/Controllers/BeatmapsControllerTest.php
@@ -11,6 +11,8 @@ use App\Models\Beatmap;
 use App\Models\Beatmapset;
 use App\Models\User;
 use Illuminate\Testing\Fluent\AssertableJson;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 use Tests\TestCase;
 
 class BeatmapsControllerTest extends TestCase
@@ -18,9 +20,7 @@ class BeatmapsControllerTest extends TestCase
     private $user;
     private $beatmap;
 
-    /**
-     * @group RequiresBeatmapDifficultyLookupCache
-     */
+    #[Group('RequiresBeatmapDifficultyLookupCache')]
     public function testAttributes(): void
     {
         $beatmap = $this->createExistingOsuBeatmap();
@@ -104,9 +104,7 @@ class BeatmapsControllerTest extends TestCase
         ])->assertStatus(422);
     }
 
-    /**
-     * @dataProvider dataProviderForTestLookupForApi
-     */
+    #[DataProvider('dataProviderForTestLookupForApi')]
     public function testLookupForApi(string $key, callable $valueFn): void
     {
         $beatmap = Beatmap::factory()->create();

--- a/tests/Controllers/BeatmapsetsControllerTest.php
+++ b/tests/Controllers/BeatmapsetsControllerTest.php
@@ -12,6 +12,7 @@ use App\Models\BeatmapsetEvent;
 use App\Models\Genre;
 use App\Models\Language;
 use App\Models\User;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Tests\TestCase;
 
 class BeatmapsetsControllerTest extends TestCase
@@ -122,9 +123,7 @@ class BeatmapsetsControllerTest extends TestCase
         $this->assertSame(0, $beatmapset->beatmapsetNominations()->current()->count());
     }
 
-    /**
-     * @dataProvider beatmapsetStatesDataProvider
-     */
+    #[DataProvider('beatmapsetStatesDataProvider')]
     public function testBeatmapsetUpdateMetadataAsModerator($state)
     {
         $owner = User::factory()->create();
@@ -156,9 +155,7 @@ class BeatmapsetsControllerTest extends TestCase
         $this->assertSame($resultLanguageId, $beatmapset->language_id);
     }
 
-    /**
-     * @dataProvider beatmapsetStatesDataProvider
-     */
+    #[DataProvider('beatmapsetStatesDataProvider')]
     public function testBeatmapsetUpdateMetadataAsOtherUser($state)
     {
         $owner = User::factory()->create();
@@ -190,9 +187,7 @@ class BeatmapsetsControllerTest extends TestCase
         $this->assertSame($resultLanguageId, $beatmapset->language_id);
     }
 
-    /**
-     * @dataProvider dataProviderForTestBeatmapsetUpdateDescriptionAsOwner
-     */
+    #[DataProvider('dataProviderForTestBeatmapsetUpdateDescriptionAsOwner')]
     public function testBeatmapsetUpdateDescriptionAsOwner(bool $downloadDisabled, ?string $downloadDisabledUrl, bool $ok)
     {
         $beatmapset = Beatmapset::factory()->owner()->withDescription()->create([
@@ -215,9 +210,7 @@ class BeatmapsetsControllerTest extends TestCase
         $this->assertSame($expectedDescription, $beatmapset->description()->bbcode()->toEditor());
     }
 
-    /**
-     * @dataProvider beatmapsetStatesDataProvider
-     */
+    #[DataProvider('beatmapsetStatesDataProvider')]
     public function testBeatmapsetUpdateMetadataAsOwner($state)
     {
         $ok = in_array($state, ['graveyard', 'wip', 'pending'], true);
@@ -249,9 +242,7 @@ class BeatmapsetsControllerTest extends TestCase
         $this->assertSame($resultLanguageId, $beatmapset->language_id);
     }
 
-    /**
-     * @dataProvider beatmapsetStatesDataProvider
-     */
+    #[DataProvider('beatmapsetStatesDataProvider')]
     public function testBeatmapsetUpdateMetadataAsProjectLoved(string $state): void
     {
         $beatmapset = Beatmapset::factory()->create([
@@ -291,9 +282,7 @@ class BeatmapsetsControllerTest extends TestCase
         $this->assertSame($resultLanguageId, $beatmapset->language_id);
     }
 
-    /**
-     * @dataProvider dataProviderForTestBeatmapsetUpdateOffset
-     */
+    #[DataProvider('dataProviderForTestBeatmapsetUpdateOffset')]
     public function testBeatmapsetUpdateOffset(string $userGroupOrOwner, bool $ok): void
     {
         $beatmapset = Beatmapset::factory()->create([
@@ -322,9 +311,7 @@ class BeatmapsetsControllerTest extends TestCase
         $this->assertSame($expectedOffset, $beatmapset->offset);
     }
 
-    /**
-     * @dataProvider dataProviderForTestBeatmapsetUpdateTags
-     */
+    #[DataProvider('dataProviderForTestBeatmapsetUpdateTags')]
     public function testBeatmapsetUpdateTags(string $userGroupOrOwner, bool $ok): void
     {
         $beatmapset = Beatmapset::factory()->create([

--- a/tests/Controllers/Chat/ChannelsControllerTest.php
+++ b/tests/Controllers/Chat/ChannelsControllerTest.php
@@ -146,9 +146,7 @@ class ChannelsControllerTest extends TestCase
 
     //endregion
 
-    /**
-     * @dataProvider dataProvider
-     */
+    #[DataProvider('dataProvider')]
     public function testChannelJoin($type, $success)
     {
         $channel = Channel::factory()->type($type)->create();
@@ -336,9 +334,7 @@ class ChannelsControllerTest extends TestCase
     //endregion
 
     //region DELETE /chat/channels/[channel_id]/users/[user_id] - Leave Channel
-    /**
-     * @dataProvider dataProvider
-     */
+    #[DataProvider('dataProvider')]
     public function testChannelLeave($type, $success)
     {
         $channel = Channel::factory()->type($type)->create();
@@ -369,9 +365,7 @@ class ChannelsControllerTest extends TestCase
         }
     }
 
-    /**
-     * @dataProvider dataProvider
-     */
+    #[DataProvider('dataProvider')]
     public function testChannelLeaveWhenNotJoined($type, $success)
     {
         $channel = Channel::factory()->type($type)->create();

--- a/tests/Controllers/Chat/ChatControllerTest.php
+++ b/tests/Controllers/Chat/ChatControllerTest.php
@@ -13,6 +13,7 @@ use App\Models\User;
 use App\Models\UserRelation;
 use Faker;
 use Illuminate\Testing\Fluent\AssertableJson;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Tests\TestCase;
 
 class ChatControllerTest extends TestCase
@@ -29,9 +30,7 @@ class ChatControllerTest extends TestCase
 
     //region POST /chat/new - Create New PM
 
-    /**
-     * @dataProvider createPmWithAuthorizedGrantDataProvider
-     */
+    #[DataProvider('createPmWithAuthorizedGrantDataProvider')]
     public function testCreatePmWithAuthorizedGrant($scopes, $expectedStatus)
     {
         $this->actAsScopedUser($this->user, $scopes);
@@ -45,9 +44,7 @@ class ChatControllerTest extends TestCase
         )->assertStatus($expectedStatus);
     }
 
-    /**
-     * @dataProvider createPmWithClientCredentialsDataProvider
-     */
+    #[DataProvider('createPmWithClientCredentialsDataProvider')]
     public function testCreatePmWithClientCredentials($scopes, $expectedStatus)
     {
         $client = Client::factory()->create(['user_id' => $this->user]);
@@ -62,9 +59,7 @@ class ChatControllerTest extends TestCase
         )->assertStatus($expectedStatus);
     }
 
-    /**
-     * @dataProvider createPmWithClientCredentialsBotGroupDataProvider
-     */
+    #[DataProvider('createPmWithClientCredentialsBotGroupDataProvider')]
     public function testCreatePmWithClientCredentialsBotGroup($scopes, $expectedStatus)
     {
         $client = Client::factory()->create(['user_id' => $this->user]);

--- a/tests/Controllers/CommentsControllerTest.php
+++ b/tests/Controllers/CommentsControllerTest.php
@@ -11,6 +11,7 @@ use App\Models\Follow;
 use App\Models\Notification;
 use App\Models\User;
 use App\Models\UserNotification;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Tests\TestCase;
 
 class CommentsControllerTest extends TestCase
@@ -20,9 +21,7 @@ class CommentsControllerTest extends TestCase
     private $beatmapset;
     private $params;
 
-    /**
-     * @dataProvider pinPermissionsDataProvider
-     */
+    #[DataProvider('pinPermissionsDataProvider')]
     public function testPin(?string $groupIdentifier, bool $onBeatmapset, bool $asBeatmapsetOwner, bool $asCommentOwner, bool $withPinned, bool $expectAllowed): void
     {
         $user = User::factory()->withGroup($groupIdentifier)->create();
@@ -266,9 +265,7 @@ class CommentsControllerTest extends TestCase
             ->assertSuccessful();
     }
 
-    /**
-     * @dataProvider apiRequiresAuthenticationDataProvider
-     */
+    #[DataProvider('apiRequiresAuthenticationDataProvider')]
     public function testApiRequiresAuthentication($method, $routeName)
     {
         $this

--- a/tests/Controllers/InterOp/UserGroupsControllerTest.php
+++ b/tests/Controllers/InterOp/UserGroupsControllerTest.php
@@ -8,6 +8,7 @@ namespace Tests\Controllers\InterOp;
 use App\Models\Group;
 use App\Models\User;
 use App\Models\UserGroupEvent;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Tests\TestCase;
 
 class UserGroupsControllerTest extends TestCase
@@ -324,9 +325,7 @@ class UserGroupsControllerTest extends TestCase
             ->assertStatus(422);
     }
 
-    /**
-     * @dataProvider userGroupRoutesDataProvider
-     */
+    #[DataProvider('userGroupRoutesDataProvider')]
     public function testWithActor(string $type, string $method, string $route): void
     {
         $user = User::factory()->create();
@@ -354,9 +353,7 @@ class UserGroupsControllerTest extends TestCase
             ->assertStatus(204);
     }
 
-    /**
-     * @dataProvider userGroupRoutesDataProvider
-     */
+    #[DataProvider('userGroupRoutesDataProvider')]
     public function testWithInvalidActor(string $type, string $method, string $route): void
     {
         $user = User::factory()->create();

--- a/tests/Controllers/LegacyApiKeyControllerTest.php
+++ b/tests/Controllers/LegacyApiKeyControllerTest.php
@@ -9,6 +9,7 @@ namespace Tests\Controllers;
 
 use App\Models\ApiKey;
 use App\Models\User;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Tests\TestCase;
 
 class LegacyApiKeyControllerTest extends TestCase
@@ -63,9 +64,7 @@ class LegacyApiKeyControllerTest extends TestCase
             ]);
     }
 
-    /**
-     * @dataProvider dataProviderForStoreWithInvalidParams
-     */
+    #[DataProvider('dataProviderForStoreWithInvalidParams')]
     public function testStoreWithInvalidParams($params): void
     {
         $user = User::factory()->create();

--- a/tests/Controllers/Multiplayer/Rooms/Playlist/ScoresControllerTest.php
+++ b/tests/Controllers/Multiplayer/Rooms/Playlist/ScoresControllerTest.php
@@ -12,6 +12,7 @@ use App\Models\Multiplayer\ScoreLink;
 use App\Models\Multiplayer\UserScoreAggregate;
 use App\Models\ScoreToken;
 use App\Models\User;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Tests\TestCase;
 
 class ScoresControllerTest extends TestCase
@@ -99,9 +100,7 @@ class ScoresControllerTest extends TestCase
         $this->assertSame($json['scores_around']['lower']['scores'][0]['id'], $scoreLinks[2]->getKey());
     }
 
-    /**
-     * @dataProvider dataProviderForTestStore
-     */
+    #[DataProvider('dataProviderForTestStore')]
     public function testStore($allowRanking, $hashParam, $status)
     {
         $origClientCheckVersion = $GLOBALS['cfg']['osu']['client']['check_version'];
@@ -165,9 +164,7 @@ class ScoresControllerTest extends TestCase
         ]))->assertStatus(422);
     }
 
-    /**
-     * @dataProvider dataProviderForTestUpdate
-     */
+    #[DataProvider('dataProviderForTestUpdate')]
     public function testUpdate($bodyParams, $status)
     {
         $user = User::factory()->create();

--- a/tests/Controllers/Multiplayer/RoomsControllerTest.php
+++ b/tests/Controllers/Multiplayer/RoomsControllerTest.php
@@ -16,6 +16,7 @@ use App\Models\Multiplayer\UserScoreAggregate;
 use App\Models\OAuth\Token;
 use App\Models\User;
 use Illuminate\Support\Arr;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Tests\TestCase;
 
 class RoomsControllerTest extends TestCase
@@ -72,9 +73,7 @@ class RoomsControllerTest extends TestCase
         $this->assertSame($playlistItemsCountInitial + 1, PlaylistItem::count());
     }
 
-    /**
-     * @dataProvider dataProviderForTestStoreWithInvalidPlayableMods
-     */
+    #[DataProvider('dataProviderForTestStoreWithInvalidPlayableMods')]
     public function testStoreWithInvalidPlayableMods(string $type, string $modType): void
     {
         $token = Token::factory()->create(['scopes' => ['*']]);
@@ -100,9 +99,7 @@ class RoomsControllerTest extends TestCase
         $this->assertSame("mod cannot be set as {$modType}: AT", $responseJson['error']);
     }
 
-    /**
-     * @dataProvider dataProviderForTestStoreWithInvalidRealtimeAllowedMods
-     */
+    #[DataProvider('dataProviderForTestStoreWithInvalidRealtimeAllowedMods')]
     public function testStoreWithInvalidRealtimeAllowedMods(string $type, bool $ok): void
     {
         $token = Token::factory()->create(['scopes' => ['*']]);
@@ -127,9 +124,7 @@ class RoomsControllerTest extends TestCase
         }
     }
 
-    /**
-     * @dataProvider dataProviderForTestStoreWithInvalidRealtimeMods
-     */
+    #[DataProvider('dataProviderForTestStoreWithInvalidRealtimeMods')]
     public function testStoreWithInvalidRealtimeMods(string $type, bool $ok): void
     {
         $token = Token::factory()->create(['scopes' => ['*']]);

--- a/tests/Controllers/OAuth/ClientsControllerTest.php
+++ b/tests/Controllers/OAuth/ClientsControllerTest.php
@@ -7,6 +7,7 @@ namespace Tests\Controllers\OAuth;
 
 use App\Models\OAuth\Client;
 use App\Models\User;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Tests\TestCase;
 
 class ClientsControllerTest extends TestCase
@@ -77,11 +78,7 @@ class ClientsControllerTest extends TestCase
         $this->assertSame($count + 1, Client::count());
     }
 
-    /**
-     * @dataProvider emptyStringsTestDataProvider
-     *
-     * @return void
-     */
+    #[DataProvider('emptyStringsTestDataProvider')]
     public function testCannotCreateClientWithEmptyStrings($name, $redirect)
     {
         $data = [

--- a/tests/Controllers/OAuth/TokensControllerTest.php
+++ b/tests/Controllers/OAuth/TokensControllerTest.php
@@ -13,6 +13,7 @@ use App\Models\User;
 use Database\Factories\OAuth\ClientFactory;
 use Database\Factories\OAuth\RefreshTokenFactory;
 use Database\Factories\UserFactory;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Tests\TestCase;
 
 class TokensControllerTest extends TestCase
@@ -81,9 +82,7 @@ class TokensControllerTest extends TestCase
         \Mail::assertQueued(UserVerificationMail::class);
     }
 
-    /**
-     * @dataProvider dataProviderForTestIssueTokenWithRefreshTokenInheritsVerified
-     */
+    #[DataProvider('dataProviderForTestIssueTokenWithRefreshTokenInheritsVerified')]
     public function testIssueTokenWithRefreshTokenInheritsVerified(bool $verified): void
     {
         \Mail::fake();

--- a/tests/Controllers/ScoreTokensControllerTest.php
+++ b/tests/Controllers/ScoreTokensControllerTest.php
@@ -11,6 +11,7 @@ use App\Models\Beatmap;
 use App\Models\Build;
 use App\Models\ScoreToken;
 use App\Models\User;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Tests\TestCase;
 
 class ScoreTokensControllerTest extends TestCase
@@ -18,9 +19,7 @@ class ScoreTokensControllerTest extends TestCase
     private Build $build;
     private User $user;
 
-    /**
-     * @dataProvider dataProviderForTestStore
-     */
+    #[DataProvider('dataProviderForTestStore')]
     public function testStore(string $beatmapState, int $status): void
     {
         $beatmap = Beatmap::factory()->$beatmapState()->create();
@@ -42,9 +41,7 @@ class ScoreTokensControllerTest extends TestCase
         )->assertStatus($status);
     }
 
-    /**
-     * @dataProvider dataProviderForTestStoreInvalidParameter
-     */
+    #[DataProvider('dataProviderForTestStoreInvalidParameter')]
     public function testStoreInvalidParameter(string $paramKey, ?string $paramValue, int $status, string $errorMessage): void
     {
         $origClientCheckVersion = $GLOBALS['cfg']['osu']['client']['check_version'];

--- a/tests/Controllers/UsersControllerTest.php
+++ b/tests/Controllers/UsersControllerTest.php
@@ -8,6 +8,7 @@ namespace Tests\Controllers;
 use App\Models\Achievement;
 use App\Models\Country;
 use App\Models\User;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Tests\TestCase;
 
 class UsersControllerTest extends TestCase
@@ -173,9 +174,7 @@ class UsersControllerTest extends TestCase
         ])->assertRedirect(route('home'));
     }
 
-    /**
-     * @dataProvider dataProviderForStoreWebInvalidParams
-     */
+    #[DataProvider('dataProviderForStoreWebInvalidParams')]
     public function testStoreWebInvalidParams($username, $email, $emailConfirmation, $password, $passwordConfirmation): void
     {
         config_set('osu.user.registration_mode.web', true);

--- a/tests/HelpersTest.php
+++ b/tests/HelpersTest.php
@@ -8,20 +8,17 @@ declare(strict_types=1);
 namespace Tests;
 
 use App\Models\Country;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class HelpersTest extends TestCase
 {
-    /**
-     * @dataProvider dataForGetStringSplit
-     */
+    #[DataProvider('dataForGetStringSplit')]
     public function testGetStringSplit(string $input, array $expected): void
     {
         $this->assertSame($expected, get_string_split($input));
     }
 
-    /**
-     * @dataProvider dataForClassWithModifiers
-     */
+    #[DataProvider('dataForClassWithModifiers')]
     public function testClassWithModifiers($class, $modifiers, $expected): void
     {
         $this->assertSame($expected, class_with_modifiers($class, ...$modifiers));
@@ -54,9 +51,7 @@ class HelpersTest extends TestCase
         $this->assertTrue(is_sql_unique_exception($exception));
     }
 
-    /**
-     * @dataProvider dataForGetLengthSeconds
-     */
+    #[DataProvider('dataForGetLengthSeconds')]
     public function testGetLengthSeconds(string $input, array $expected): void
     {
         $this->assertSame($expected, get_length_seconds($input));

--- a/tests/Jobs/RemoveBeatmapsetSoloScoresTest.php
+++ b/tests/Jobs/RemoveBeatmapsetSoloScoresTest.php
@@ -14,17 +14,15 @@ use App\Models\BeatmapLeader;
 use App\Models\Beatmapset;
 use App\Models\Country;
 use App\Models\Genre;
-use App\Models\Group;
 use App\Models\Language;
 use App\Models\Solo\Score;
 use App\Models\User;
 use App\Models\UserGroup;
 use App\Models\UserGroupEvent;
+use PHPUnit\Framework\Attributes\Group;
 use Tests\TestCase;
 
-/**
- * @group RequiresScoreIndexer
- */
+#[Group('RequiresScoreIndexer')]
 class RemoveBeatmapsetSoloScoresTest extends TestCase
 {
     protected $connectionsToTransact = [];

--- a/tests/Libraries/BBCodeForDBTest.php
+++ b/tests/Libraries/BBCodeForDBTest.php
@@ -7,13 +7,12 @@ namespace Tests\Libraries;
 
 use App\Libraries\BBCodeForDB;
 use App\Models\User;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Tests\TestCase;
 
 class BBCodeForDBTest extends TestCase
 {
-    /**
-     * @dataProvider examples
-     */
+    #[DataProvider('examples')]
     public function testGenerate($name, $path)
     {
         $baseFilePath = "{$path}/{$name}.base.txt";

--- a/tests/Libraries/BBCodeFromDBTest.php
+++ b/tests/Libraries/BBCodeFromDBTest.php
@@ -6,13 +6,12 @@
 namespace Tests\Libraries;
 
 use App\Libraries\BBCodeFromDB;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Tests\TestCase;
 
 class BBCodeFromDBTest extends TestCase
 {
-    /**
-     * @dataProvider examples
-     */
+    #[DataProvider('examples')]
     public function testGenerateHTML($name, $path)
     {
         $dbFilePath = "{$path}/{$name}.db.txt";
@@ -27,9 +26,7 @@ class BBCodeFromDBTest extends TestCase
         $this->assertSame($referenceOutput, $output);
     }
 
-    /**
-     * @dataProvider removeQuoteExamples
-     */
+    #[DataProvider('removeQuoteExamples')]
     public function testRemoveBlockQuotes($name, $path)
     {
         $dbFilePath = "{$path}/{$name}.db.txt";

--- a/tests/Libraries/Beatmapset/ChangeBeatmapOwnersTest.php
+++ b/tests/Libraries/Beatmapset/ChangeBeatmapOwnersTest.php
@@ -19,6 +19,7 @@ use App\Models\DeletedUser;
 use App\Models\User;
 use Arr;
 use Bus;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Tests\TestCase;
 
 class ChangeBeatmapOwnersTest extends TestCase
@@ -76,9 +77,7 @@ class ChangeBeatmapOwnersTest extends TestCase
         Bus::assertDispatched(BeatmapOwnerChange::class);
     }
 
-    /**
-     * @dataProvider dataProviderForInvalidUser
-     */
+    #[DataProvider('dataProviderForInvalidUser')]
     public function testInvalidUser(string $group): void
     {
         $moderator = User::factory()->withGroup('nat')->create();
@@ -103,9 +102,7 @@ class ChangeBeatmapOwnersTest extends TestCase
         Bus::assertNotDispatched(BeatmapOwnerChange::class);
     }
 
-    /**
-     * @dataProvider dataProviderForUpdateOwner
-     */
+    #[DataProvider('dataProviderForUpdateOwner')]
     public function testUpdateOwner(array $states, bool $success): void
     {
         $factory = User::factory();
@@ -204,9 +201,7 @@ class ChangeBeatmapOwnersTest extends TestCase
         Bus::assertNotDispatched(BeatmapOwnerChange::class);
     }
 
-    /**
-     * @dataProvider dataProviderForUpdateOwnerLoved
-     */
+    #[DataProvider('dataProviderForUpdateOwnerLoved')]
     public function testUpdateOwnerLoved(int $approved, bool $ok): void
     {
         $moderator = User::factory()->withGroup('loved')->create();

--- a/tests/Libraries/BeatmapsetDiscussion/DiscussionTest.php
+++ b/tests/Libraries/BeatmapsetDiscussion/DiscussionTest.php
@@ -23,6 +23,7 @@ use App\Models\Notification;
 use App\Models\User;
 use App\Models\UserNotification;
 use Event;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Queue;
 use Tests\TestCase;
 
@@ -32,9 +33,7 @@ class DiscussionTest extends TestCase
 
     private User $mapper;
 
-    /**
-     * @dataProvider minPlaysVerificationDataProvider
-     */
+    #[DataProvider('minPlaysVerificationDataProvider')]
     public function testMinPlaysVerification(\Closure $minPlays, bool $verified, bool $success)
     {
         config_set('osu.user.post_action_verification', false);
@@ -63,9 +62,8 @@ class DiscussionTest extends TestCase
     /**
      * See testReopeningProblemDoesNotDisqualifyOrResetNominations for assertions
      * jobs are not queued when reopening a resolved discussion.
-     *
-     * @dataProvider newDiscussionQueuesJobsDataProvider
      */
+    #[DataProvider('newDiscussionQueuesJobsDataProvider')]
     public function testNewDiscussionQueuesJobs(string $state, ?string $group, array $queued, array $notQueued)
     {
         $user = User::factory()->withGroup($group)->create()->markSessionVerified();
@@ -88,9 +86,7 @@ class DiscussionTest extends TestCase
         }
     }
 
-    /**
-     * @dataProvider shouldDisqualifyOrResetNominationsDataProvider
-     */
+    #[DataProvider('shouldDisqualifyOrResetNominationsDataProvider')]
     public function testShouldDisqualifyOrResetNominations(string $state, ?string $group, string $messageType, bool $expects)
     {
         $user = User::factory()->withGroup($group)->create()->markSessionVerified();
@@ -143,9 +139,7 @@ class DiscussionTest extends TestCase
         (new Discussion($this->mapper, $beatmapset, $this->makeParams('mapper_note'), static::TEST_MESSAGE))->handle();
     }
 
-    /**
-     * @dataProvider newMapperNoteByOtherUsersDataProvider
-     */
+    #[DataProvider('newMapperNoteByOtherUsersDataProvider')]
     public function testNewMapperNoteByOtherUsers(?string $group, bool $expected)
     {
         $user = User::factory()->withGroup($group)->create()->markSessionVerified();
@@ -200,9 +194,7 @@ class DiscussionTest extends TestCase
 
     //region Reporting problem on a beatmap
 
-    /**
-     * @dataProvider problemOnQualifiedBeatmapsetDataProvider
-     */
+    #[DataProvider('problemOnQualifiedBeatmapsetDataProvider')]
     public function testProblemOnQualifiedBeatmapset(string $state, string $assertMethod)
     {
         $user = User::factory()->create()->markSessionVerified();
@@ -244,11 +236,7 @@ class DiscussionTest extends TestCase
         Event::assertNotDispatched(NewPrivateNotificationEvent::class);
     }
 
-    /**
-     * @dataProvider problemOnQualifiedBeatmapsetModesNotificationDataProvider
-     *
-     * @return void
-     */
+    #[DataProvider('problemOnQualifiedBeatmapsetModesNotificationDataProvider')]
     public function testProblemOnQualifiedBeatmapsetModesNotification(string $mode, array $notificationModes, bool $expectsNotification)
     {
         $user = User::factory()->create()->markSessionVerified();

--- a/tests/Libraries/BeatmapsetDiscussion/ReviewTest.php
+++ b/tests/Libraries/BeatmapsetDiscussion/ReviewTest.php
@@ -19,6 +19,7 @@ use App\Models\Notification;
 use App\Models\User;
 use Faker;
 use Illuminate\Support\Facades\Event;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Queue;
 use Tests\TestCase;
 
@@ -322,9 +323,7 @@ class ReviewTest extends TestCase
     }
 
     // valid document containing issue embeds should reset nominations (for GMT)
-    /**
-     * @dataProvider dataProviderForQualifiedProblem
-     */
+    #[DataProvider('dataProviderForQualifiedProblem')]
     public function testCreateDocumentDocumentValidWithNewIssuesShouldNotify($state, $shouldNotify)
     {
         $gmtUser = User::factory()->withGroup('gmt')->create();
@@ -642,9 +641,7 @@ class ReviewTest extends TestCase
         Event::assertDispatched(NewPrivateNotificationEvent::class);
     }
 
-    /**
-     * @dataProvider dataProviderForQualifiedProblem
-     */
+    #[DataProvider('dataProviderForQualifiedProblem')]
     public function testUpdateDocumentWithNewIssueShouldNotifyIfQualified($state, $shouldNotify)
     {
         $gmtUser = User::factory()->withGroup('gmt')->create();

--- a/tests/Libraries/ChatTest.php
+++ b/tests/Libraries/ChatTest.php
@@ -19,14 +19,13 @@ use App\Models\UserNotificationOption;
 use Event;
 use Exception;
 use Mail;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Queue;
 use Tests\TestCase;
 
 class ChatTest extends TestCase
 {
-    /**
-     * @dataProvider createAnnouncementApiDataProvider
-     */
+    #[DataProvider('createAnnouncementApiDataProvider')]
     public function testCreateAnnouncementApi(?string $group, bool $isApiRequest, bool $isAllowed)
     {
         $sender = User::factory()->withGroup($group)->create()->markSessionVerified();
@@ -81,9 +80,7 @@ class ChatTest extends TestCase
         Mail::assertSent(UserNotificationDigest::class);
     }
 
-    /**
-     * @dataProvider minPlaysDataProvider
-     */
+    #[DataProvider('minPlaysDataProvider')]
     public function testMinPlaysSendMessage(?string $groupIdentifier, bool $hasMinPlays, bool $successful)
     {
         config_set('osu.user.min_plays_allow_verified_bypass', false);
@@ -106,9 +103,7 @@ class ChatTest extends TestCase
         Chat::sendMessage($sender, $channel, 'test', false);
     }
 
-    /**
-     * @dataProvider minPlaysDataProvider
-     */
+    #[DataProvider('minPlaysDataProvider')]
     public function testMinPlaysSendPM(?string $groupIdentifier, bool $hasMinPlays, bool $successful)
     {
         config_set('osu.user.min_plays_allow_verified_bypass', false);
@@ -135,9 +130,7 @@ class ChatTest extends TestCase
         }
     }
 
-    /**
-     * @dataProvider verifiedDataProvider
-     */
+    #[DataProvider('verifiedDataProvider')]
     public function testSendMessage(bool $verified, ?string $expectedException)
     {
         $sender = User::factory()->create();
@@ -234,9 +227,7 @@ class ChatTest extends TestCase
         $this->assertInstanceOf(Channel::class, Channel::findPM($sender, $target));
     }
 
-    /**
-     * @dataProvider sendPmFriendsOnlyGroupsDataProvider
-     */
+    #[DataProvider('sendPmFriendsOnlyGroupsDataProvider')]
     public function testSendPMFriendsOnly(?string $groupIdentifier, bool $successful)
     {
         $sender = User::factory()->withGroup($groupIdentifier)->create();
@@ -266,9 +257,7 @@ class ChatTest extends TestCase
         }
     }
 
-    /**
-     * @dataProvider sendPmSenderFriendsOnlyGroupsDataProvider
-     */
+    #[DataProvider('sendPmSenderFriendsOnlyGroupsDataProvider')]
     public function testSendPmSenderFriendsOnly(?string $groupIdentifier)
     {
         $sender = User::factory()->withGroup($groupIdentifier)->create(['pm_friends_only' => true]);

--- a/tests/Libraries/Fulfillments/SupporterTagFulfillmentTest.php
+++ b/tests/Libraries/Fulfillments/SupporterTagFulfillmentTest.php
@@ -19,6 +19,7 @@ use App\Models\User;
 use App\Models\UserDonation;
 use Carbon\Carbon;
 use Mail;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Tests\TestCase;
 
 class SupporterTagFulfillmentTest extends TestCase
@@ -75,9 +76,7 @@ class SupporterTagFulfillmentTest extends TestCase
         $this->assertSame(1, $donor->support_length);
     }
 
-    /**
-     * @dataProvider boolDataProvider
-     */
+    #[DataProvider('boolDataProvider')]
     public function testMailDonateSupporterTagToOthers(bool $hidden)
     {
         Mail::fake();
@@ -120,9 +119,7 @@ class SupporterTagFulfillmentTest extends TestCase
         Mail::assertQueued(DonationThanks::class, 1);
     }
 
-    /**
-     * @dataProvider boolDataProvider
-     */
+    #[DataProvider('boolDataProvider')]
     public function testMailDonateSupporterTagToSelf(bool $hidden)
     {
         Mail::fake();

--- a/tests/Libraries/Markdown/ProcessorTest.php
+++ b/tests/Libraries/Markdown/ProcessorTest.php
@@ -6,13 +6,12 @@
 namespace Tests\Libraries\Markdown;
 
 use App\Libraries\Markdown\OsuMarkdown;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Tests\TestCase;
 
 class ProcessorTest extends TestCase
 {
-    /**
-     * @dataProvider htmlExamples
-     */
+    #[DataProvider('htmlExamples')]
     public function testHtml($name, $path)
     {
         [$osuMarkdown, $expectedOutput] = $this->loadOutputTest($name, $path, 'html');
@@ -23,9 +22,7 @@ class ProcessorTest extends TestCase
         );
     }
 
-    /**
-     * @dataProvider indexableExamples
-     */
+    #[DataProvider('indexableExamples')]
     public function testIndexable($name, $path)
     {
         [$osuMarkdown, $expectedOutput] = $this->loadOutputTest($name, $path, 'txt');

--- a/tests/Libraries/Score/ScoringModeTest.php
+++ b/tests/Libraries/Score/ScoringModeTest.php
@@ -7,6 +7,7 @@ namespace Tests\Libraries\Score;
 
 use App\Enums\Ruleset;
 use App\Models\Solo\Score;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Tests\TestCase;
 
 class ScoringModeTest extends TestCase
@@ -33,9 +34,7 @@ class ScoringModeTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider classicScoreConversionDataProvider
-     */
+    #[DataProvider('classicScoreConversionDataProvider')]
     public function testConvertToClassic(int $standardisedScore, int $classicScore, string $maxHitResult): void
     {
         // Hardcoded by the referenced test

--- a/tests/Libraries/Search/BeatmapsetQueryParserTest.php
+++ b/tests/Libraries/Search/BeatmapsetQueryParserTest.php
@@ -8,6 +8,7 @@ namespace Tests\Libraries\Search;
 use App\Libraries\Search\BeatmapsetQueryParser;
 use App\Models\Beatmapset;
 use Carbon\CarbonImmutable;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Tests\TestCase;
 
 class BeatmapsetQueryParserTest extends TestCase
@@ -109,9 +110,7 @@ class BeatmapsetQueryParserTest extends TestCase
         return CarbonImmutable::parse($timeString)->getTimestampMs();
     }
 
-    /**
-     * @dataProvider queryDataProvider
-     */
+    #[DataProvider('queryDataProvider')]
     public function testParse(?string $query, ?array $expected)
     {
         $this->assertSame(json_encode($expected), json_encode(BeatmapsetQueryParser::parse($query)));

--- a/tests/Libraries/Search/BeatmapsetSearchRequestParamsTest.php
+++ b/tests/Libraries/Search/BeatmapsetSearchRequestParamsTest.php
@@ -8,13 +8,12 @@ namespace Tests\Libraries\Search;
 use App\Exceptions\InvariantException;
 use App\Libraries\Search\BeatmapsetSearchRequestParams;
 use App\Models\User;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Tests\TestCase;
 
 class BeatmapsetSearchRequestParamsTest extends TestCase
 {
-    /**
-     * @dataProvider cursorsDataProvider
-     */
+    #[DataProvider('cursorsDataProvider')]
     public function testCursors(?string $sort, ?array $cursor, bool $throws, ?array $expected)
     {
         $requestParams = [];
@@ -36,9 +35,7 @@ class BeatmapsetSearchRequestParamsTest extends TestCase
         $this->assertSame($expected, $searchAfter);
     }
 
-    /**
-     * @dataProvider cursorsGuestDataProvider
-     */
+    #[DataProvider('cursorsGuestDataProvider')]
     public function testCursorsGuest(?string $sort, ?array $cursor, bool $throws, ?array $expected)
     {
         $requestParams = [];

--- a/tests/Libraries/Search/ScoreSearchParamsTest.php
+++ b/tests/Libraries/Search/ScoreSearchParamsTest.php
@@ -8,6 +8,7 @@ namespace Tests\Libraries\Search;
 use App\Libraries\Search\ScoreSearchParams;
 use App\Models\Solo\Score;
 use App\Models\User;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Tests\TestCase;
 
 class ScoreSearchParamsTest extends TestCase
@@ -45,9 +46,7 @@ class ScoreSearchParamsTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider showLegacyForUserAndGuestDataProvider
-     */
+    #[DataProvider('showLegacyForUserAndGuestDataProvider')]
     public function testShowLegacyForGuest(?bool $legacyOnly, ?bool $isApiRequest, ?bool $expected)
     {
         $this->assertSame(
@@ -56,9 +55,7 @@ class ScoreSearchParamsTest extends TestCase
         );
     }
 
-    /**
-     * @dataProvider showLegacyForUserAndGuestDataProvider
-     */
+    #[DataProvider('showLegacyForUserAndGuestDataProvider')]
     public function testShowLegacyForUser(?bool $legacyOnly, ?bool $isApiRequest, ?bool $expected)
     {
         $user = User::factory()->create();
@@ -69,9 +66,7 @@ class ScoreSearchParamsTest extends TestCase
         );
     }
 
-    /**
-     * @dataProvider showLegacyForUserFromScoreDataProvider
-     */
+    #[DataProvider('showLegacyForUserFromScoreDataProvider')]
     public function testShowLegacyForUserFromScore(?bool $legacyScore, ?bool $expected)
     {
         $factory = User::factory();
@@ -95,9 +90,7 @@ class ScoreSearchParamsTest extends TestCase
         $this->assertSame($legacyScore, $user->fresh()->userProfileCustomization->options['legacy_score_only'] ?? null);
     }
 
-    /**
-     * @dataProvider showLegacyForUserSettingDataProvider
-     */
+    #[DataProvider('showLegacyForUserSettingDataProvider')]
     public function testShowLegacyForUserSetting(?bool $setting, ?bool $expected)
     {
         $user = User::factory()->create();

--- a/tests/Libraries/SignedRandomStringTest.php
+++ b/tests/Libraries/SignedRandomStringTest.php
@@ -9,6 +9,7 @@ namespace Tests\Libraries;
 
 use App\Libraries\Base64Url;
 use App\Libraries\SignedRandomString;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Tests\TestCase;
 
 class SignedRandomStringTest extends TestCase
@@ -18,9 +19,7 @@ class SignedRandomStringTest extends TestCase
         $this->assertTrue(SignedRandomString::isValid(SignedRandomString::create(40)));
     }
 
-    /**
-     * @dataProvider dataProviderForTestIsValidInvalid
-     */
+    #[DataProvider('dataProviderForTestIsValidInvalid')]
     public function testIsValidInvalid(string $value): void
     {
         $this->assertFalse(SignedRandomString::isValid($value));

--- a/tests/Libraries/Store/ShopifyOrderTest.php
+++ b/tests/Libraries/Store/ShopifyOrderTest.php
@@ -9,6 +9,7 @@ namespace Tests\Libraries\Store;
 
 use App\Libraries\Store\ShopifyOrder;
 use App\Models\Store\Order;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Tests\TestCase;
 
 class ShopifyOrderTest extends TestCase
@@ -59,14 +60,8 @@ class ShopifyOrderTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider dataProviderForUpdateOrderStatus
-     *
-     * @param array $node
-     * @param string $expectedStatus
-     * @return void
-     */
-    public function testUpdateOrderStatus(array $node, string $expectedStatus)
+    #[DataProvider('dataProviderForUpdateOrderStatus')]
+    public function testUpdateOrderStatus(array $node, string $expectedStatus): void
     {
         $order = Order::factory()->shopify()->paymentApproved()->state(['reference' => 'gid://shopify/Cart/1'])->create();
         $shopifyOrder = new ShopifyOrder($order);

--- a/tests/Libraries/User/CountryChangeTest.php
+++ b/tests/Libraries/User/CountryChangeTest.php
@@ -13,13 +13,12 @@ use App\Models\Beatmap;
 use App\Models\Country;
 use App\Models\Score\Best\Model as ScoreBestModel;
 use App\Models\User;
+use PHPUnit\Framework\Attributes\Group;
 use Tests\TestCase;
 
 class CountryChangeTest extends TestCase
 {
-    /**
-     * @group RequiresScoreIndexer
-     */
+    #[Group('RequiresScoreIndexer')]
     public function testDo(): void
     {
         $user = User::factory();

--- a/tests/Libraries/UsernameValidationTest.php
+++ b/tests/Libraries/UsernameValidationTest.php
@@ -13,6 +13,7 @@ use App\Models\Beatmapset;
 use App\Models\RankHighest;
 use App\Models\User;
 use Carbon\Carbon;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Tests\TestCase;
 
 class UsernameValidationTest extends TestCase
@@ -55,9 +56,7 @@ class UsernameValidationTest extends TestCase
         $this->assertFalse(UsernameValidation::validateAvailability('Old username')->isEmpty());
     }
 
-    /**
-     * @dataProvider usernameValidationDataProvider
-     */
+    #[DataProvider('usernameValidationDataProvider')]
     public function testValidateUsername(string $username, bool $expectValid): void
     {
         $this->assertSame(
@@ -66,9 +65,7 @@ class UsernameValidationTest extends TestCase
         );
     }
 
-    /**
-     * @dataProvider usersOfUsernameLookupDataProvider
-     */
+    #[DataProvider('usersOfUsernameLookupDataProvider')]
     public function testValidateUsersOfUsername(
         bool $throughUsernameHistory,
         bool $underscoresReplaced,
@@ -137,9 +134,7 @@ class UsernameValidationTest extends TestCase
         $this->assertFalse(UsernameValidation::validateUsersOfUsername($user->username)->isEmpty());
     }
 
-    /**
-     * @dataProvider usernameAvailabilityWithBeatmapStateDataProvider
-     */
+    #[DataProvider('usernameAvailabilityWithBeatmapStateDataProvider')]
     public function testValidateUsersOfUsernameHasBeatmapsets(string $state, bool $expectValid): void
     {
         $user = User
@@ -153,9 +148,7 @@ class UsernameValidationTest extends TestCase
         );
     }
 
-    /**
-     * @dataProvider usernameAvailabilityWithBeatmapStateDataProvider
-     */
+    #[DataProvider('usernameAvailabilityWithBeatmapStateDataProvider')]
     public function testValidateUsersOfUsernameHasGuestBeatmaps(string $state, bool $expectValid): void
     {
         $user = User::factory()->create();

--- a/tests/LocaleTest.php
+++ b/tests/LocaleTest.php
@@ -7,6 +7,7 @@ namespace Tests;
 
 use App;
 use App\Models\User;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class LocaleTest extends TestCase
 {
@@ -69,17 +70,13 @@ class LocaleTest extends TestCase
         $this->assertSame('', osu_trans('key_1.empty_missing'));
     }
 
-    /**
-     * @dataProvider availableLocalesProvider
-     */
+    #[DataProvider('availableLocalesProvider')]
     public function testCorrespondingLocaleFile($locale)
     {
         $this->assertNotNull(unmix("js/locales/{$locale}.js"));
     }
 
-    /**
-     * @dataProvider availableLocalesProvider
-     */
+    #[DataProvider('availableLocalesProvider')]
     public function testCorrespondingMomentLocaleFile($locale)
     {
         $this->assertNotNull(unmix('js/moment-locales/'.locale_meta($locale)->moment().'.js'));

--- a/tests/Middleware/RequireScopesTest.php
+++ b/tests/Middleware/RequireScopesTest.php
@@ -9,6 +9,7 @@ use App\Http\Middleware\RequireScopes;
 use App\Models\User;
 use Illuminate\Routing\Route;
 use Laravel\Passport\Exceptions\MissingScopeException;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Request;
 use Tests\TestCase;
 
@@ -18,9 +19,7 @@ class RequireScopesTest extends TestCase
     protected $request;
     protected $user;
 
-    /**
-     * @dataProvider clientCredentialsTestDataProvider
-     */
+    #[DataProvider('clientCredentialsTestDataProvider')]
     public function testClientCredentials($scopes, $expectedException)
     {
         $this->setRequest(['public']);
@@ -91,9 +90,7 @@ class RequireScopesTest extends TestCase
         $this->assertTrue(!oauth_token()->isClientCredentials());
     }
 
-    /**
-     * @dataProvider userScopesTestDataProvider
-     */
+    #[DataProvider('userScopesTestDataProvider')]
     public function testUserScopes($requiredScopes, $userScopes, $expectedException)
     {
         $this->setRequest($requiredScopes);

--- a/tests/Middleware/RouteScopesTest.php
+++ b/tests/Middleware/RouteScopesTest.php
@@ -11,6 +11,7 @@ use App\Models\Build;
 use App\Models\Changelog;
 use App\Models\Comment;
 use App\Models\UpdateStream;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Route;
 use Tests\TestCase;
 
@@ -18,9 +19,7 @@ class RouteScopesTest extends TestCase
 {
     private static $expectations;
 
-    /**
-     * @dataProvider routeScopesDataProvider
-     */
+    #[DataProvider('routeScopesDataProvider')]
     public function testApiRouteScopes($route)
     {
         $this->importExpectations();
@@ -30,9 +29,7 @@ class RouteScopesTest extends TestCase
         $this->assertSame(static::$expectations[$key], $route, $key);
     }
 
-    /**
-     * @dataProvider routesDataProvider
-     */
+    #[DataProvider('routesDataProvider')]
     public function testUnscopedRequestsRequireAuthentication(string $url, string $method, array $middlewares)
     {
         // factory some objects so unauthed endpoints don't 404.

--- a/tests/Middleware/ThrottleRequestsTest.php
+++ b/tests/Middleware/ThrottleRequestsTest.php
@@ -12,6 +12,7 @@ use App\Models\OAuth\Token;
 use App\Models\User;
 use Closure;
 use LaravelRedis;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Route;
 use Tests\TestCase;
 
@@ -21,9 +22,7 @@ class ThrottleRequestsTest extends TestCase
 
     protected Token $token;
 
-    /**
-     * @dataProvider throttleDataProvider
-     */
+    #[DataProvider('throttleDataProvider')]
     public function testThrottle(array $middlewares, int $remaining, ?Closure $action = null)
     {
         $action ??= (fn () => []);

--- a/tests/Models/BeatmapDiscussionTest.php
+++ b/tests/Models/BeatmapDiscussionTest.php
@@ -11,15 +11,15 @@ use App\Models\Beatmapset;
 use App\Models\KudosuHistory;
 use App\Models\User;
 use Illuminate\Database\Eloquent\Builder;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Tests\TestCase;
 
 class BeatmapDiscussionTest extends TestCase
 {
     /**
      * Valid beatmapset status always maps to a scope method sanity test.
-     *
-     * @dataProvider validBeatmapsetStatuses
      */
+    #[DataProvider('validBeatmapsetStatuses')]
     public function testBeatmapsetScopesExist($scope)
     {
         $this->assertInstanceOf(Builder::class, Beatmapset::$scope());

--- a/tests/Models/BeatmapPackUserCompletionTest.php
+++ b/tests/Models/BeatmapPackUserCompletionTest.php
@@ -14,17 +14,16 @@ use App\Models\BeatmapPackItem;
 use App\Models\Beatmapset;
 use App\Models\Country;
 use App\Models\Genre;
-use App\Models\Group;
 use App\Models\Language;
 use App\Models\Solo\Score;
 use App\Models\User;
 use App\Models\UserGroup;
 use App\Models\UserGroupEvent;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 use Tests\TestCase;
 
-/**
- * @group RequiresScoreIndexer
- */
+#[Group('RequiresScoreIndexer')]
 class BeatmapPackUserCompletionTest extends TestCase
 {
     private static array $users;
@@ -86,9 +85,7 @@ class BeatmapPackUserCompletionTest extends TestCase
 
     protected $connectionsToTransact = [];
 
-    /**
-     * @dataProvider dataProviderForTestBasic
-     */
+    #[DataProvider('dataProviderForTestBasic')]
     public function testBasic(string $userType, ?string $packRuleset, bool $completed): void
     {
         $user = static::$users[$userType];

--- a/tests/Models/BeatmapsetTest.php
+++ b/tests/Models/BeatmapsetTest.php
@@ -28,6 +28,7 @@ use App\Models\User;
 use App\Models\UserNotification;
 use Bus;
 use Database\Factories\BeatmapsetFactory;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Queue;
 use Tests\TestCase;
 
@@ -245,9 +246,7 @@ class BeatmapsetTest extends TestCase
         $this->assertSame('fruits', $beatmapset->mainRuleset());
     }
 
-    /**
-     * @dataProvider mainRulesetHybridBeatmapsetSameCountDataProvider
-     */
+    #[DataProvider('mainRulesetHybridBeatmapsetSameCountDataProvider')]
     public function testMainRulesetHybridBeatmapsetSameCount(array $steps)
     {
         $userFactory = User::factory()->withGroup('bng', ['osu', 'taiko', 'fruits', 'mania']);
@@ -287,9 +286,7 @@ class BeatmapsetTest extends TestCase
         $this->assertSame('fruits', $beatmapset->mainRuleset());
     }
 
-    /**
-     * @dataProvider mainRulesetHybridBeatmapsetWithGuestMappersSameCountDataProvider
-     */
+    #[DataProvider('mainRulesetHybridBeatmapsetWithGuestMappersSameCountDataProvider')]
     public function testMainRulesetHybridBeatmapsetWithGuestMappersSameCount(array $steps)
     {
         $userFactory = User::factory()->withGroup('bng', ['osu', 'taiko', 'fruits', 'mania']);
@@ -367,9 +364,7 @@ class BeatmapsetTest extends TestCase
 
     //region single-playmode beatmap sets
 
-    /**
-     * @dataProvider nominateDataProvider
-     */
+    #[DataProvider('nominateDataProvider')]
     public function testNominate(string $group, array $groupPlaymodes, string $ruleset, bool $success)
     {
         $beatmapset = $this->beatmapsetFactory()->withBeatmaps($ruleset)->create();
@@ -449,9 +444,7 @@ class BeatmapsetTest extends TestCase
         priv_check_user($nominator, 'BeatmapsetNominate', $beatmapset)->ensureCan();
     }
 
-    /**
-     * @dataProvider qualifyingNominationsDataProvider
-     */
+    #[DataProvider('qualifyingNominationsDataProvider')]
     public function testQualifyingNominations(string $initialGroup, string $qualifyingGroup, bool $success)
     {
         $ruleset = array_rand(Beatmap::MODES);
@@ -478,9 +471,7 @@ class BeatmapsetTest extends TestCase
         }
     }
 
-    /**
-     * @dataProvider dataProviderForTestRank
-     */
+    #[DataProvider('dataProviderForTestRank')]
     public function testRank(string $state, bool $success): void
     {
         $beatmapset = $this->beatmapsetFactory()->withBeatmaps()->$state()->create();
@@ -507,9 +498,7 @@ class BeatmapsetTest extends TestCase
         }
     }
 
-    /**
-     * @dataProvider rankWithOpenIssueDataProvider
-     */
+    #[DataProvider('rankWithOpenIssueDataProvider')]
     public function testRankWithOpenIssue(string $type): void
     {
         $beatmapset = $this->beatmapsetFactory()->withBeatmaps()
@@ -771,9 +760,7 @@ class BeatmapsetTest extends TestCase
         Bus::assertDispatched(CheckBeatmapsetCovers::class);
     }
 
-    /**
-     * @dataProvider qualifyingNominationsHybridDataProvider
-     */
+    #[DataProvider('qualifyingNominationsHybridDataProvider')]
     public function testQualifyingNominationsHybrid(string $initialGroup, string $qualifyingGroup, bool $success)
     {
         $nominator = User::factory()->withGroup($qualifyingGroup, ['osu', 'taiko'])->create();
@@ -819,9 +806,7 @@ class BeatmapsetTest extends TestCase
 
     //region disqualification
 
-    /**
-     * @dataProvider disqualifyOrResetNominationsDataProvider
-     */
+    #[DataProvider('disqualifyOrResetNominationsDataProvider')]
     public function testDisqualifyOrResetNominations(string $state, string $pushed)
     {
         $user = User::factory()->withGroup('bng')->create();

--- a/tests/Models/ChangelogEntryTest.php
+++ b/tests/Models/ChangelogEntryTest.php
@@ -7,13 +7,12 @@ namespace Tests\Models;
 
 use App\Models\Changelog;
 use App\Models\ChangelogEntry;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Tests\TestCase;
 
 class ChangelogEntryTest extends TestCase
 {
-    /**
-     * @dataProvider dataForGetDisplayMessage
-     */
+    #[DataProvider('dataForGetDisplayMessage')]
     public function testGetDisplayMessage($message, $html)
     {
         $this->assertSame($html, ChangelogEntry::getDisplayMessage($message));

--- a/tests/Models/Chat/ChannelTest.php
+++ b/tests/Models/Chat/ChannelTest.php
@@ -15,6 +15,7 @@ use App\Models\User;
 use App\Models\UserRelation;
 use Event;
 use Illuminate\Filesystem\Filesystem;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Queue;
 use SplFileInfo;
 use Storage;
@@ -88,9 +89,7 @@ class ChannelTest extends TestCase
         $this->assertEquals($channel2->users(), $users);
     }
 
-    /**
-     * @dataProvider channelWithBlockedUserVisibilityDataProvider
-     */
+    #[DataProvider('channelWithBlockedUserVisibilityDataProvider')]
     public function testChannelWithBlockedUserVisibility(?string $otherUserGroup, bool $expectVisible)
     {
         $user = User::factory()->create();
@@ -106,9 +105,7 @@ class ChannelTest extends TestCase
         $this->assertSame($expectVisible, $channel->isVisibleFor($user));
     }
 
-    /**
-     * @dataProvider channelCanMessageModeratedChannelDataProvider
-     */
+    #[DataProvider('channelCanMessageModeratedChannelDataProvider')]
     public function testChannelCanMessageModeratedPmChannel(?string $group, bool $canMessage)
     {
         $user = User::factory()->withGroup($group)->create();
@@ -118,9 +115,7 @@ class ChannelTest extends TestCase
         $this->assertSame($canMessage, $channel->checkCanMessage($user)->can());
     }
 
-    /**
-     * @dataProvider channelCanMessageModeratedChannelDataProvider
-     */
+    #[DataProvider('channelCanMessageModeratedChannelDataProvider')]
     public function testChannelCanMessageModeratedPublicChannel(?string $group, bool $canMessage)
     {
         $user = User::factory()->withGroup($group)->create();
@@ -129,9 +124,7 @@ class ChannelTest extends TestCase
         $this->assertSame($canMessage, $channel->checkCanMessage($user)->can());
     }
 
-    /**
-     * @dataProvider channelCanMessageWhenBlockedDataProvider
-     */
+    #[DataProvider('channelCanMessageWhenBlockedDataProvider')]
     public function testChannelCanMessagePmChannelWhenBlocked(?string $group, bool $canMessage)
     {
         $user = User::factory()->withGroup($group)->create();
@@ -154,9 +147,7 @@ class ChannelTest extends TestCase
         $this->assertSame($canMessage, $channel->checkCanMessage($user)->can());
     }
 
-    /**
-     * @dataProvider channelCanMessageWhenBlockedDataProvider
-     */
+    #[DataProvider('channelCanMessageWhenBlockedDataProvider')]
     public function testChannelCanMessagePmChannelWhenBlocking(?string $group, bool $canMessage)
     {
         $user = User::factory()->withGroup($group)->create();
@@ -179,9 +170,7 @@ class ChannelTest extends TestCase
         $this->assertSame($canMessage, $channel->checkCanMessage($user)->can());
     }
 
-    /**
-     * @dataProvider channelCanMessageWhenBlockedDataProvider
-     */
+    #[DataProvider('channelCanMessageWhenBlockedDataProvider')]
     public function testChannelCanMessagePmChannelWhenFriendsOnly(?string $group, bool $canMessage)
     {
         $user = User::factory()->withGroup($group)->create();
@@ -222,9 +211,7 @@ class ChannelTest extends TestCase
         );
     }
 
-    /**
-     * @dataProvider leaveChannelDataProvider
-     */
+    #[DataProvider('leaveChannelDataProvider')]
     public function testLeaveChannel(string $type, bool $inChannel)
     {
         $users = User::factory()->count(2)->create();

--- a/tests/Models/CommentTest.php
+++ b/tests/Models/CommentTest.php
@@ -11,13 +11,12 @@ use App\Models\Comment;
 use App\Models\Notification;
 use App\Models\User;
 use App\Models\UserNotificationOption;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Tests\TestCase;
 
 class CommentTest extends TestCase
 {
-    /**
-     * @dataProvider commentReplyOptionDataProvider
-     */
+    #[DataProvider('commentReplyOptionDataProvider')]
     public function testCommentReplyNotification($option, $shouldBeSent)
     {
         $user = User::factory()->create();
@@ -69,9 +68,7 @@ class CommentTest extends TestCase
         $this->assertArrayHasKey('parent_id', $comment->validationErrors()->all());
     }
 
-    /**
-     * @dataProvider dataProviderForSetCommentableInvalid
-     */
+    #[DataProvider('dataProviderForSetCommentableInvalid')]
     public function testSetCommentableInvalid($type, $id)
     {
         $comment = new Comment(['commentable_type' => $type, 'commentable_id' => $id]);

--- a/tests/Models/ContestTest.php
+++ b/tests/Models/ContestTest.php
@@ -21,6 +21,7 @@ use App\Models\Multiplayer\UserScoreAggregate;
 use App\Models\User;
 use Carbon\Carbon;
 use Closure;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Tests\TestCase;
 
 class ContestTest extends TestCase
@@ -101,9 +102,7 @@ class ContestTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider dataProviderForTestAssertVoteRequirementPlaylistBeatmapsets
-     */
+    #[DataProvider('dataProviderForTestAssertVoteRequirementPlaylistBeatmapsets')]
     public function testAssertVoteRequirementPlaylistBeatmapsets(
         bool $loggedIn,
         bool $played,
@@ -188,9 +187,7 @@ class ContestTest extends TestCase
         $this->assertTrue(true, 'no exception');
     }
 
-    /**
-     * @dataProvider dataProviderForTestCalculateScoresStd
-     */
+    #[DataProvider('dataProviderForTestCalculateScoresStd')]
     public function testCalculateScoresStd(Closure $scoreFn, array $entriesStdDev, array $votesStdDev): void
     {
         $contest = Contest::factory()
@@ -226,9 +223,7 @@ class ContestTest extends TestCase
         }
     }
 
-    /**
-     * @dataProvider dataProviderForTestShowEntryUser
-     */
+    #[DataProvider('dataProviderForTestShowEntryUser')]
     public function testShowEntryUser(bool $showVotes, ?bool $showEntryUserOption, bool $result): void
     {
         $extraOptions = $showEntryUserOption === null
@@ -241,9 +236,7 @@ class ContestTest extends TestCase
         $this->assertSame($result, $contest->showEntryUser());
     }
 
-    /**
-     * @dataProvider dataProviderForTestShowJudges
-     */
+    #[DataProvider('dataProviderForTestShowJudges')]
     public function testShowJudges(?bool $showJudgesOption, bool $result): void
     {
         $extraOptions = $showJudgesOption === null
@@ -255,9 +248,7 @@ class ContestTest extends TestCase
         $this->assertSame($result, $contest->show_judges);
     }
 
-    /**
-     * @dataProvider dataProviderForTestAllowedExtensions
-     */
+    #[DataProvider('dataProviderForTestAllowedExtensions')]
     public function testAllowedExtensions(string $type, ?array $allowedExtensions, array $expectedResult): void
     {
         $extraOptions = $allowedExtensions === null
@@ -270,9 +261,7 @@ class ContestTest extends TestCase
         $this->assertSame($expectedResult, $contest->getAllowedExtensions());
     }
 
-    /**
-     * @dataProvider dataProviderForTestMaxFilesize
-     */
+    #[DataProvider('dataProviderForTestMaxFilesize')]
     public function testMaxFilesize(string $type, ?int $maxFilesize, int $expectedResult): void
     {
         $extraOptions = $maxFilesize === null

--- a/tests/Models/ModelCompositePrimaryKeysTest.php
+++ b/tests/Models/ModelCompositePrimaryKeysTest.php
@@ -25,13 +25,12 @@ use App\Models\UserGroup;
 use App\Models\UserRelation;
 use App\Models\UserReplaysWatchedCount;
 use Carbon\Carbon;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Tests\TestCase;
 
 class ModelCompositePrimaryKeysTest extends TestCase
 {
-    /**
-     * @dataProvider dataProviderBase
-     */
+    #[DataProvider('dataProviderBase')]
     public function testDelete(string $class, array $baseParams, array $item2Params, array $check)
     {
         [$item1, $item2] = $this->createModels($class, $baseParams, $item2Params, $check);
@@ -42,9 +41,7 @@ class ModelCompositePrimaryKeysTest extends TestCase
         $this->assertNotNull($item2->fresh());
     }
 
-    /**
-     * @dataProvider dataProviderBase
-     */
+    #[DataProvider('dataProviderBase')]
     public function testFresh(string $class, array $baseParams, array $item2Params, array $check)
     {
         [$item1, $item2] = $this->createModels($class, $baseParams, $item2Params, $check);
@@ -58,9 +55,7 @@ class ModelCompositePrimaryKeysTest extends TestCase
         $this->assertSame($cast($check[2]), $cast($item2->fresh()->$key));
     }
 
-    /**
-     * @dataProvider dataProviderBase
-     */
+    #[DataProvider('dataProviderBase')]
     public function testUpdate(string $class, array $baseParams, array $item2Params, array $check)
     {
         [$item1, $item2] = $this->createModels($class, $baseParams, $item2Params, $check);

--- a/tests/Models/ModelTest.php
+++ b/tests/Models/ModelTest.php
@@ -10,13 +10,12 @@ namespace Tests\Models;
 use App\Models\Artist;
 use App\Models\Country;
 use Exception;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Tests\TestCase;
 
 class ModelTest extends TestCase
 {
-    /**
-     * @dataProvider dataProviderForDecrementInstance
-     */
+    #[DataProvider('dataProviderForDecrementInstance')]
     public function testDecrementInstance(callable $countryFn, bool $isChanged): void
     {
         $country = $countryFn();
@@ -31,9 +30,7 @@ class ModelTest extends TestCase
         $anotherCountry->refresh();
     }
 
-    /**
-     * @dataProvider dataProviderForDecrementInstance
-     */
+    #[DataProvider('dataProviderForDecrementInstance')]
     public function testDecrementInstanceSpecifyCount(callable $countryFn, bool $isChanged): void
     {
         $country = $countryFn();
@@ -95,9 +92,7 @@ class ModelTest extends TestCase
         Artist::select()->getWithHasMore();
     }
 
-    /**
-     * @dataProvider dataProviderForDecrementInstance
-     */
+    #[DataProvider('dataProviderForDecrementInstance')]
     public function testIncrementInstance(callable $countryFn, bool $isChanged): void
     {
         $country = $countryFn();
@@ -112,9 +107,7 @@ class ModelTest extends TestCase
         $anotherCountry->refresh();
     }
 
-    /**
-     * @dataProvider dataProviderForDecrementInstance
-     */
+    #[DataProvider('dataProviderForDecrementInstance')]
     public function testIncrementInstanceSpecifyCount(callable $countryFn, bool $isChanged): void
     {
         $country = $countryFn();

--- a/tests/Models/Multiplayer/PlaylistItemTest.php
+++ b/tests/Models/Multiplayer/PlaylistItemTest.php
@@ -10,6 +10,7 @@ use App\Models\Beatmap;
 use App\Models\Multiplayer\PlaylistItem;
 use App\Models\Multiplayer\Room;
 use App\Models\User;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Tests\TestCase;
 
 class PlaylistItemTest extends TestCase
@@ -24,9 +25,7 @@ class PlaylistItemTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider rulesetsProvider
-     */
+    #[DataProvider('rulesetsProvider')]
     public function testOsuBeatmapPlayableInAnyRuleset(int $rulesetId)
     {
         $beatmap = Beatmap::factory()->create([

--- a/tests/Models/Multiplayer/RoomTest.php
+++ b/tests/Models/Multiplayer/RoomTest.php
@@ -12,13 +12,12 @@ use App\Models\Multiplayer\PlaylistItem;
 use App\Models\Multiplayer\Room;
 use App\Models\User;
 use Exception;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Tests\TestCase;
 
 class RoomTest extends TestCase
 {
-    /**
-     * @dataProvider startGameDurationDataProvider
-     */
+    #[DataProvider('startGameDurationDataProvider')]
     public function testStartGameDuration(int $duration, bool $isSupporter, bool $expectException)
     {
         $beatmap = Beatmap::factory()->create();
@@ -338,9 +337,7 @@ class RoomTest extends TestCase
         $this->assertSame('good word', $room->name);
     }
 
-    /**
-     * @dataProvider difficultyRangeDataProvider
-     */
+    #[DataProvider('difficultyRangeDataProvider')]
     public function testRoomDifficultyRange(bool $preloadPlaylist, bool $preloadBeatmaps, bool $allItemsExpired, float $minDifficulty, float $maxDifficulty)
     {
         $room = Room::factory()->create();

--- a/tests/Models/Score/ModelTest.php
+++ b/tests/Models/Score/ModelTest.php
@@ -8,6 +8,7 @@ namespace Tests\Models\Score;
 use App\Exceptions\ClassNotFoundException;
 use App\Models\Beatmap;
 use App\Models\Score\Model;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Tests\TestCase;
 
 class ModelTest extends TestCase
@@ -20,9 +21,7 @@ class ModelTest extends TestCase
         }
     }
 
-    /**
-     * @dataProvider dataProviderForTestGetClassInvalidRuleset
-     */
+    #[DataProvider('dataProviderForTestGetClassInvalidRuleset')]
     public function testGetClassInvalidRuleset(string $ruleset)
     {
         $this->expectException(ClassNotFoundException::class);

--- a/tests/Models/Solo/ScoreEsIndexTest.php
+++ b/tests/Models/Solo/ScoreEsIndexTest.php
@@ -12,18 +12,17 @@ use App\Models\Beatmap;
 use App\Models\Beatmapset;
 use App\Models\Country;
 use App\Models\Genre;
-use App\Models\Group;
 use App\Models\Language;
 use App\Models\Solo\Score;
 use App\Models\User;
 use App\Models\UserGroup;
 use App\Models\UserGroupEvent;
 use App\Models\UserRelation;
+use PHPUnit\Framework\Attributes\DataProvider;
+use PHPUnit\Framework\Attributes\Group;
 use Tests\TestCase;
 
-/**
- * @group RequiresScoreIndexer
- */
+#[Group('RequiresScoreIndexer')]
 class ScoreEsIndexTest extends TestCase
 {
     private static Beatmap $beatmap;
@@ -115,9 +114,7 @@ class ScoreEsIndexTest extends TestCase
         });
     }
 
-    /**
-     * @dataProvider dataProviderForTestUserRank
-     */
+    #[DataProvider('dataProviderForTestUserRank')]
     public function testUserRank(string $key, ?array $params, int $rank): void
     {
         $score = static::$scores[$key]->fresh();

--- a/tests/Models/Store/OrderItemTest.php
+++ b/tests/Models/Store/OrderItemTest.php
@@ -9,13 +9,12 @@ use App\Exceptions\InsufficientStockException;
 use App\Exceptions\InvariantException;
 use App\Models\Store\OrderItem;
 use App\Models\Store\Product;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Tests\TestCase;
 
 class OrderItemTest extends TestCase
 {
-    /**
-     * @dataProvider deleteDataProvider
-     */
+    #[DataProvider('deleteDataProvider')]
     public function testDelete(string $status, ?string $expectedException)
     {
         [, $orderItem] = $this->createProductAndOrderItem(5, false);

--- a/tests/Models/TeamTest.php
+++ b/tests/Models/TeamTest.php
@@ -14,6 +14,7 @@ use App\Models\TeamApplication;
 use App\Models\TeamMember;
 use App\Models\TeamStatistics;
 use App\Models\User;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Tests\TestCase;
 
 class TeamTest extends TestCase
@@ -76,9 +77,7 @@ class TeamTest extends TestCase
         $team->fresh()->delete();
     }
 
-    /**
-     * @dataProvider dataProviderForTestSaveNullDefaultRulesetIdFollowsLeader
-     */
+    #[DataProvider('dataProviderForTestSaveNullDefaultRulesetIdFollowsLeader')]
     public function testSaveNullDefaultRulesetIdFollowsLeader(int $leaderRulesetId): void
     {
         $leader = User::factory()->create(['osu_playmode' => $leaderRulesetId]);
@@ -93,9 +92,7 @@ class TeamTest extends TestCase
     }
 
 
-    /**
-     * @dataProvider dataProviderForTestUniquenessValidation
-     */
+    #[DataProvider('dataProviderForTestUniquenessValidation')]
     public function testUniquenessValidation(string $field): void
     {
         $existingTeam = Team::factory()->create();

--- a/tests/Models/UserNotificationTest.php
+++ b/tests/Models/UserNotificationTest.php
@@ -9,6 +9,7 @@ use App\Libraries\Notification\BatchIdentities;
 use App\Models\Notification;
 use App\Models\User;
 use App\Models\UserNotification;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Tests\TestCase;
 
 class UserNotificationTest extends TestCase
@@ -144,9 +145,8 @@ class UserNotificationTest extends TestCase
 
     /**
      * Didn't accidentally break masks sanity test.
-     *
-     * @dataProvider deliveryMaskDataProvider
      */
+    #[DataProvider('deliveryMaskDataProvider')]
     public function testDeliveryMasks($mask, $type, $result)
     {
         $userNotification = new UserNotification(['delivery' => $mask]);

--- a/tests/Models/UserReportTest.php
+++ b/tests/Models/UserReportTest.php
@@ -22,6 +22,7 @@ use App\Models\User;
 use App\Models\UserReport;
 use Carbon\Carbon;
 use Exception;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Tests\TestCase;
 
 class UserReportTest extends TestCase
@@ -101,9 +102,7 @@ class UserReportTest extends TestCase
 
     private User $reporter;
 
-    /**
-     * @dataProvider reportableClasses
-     */
+    #[DataProvider('reportableClasses')]
     public function testCannotReportOwnThing(string $class)
     {
         $reportable = static::makeReportable($class);
@@ -141,9 +140,7 @@ class UserReportTest extends TestCase
         $team->reportBy($reporter, static::reportParams());
     }
 
-    /**
-     * @dataProvider reportableClasses
-     */
+    #[DataProvider('reportableClasses')]
     public function testInvalidReason(string $class)
     {
         $reportable = static::makeReportable($class);
@@ -156,9 +153,7 @@ class UserReportTest extends TestCase
         ]));
     }
 
-    /**
-     * @dataProvider reportableClasses
-     */
+    #[DataProvider('reportableClasses')]
     public function testNoComments(string $class): void
     {
         $reportable = static::makeReportable($class);
@@ -174,9 +169,7 @@ class UserReportTest extends TestCase
         ]));
     }
 
-    /**
-     * @dataProvider reportableClasses
-     */
+    #[DataProvider('reportableClasses')]
     public function testNoCommentsReasonOther(string $class): void
     {
         $reportable = static::makeReportable($class);
@@ -189,9 +182,7 @@ class UserReportTest extends TestCase
         ]));
     }
 
-    /**
-     * @dataProvider reportableClasses
-     */
+    #[DataProvider('reportableClasses')]
     public function testReportableInstance(string $class)
     {
         $reportable = static::makeReportable($class);
@@ -214,9 +205,7 @@ class UserReportTest extends TestCase
         $this->assertTrue($report->reportable->is($reportable));
     }
 
-    /**
-     * @dataProvider reportableClasses
-     */
+    #[DataProvider('reportableClasses')]
     public function testReportableNotificationEndpoint(string $class): void
     {
         $reportable = static::makeReportable($class);

--- a/tests/Models/UserStatistics/ModelTest.php
+++ b/tests/Models/UserStatistics/ModelTest.php
@@ -8,22 +8,19 @@ namespace Tests\Models\UserStatistics;
 use App\Exceptions\ClassNotFoundException;
 use App\Models\Beatmap;
 use App\Models\UserStatistics\Model;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Tests\TestCase;
 
 class ModelTest extends TestCase
 {
-    /**
-     * @dataProvider validModes
-     */
+    #[DataProvider('validModes')]
     public function testGetClass($mode, $variant)
     {
         $class = Model::getClass($mode, $variant);
         $this->assertInstanceOf(Model::class, new $class());
     }
 
-    /**
-     * @dataProvider invalidModes
-     */
+    #[DataProvider('invalidModes')]
     public function testGetClassByThrowsExceptionIfModeDoesNotExist($mode, $variant)
     {
         $this->expectException(ClassNotFoundException::class);

--- a/tests/Models/UserTest.php
+++ b/tests/Models/UserTest.php
@@ -13,6 +13,7 @@ use App\Models\User;
 use App\Models\UsernameChangeHistory;
 use Carbon\CarbonImmutable;
 use Database\Factories\OAuth\RefreshTokenFactory;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Tests\TestCase;
 
 class UserTest extends TestCase
@@ -90,9 +91,7 @@ class UserTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider dataProviderForAttributeTwitter
-     */
+    #[DataProvider('dataProviderForAttributeTwitter')]
     public function testAttributeTwitter($setValue, $getValue)
     {
         $user = new User(['user_twitter' => $setValue]);
@@ -160,9 +159,7 @@ class UserTest extends TestCase
         $this->assertGreaterThanOrEqual($allowedAt, $user->getUsernameAvailableAt());
     }
 
-    /**
-     * @dataProvider dataProviderForUsernameChangeCost
-     */
+    #[DataProvider('dataProviderForUsernameChangeCost')]
     public function testUsernameChangeCost(int $changes, int $cost)
     {
         $user = User::factory()
@@ -218,9 +215,7 @@ class UserTest extends TestCase
         $this->assertSame(8, $user->usernameChangeCost());
     }
 
-    /**
-     * @dataProvider dataProviderForUsernameChangeCostType
-     */
+    #[DataProvider('dataProviderForUsernameChangeCostType')]
     public function testUsernameChangeCostType(string $type, int $cost)
     {
         $user = User::factory()
@@ -230,9 +225,7 @@ class UserTest extends TestCase
         $this->assertSame($cost, $user->usernameChangeCost());
     }
 
-    /**
-     * @dataProvider dataProviderForUsernameChangeCostWindow
-     */
+    #[DataProvider('dataProviderForUsernameChangeCostWindow')]
     public function testUsernameChangeCostWindow(int $years, int $cost)
     {
         $now = CarbonImmutable::now();
@@ -255,9 +248,7 @@ class UserTest extends TestCase
         $this->assertSame($cost, $user->usernameChangeCost());
     }
 
-    /**
-     * @dataProvider dataProviderValidDiscordUsername
-     */
+    #[DataProvider('dataProviderValidDiscordUsername')]
     public function testValidDiscordUsername(string $username, bool $valid)
     {
         $user = User::factory()->make();

--- a/tests/OAuthClientCredentialsRequestTest.php
+++ b/tests/OAuthClientCredentialsRequestTest.php
@@ -7,12 +7,11 @@ namespace Tests;
 
 use App\Models\OAuth\Client;
 use App\Models\User;
+use PHPUnit\Framework\Attributes\DataProvider;
 
 class OAuthClientCredentialsRequestTest extends TestCase
 {
-    /**
-     * @dataProvider botRequestingScopeDataProvider
-     */
+    #[DataProvider('botRequestingScopeDataProvider')]
     public function testBotRequestingScope($scope, $status)
     {
         $client = Client::factory()->create([
@@ -30,9 +29,7 @@ class OAuthClientCredentialsRequestTest extends TestCase
             ->assertStatus($status);
     }
 
-    /**
-     * @dataProvider nonBotRequestingScopeDataProvider
-     */
+    #[DataProvider('nonBotRequestingScopeDataProvider')]
     public function testNonBotRequestingScope($scope, $status)
     {
         $client = Client::factory()->create();

--- a/tests/Providers/AuthServiceProviderTest.php
+++ b/tests/Providers/AuthServiceProviderTest.php
@@ -13,15 +13,14 @@ use App\Http\Controllers\Passport\AuthorizationController;
 use Laravel\Passport\Http\Controllers\AccessTokenController;
 use Laravel\Passport\Http\Controllers\ApproveAuthorizationController;
 use Laravel\Passport\Http\Controllers\DenyAuthorizationController;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Request;
 use Route;
 use Tests\TestCase;
 
 class AuthServiceProviderTest extends TestCase
 {
-    /**
-     * @dataProvider oauthRoutesRegisteredDataProvider
-     */
+    #[DataProvider('oauthRoutesRegisteredDataProvider')]
     public function testOAuthRoutesRegistered($url, $method, $uses)
     {
         $route = Route::getRoutes()->match(Request::create($url, $method));

--- a/tests/Singletons/ChatFiltersTest.php
+++ b/tests/Singletons/ChatFiltersTest.php
@@ -7,6 +7,7 @@ namespace Tests\Singletons;
 
 use App\Exceptions\ContentModerationException;
 use App\Models\ChatFilter;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Tests\TestCase;
 
 class ChatFiltersTest extends TestCase
@@ -45,9 +46,7 @@ class ChatFiltersTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider plainFilterTests
-     */
+    #[DataProvider('plainFilterTests')]
     public function testPlainFilterReplacement($input, $expectedOutput)
     {
         ChatFilter::factory()->createMany([
@@ -60,9 +59,7 @@ class ChatFiltersTest extends TestCase
         $this->assertSame($expectedOutput, $result);
     }
 
-    /**
-     * @dataProvider fullWordFilterTests
-     */
+    #[DataProvider('fullWordFilterTests')]
     public function testWhitespaceDelimitedFilterReplacement($input, $expectedOutput)
     {
         ChatFilter::factory()->createMany([
@@ -78,9 +75,7 @@ class ChatFiltersTest extends TestCase
         $this->assertSame($expectedOutput, $result);
     }
 
-    /**
-     * @dataProvider blockingFilterTests
-     */
+    #[DataProvider('blockingFilterTests')]
     public function testBlockingFilter($input)
     {
         ChatFilter::factory()->createMany([

--- a/tests/Singletons/Ip2AsnTest.php
+++ b/tests/Singletons/Ip2AsnTest.php
@@ -6,13 +6,12 @@
 namespace Tests\Singletons;
 
 use App\Singletons\Ip2Asn;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Tests\TestCase;
 
 class Ip2AsnTest extends TestCase
 {
-    /**
-     * @dataProvider dataProviderForLookup
-     */
+    #[DataProvider('dataProviderForLookup')]
     public function testLookup(string $ip, string $asn)
     {
         $this->assertSame((new Ip2Asn())->lookup($ip), $asn);

--- a/tests/Singletons/ModsTest.php
+++ b/tests/Singletons/ModsTest.php
@@ -7,6 +7,7 @@ namespace Tests\Singletons;
 
 use App\Enums\Ruleset;
 use App\Exceptions\InvariantException;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Tests\TestCase;
 
 class ModsTest extends TestCase
@@ -76,9 +77,7 @@ class ModsTest extends TestCase
         app('mods')->validateSelection(-1, []);
     }
 
-    /**
-     * @dataProvider modComboExclusives
-     */
+    #[DataProvider('modComboExclusives')]
     public function testAssertValidExclusivity(Ruleset $ruleset, $mods, $isValid)
     {
         if (!$isValid) {
@@ -90,9 +89,7 @@ class ModsTest extends TestCase
         $result = app('mods')->assertValidExclusivity($ruleset->value, $mods);
     }
 
-    /**
-     * @dataProvider multiplayerModComboExclusives
-     */
+    #[DataProvider('multiplayerModComboExclusives')]
     public function testAssertValidMultiplayerExclusivity(Ruleset $ruleset, $requiredIds, $allowedIds, $isValid)
     {
         if (!$isValid) {
@@ -104,9 +101,7 @@ class ModsTest extends TestCase
         app('mods')->assertValidMultiplayerExclusivity($ruleset->value, $requiredIds, $allowedIds);
     }
 
-    /**
-     * @dataProvider modCombos
-     */
+    #[DataProvider('modCombos')]
     public function testValidateSelection(Ruleset $ruleset, $modCombo, $isValid)
     {
         if (!$isValid) {

--- a/tests/Transformers/BeatmapDiscussionPostTransformerTest.php
+++ b/tests/Transformers/BeatmapDiscussionPostTransformerTest.php
@@ -10,6 +10,7 @@ use App\Models\BeatmapDiscussionPost;
 use App\Models\Beatmapset;
 use App\Models\User;
 use App\Transformers\BeatmapDiscussionPostTransformer;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Tests\TestCase;
 
 class BeatmapDiscussionPostTransformerTest extends TestCase
@@ -20,9 +21,7 @@ class BeatmapDiscussionPostTransformerTest extends TestCase
     /** @var BeatmapDiscussionPost */
     protected $deletedPost;
 
-    /**
-     * @dataProvider groupsDataProvider
-     */
+    #[DataProvider('groupsDataProvider')]
     public function testWithOAuth(?string $groupIdentifier)
     {
         $viewer = User::factory()->withGroup($groupIdentifier)->create();
@@ -32,9 +31,7 @@ class BeatmapDiscussionPostTransformerTest extends TestCase
         $this->assertEmpty($json);
     }
 
-    /**
-     * @dataProvider groupsDataProvider
-     */
+    #[DataProvider('groupsDataProvider')]
     public function testWithoutOAuth(?string $groupIdentifier, bool $visible)
     {
         $viewer = User::factory()->withGroup($groupIdentifier)->create();

--- a/tests/Transformers/BeatmapDiscussionTransformerTest.php
+++ b/tests/Transformers/BeatmapDiscussionTransformerTest.php
@@ -8,15 +8,14 @@ namespace Tests\Transformers;
 use App\Models\Beatmapset;
 use App\Models\User;
 use App\Transformers\BeatmapDiscussionTransformer;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Tests\TestCase;
 
 class BeatmapDiscussionTransformerTest extends TestCase
 {
     protected $deletedBeatmapDiscussion;
 
-    /**
-     * @dataProvider groupsDataProvider
-     */
+    #[DataProvider('groupsDataProvider')]
     public function testWithOAuth(?string $groupIdentifier)
     {
         $viewer = User::factory()->withGroup($groupIdentifier)->create();
@@ -28,9 +27,7 @@ class BeatmapDiscussionTransformerTest extends TestCase
         $this->assertEmpty($json);
     }
 
-    /**
-     * @dataProvider groupsDataProvider
-     */
+    #[DataProvider('groupsDataProvider')]
     public function testWithoutOAuth(?string $groupIdentifier, bool $visible)
     {
         $viewer = User::factory()->withGroup($groupIdentifier)->create();

--- a/tests/Transformers/BeatmapTransformerTest.php
+++ b/tests/Transformers/BeatmapTransformerTest.php
@@ -9,6 +9,7 @@ use App\Models\Beatmap;
 use App\Models\Beatmapset;
 use App\Models\User;
 use App\Transformers\BeatmapTransformer;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Tests\TestCase;
 
 class BeatmapTransformerTest extends TestCase
@@ -16,9 +17,7 @@ class BeatmapTransformerTest extends TestCase
     /** @var Beatmap */
     protected $deletedBeatmap;
 
-    /**
-     * @dataProvider groupsDataProvider
-     */
+    #[DataProvider('groupsDataProvider')]
     public function testWithOAuth(?string $groupIdentifier)
     {
         $viewer = User::factory()->withGroup($groupIdentifier)->create();
@@ -29,9 +28,7 @@ class BeatmapTransformerTest extends TestCase
         $this->assertEmpty($json);
     }
 
-    /**
-     * @dataProvider groupsDataProvider
-     */
+    #[DataProvider('groupsDataProvider')]
     public function testWithoutOAuth(?string $groupIdentifier, bool $visible)
     {
         $viewer = User::factory()->withGroup($groupIdentifier)->create();

--- a/tests/Transformers/BeatmapsetCompactTransformerTest.php
+++ b/tests/Transformers/BeatmapsetCompactTransformerTest.php
@@ -8,6 +8,7 @@ namespace Tests\Transformers;
 use App\Models\Beatmapset;
 use App\Models\User;
 use App\Transformers\BeatmapsetCompactTransformer;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Tests\TestCase;
 
 class BeatmapsetCompactTransformerTest extends TestCase
@@ -15,9 +16,7 @@ class BeatmapsetCompactTransformerTest extends TestCase
     protected $beatmapset;
     protected $viewer;
 
-    /**
-     * @dataProvider regularOAuthScopesDataProvider
-     */
+    #[DataProvider('regularOAuthScopesDataProvider')]
     public function testHasFavouritedWithOAuthNormalScopes($scope)
     {
         $this->actAsScopedUser($this->viewer, [$scope]);
@@ -42,9 +41,7 @@ class BeatmapsetCompactTransformerTest extends TestCase
         $this->assertArrayHasKey('has_favourited', $json);
     }
 
-    /**
-     * @dataProvider propertyPermissionsDataProvider
-     */
+    #[DataProvider('propertyPermissionsDataProvider')]
     public function testPropertyIsNotVisibleWithOAuth(string $property)
     {
         $this->actAsScopedUser($this->viewer);
@@ -53,9 +50,7 @@ class BeatmapsetCompactTransformerTest extends TestCase
         $this->assertArrayNotHasKey($property, $json);
     }
 
-    /**
-     * @dataProvider propertyPermissionsDataProvider
-     */
+    #[DataProvider('propertyPermissionsDataProvider')]
     public function testPropertyIsVisibleWithoutOAuth(string $property)
     {
         $this->actAsUser($this->viewer);

--- a/tests/Transformers/BeatmapsetDescriptionTransformerTest.php
+++ b/tests/Transformers/BeatmapsetDescriptionTransformerTest.php
@@ -8,6 +8,7 @@ namespace Tests\Transformers;
 use App\Models\Beatmapset;
 use App\Models\User;
 use App\Transformers\BeatmapsetDescriptionTransformer;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Tests\TestCase;
 
 class BeatmapsetDescriptionTransformerTest extends TestCase
@@ -15,9 +16,7 @@ class BeatmapsetDescriptionTransformerTest extends TestCase
     protected Beatmapset $beatmapset;
     protected User $mapper;
 
-    /**
-     * @dataProvider groupsDataProvider
-     */
+    #[DataProvider('groupsDataProvider')]
     public function testWithOAuth(?string $groupIdentifier)
     {
         $viewer = User::factory()->withGroup($groupIdentifier)->create();
@@ -28,9 +27,7 @@ class BeatmapsetDescriptionTransformerTest extends TestCase
         $this->assertArrayNotHasKey('bbcode', $json);
     }
 
-    /**
-     * @dataProvider groupsDataProvider
-     */
+    #[DataProvider('groupsDataProvider')]
     public function testWithoutOAuth(?string $groupIdentifier, bool $visible)
     {
         $viewer = User::factory()->withGroup($groupIdentifier)->create();

--- a/tests/Transformers/BeatmapsetEventTransformerTest.php
+++ b/tests/Transformers/BeatmapsetEventTransformerTest.php
@@ -9,6 +9,7 @@ use App\Models\Beatmapset;
 use App\Models\BeatmapsetEvent;
 use App\Models\User;
 use App\Transformers\BeatmapsetEventTransformer;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Tests\TestCase;
 
 class BeatmapsetEventTransformerTest extends TestCase
@@ -16,9 +17,7 @@ class BeatmapsetEventTransformerTest extends TestCase
     /** @var Beatmapset */
     protected $beatmapset;
 
-    /**
-     * @dataProvider dataProvider
-     */
+    #[DataProvider('dataProvider')]
     public function testWithOAuth(?string $groupIdentifier, string $eventType, bool $visibleWithOAuth)
     {
         $event = $this->beatmapset->events()->create([
@@ -37,9 +36,7 @@ class BeatmapsetEventTransformerTest extends TestCase
         }
     }
 
-    /**
-     * @dataProvider dataProvider
-     */
+    #[DataProvider('dataProvider')]
     public function testWithoutOAuth(?string $groupIdentifier, string $eventType, bool $visibleWithOAuth, bool $visibleWithoutOAuth)
     {
         $event = $this->beatmapset->events()->create([

--- a/tests/Transformers/BeatmapsetTransformerTest.php
+++ b/tests/Transformers/BeatmapsetTransformerTest.php
@@ -8,13 +8,12 @@ namespace Tests\Transformers;
 use App\Models\Beatmapset;
 use App\Models\User;
 use App\Transformers\BeatmapsetTransformer;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Tests\TestCase;
 
 class BeatmapsetTransformerTest extends TestCase
 {
-    /**
-     * @dataProvider groupsDataProvider
-     */
+    #[DataProvider('groupsDataProvider')]
     public function testDeletedBeatmapsetGroupPermissionsWithOAuth(?string $groupIdentifier)
     {
         $viewer = User::factory()->withGroup($groupIdentifier)->create();
@@ -26,9 +25,7 @@ class BeatmapsetTransformerTest extends TestCase
         $this->assertEmpty($json);
     }
 
-    /**
-     * @dataProvider groupsDataProvider
-     */
+    #[DataProvider('groupsDataProvider')]
     public function testDeletedBeatmapsetGroupPermissionsWithoutOAuth(?string $groupIdentifier, bool $visible)
     {
         $viewer = User::factory()->withGroup($groupIdentifier)->create();

--- a/tests/Transformers/CommentTransformerTest.php
+++ b/tests/Transformers/CommentTransformerTest.php
@@ -8,13 +8,12 @@ namespace Tests\Transformers;
 use App\Models\Comment;
 use App\Models\User;
 use App\Transformers\CommentTransformer;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Tests\TestCase;
 
 class CommentTransformerTest extends TestCase
 {
-    /**
-     * @dataProvider groupsDataProvider
-     */
+    #[DataProvider('groupsDataProvider')]
     public function testWithOAuth(?string $groupIdentifier)
     {
         $viewer = User::factory()->withGroup($groupIdentifier)->create();
@@ -27,9 +26,7 @@ class CommentTransformerTest extends TestCase
         $this->assertArrayNotHasKey('message_html', $json);
     }
 
-    /**
-     * @dataProvider groupsDataProvider
-     */
+    #[DataProvider('groupsDataProvider')]
     public function testWithoutOAuth(?string $groupIdentifier, bool $visible)
     {
         $viewer = User::factory()->withGroup($groupIdentifier)->create();

--- a/tests/Transformers/DeclaredPermissionsTest.php
+++ b/tests/Transformers/DeclaredPermissionsTest.php
@@ -7,6 +7,7 @@ namespace Tests\Transformers;
 
 use App\Transformers\TransformerAbstract;
 use League\Fractal\TransformerAbstract as FractalTrasformerAbstract;
+use PHPUnit\Framework\Attributes\DataProvider;
 use ReflectionClass;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\Finder\SplFileInfo;
@@ -14,17 +15,13 @@ use Tests\TestCase;
 
 class DeclaredPermissionsTest extends TestCase
 {
-    /**
-     * @dataProvider transformerClassesDataProvider
-     */
+    #[DataProvider('transformerClassesDataProvider')]
     public function testCorrectSubclass($class)
     {
         $this->assertTrue(is_subclass_of($class, TransformerAbstract::class));
     }
 
-    /**
-     * @dataProvider privilegeDataProvider
-     */
+    #[DataProvider('privilegeDataProvider')]
     public function testPrivilegeExists($class, ?string $include, string $privilege)
     {
         /** @var TransformerAbstract $transformer */

--- a/tests/Transformers/OAuth/ClientTransformerTest.php
+++ b/tests/Transformers/OAuth/ClientTransformerTest.php
@@ -8,6 +8,7 @@ namespace Tests\Transformers\OAuth;
 use App\Models\OAuth\Client;
 use App\Models\User;
 use App\Transformers\OAuth\ClientTransformer;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Tests\TestCase;
 
 class ClientTransformerTest extends TestCase
@@ -36,9 +37,7 @@ class ClientTransformerTest extends TestCase
         $this->assertArrayNotHasKey('secret', $json);
     }
 
-    /**
-     * @dataProvider groupsDataProvider
-     */
+    #[DataProvider('groupsDataProvider')]
     public function testRedirectAndSecretNotVisibleToGroup($groupIdentifier)
     {
         $user = User::factory()->withGroup($groupIdentifier)->create();

--- a/tests/Transformers/PollOptionTransformerTest.php
+++ b/tests/Transformers/PollOptionTransformerTest.php
@@ -11,13 +11,12 @@ use App\Models\Forum\Topic;
 use App\Models\User;
 use App\Transformers\Forum\PollOptionTransformer;
 use Carbon\Carbon;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Tests\TestCase;
 
 class PollOptionTransformerTest extends TestCase
 {
-    /**
-     * @dataProvider voteCountPermissionsDataProvider
-     */
+    #[DataProvider('voteCountPermissionsDataProvider')]
     public function testVoteCountPermissions(
         bool $isOAuth,
         bool $pollEnded,

--- a/tests/Transformers/UserCompactTransformerTest.php
+++ b/tests/Transformers/UserCompactTransformerTest.php
@@ -8,13 +8,12 @@ namespace Tests\Transformers;
 use App\Models\User;
 use App\Transformers\UserCompactTransformer;
 use App\Transformers\UserTransformer;
+use PHPUnit\Framework\Attributes\DataProvider;
 use Tests\TestCase;
 
 class UserCompactTransformerTest extends TestCase
 {
-    /**
-     * @dataProvider regularOAuthScopesDataProvider
-     */
+    #[DataProvider('regularOAuthScopesDataProvider')]
     public function testFriendsIsNotVisibleWithOAuth($scopes)
     {
         $viewer = User::factory()->create();
@@ -25,9 +24,7 @@ class UserCompactTransformerTest extends TestCase
         $this->assertArrayNotHasKey('friends', $json);
     }
 
-    /**
-     * @dataProvider groupsDataProvider
-     */
+    #[DataProvider('groupsDataProvider')]
     public function testGroupPermissionsUserSilenceShowExtendedInfo(?string $groupIdentifier)
     {
         $viewer = User::factory()->withGroup($groupIdentifier)->create();
@@ -47,9 +44,7 @@ class UserCompactTransformerTest extends TestCase
         $this->assertSame($accountHistories, $publicInfringements);
     }
 
-    /**
-     * @dataProvider groupsDataProvider
-     */
+    #[DataProvider('groupsDataProvider')]
     public function testGroupPermissionsWithOAuth(?string $groupIdentifier)
     {
         $viewer = User::factory()->withGroup($groupIdentifier)->create();
@@ -63,9 +58,7 @@ class UserCompactTransformerTest extends TestCase
         $this->assertArrayNotHasKey('supporting_url', $accountHistory);
     }
 
-    /**
-     * @dataProvider groupsDataProvider
-     */
+    #[DataProvider('groupsDataProvider')]
     public function testGroupPermissionsWithoutOAuth(?string $groupIdentifier, bool $visible)
     {
         $viewer = User::factory()->withGroup($groupIdentifier)->create();
@@ -84,9 +77,7 @@ class UserCompactTransformerTest extends TestCase
         }
     }
 
-    /**
-     * @dataProvider propertyPermissionsDataProvider
-     */
+    #[DataProvider('propertyPermissionsDataProvider')]
     public function testPropertyIsNotVisibleWithOAuth(string $property)
     {
         $viewer = User::factory()->create();
@@ -97,9 +88,7 @@ class UserCompactTransformerTest extends TestCase
         $this->assertArrayNotHasKey($property, $json);
     }
 
-    /**
-     * @dataProvider propertyPermissionsDataProvider
-     */
+    #[DataProvider('propertyPermissionsDataProvider')]
     public function testPropertyIsVisibleWithoutOAuth(string $property)
     {
         $viewer = User::factory()->create();

--- a/tests/ZalgoTest.php
+++ b/tests/ZalgoTest.php
@@ -7,6 +7,7 @@ declare(strict_types=1);
 
 namespace Tests;
 
+use PHPUnit\Framework\Attributes\DataProvider;
 use Symfony\Component\Finder\Finder;
 
 class ZalgoTest extends TestCase
@@ -29,9 +30,7 @@ class ZalgoTest extends TestCase
         ];
     }
 
-    /**
-     * @dataProvider dataProviderForCombination
-     */
+    #[DataProvider('dataProviderForCombination')]
     public function testCombination(string $text)
     {
         $this->assertSame(unzalgo($text), $text);
@@ -51,9 +50,8 @@ class ZalgoTest extends TestCase
 
     /**
      * This does not seem like the best idea.
-     *
-     * @dataProvider dataProviderForUnzalgo
      */
+    #[DataProvider('dataProviderForUnzalgo')]
     public function testUnzalgo(string $expected, int $level)
     {
         $text = 't́̌͌̌͘e̎̀́͐̅s̐̑̈͋͡ť̎̅̌̅i͛̋̋͋̽ñ̈́̌̽̿g̈́̆͋͡͞';


### PR DESCRIPTION
The doc comment syntax is deprecated in phpunit 11.

~~There is also `@group` thing but it'll be done separately as it requires some manual tests.~~ Can't use both syntaxes so might as well convert them all.