### PR TITLE
Sort mods terms in score search query

### DIFF
--- a/app/Libraries/Search/ScoreSearch.php
+++ b/app/Libraries/Search/ScoreSearch.php
@@ -143,7 +143,7 @@ class ScoreSearch extends RecordSearch
 
     private function addModsFilter(BoolQuery $query): void
     {
-        $mods = $this->params->mods;
+        $mods = array_values(array_sort($this->params->mods));
         if ($mods === null || count($mods) === 0) {
             return;
         }
@@ -177,7 +177,7 @@ class ScoreSearch extends RecordSearch
         }
 
         if (isset($modsSubQuery)) {
-            $excludedMods = array_values(array_diff($allMods->toArray(), $allSearchMods));
+            $excludedMods = array_values(array_sort(array_diff($allMods->toArray(), $allSearchMods)));
             if (count($excludedMods) > 0) {
                 foreach ($excludedMods as $excludedMod) {
                     $modsSubQuery->mustNot(['term' => ['mods' => $excludedMod]]);


### PR DESCRIPTION
apparently, terms in a different order are considered different queries and have separate query cache entries.