### PR TITLE
Update commonmark

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -27,7 +27,7 @@
     "laravel/passport": "*",
     "laravel/slack-notification-channel": "*",
     "laravel/tinker": "*",
-    "league/commonmark": "^2.0",
+    "league/commonmark": "^2.9.0",
     "league/flysystem-aws-s3-v3": "*",
     "league/fractal": "*",
     "league/oauth2-github": "^3.1",

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1ff162f31bb41b208bbd00e5475bb048",
+    "content-hash": "1583b45e4c8781483ebfa705fcaa9812",
     "packages": [
         {
             "name": "aws/aws-crt-php",
@@ -3524,16 +3524,16 @@
         },
         {
             "name": "league/commonmark",
-            "version": "2.8.2",
+            "version": "2.9.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/commonmark.git",
-                "reference": "59fb075d2101740c337c7216e3f32b36c204218b"
+                "reference": "5703d83ba3da3b2e356a5fedc848ed6d8ffb6529"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/commonmark/zipball/59fb075d2101740c337c7216e3f32b36c204218b",
-                "reference": "59fb075d2101740c337c7216e3f32b36c204218b",
+                "url": "https://api.github.com/repos/thephpleague/commonmark/zipball/5703d83ba3da3b2e356a5fedc848ed6d8ffb6529",
+                "reference": "5703d83ba3da3b2e356a5fedc848ed6d8ffb6529",
                 "shasum": ""
             },
             "require": {
@@ -3555,8 +3555,8 @@
                 "github/gfm": "0.29.0",
                 "michelf/php-markdown": "^1.4 || ^2.0",
                 "nyholm/psr7": "^1.5",
-                "phpstan/phpstan": "^1.8.2",
-                "phpunit/phpunit": "^9.5.21 || ^10.5.9 || ^11.0.0",
+                "phpstan/phpstan": "^2.0.0",
+                "phpunit/phpunit": "^9.5.21 || ^10.5.9 || ^11.0.0 || ^12.0.0 || ^13.0.0",
                 "scrutinizer/ocular": "^1.8.1",
                 "symfony/finder": "^5.3 | ^6.0 | ^7.0 || ^8.0",
                 "symfony/process": "^5.4 | ^6.0 | ^7.0 || ^8.0",
@@ -3570,7 +3570,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "2.9-dev"
+                    "dev-main": "2.10-dev"
                 }
             },
             "autoload": {
@@ -3627,7 +3627,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-03-19T13:16:38+00:00"
+            "time": "2026-08-03T13:42:31+00:00"
         },
         {
             "name": "league/config",

--- a/tests/Libraries/Markdown/html_markdown_examples/footnote_invalid_duplicate.html
+++ b/tests/Libraries/Markdown/html_markdown_examples/footnote_invalid_duplicate.html
@@ -12,14 +12,6 @@ Second
 </sup>
 </p>
 
-<li class="osu-md__list-item osu-md__list-item--footnote" id="fn-test" role="doc-endnote">
-  <p class="osu-md__paragraph">
-Invalid
-&nbsp;<a class="osu-md__link" rev="footnote" href="#fnref-test" role="doc-backlink">↑</a>
-&nbsp;<a class="osu-md__link" rev="footnote" href="#fnref-test__2" role="doc-backlink">↑</a>
-  </p>
-</li>
-
 <div class="osu-md__footnote-container" role="doc-endnotes">
   <ol>
     <li class="osu-md__list-item osu-md__list-item--footnote" id="fn-test" role="doc-endnote">

--- a/tests/Libraries/Markdown/html_markdown_examples/footnote_invalid_duplicate.md
+++ b/tests/Libraries/Markdown/html_markdown_examples/footnote_invalid_duplicate.md
@@ -2,5 +2,5 @@ First[^test]
 
 Second[^test]
 
-[^test]: Invalid
 [^test]: Valid
+[^test]: Invalid


### PR DESCRIPTION
This includes a behaviour change where duplicate footnotes will only have the first one shown instead of some weird invalid html thing.

It shouldn't happen in the first place anyway so there should be no impact.

Reference: https://github.com/thephpleague/commonmark/blob/2.9/CHANGELOG.md#changed

- [x] mainly so I don't need to deal with lockfile merges #13211