### PR TITLE
Use updated php white space lint

### DIFF
--- a/phpcs.xml
+++ b/phpcs.xml
@@ -34,6 +34,7 @@
     <rule ref="Generic.PHP.DeprecatedFunctions"/>
     <rule ref="Generic.PHP.ForbiddenFunctions"/>
     <rule ref="Generic.PHP.NoSilencedErrors"/>
+    <rule ref="Generic.WhiteSpace.LanguageConstructSpacing"/>
     <rule ref="SlevomatCodingStandard.Arrays.TrailingArrayComma"/>
     <rule ref="SlevomatCodingStandard.Classes.ClassConstantVisibility">
         <properties>
@@ -118,7 +119,6 @@
         <exclude name="Squiz.Strings.DoubleQuoteUsage.ContainsVar"/>
     </rule>
     <rule ref="Squiz.WhiteSpace.CastSpacing"/>
-    <rule ref="Squiz.WhiteSpace.LanguageConstructSpacing"/>
     <rule ref="Squiz.WhiteSpace.LogicalOperatorSpacing"/>
     <rule ref="Squiz.WhiteSpace.OperatorSpacing">
         <properties>


### PR DESCRIPTION
-  Squiz.WhiteSpace.LanguageConstructSpacing
   This sniff has been deprecated since v3.3.0 and will be removed in v4.0.0. Use the Generic.WhiteSpace.LanguageConstructSpacing sniff instead.

it says.

They're not the same test and I can't really tell what either of them exactly are ┐( ･_･)┌