### PR TITLE
Clean up browser test warnings

### DIFF
--- a/routes/web.php
+++ b/routes/web.php
@@ -697,5 +697,5 @@ Route::group(['prefix' => '_lio', 'middleware' => 'lio', 'as' => 'interop.'], fu
     });
 });
 
-Route::get('opensearch.xml', 'HomeController@opensearch');
+Route::get('opensearch.xml', 'HomeController@opensearch')->name('opensearch');
 Route::any('{catchall}', 'FallbackController@index')->where('catchall', '.*')->fallback();

--- a/tests/Browser/SanityTest.php
+++ b/tests/Browser/SanityTest.php
@@ -360,8 +360,10 @@ class SanityTest extends DuskTestCase
             '_lio',
             'api/',
             'clockwork',
+            'news/{tumblrId}',
             'oauth/',
             'payments/',
+            '{catchall}',
         ];
         static $types = ['user', 'guest'];
 


### PR DESCRIPTION
Explicitly skip old route and catchall route. And actually test opensearch endpoint.