### PR TITLE
Add wiki suggestion API endpoint

### DIFF
--- a/app/Http/Controllers/SuggestionsController.php
+++ b/app/Http/Controllers/SuggestionsController.php
@@ -42,6 +42,11 @@ class SuggestionsController extends Controller
     public function wiki()
     {
         $search = new WikiSuggestions(new WikiSuggestionsRequestParams(\Request::all()));
+
+        if (is_api_request()) {
+            $search->useMarkdownHighlightTags();
+        }
+
         return json_collection([...$search->response()], new WikiSuggestionsHitTransformer());
     }
 }

--- a/app/Http/Middleware/RequireScopes.php
+++ b/app/Http/Middleware/RequireScopes.php
@@ -18,6 +18,7 @@ class RequireScopes
         'api/v2/comments/',
         'api/v2/news/',
         'api/v2/seasonal-backgrounds/',
+        'api/v2/suggestions/wiki/',
         'api/v2/wiki/',
     ];
 

--- a/app/Libraries/Elasticsearch/Highlight.php
+++ b/app/Libraries/Elasticsearch/Highlight.php
@@ -12,8 +12,9 @@ namespace App\Libraries\Elasticsearch;
 class Highlight implements Queryable
 {
     protected $fields = [];
-    protected $numberOfFragments = 5;
     protected $fragmentSize = 100;
+    protected $markdownTags = false;
+    protected $numberOfFragments = 5;
 
     /**
      * @return $this
@@ -55,15 +56,35 @@ class Highlight implements Queryable
     }
 
     /**
+     * Sets the highlight tags to use markdown (asterisk) tags.
+     *
+     * @return $this
+     */
+    public function markdownTags()
+    {
+        $this->markdownTags = true;
+
+        return $this;
+    }
+
+    /**
      * {@inheritdoc}
      */
     public function toArray(): array
     {
-        return [
+        $highlight = [
             'encoder' => 'html',
             'fragment_size' => $this->fragmentSize,
             'fields' => $this->fields,
             'number_of_fragments' => $this->numberOfFragments,
         ];
+
+        if ($this->markdownTags) {
+            $highlight['encoder'] = 'default';
+            $highlight['pre_tags'] = ['*'];
+            $highlight['post_tags'] = ['*'];
+        }
+
+        return $highlight;
     }
 }

--- a/app/Libraries/Search/WikiSuggestions.php
+++ b/app/Libraries/Search/WikiSuggestions.php
@@ -32,6 +32,11 @@ class WikiSuggestions extends Search
         return $this->response();
     }
 
+    public function useMarkdownHighlightTags()
+    {
+        $this->highlight->markdownTags();
+    }
+
     public function getQuery(): BoolQuery
     {
         $langQuery = (new BoolQuery())

--- a/routes/web.php
+++ b/routes/web.php
@@ -632,6 +632,8 @@ Route::group(['as' => 'api.', 'prefix' => 'api', 'middleware' => ['api', Throttl
 
         Route::get('wiki/{locale}/{path}', 'WikiController@show')->name('wiki.show')->where('path', '.+');
 
+        Route::get('suggestions/wiki', 'SuggestionsController@wiki')->name('suggestions.wiki');
+
         // Tags
         Route::apiResource('tags', 'TagsController', ['only' => ['index']]);
 

--- a/tests/api_routes.json
+++ b/tests/api_routes.json
@@ -1744,6 +1744,19 @@
         "scopes": []
     },
     {
+        "uri": "api/v2/suggestions/wiki",
+        "methods": [
+            "GET",
+            "HEAD"
+        ],
+        "controller": "App\\Http\\Controllers\\SuggestionsController@wiki",
+        "middlewares": [
+            "App\\Http\\Middleware\\ThrottleRequests:1200,1,api:",
+            "App\\Http\\Middleware\\RequireScopes"
+        ],
+        "scopes": []
+    },
+    {
         "uri": "api/v2/tags",
         "methods": [
             "GET",


### PR DESCRIPTION
Pre-req for wiki suggestion search box in lazer.

The endpoint is public to match `/wiki/` endpoint and also match the wiki suggestion search box on web (can be used without login).

Use asterisk (`*`) as highlight tags instead of default `<em>` html tag for easier parsing in client.

reference:

- https://www.elastic.co/guide/en/elasticsearch/reference/7.17/highlighting.html#configure-tags
- https://www.elastic.co/guide/en/elasticsearch/reference/7.17/highlighting.html#highlighting-settings