### PR TITLE
Add compact display for usergroup badges

### DIFF
--- a/resources/css/bem/user-card.less
+++ b/resources/css/bem/user-card.less
@@ -217,6 +217,7 @@
   }
 
   &__group-badge {
+    display: flex;
     margin-left: 2px;
   }
 

--- a/resources/css/bem/user-group-badge.less
+++ b/resources/css/bem/user-group-badge.less
@@ -52,6 +52,36 @@
     background-color: @osu-colour-b6;
   }
 
+  &--combined {
+    gap: 4px;
+    padding-left: 6px;
+    padding-right: 6px;
+
+    &::before {
+      content: none;
+    }
+  }
+
+  &__colour {
+    .circle(7px);
+    flex: none;
+    background-color: var(--group-colour, @osu-colour-c1);
+
+    &--probationary {
+      opacity: 0.6;
+    }
+  }
+
+  &__popup {
+    .default-box-shadow();
+    display: flex;
+    flex-wrap: wrap;
+    gap: 5px;
+    background: hsl(var(--hsl-b5));
+    padding: 10px;
+    border-radius: @border-radius-large;
+  }
+
   &__modes {
     color: white;
     padding-left: 5px;

--- a/resources/js/components/user-card.tsx
+++ b/resources/js/components/user-card.tsx
@@ -120,7 +120,10 @@ export class UserCard extends React.PureComponent<Props, State> {
       this.props.modifiers,
       this.props.mode,
       // Setting the active modifiers from the parent causes unwanted renders unless deep comparison is used.
-      this.popupMenuState.active || this.props.activated ? 'active' : 'highlightable',
+      {
+        active: this.popupMenuState.active,
+        highlightable: !this.popupMenuState.active && !this.props.activated,
+      },
     );
 
     this.url = this.isUserVisible ? route('users.show', { user: this.user.id }) : undefined;

--- a/resources/js/components/user-group-badges-combined.tsx
+++ b/resources/js/components/user-group-badges-combined.tsx
@@ -1,0 +1,106 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
+import UserGroupJson from 'interfaces/user-group-json';
+import * as React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { ContainerContext, KeyContext } from 'stateful-activation-context';
+import { TooltipContext } from 'tooltip-context';
+import { classWithModifiers, groupColour, Modifiers } from 'utils/css';
+import { qtipPosition } from 'utils/qtip-helper';
+import UserGroupBadge from './user-group-badge';
+
+interface Props {
+  groups: UserGroupJson[];
+  modifiers?: Modifiers;
+}
+
+export default function UserGroupBadgesCombined({ groups, modifiers }: Props) {
+  const container = React.useContext(ContainerContext);
+  const key = React.useContext(KeyContext);
+  const tooltipContext = React.useContext(TooltipContext);
+  const valueRef = React.useRef<HTMLDivElement>(null);
+  const tooltipHideEventRef = React.useRef<unknown>(null);
+
+  const parentQtip = () => {
+    const el = tooltipContext?.closest('.qtip');
+    return el == null ? null : $(el);
+  };
+
+  React.useEffect(() => () => {
+    container.setValue(null);
+    parentQtip()?.qtip('option', 'hide.event', tooltipHideEventRef.current);
+    if (valueRef.current != null) {
+      $(valueRef.current).qtip('destroy', true);
+    }
+  }, [container, tooltipContext]);
+
+  const onMouseOver = (event: React.MouseEvent<HTMLDivElement>) => {
+    const el = event.currentTarget;
+    if (el._tooltip != null) return;
+    el._tooltip = '1';
+
+    $(el).qtip({
+      content: {
+        text: renderToStaticMarkup(
+          <div className='user-group-badge__popup'>
+            {groups.map((group) => (
+              <UserGroupBadge key={group.identifier} group={group} modifiers={modifiers} />
+            ))}
+          </div>,
+        ),
+      },
+      events: {
+        hide() {
+          parentQtip()?.qtip('option', 'hide.event', tooltipHideEventRef.current);
+          container.setValue(null);
+        },
+        show() {
+          container.setValue(key);
+          const $parent = parentQtip();
+          if ($parent != null) {
+            tooltipHideEventRef.current = $parent.qtip('option', 'hide.event');
+            $parent.qtip('option', 'hide.event', false);
+          }
+        },
+      },
+      hide: {
+        delay: 200,
+        fixed: true,
+      },
+      overwrite: false,
+      position: {
+        ...qtipPosition('top center'),
+        adjust: { scroll: false },
+      },
+      show: {
+        delay: 200,
+        event: event.type,
+        ready: true,
+      },
+      style: {
+        classes: 'qtip qtip--user-list',
+        def: false,
+        tip: false,
+      },
+    }, event);
+  };
+
+  return (
+    <div
+      ref={valueRef}
+      className={classWithModifiers('user-group-badge', 'combined', modifiers)}
+      onMouseOver={onMouseOver}
+    >
+      {groups.map((group) => (
+        <span
+          key={group.identifier}
+          className={classWithModifiers('user-group-badge__colour', {
+            probationary: group.is_probationary,
+          })}
+          style={groupColour(group)}
+        />
+      ))}
+    </div>
+  );
+}

--- a/resources/js/components/user-group-badges-combined.tsx
+++ b/resources/js/components/user-group-badges-combined.tsx
@@ -4,7 +4,7 @@
 import UserGroupJson from 'interfaces/user-group-json';
 import * as React from 'react';
 import { renderToStaticMarkup } from 'react-dom/server';
-import { ContainerContext, KeyContext } from 'stateful-activation-context';
+import { ActiveKeyState, ContainerContext, KeyContext } from 'stateful-activation-context';
 import { TooltipContext } from 'tooltip-context';
 import { classWithModifiers, groupColour, Modifiers } from 'utils/css';
 import { qtipPosition } from 'utils/qtip-helper';
@@ -15,27 +15,53 @@ interface Props {
   modifiers?: Modifiers;
 }
 
-export default function UserGroupBadgesCombined({ groups, modifiers }: Props) {
-  const container = React.useContext(ContainerContext);
-  const key = React.useContext(KeyContext);
-  const tooltipContext = React.useContext(TooltipContext);
-  const valueRef = React.useRef<HTMLDivElement>(null);
-  const tooltipHideEventRef = React.useRef<unknown>(null);
+interface InnerProps extends Props {
+  activationKey: React.Key | null;
+  container: ActiveKeyState;
+}
 
-  const parentQtip = () => {
-    const el = tooltipContext?.closest('.qtip');
+class UserGroupBadgesCombinedInner extends React.PureComponent<InnerProps> {
+  static readonly contextType = TooltipContext;
+  declare context: React.ContextType<typeof TooltipContext>;
+
+  private tooltipHideEvent: unknown;
+  private readonly valueRef = React.createRef<HTMLDivElement>();
+
+  private get $tooltipElement() {
+    const el = this.context?.closest('.qtip');
+
     return el == null ? null : $(el);
-  };
+  }
 
-  React.useEffect(() => () => {
-    container.setValue(null);
-    parentQtip()?.qtip('option', 'hide.event', tooltipHideEventRef.current);
-    if (valueRef.current != null) {
-      $(valueRef.current).qtip('destroy', true);
+  componentWillUnmount() {
+    this.props.container.setValue(null);
+    this.$tooltipElement?.qtip('option', 'hide.event', this.tooltipHideEvent);
+    if (this.valueRef.current != null) {
+      $(this.valueRef.current).qtip('destroy', true);
     }
-  }, [container, tooltipContext]);
+  }
 
-  const onMouseOver = (event: React.MouseEvent<HTMLDivElement>) => {
+  render() {
+    return (
+      <div
+        ref={this.valueRef}
+        className={classWithModifiers('user-group-badge', 'combined', this.props.modifiers)}
+        onMouseOver={this.onMouseOver}
+      >
+        {this.props.groups.map((group) => (
+          <span
+            key={group.identifier}
+            className={classWithModifiers('user-group-badge__colour', {
+              probationary: group.is_probationary,
+            })}
+            style={groupColour(group)}
+          />
+        ))}
+      </div>
+    );
+  }
+
+  private readonly onMouseOver = (event: React.MouseEvent<HTMLDivElement>) => {
     const el = event.currentTarget;
     if (el._tooltip != null) return;
     el._tooltip = '1';
@@ -44,25 +70,15 @@ export default function UserGroupBadgesCombined({ groups, modifiers }: Props) {
       content: {
         text: renderToStaticMarkup(
           <div className='user-group-badge__popup'>
-            {groups.map((group) => (
-              <UserGroupBadge key={group.identifier} group={group} modifiers={modifiers} />
+            {this.props.groups.map((group) => (
+              <UserGroupBadge key={group.identifier} group={group} modifiers={this.props.modifiers} />
             ))}
           </div>,
         ),
       },
       events: {
-        hide() {
-          parentQtip()?.qtip('option', 'hide.event', tooltipHideEventRef.current);
-          container.setValue(null);
-        },
-        show() {
-          container.setValue(key);
-          const $parent = parentQtip();
-          if ($parent != null) {
-            tooltipHideEventRef.current = $parent.qtip('option', 'hide.event');
-            $parent.qtip('option', 'hide.event', false);
-          }
-        },
+        hide: this.onTooltipHide,
+        show: this.onTooltipShow,
       },
       hide: {
         delay: 200,
@@ -86,21 +102,33 @@ export default function UserGroupBadgesCombined({ groups, modifiers }: Props) {
     }, event);
   };
 
+  private readonly onTooltipHide = () => {
+    this.$tooltipElement?.qtip('option', 'hide.event', this.tooltipHideEvent);
+    this.props.container.setValue(null);
+  };
+
+  // Otherwise the parent user-card tooltip closes.
+  private readonly onTooltipShow = () => {
+    this.props.container.setValue(this.props.activationKey);
+
+    const $tooltipElement = this.$tooltipElement;
+    if ($tooltipElement != null) {
+      this.tooltipHideEvent = $tooltipElement.qtip('option', 'hide.event');
+      $tooltipElement.qtip('option', 'hide.event', false);
+    }
+  };
+}
+
+/**
+ * Reads ContainerContext and KeyContext so a parent user-card tooltip stays open.
+ * Is a functional component to be able to use useContext.
+ */
+export default function UserGroupBadgesCombined(props: Props) {
   return (
-    <div
-      ref={valueRef}
-      className={classWithModifiers('user-group-badge', 'combined', modifiers)}
-      onMouseOver={onMouseOver}
-    >
-      {groups.map((group) => (
-        <span
-          key={group.identifier}
-          className={classWithModifiers('user-group-badge__colour', {
-            probationary: group.is_probationary,
-          })}
-          style={groupColour(group)}
-        />
-      ))}
-    </div>
+    <UserGroupBadgesCombinedInner
+      {...props}
+      activationKey={React.useContext(KeyContext)}
+      container={React.useContext(ContainerContext)}
+    />
   );
 }

--- a/resources/js/components/user-group-badges.tsx
+++ b/resources/js/components/user-group-badges.tsx
@@ -5,6 +5,7 @@ import UserGroupJson from 'interfaces/user-group-json';
 import * as React from 'react';
 import { Modifiers } from 'utils/css';
 import UserGroupBadge from './user-group-badge';
+import UserGroupBadgesCombined from './user-group-badges-combined';
 
 interface Props {
   groups?: UserGroupJson[];
@@ -20,6 +21,21 @@ export default function UserGroupBadges(props: Props) {
     short = false,
     wrapper,
   } = props;
+
+  if (short && groups.length >= 3) {
+    const [mainGroup, ...otherGroups] = groups;
+
+    return (
+      <>
+        <span className={wrapper}>
+          <UserGroupBadge group={mainGroup} modifiers={modifiers} />
+        </span>
+        <span className={wrapper}>
+          <UserGroupBadgesCombined groups={otherGroups} modifiers={modifiers} />
+        </span>
+      </>
+    );
+  }
 
   let mainGroupWasSet = false;
 


### PR DESCRIPTION
Discussed internally [here](https://discord.com/channels/90072389919997952/892258907135836212/1534992035092762645) and [here](https://discord.com/channels/90072389919997952/892258907135836212/1535492365223993416).

<table>
<tr>
 <td>master
 <td>PR
 <td>PR (hover)
<tr>
 <td> <img width="306" height="129" alt="image" src="https://github.com/user-attachments/assets/d04a2fb7-3398-4549-ad99-948201d791d8" />
 <td> <img width="304" height="134" alt="image" src="https://github.com/user-attachments/assets/df43af17-da56-49b4-9e9a-5423cf3bfa0b" />
 <td> <img width="306" height="136" alt="image" src="https://github.com/user-attachments/assets/68ec6176-cbf2-48d9-9a06-1a4f594d2a9a" />
</table>