### PR TITLE
Fix text wrapping on beatmap status on info page

### DIFF
--- a/resources/css/bem/beatmapset-header.less
+++ b/resources/css/bem/beatmapset-header.less
@@ -112,9 +112,10 @@
   &__status {
     height: @beatmap-picker-size;
     font-size: @font-size--title-small;
-    margin: -5px -5px 5px;
     display: flex;
-    margin-left: auto;
+    gap: 10px;
+    margin-bottom: 10px;
+    align-self: end;
   }
 
   &__value {

--- a/resources/css/bem/beatmapset-status.less
+++ b/resources/css/bem/beatmapset-status.less
@@ -41,15 +41,14 @@
   &--show {
     padding: 0 35px;
     font-size: inherit;
-    margin: 5px;
     height: 100%;
+    white-space: nowrap;
     .center-content();
   }
 
   &--show-icon {
     font-size: inherit;
     padding: 0;
-    margin: 5px;
     .circle(@beatmap-picker-size);
     .center-content();
   }


### PR DESCRIPTION
Mainly for WIP maps with storyboard and video in Russian locale.

Also added more gap between status area and info box.

Resolves #13151.