### PR TITLE
Limit profile page chart y axis label to integer

### DIFF
--- a/resources/js/profile-page/chart.tsx
+++ b/resources/js/profile-page/chart.tsx
@@ -64,7 +64,7 @@ export default class Chart extends React.Component<Props> {
         circleLine: true,
         curve: curveLinear,
         formatX: (d: Date) => moment.utc(d).format(trans('common.datetime.year_month_short.moment')),
-        formatY: (d: number) => formatNumber(d),
+        formatY: (d: number) => Number.isInteger(d) ? formatNumber(d) : '',
         infoBoxFormatX: (d: Date) => moment.utc(d).format(trans('common.datetime.year_month.moment')),
         infoBoxFormatY: (d: number) => `<strong>${this.props.labelY}</strong> ${escape(formatNumber(d))}`,
         marginRight: 60, // more spacing for x axis label


### PR DESCRIPTION
Resolves #13046.

None of the charts have decimal value.