### PR TITLE
Fix beatmapset exact search

### DIFF
--- a/app/Libraries/Search/BeatmapsetSearch.php
+++ b/app/Libraries/Search/BeatmapsetSearch.php
@@ -409,10 +409,13 @@ class BeatmapsetSearch extends RecordSearch
             $searchFields[] = $field;
             $searchFields[] = "{$field}.*";
 
-            $subQuery->should(['term' => ["{$field}.raw" => ['value' => $value, 'boost' => 100]]]);
+            $valueWithoutQuotes = preg_replace('/^"\s*(.*)\s*"$/', '\1', $value);
+            $subQuery->should(['term' => ["{$field}.raw" => ['value' => $valueWithoutQuotes, 'boost' => 100]]]);
         }
 
-        $subQuery->should(QueryHelper::queryString($value, $searchFields, 'and'));
+        if (preg_match('/^".*"$/', $value) !== 1) {
+            $subQuery->should(QueryHelper::queryString($value, $searchFields, 'and'));
+        }
 
         $query->must($subQuery);
     }

--- a/app/Libraries/Search/BeatmapsetSearchRequestParams.php
+++ b/app/Libraries/Search/BeatmapsetSearchRequestParams.php
@@ -187,9 +187,26 @@ class BeatmapsetSearchRequestParams extends BeatmapsetSearchParams
         return present($this->requestQuery);
     }
 
+    private function isRelevanceSearch(): bool
+    {
+        if (present($this->queryString)) {
+            return true;
+        }
+
+        foreach (['artist', 'creator', 'title', 'source'] as $field) {
+            $value = $this->$field;
+
+            if (present($value) && preg_match('/^".*"$/', $value) !== 1) {
+                return true;
+            }
+        }
+
+        return false;
+    }
+
     private function getDefaultSortField(): string
     {
-        if (present($this->queryString) || present($this->artist) || present($this->creator) || present($this->title) || present($this->source)) {
+        if ($this->isRelevanceSearch()) {
             return 'relevance';
         }
 

--- a/tests/Libraries/Search/BeatmapsetSearch/TitleFilterTest.php
+++ b/tests/Libraries/Search/BeatmapsetSearch/TitleFilterTest.php
@@ -17,7 +17,7 @@ class TitleFilterTest extends TestCase
             [['q' => 'title=best'], [0, 1, 2]],
             [['q' => 'title="best beatmap"'], [1, 2]],
             [['q' => 'title="the beatmap"'], [1, 2]],
-            [['q' => 'title=""best beatmap""'], [1, 2]],
+            [['q' => 'title=""the best beatmap""'], [1]],
             [['q' => 'title=""the beatmap""'], []],
         ];
     }


### PR DESCRIPTION
Looks like es gets very confused when the search relevance score are all the same 🤔 

This doesn't really fix the problem but changes the behaviour when only exact search is involved.

Resolves #12420.

~~(this probably will fail tests)~~