### PR TITLE
Fix literal quotes incorrectly included for term search

### DIFF
--- a/app/Libraries/Search/BeatmapsetSearch.php
+++ b/app/Libraries/Search/BeatmapsetSearch.php
@@ -409,7 +409,8 @@ class BeatmapsetSearch extends RecordSearch
             $searchFields[] = $field;
             $searchFields[] = "{$field}.*";
 
-            $subQuery->should(['term' => ["{$field}.raw" => ['value' => $value, 'boost' => 100]]]);
+            $valueWithoutQuotes = preg_replace('/^"\s*(.*)\s*"$/', '\1', $value);
+            $subQuery->should(['term' => ["{$field}.raw" => ['value' => $valueWithoutQuotes, 'boost' => 100]]]);
         }
 
         $subQuery->should(QueryHelper::queryString($value, $searchFields, 'and'));


### PR DESCRIPTION
It matches nothing...

The normal query string already gives exact match pretty high score anyway though so probably doesn't matter as much except for some rare cases like `artist=""-45""`