### PR TITLE
More explicit beatmapset discussion state typings

### DIFF
--- a/resources/js/beatmap-discussions-history/main.tsx
+++ b/resources/js/beatmap-discussions-history/main.tsx
@@ -36,7 +36,6 @@ export default class Main extends React.Component<BeatmapsetDiscussionsBundleJso
               </a>
               <Discussion
                 discussion={discussion}
-                discussionsState={null}
                 isTimelineVisible={false}
                 store={this.store}
               />

--- a/resources/js/beatmap-discussions/discussion.tsx
+++ b/resources/js/beatmap-discussions/discussion.tsx
@@ -3,7 +3,7 @@
 
 import BeatmapsetDiscussionJson, { BeatmapsetDiscussionJsonForBundle, BeatmapsetDiscussionJsonForShow } from 'interfaces/beatmapset-discussion-json';
 import BeatmapsetDiscussionPostJson from 'interfaces/beatmapset-discussion-post-json';
-import BeatmapsetDiscussionsStore from 'interfaces/beatmapset-discussions-store';
+import { HasDiscussionsEditable, HasDiscussionsReadOnly } from 'interfaces/has-discussions';
 import { findLast } from 'lodash';
 import { action, computed, makeObservable } from 'mobx';
 import { observer } from 'mobx-react';
@@ -16,7 +16,6 @@ import { classWithModifiers, groupColour } from 'utils/css';
 import { trans, transChoice } from 'utils/lang';
 import { DiscussionType, discussionTypeIcons } from './discussion-type';
 import DiscussionVoteButtons from './discussion-vote-buttons';
-import DiscussionsState from './discussions-state';
 import { NewReply } from './new-reply';
 import Post from './post';
 import SystemPost from './system-post';
@@ -27,16 +26,13 @@ const bn = 'beatmap-discussion';
 interface BaseProps {
   isTimelineVisible: boolean;
   parentDiscussion?: BeatmapsetDiscussionJson | null;
-  store: BeatmapsetDiscussionsStore;
 }
 
-type Props = BaseProps & ({
-  discussion: BeatmapsetDiscussionJsonForBundle;
-  discussionsState: null; // TODO: make optional?
-} | {
-  discussion: BeatmapsetDiscussionJsonForShow;
-  discussionsState: DiscussionsState;
-});
+type Props = BaseProps
+  & (
+    ({ discussion: BeatmapsetDiscussionJsonForBundle } & HasDiscussionsReadOnly)
+    | ({ discussion: BeatmapsetDiscussionJsonForShow } & HasDiscussionsEditable)
+  );
 
 function DiscussionTypeIcon({ type }: { type: DiscussionType | 'resolved' }) {
   const titleKey = type === 'resolved'
@@ -233,20 +229,33 @@ export class Discussion extends React.Component<Props> {
       );
     }
 
-    return (
-      <Post
-        key={post.id}
-        discussion={this.props.discussion}
-        discussionsState={this.props.discussionsState}
-        post={post}
-        read={this.isRead(post)}
-        readonly={this.readonly}
-        resolvedStateChangedPostId={this.resolvedStateChangedPostId}
-        store={this.props.store}
-        type={type}
-        user={user}
-      />
-    );
+    // can't discriminate type without this even though the props are the same.
+    return this.props.discussionsState == null
+      ? (
+        <Post
+          key={post.id}
+          discussion={this.props.discussion}
+          discussionsState={this.props.discussionsState}
+          post={post}
+          read={this.isRead(post)}
+          resolvedStateChangedPostId={this.resolvedStateChangedPostId}
+          store={this.props.store}
+          type={type}
+          user={user}
+        />
+      ) : (
+        <Post
+          key={post.id}
+          discussion={this.props.discussion}
+          discussionsState={this.props.discussionsState}
+          post={post}
+          read={this.isRead(post)}
+          resolvedStateChangedPostId={this.resolvedStateChangedPostId}
+          store={this.props.store}
+          type={type}
+          user={user}
+        />
+      );
   }
 
   private renderPostButtons() {

--- a/resources/js/beatmap-discussions/discussion.tsx
+++ b/resources/js/beatmap-discussions/discussion.tsx
@@ -229,33 +229,19 @@ export class Discussion extends React.Component<Props> {
       );
     }
 
-    // can't discriminate type without this even though the props are the same.
-    return this.props.discussionsState == null
-      ? (
-        <Post
-          key={post.id}
-          discussion={this.props.discussion}
-          discussionsState={this.props.discussionsState}
-          post={post}
-          read={this.isRead(post)}
-          resolvedStateChangedPostId={this.resolvedStateChangedPostId}
-          store={this.props.store}
-          type={type}
-          user={user}
-        />
-      ) : (
-        <Post
-          key={post.id}
-          discussion={this.props.discussion}
-          discussionsState={this.props.discussionsState}
-          post={post}
-          read={this.isRead(post)}
-          resolvedStateChangedPostId={this.resolvedStateChangedPostId}
-          store={this.props.store}
-          type={type}
-          user={user}
-        />
-      );
+    const sharedProps = {
+      discussion: this.props.discussion,
+      key: post.id,
+      post,
+      read: this.isRead(post),
+      resolvedStateChangedPostId: this.resolvedStateChangedPostId,
+      type,
+      user,
+    };
+
+    return this.props.discussionsState != null
+      ? <Post {...sharedProps} discussionsState={this.props.discussionsState} store={this.props.store} />
+      : <Post {...sharedProps} store={this.props.store} />;
   }
 
   private renderPostButtons() {

--- a/resources/js/beatmap-discussions/discussions.tsx
+++ b/resources/js/beatmap-discussions/discussions.tsx
@@ -3,25 +3,20 @@
 
 import IconExpand from 'components/icon-expand';
 import { BeatmapsetDiscussionJsonForShow } from 'interfaces/beatmapset-discussion-json';
-import BeatmapsetDiscussionsStore from 'interfaces/beatmapset-discussions-store';
+import { HasDiscussionsEditable } from 'interfaces/has-discussions';
 import { action, computed, makeObservable } from 'mobx';
 import { observer } from 'mobx-react';
 import * as React from 'react';
 import { classWithModifiers } from 'utils/css';
 import { trans } from 'utils/lang';
 import { Discussion } from './discussion';
-import DiscussionsState from './discussions-state';
 import Sort, { sortPresets } from './sort';
 
 const bn = 'beatmap-discussions';
 
-interface Props {
-  discussionsState: DiscussionsState;
-  store: BeatmapsetDiscussionsStore;
-}
 
 @observer
-export class Discussions extends React.Component<Props> {
+export class Discussions extends React.Component<HasDiscussionsEditable> {
   private get discussionsState() {
     return this.props.discussionsState;
   }
@@ -58,7 +53,7 @@ export class Discussions extends React.Component<Props> {
     });
   }
 
-  constructor(props: Props) {
+  constructor(props: HasDiscussionsEditable) {
     super(props);
     makeObservable(this);
   }

--- a/resources/js/beatmap-discussions/editor-discussion-component.tsx
+++ b/resources/js/beatmap-discussions/editor-discussion-component.tsx
@@ -3,7 +3,7 @@
 
 import { EmbedElement } from 'editor';
 import BeatmapsetDiscussionJson from 'interfaces/beatmapset-discussion-json';
-import BeatmapsetDiscussionsStore from 'interfaces/beatmapset-discussions-store';
+import { HasDiscussionsEditable } from 'interfaces/has-discussions';
 import { Observer, observer } from 'mobx-react';
 import * as React from 'react';
 import { Transforms } from 'slate';
@@ -14,7 +14,6 @@ import { classWithModifiers } from 'utils/css';
 import { trans, transArray } from 'utils/lang';
 import { qtipPosition } from 'utils/qtip-helper';
 import { linkHtml } from 'utils/url';
-import DiscussionsState from './discussions-state';
 import { DraftsContext } from './drafts-context';
 import EditorBeatmapSelector from './editor-beatmap-selector';
 import EditorIssueTypeSelector from './editor-issue-type-selector';
@@ -31,12 +30,10 @@ interface Cache {
   };
 }
 
-interface Props extends RenderElementProps {
-  discussionsState: DiscussionsState;
+interface Props extends RenderElementProps, HasDiscussionsEditable {
   editMode?: boolean;
   element: EmbedElement;
   readOnly?: boolean;
-  store: BeatmapsetDiscussionsStore;
 }
 
 @observer

--- a/resources/js/beatmap-discussions/editor.tsx
+++ b/resources/js/beatmap-discussions/editor.tsx
@@ -5,9 +5,8 @@ import { CircularProgress } from 'components/circular-progress';
 import { Spinner } from 'components/spinner';
 import { EmbedElement } from 'editor';
 import BeatmapExtendedJson from 'interfaces/beatmap-extended-json';
-import BeatmapsetDiscussionJson from 'interfaces/beatmapset-discussion-json';
-import BeatmapsetDiscussionsStore from 'interfaces/beatmapset-discussions-store';
 import BeatmapsetWithDiscussionsJson from 'interfaces/beatmapset-with-discussions-json';
+import { HasDiscussionsEditable } from 'interfaces/has-discussions';
 import isHotkey from 'is-hotkey';
 import { route } from 'laroute';
 import { observer } from 'mobx-react';
@@ -21,7 +20,6 @@ import { onError } from 'utils/ajax';
 import { timestampRegex } from 'utils/beatmapset-discussion-helper';
 import { classWithModifiers } from 'utils/css';
 import { trans } from 'utils/lang';
-import DiscussionsState from './discussions-state';
 import { DraftsContext } from './drafts-context';
 import EditorDiscussionComponent from './editor-discussion-component';
 import {
@@ -44,14 +42,11 @@ interface CacheInterface {
   sortedBeatmaps?: BeatmapExtendedJson[];
 }
 
-interface Props {
-  discussion?: BeatmapsetDiscussionJson;
-  discussionsState: DiscussionsState;
+interface Props extends HasDiscussionsEditable {
   document?: string;
   editing: boolean;
   onChange?: () => void;
   onFocus?: () => void;
-  store: BeatmapsetDiscussionsStore;
 }
 
 interface State {

--- a/resources/js/beatmap-discussions/new-review.tsx
+++ b/resources/js/beatmap-discussions/new-review.tsx
@@ -1,7 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
-import BeatmapsetDiscussionsStore from 'interfaces/beatmapset-discussions-store';
+import { HasDiscussionsEditable } from 'interfaces/has-discussions';
 import { action, computed, makeObservable, observable } from 'mobx';
 import { observer } from 'mobx-react';
 import core from 'osu-core-singleton';
@@ -9,15 +9,12 @@ import * as React from 'react';
 import { downloadLimited } from 'utils/beatmapset-helper';
 import { classWithModifiers } from 'utils/css';
 import { trans } from 'utils/lang';
-import DiscussionsState from './discussions-state';
 import Editor from './editor';
 
-interface Props {
-  discussionsState: DiscussionsState;
+interface Props extends HasDiscussionsEditable {
   innerRef: React.RefObject<HTMLDivElement>;
   onFocus?: () => void;
   stickTo?: React.RefObject<HTMLDivElement>;
-  store: BeatmapsetDiscussionsStore;
 }
 
 @observer

--- a/resources/js/beatmap-discussions/post.tsx
+++ b/resources/js/beatmap-discussions/post.tsx
@@ -12,8 +12,8 @@ import TimeWithTooltip from 'components/time-with-tooltip';
 import UserLink from 'components/user-link';
 import BeatmapsetDiscussionJson from 'interfaces/beatmapset-discussion-json';
 import { BeatmapsetDiscussionMessagePostJson } from 'interfaces/beatmapset-discussion-post-json';
-import BeatmapsetDiscussionsStore from 'interfaces/beatmapset-discussions-store';
 import BeatmapsetWithDiscussionsJson from 'interfaces/beatmapset-with-discussions-json';
+import { HasDiscussionsEditable, HasDiscussionsReadOnly } from 'interfaces/has-discussions';
 import UserJson from 'interfaces/user-json';
 import { route } from 'laroute';
 import { isEqual } from 'lodash';
@@ -30,22 +30,20 @@ import { InputEventType, makeTextAreaHandler } from 'utils/input-handler';
 import { trans } from 'utils/lang';
 import DiscussionMessage from './discussion-message';
 import DiscussionMessageLengthCounter from './discussion-message-length-counter';
-import DiscussionsState from './discussions-state';
 import { UserCard } from './user-card';
 
 const bn = 'beatmap-discussion-post';
 
-interface Props {
+interface BaseProps {
   discussion: BeatmapsetDiscussionJson;
-  discussionsState: DiscussionsState | null; // TODO: make optional
   post: BeatmapsetDiscussionMessagePostJson;
   read: boolean;
-  readonly: boolean;
   resolvedStateChangedPostId: number;
-  store: BeatmapsetDiscussionsStore;
   type: string;
   user: UserJson;
 }
+
+type Props = BaseProps & (HasDiscussionsEditable | HasDiscussionsReadOnly);
 
 @observer
 export default class Post extends React.Component<Props> {
@@ -295,7 +293,6 @@ export default class Post extends React.Component<Props> {
         {this.isReview ? (
           <Editor
             ref={this.reviewEditorRef}
-            discussion={this.props.discussion}
             discussionsState={this.props.discussionsState}
             document={document}
             editing={this.editing}
@@ -399,7 +396,7 @@ export default class Post extends React.Component<Props> {
   }
 
   private renderMessageViewerEditingActions() {
-    if (this.props.readonly || this.props.discussionsState == null) return;
+    if (this.props.discussionsState == null) return;
 
     return (
       <>

--- a/resources/js/interfaces/beatmapset-discussions-store.ts
+++ b/resources/js/interfaces/beatmapset-discussions-store.ts
@@ -1,14 +1,18 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
-import BeatmapExtendedJson from 'interfaces/beatmap-extended-json';
-import BeatmapsetDiscussionJson from 'interfaces/beatmapset-discussion-json';
-import BeatmapsetExtendedJson from 'interfaces/beatmapset-extended-json';
-import UserJson from 'interfaces/user-json';
+import BeatmapExtendedJson from './beatmap-extended-json';
+import BeatmapJson from './beatmap-json';
+import BeatmapsetDiscussionJson from './beatmapset-discussion-json';
+import BeatmapsetExtendedJson from './beatmapset-extended-json';
+import UserJson from './user-json';
 
-export default interface BeatmapsetDiscussionsStore {
-  beatmaps: Map<number, BeatmapExtendedJson>;
+export default interface BeatmapsetDiscussionsStore<
+  B extends BeatmapJson = BeatmapExtendedJson,
+  D extends BeatmapsetDiscussionJson = BeatmapsetDiscussionJson,
+> {
+  beatmaps: Map<number, B>;
   beatmapsets: Map<number, BeatmapsetExtendedJson>;
-  discussions: Map<number | null | undefined, BeatmapsetDiscussionJson>;
+  discussions: Map<number | null | undefined, D>;
   users: Map<number | null | undefined, UserJson>;
 }

--- a/resources/js/interfaces/has-discussions.ts
+++ b/resources/js/interfaces/has-discussions.ts
@@ -7,7 +7,7 @@ import BeatmapsetDiscussionsShowStore from 'stores/beatmapset-discussions-show-s
 import BeatmapsetDiscussionsStore from './beatmapset-discussions-store';
 
 export interface HasDiscussionsReadOnly {
-  discussionsState: null;
+  discussionsState?: never;
   store: BeatmapsetDiscussionsStore;
 }
 

--- a/resources/js/interfaces/has-discussions.ts
+++ b/resources/js/interfaces/has-discussions.ts
@@ -3,10 +3,8 @@
 
 
 import DiscussionsState from 'beatmap-discussions/discussions-state';
-import BeatmapExtendedJson from 'interfaces/beatmap-extended-json';
-import { BeatmapsetDiscussionJsonForShow } from 'interfaces/beatmapset-discussion-json';
-import BeatmapsetDiscussionsStore from 'interfaces/beatmapset-discussions-store';
-import WithBeatmapOwners from 'interfaces/with-beatmap-owners';
+import BeatmapsetDiscussionsShowStore from 'stores/beatmapset-discussions-show-store';
+import BeatmapsetDiscussionsStore from './beatmapset-discussions-store';
 
 export interface HasDiscussionsReadOnly {
   discussionsState: null;
@@ -15,5 +13,5 @@ export interface HasDiscussionsReadOnly {
 
 export interface HasDiscussionsEditable {
   discussionsState: DiscussionsState;
-  store: BeatmapsetDiscussionsStore<WithBeatmapOwners<BeatmapExtendedJson>, BeatmapsetDiscussionJsonForShow>;
+  store: BeatmapsetDiscussionsShowStore;
 }

--- a/resources/js/interfaces/has-discussions.ts
+++ b/resources/js/interfaces/has-discussions.ts
@@ -1,0 +1,19 @@
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
+
+import DiscussionsState from 'beatmap-discussions/discussions-state';
+import BeatmapExtendedJson from 'interfaces/beatmap-extended-json';
+import { BeatmapsetDiscussionJsonForShow } from 'interfaces/beatmapset-discussion-json';
+import BeatmapsetDiscussionsStore from 'interfaces/beatmapset-discussions-store';
+import WithBeatmapOwners from 'interfaces/with-beatmap-owners';
+
+export interface HasDiscussionsReadOnly {
+  discussionsState: null;
+  store: BeatmapsetDiscussionsStore;
+}
+
+export interface HasDiscussionsEditable {
+  discussionsState: DiscussionsState;
+  store: BeatmapsetDiscussionsStore<WithBeatmapOwners<BeatmapExtendedJson>, BeatmapsetDiscussionJsonForShow>;
+}

--- a/resources/js/modding-profile/discussions.tsx
+++ b/resources/js/modding-profile/discussions.tsx
@@ -51,7 +51,6 @@ export default class Discussions extends React.Component<Props> {
         </a>
         <Discussion
           discussion={discussion}
-          discussionsState={null}
           isTimelineVisible={false}
           store={this.props.store}
         />

--- a/resources/js/modding-profile/posts.tsx
+++ b/resources/js/modding-profile/posts.tsx
@@ -75,7 +75,6 @@ export default class Posts extends React.Component<Props> {
               discussionsState={null}
               post={post}
               read
-              readonly
               store={this.props.store}
               type='reply'
               user={this.props.store.users.get(post.user_id) ?? deletedUserJson}

--- a/resources/js/modding-profile/posts.tsx
+++ b/resources/js/modding-profile/posts.tsx
@@ -72,7 +72,6 @@ export default class Posts extends React.Component<Props> {
           <div className='beatmap-discussion__discussion'>
             <Post
               discussion={discussion}
-              discussionsState={null}
               post={post}
               read
               store={this.props.store}

--- a/resources/js/stores/beatmapset-discussions-show-store.ts
+++ b/resources/js/stores/beatmapset-discussions-show-store.ts
@@ -1,7 +1,7 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
-import BeatmapJson from 'interfaces/beatmap-json';
+import BeatmapExtendedJson from 'interfaces/beatmap-extended-json';
 import { BeatmapsetDiscussionJsonForShow } from 'interfaces/beatmapset-discussion-json';
 import BeatmapsetDiscussionsStore from 'interfaces/beatmapset-discussions-store';
 import BeatmapsetExtendedJson from 'interfaces/beatmapset-extended-json';
@@ -10,7 +10,7 @@ import WithBeatmapOwners from 'interfaces/with-beatmap-owners';
 import { computed, makeObservable, observable } from 'mobx';
 import { mapBy, mapByWithNulls } from 'utils/map';
 
-export default class BeatmapsetDiscussionsShowStore implements BeatmapsetDiscussionsStore<WithBeatmapOwners<BeatmapJson>, BeatmapsetDiscussionJsonForShow> {
+export default class BeatmapsetDiscussionsShowStore implements BeatmapsetDiscussionsStore<WithBeatmapOwners<BeatmapExtendedJson>, BeatmapsetDiscussionJsonForShow> {
   @observable beatmapset: BeatmapsetWithDiscussionsJson;
 
   @computed

--- a/resources/js/stores/beatmapset-discussions-show-store.ts
+++ b/resources/js/stores/beatmapset-discussions-show-store.ts
@@ -1,13 +1,16 @@
 // Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
 // See the LICENCE file in the repository root for full licence text.
 
+import BeatmapJson from 'interfaces/beatmap-json';
+import { BeatmapsetDiscussionJsonForShow } from 'interfaces/beatmapset-discussion-json';
 import BeatmapsetDiscussionsStore from 'interfaces/beatmapset-discussions-store';
 import BeatmapsetExtendedJson from 'interfaces/beatmapset-extended-json';
 import BeatmapsetWithDiscussionsJson from 'interfaces/beatmapset-with-discussions-json';
+import WithBeatmapOwners from 'interfaces/with-beatmap-owners';
 import { computed, makeObservable, observable } from 'mobx';
 import { mapBy, mapByWithNulls } from 'utils/map';
 
-export default class BeatmapsetDiscussionsShowStore implements BeatmapsetDiscussionsStore {
+export default class BeatmapsetDiscussionsShowStore implements BeatmapsetDiscussionsStore<WithBeatmapOwners<BeatmapJson>, BeatmapsetDiscussionJsonForShow> {
   @observable beatmapset: BeatmapsetWithDiscussionsJson;
 
   @computed


### PR DESCRIPTION
More explicit type discrimination of `Props` between editable and readonly discussions

Part of adding notes to discussion reviews for #13185 that I'm splitting off for sanity checking the types make sense