### PR TITLE
Fix Beatmap Discussion Review post embed stripe colour

### DIFF
--- a/resources/css/bem/beatmap-discussion-review-post-embed-preview.less
+++ b/resources/css/bem/beatmap-discussion-review-post-embed-preview.less
@@ -18,7 +18,7 @@
   .default-border-radius();
 
   &--lighter {
-    --stripe-colour: hsl(var(--hsl-b4));
+    --stripe-colour: hsl(var(--hsl-b3));
   }
 
   &--praise {


### PR DESCRIPTION
Make it not blend into the background. I assume the stripe is supposed to be the colour of the embed's container background... (otherwise it should just be `b5`)

<img width="165" height="40" alt="image" src="https://github.com/user-attachments/assets/6378bb09-9c5d-44e2-8b74-3612c7f45654" />
