### PR TITLE
More fix Beatmap Discussions timestamp parsing

### DIFF
--- a/resources/js/utils/beatmapset-discussion-helper.ts
+++ b/resources/js/utils/beatmapset-discussion-helper.ts
@@ -74,7 +74,7 @@ const generalPages = new Set<unknown>(['events', 'generalAll', 'reviews']);
 
 const defaultBeatmapId = '-';
 
-export const timestampRegex = /\b(((\d{2,}):([0-5]\d)[:.](\d{3}))(\s\((?:\d+[,|])*\d+\))?)\b/;
+export const timestampRegex = /\b(((\d{2,}):([0-5]\d)[:.](\d{3}))(\s\((?:\d+[,|])*\d+\))?)/;
 export const timestampRegexGlobal = new RegExp(timestampRegex, 'g');
 export const maxLengthTimeline = 750;
 export const maxMessagePreviewLength = 100;


### PR DESCRIPTION
~~Limit by space or end of line (non-review posts don't use line breaks) instead since brackets are considered non-words and `12:34.567 (1)` is a valid timestamp.~~

~~`12:34.567 (1)` is `12:34.567 (1)`~~
~~`12:34.567a` is not parsed as a timestamp~~
~~`12:34.567 (1)a` is parsed as `12:34.567`~~


Just revert the regex change from #13265 and probably look at fixing `BeatmapDiscussionPost::parseTimestamp` behaviour to allow `12:34.567a` as a timestamp instead...

Resolves #13268.