### PR TITLE
Hash oauth client secrets

### DIFF
--- a/app/Http/Controllers/AccountController.php
+++ b/app/Http/Controllers/AccountController.php
@@ -114,7 +114,11 @@ class AccountController extends Controller
         $currentSessionId = \Session::getId();
 
         $authorizedClients = json_collection(Client::forUser($user), new ClientTransformer(), 'user');
-        $ownClients = json_collection($user->clients()->where('revoked', false)->get(), new ClientTransformer(), ['redirect', 'secret']);
+        $ownClients = json_collection(
+            $user->clients()->where('revoked', false)->get(),
+            new ClientTransformer(),
+            ['redirect', 'secret', 'secret_hint'],
+        );
 
         $legacyApiKey = $user->apiKeys()->available()->first();
         $legacyApiKeyJson = $legacyApiKey === null ? null : json_item($legacyApiKey, new LegacyApiKeyTransformer());

--- a/app/Http/Controllers/OAuth/ClientsController.php
+++ b/app/Http/Controllers/OAuth/ClientsController.php
@@ -29,7 +29,11 @@ class ClientsController extends Controller
 
     public function index()
     {
-        return json_collection(\Auth::user()->clients()->where('revoked', false)->get(), new ClientTransformer(), ['redirect', 'secret']);
+        return json_collection(
+            \Auth::user()->clients()->where('revoked', false)->get(),
+            new ClientTransformer(),
+            ['redirect', 'secret', 'secret_hint'],
+        );
     }
 
     public function resetSecret($clientId)
@@ -40,7 +44,7 @@ class ClientsController extends Controller
             return error_popup(osu_trans('oauth.client.reset_failed'));
         }
 
-        return json_item($client, new ClientTransformer(), ['redirect', 'secret']);
+        return json_item($client, new ClientTransformer(), ['redirect', 'secret', 'secret_hint']);
     }
 
     public function store()
@@ -67,7 +71,7 @@ class ClientsController extends Controller
             ], 422);
         }
 
-        return json_item($client, new ClientTransformer(), ['redirect', 'secret']);
+        return json_item($client, new ClientTransformer(), ['redirect', 'secret', 'secret_hint']);
     }
 
     public function update($clientId)
@@ -83,6 +87,6 @@ class ClientsController extends Controller
             ], 422);
         }
 
-        return json_item($client, new ClientTransformer(), ['redirect', 'secret']);
+        return json_item($client, new ClientTransformer(), ['redirect', 'secret', 'secret_hint']);
     }
 }

--- a/app/Libraries/OAuth/BridgeClientRepository.php
+++ b/app/Libraries/OAuth/BridgeClientRepository.php
@@ -16,6 +16,14 @@ class BridgeClientRepository extends BaseClientRepository
     {
         $record = $this->clients->findActive($clientIdentifier);
 
-        return $record !== null && hash_equals($record->secret, $clientSecret ?? '');
+        if ($record === null) {
+            return false;
+        }
+
+        $secret = $record->secret;
+
+        return str_starts_with('$', $secret)
+            ? $this->hasher->check($clientSecret, $secret)
+            : hash_equals($secret, $clientSecret ?? '');
     }
 }

--- a/app/Models/OAuth/Client.php
+++ b/app/Models/OAuth/Client.php
@@ -163,6 +163,10 @@ class Client extends PassportClient
             return false;
         }
 
+        if (isset($this->plainSecret)) {
+            $this->secret_hint = substr($this->plainSecret, -4);
+        }
+
         return parent::save($options);
     }
 
@@ -191,18 +195,6 @@ class Client extends PassportClient
                 'password' => $this->password_client,
                 'refresh_token' => true,
             ])),
-        );
-    }
-
-    #[\Override]
-    protected function secret(): Attribute
-    {
-        return Attribute::make(
-            set: function (?string $value): ?string {
-                $this->plainSecret = $value;
-
-                return $value;
-            },
         );
     }
 

--- a/app/Transformers/OAuth/ClientTransformer.php
+++ b/app/Transformers/OAuth/ClientTransformer.php
@@ -14,12 +14,14 @@ class ClientTransformer extends TransformerAbstract
     protected array $availableIncludes = [
         'redirect',
         'secret',
+        'secret_hint',
         'user',
     ];
 
     protected $permissions = [
         'redirect' => 'IsOwnClient',
         'secret' => 'IsOwnClient',
+        'secret_hint' => 'IsOwnClient',
     ];
 
     public function transform(Client $client)
@@ -46,6 +48,12 @@ class ClientTransformer extends TransformerAbstract
 
     public function includeSecret(Client $client)
     {
-        return $this->primitive($client->secret);
+        return $this->primitive($client->plainSecret);
+    }
+
+    public function includeSecretHint(Client $client)
+    {
+        // The fallback assumes the model hasn't been updated to have hashed secret
+        return $this->primitive($client->secret_hint ?? substr($client->secret, -4));
     }
 }

--- a/database/migrations/2026_09_11_143317_add_secret_hint_to_oauth_clients.php
+++ b/database/migrations/2026_09_11_143317_add_secret_hint_to_oauth_clients.php
@@ -1,0 +1,27 @@
+<?php
+
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('oauth_clients', function (Blueprint $table) {
+            $table->string('secret_hint', 10)->nullable()->after('secret');
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('oauth_clients', function (Blueprint $table) {
+            $table->dropColumn('secret_hint');
+        });
+    }
+};

--- a/resources/js/interfaces/own-client-json.ts
+++ b/resources/js/interfaces/own-client-json.ts
@@ -5,5 +5,6 @@ import { ClientJson } from 'interfaces/client-json';
 
 export interface OwnClientJson extends ClientJson {
   redirect: string;
-  secret: string;
+  secret: null | string;
+  secret_hint: string;
 }

--- a/resources/js/models/oauth/own-client.ts
+++ b/resources/js/models/oauth/own-client.ts
@@ -9,7 +9,8 @@ import { Client } from 'models/oauth/client';
 export class OwnClient extends Client {
   @observable isResetting = false;
   @observable isUpdating = false;
-  secret: string;
+  secret: null | string;
+  secretHint: string;
 
   @observable private redirectOrig: string;
 
@@ -23,6 +24,7 @@ export class OwnClient extends Client {
 
     this.redirectOrig = client.redirect;
     this.secret = client.secret;
+    this.secretHint = client.secret_hint;
 
     makeObservable(this);
   }
@@ -72,6 +74,7 @@ export class OwnClient extends Client {
     this.user = json.user;
     this.redirectOrig = json.redirect;
     this.secret = json.secret;
+    this.secretHint = json.secret_hint;
   }
 
   @action

--- a/resources/js/oauth/client-details.tsx
+++ b/resources/js/oauth/client-details.tsx
@@ -48,17 +48,19 @@ export class ClientDetails extends React.Component<Props> {
             {
               this.isSecretVisible
                 ? this.props.client.secret
-                : 'xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx'
+                : `*****${this.props.client.secretHint}`
             }
           </div>
           <div className='oauth-client-details__buttons'>
-            <button
-              className='btn-osu-big'
-              onClick={this.handleToggleSecret}
-              type='button'
-            >
-              {trans(`oauth.client.secret_visible.${this.isSecretVisible}`)}
-            </button>
+            {this.props.client.secret != null &&
+              <button
+                className='btn-osu-big'
+                onClick={this.handleToggleSecret}
+                type='button'
+              >
+                {trans(`oauth.client.secret_visible.${this.isSecretVisible}`)}
+              </button>
+            }
             <button
               className='btn-osu-big btn-osu-big--danger'
               disabled={this.props.client.isResetting || this.props.client.revoked}
@@ -68,6 +70,7 @@ export class ClientDetails extends React.Component<Props> {
               {this.props.client.isResetting ? <Spinner /> : trans('oauth.client.reset')}
             </button>
           </div>
+          {this.renderSecretVisibilityInfo()}
         </div>
 
         <label className='oauth-client-details__group'>
@@ -162,4 +165,14 @@ export class ClientDetails extends React.Component<Props> {
       this.errors.clear();
     }).catch(this.errors.handleResponse);
   };
+
+  private renderSecretVisibilityInfo() {
+    let message = trans('oauth.own_clients.secret.visible_once');
+    message += ' ';
+    message += this.props.client.secret == null
+      ? trans('oauth.own_clients.secret.generate_new')
+      : trans('oauth.own_clients.secret.copy');
+
+    return <p>{message}</p>;
+  }
 }

--- a/resources/lang/en/oauth.php
+++ b/resources/lang/en/oauth.php
@@ -58,5 +58,11 @@ return [
             'false' => 'Delete',
             'true' => 'Deleted',
         ],
+
+        'secret' => [
+            'copy' => 'Make sure to copy the value before navigating away.',
+            'generate_new' => 'Reset client secret to generate a new one.',
+            'visible_once' => 'Client secret is only visible after initial creation.',
+        ],
     ],
 ];

--- a/tests/Transformers/OAuth/ClientTransformerTest.php
+++ b/tests/Transformers/OAuth/ClientTransformerTest.php
@@ -24,7 +24,7 @@ class ClientTransformerTest extends TestCase
         $json = json_item($this->client, new ClientTransformer(), ['redirect', 'secret']);
 
         $this->assertSame($this->client->redirect, $json['redirect']);
-        $this->assertSame($this->client->secret, $json['secret']);
+        $this->assertTrue(\Hash::check($json['secret'], $this->client->secret));
     }
 
     public function testRedirectAndSecretNotVisibleToOtherUsers()


### PR DESCRIPTION
The transitional code (one that handles non-hashed secret) will be removed after this is deployed and have all the existing clients updated with `passport:hash` artisan command.

depends on
- [x] #13237
- [x] #13257