### PR TITLE
Add markdown content in news api

### DIFF
--- a/app/Http/Controllers/NewsController.php
+++ b/app/Http/Controllers/NewsController.php
@@ -14,6 +14,29 @@ use App\Transformers\NewsPostTransformer;
  */
 class NewsController extends Controller
 {
+    private static function newsPostContentIncludes(?array $formats): array
+    {
+        static $validFormats = [
+            'html' => 'content',
+            'markdown' => 'content_markdown',
+        ];
+
+        if (is_api_request()) {
+            $ret = [];
+            foreach ($formats ?? [] as $format) {
+                if (array_key_exists($format, $validFormats)) {
+                    $ret[$format] ??= $validFormats[$format];
+                }
+            }
+
+            return count($ret) === 0
+                ? [$validFormats['html'], $validFormats['markdown']]
+                : array_values($ret);
+        } else {
+            return [$validFormats['html']];
+        }
+    }
+
     /**
      * Get News Listing
      *
@@ -136,6 +159,7 @@ class NewsController extends Controller
      * Returns a [NewsPost](#newspost) with `content`, `content_markdown`, and `navigation` included.
      *
      * @urlParam news string required News post slug or ID. Example: 2021-04-27-results-a-labour-of-love
+     * @queryParam content_formats[] string `html`, `markdown`. Default to both.
      * @queryParam key string Unset to query by slug, or `id` to query by ID. No-example
      * @response {
      *   "id": 943,
@@ -190,7 +214,10 @@ class NewsController extends Controller
             abort(404);
         }
 
-        $postJson = json_item($post, new NewsPostTransformer(), ['content', 'content_markdown', 'navigation']);
+        $postJson = json_item($post, new NewsPostTransformer(), [
+            ...static::newsPostContentIncludes(get_arr(request('content_formats'))),
+            'navigation',
+        ]);
 
         if (is_json_request()) {
             return $postJson;

--- a/app/Http/Controllers/NewsController.php
+++ b/app/Http/Controllers/NewsController.php
@@ -133,7 +133,7 @@ class NewsController extends Controller
      *
      * ### Response Format
      *
-     * Returns a [NewsPost](#newspost) with `content` and `navigation` included.
+     * Returns a [NewsPost](#newspost) with `content`, `content_markdown`, and `navigation` included.
      *
      * @urlParam news string required News post slug or ID. Example: 2021-04-27-results-a-labour-of-love
      * @queryParam key string Unset to query by slug, or `id` to query by ID. No-example
@@ -147,6 +147,7 @@ class NewsController extends Controller
      *   "slug": "2021-04-27-results-a-labour-of-love",
      *   "title": "Results - A Labour of Love",
      *   "content": "<div class='osu-md osu-md--news'>...</div>",
+     *   "content_markdown": "...",
      *   "navigation": {
      *     "newer": {
      *       "id": 944,
@@ -189,7 +190,7 @@ class NewsController extends Controller
             abort(404);
         }
 
-        $postJson = json_item($post, new NewsPostTransformer(), ['content', 'navigation']);
+        $postJson = json_item($post, new NewsPostTransformer(), ['content', 'content_markdown', 'navigation']);
 
         if (is_json_request()) {
             return $postJson;

--- a/app/Models/NewsPost.php
+++ b/app/Models/NewsPost.php
@@ -34,7 +34,7 @@ class NewsPost extends Model implements CommentableInterface, Wiki\WikiObject
 
     // in minutes
     const CACHE_DURATION = 86400;
-    const VERSION = 3;
+    const VERSION = 4;
     // should be higher than landing limit
     const DASHBOARD_LIMIT = 8;
     // also for number of large posts in user dashboard
@@ -306,6 +306,11 @@ class NewsPost extends Model implements CommentableInterface, Wiki\WikiObject
         ];
     }
 
+    public function markdown(): string
+    {
+        return $this->page['markdown'];
+    }
+
     public function newer()
     {
         return $this->memoize(__FUNCTION__, function () {
@@ -362,11 +367,14 @@ class NewsPost extends Model implements CommentableInterface, Wiki\WikiObject
 
         $rawPage = $file->content();
 
-        $this->page = (new OsuMarkdown(
+        $page = (new OsuMarkdown(
             'news',
             osuExtensionConfig: ['relative_url_root' => route('news.show', $this->slug)]
         ))->load($rawPage)->toArray();
 
+        $page['markdown'] = $rawPage;
+
+        $this->page = $page;
         $this->version = static::pageVersion();
         $this->published_at = $this->pagePublishedAt();
         $this->tumblr_id = $this->pageTumblrId();

--- a/app/Transformers/NewsPostTransformer.php
+++ b/app/Transformers/NewsPostTransformer.php
@@ -11,6 +11,7 @@ class NewsPostTransformer extends TransformerAbstract
 {
     protected array $availableIncludes = [
         'content',
+        'content_markdown',
         'navigation',
         'preview',
     ];
@@ -36,6 +37,11 @@ class NewsPostTransformer extends TransformerAbstract
     public function includeContent(NewsPost $post)
     {
         return $this->primitive($post->bodyHtml());
+    }
+
+    public function includeContentMarkdown(NewsPost $post)
+    {
+        return $this->primitive($post->markdown());
     }
 
     public function includeNavigation(NewsPost $post)

--- a/resources/views/docs/_structures/news_post.md
+++ b/resources/views/docs/_structures/news_post.md
@@ -14,11 +14,12 @@ updated_at     | [Timestamp](#timestamp) | |
 
 ### Optional Attributes
 
-Field      | Type                               | Description
------------|------------------------------------|------------
-content    | string                             | HTML post content.
-navigation | [Navigation](#newspost-navigation) | Navigation metadata.
-preview    | string                             | First paragraph of `content` with HTML markup stripped.
+Field            | Type                               | Description
+-----------------|------------------------------------|------------
+content          | string                             | HTML post content.
+content_markdown | string                             | Markdown post content.
+navigation       | [Navigation](#newspost-navigation) | Navigation metadata.
+preview          | string                             | First paragraph of `content` with HTML markup stripped.
 
 <div id="newspost-navigation" data-unique="newspost-navigation"></div>
 


### PR DESCRIPTION
Currently `content` in news API is html output instead of the original markdown content. I added `content_markdown` mainly for future use in lazer news overlay.