### PR TITLE
Fix client credentials check

### DIFF
--- a/app/Http/Middleware/AuthApi.php
+++ b/app/Http/Middleware/AuthApi.php
@@ -67,7 +67,6 @@ class AuthApi
     private function validTokenFromRequest($psr)
     {
         $psrClientId = $psr->getAttribute('oauth_client_id');
-        $psrUserId = get_int($psr->getAttribute('oauth_user_id'));
         $psrTokenId = $psr->getAttribute('oauth_access_token_id');
 
         $client = $this->clients->findActive($psrClientId);
@@ -90,14 +89,8 @@ class AuthApi
 
         $user = $token->getResourceOwner();
 
-        if ($token->isClientCredentials()) {
-            if ($psrUserId !== null) {
-                throw new AuthenticationException();
-            }
-        } else {
-            if ($user === null || $user->getKey() !== $psrUserId) {
-                throw new AuthenticationException();
-            }
+        if (!$token->isClientCredentials() && $user === null) {
+            throw new AuthenticationException();
         }
 
         if ($user !== null) {


### PR DESCRIPTION
I forgot #13233 hasn't been merged. Either that or this.

Related: https://github.com/thephpleague/oauth2-server/issues/1456

There's this nonsense:

> However, if you have set Passport::$clientUuids to false, a client credentials token may inadvertently resolve a user whose ID matches the client's ID. In such cases, using this middleware cannot guarantee that the incoming token is a client credentials token.

https://laravel.com/framework/docs/13.x/passport#client-credentials-grant

(we don't use most of their middleware though so it's not really relevant... yet?)

Which is one of the reasons I made the linked pr.