### PR TITLE
Add oauth client grant types column

### DIFF
--- a/app/Http/Controllers/OAuth/ClientsController.php
+++ b/app/Http/Controllers/OAuth/ClientsController.php
@@ -52,13 +52,12 @@ class ClientsController extends Controller
 
         // from ClientRepository::create but with custom Client.
         $client = (new Client())->forceFill([
-            'user_id' => auth()->user()->getKey(),
+            'grant_types' => ['authorization_code', 'client_credentials', 'refresh_token'],
             'name' => $params['name'] ?? null,
-            'secret' => str_random(40),
             'redirect' => $params['redirect'] ?? '',
-            'personal_access_client' => false,
-            'password_client' => false,
             'revoked' => false,
+            'secret' => str_random(40),
+            'user_id' => \Auth::user()->getKey(),
         ]);
 
         if (!$client->save()) {

--- a/app/Models/OAuth/Client.php
+++ b/app/Models/OAuth/Client.php
@@ -185,7 +185,7 @@ class Client extends PassportClient
     protected function grantTypes(): Attribute
     {
         return Attribute::make(
-            get: fn (): array => array_keys(array_filter([
+            get: fn (?string $value): array => isset($value) ? $this->fromJson($value) : array_keys(array_filter([
                 'authorization_code' => !$this->firstParty(),
                 'client_credentials' => $this->confidential(),
                 'password' => $this->password_client,

--- a/database/factories/OAuth/ClientFactory.php
+++ b/database/factories/OAuth/ClientFactory.php
@@ -18,13 +18,15 @@ class ClientFactory extends Factory
     public function definition(): array
     {
         return [
-            'user_id' => User::factory(),
+            'grant_types' => ['authorization_code', 'client_credentials', 'refresh_token'],
             'name' => fn () => $this->faker->realText(20),
-            'secret' => str_random(40),
             'redirect' => 'https://localhost/callback',
-            'personal_access_client' => false,
-            'password_client' => false,
             'revoked' => false,
+            'secret' => str_random(40),
+            'user_id' => User::factory(),
+
+            'password_client' => false,
+            'personal_access_client' => false,
         ];
     }
 }

--- a/database/migrations/2026_09_09_064153_add_grant_types_to_oauth_clients.php
+++ b/database/migrations/2026_09_09_064153_add_grant_types_to_oauth_clients.php
@@ -1,0 +1,31 @@
+<?php
+
+// Copyright (c) ppy Pty Ltd <contact@ppy.sh>. Licensed under the GNU Affero General Public License v3.0.
+// See the LICENCE file in the repository root for full licence text.
+
+declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::table('oauth_clients', function (Blueprint $table) {
+            $table->json('grant_types')->nullable()->after('redirect');
+            $table->boolean('personal_access_client')->default(false)->change();
+            $table->boolean('password_client')->default(false)->change();
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::table('oauth_clients', function (Blueprint $table) {
+            $table->dropColumn('grant_types');
+            $table->boolean('personal_access_client')->change();
+            $table->boolean('password_client')->change();
+        });
+    }
+};

--- a/tests/Controllers/OAuth/TokensControllerTest.php
+++ b/tests/Controllers/OAuth/TokensControllerTest.php
@@ -58,6 +58,7 @@ class TokensControllerTest extends TestCase
 
         $user = User::factory()->create();
         $client = (new ClientFactory())->create([
+            'grant_types' => ['password'],
             'password_client' => true,
         ]);
 


### PR DESCRIPTION
This is the first part which adds the column and data. The second part will remove the old columns and use the new one for queries and stuff (and remove the attribute override).

Once merged, existing clients will need to be migrated like so:

```php
App\Models\OAuth\Client::chunkById(1000, function ($clients) {
    DB::transaction(function () use ($clients) {
        foreach ($clients as $client) {
             $client->update(['grant_types' => $client->grant_types]);
        }
    });
})
```