### PR TITLE
Enable spanish (latin america) locale

### DIFF
--- a/app/Libraries/LocaleMeta.php
+++ b/app/Libraries/LocaleMeta.php
@@ -53,6 +53,12 @@ class LocaleMeta
             'flag' => 'ES',
             'name' => 'español',
         ],
+        'es-419' => [
+            'flag' => 'MX',
+            'laravelPlural' => 'es_MX',
+            'moment' => 'es-mx',
+            'name' => 'español (Latinoamérica)',
+        ],
         'fi' => [
             'flag' => 'FI',
             'name' => 'suomi',

--- a/config/app.php
+++ b/config/app.php
@@ -108,6 +108,7 @@ return [
         'de',
         'el',
         'es',
+        'es-419',
         'fi',
         'fil',
         'fr',


### PR DESCRIPTION
The last one, with a totally non-controversial flag choice.