### PR TITLE
Add note to "block non-friend PMs" setting mentioning it also works for lazer multiplayer room invites and ranked play duel requests

### DIFF
--- a/resources/lang/en/accounts.php
+++ b/resources/lang/en/accounts.php
@@ -144,6 +144,7 @@ return [
 
     'privacy' => [
         'friends_only' => 'block private messages from people not on your friends list',
+        'friends_only_info' => 'this block also applies to osu!lazer multiplayer invites and ranked play duel requests',
         'hide_online' => 'hide your online presence',
         'hide_online_info' => 'this maps to the "appear offline" mode in osu!lazer',
         'title' => 'Privacy',

--- a/resources/views/accounts/_edit_privacy.blade.php
+++ b/resources/views/accounts/_edit_privacy.blade.php
@@ -24,6 +24,9 @@
 
                     <span class="account-edit-entry__checkbox-label">
                         {{ osu_trans('accounts.privacy.friends_only') }}
+                        <span class="account-edit-entry__checkbox-label-info">
+                            {{ osu_trans('accounts.privacy.friends_only_info') }}
+                        </span>
                     </span>
 
                     <div class="account-edit-entry__checkbox-status">


### PR DESCRIPTION
<img width="1019" height="143" alt="Screenshot 2026-09-11 at 12 16 50" src="https://github.com/user-attachments/assets/b70a2886-3978-45fe-9769-8b7f057ecdfe" />

---

[As requested internally](https://discord.com/channels/90072389919997952/1458132886946451497/1547835696016916583), cc @peppy.

This is an existing behaviour in osu-server-spectator ([source](https://github.com/ppy/osu-server-spectator/blob/daabc11b9697f300bec31ed2a68acd356f64e794/osu.Server.Spectator/Hubs/Multiplayer/MultiplayerHub.cs#L552-L554)) which was not visibly documented.

Phrasing is intentionally lazer-specific, because as far as I can tell from source inspection, this does not extend to stable / bancho.