### PR TITLE
Enable php jit

### DIFF
--- a/docker/php.ini
+++ b/docker/php.ini
@@ -4,3 +4,5 @@ post_max_size=200M
 
 ; leaving memory limit to container runtime
 memory_limit=-1
+
+opcache.jit=on


### PR DESCRIPTION
Doesn't seem to break anything? 🤷 

On `/beatmapsets`, I'm getting 11k requests/10s with it enabled compared to 10k requests/10s disabled.