### PR TITLE
Count cache cleanup

### DIFF
--- a/app/Http/Controllers/BeatmapsController.php
+++ b/app/Http/Controllers/BeatmapsController.php
@@ -92,21 +92,17 @@ class BeatmapsController extends Controller
         $totalsEnabled = $GLOBALS['cfg']['osu']['scores']['leaderboard_totals_enabled'];
 
         if ($isApi && $totalsEnabled) {
-            $cacheKey = null;
-
-            $sortedMods = implode(',', array_sort($mods));
-            $legacyMode = $isLegacy ? '1' : '0';
-
-            switch ($type) {
-                case 'global':
-                    $cacheKey = 'lb_count_global:'.$beatmap->getKey().'-'.$beatmap->approved.'-'.$legacyMode.'-'.$rulesetId.'-'.$sortedMods;
-                    break;
-                case 'country':
-                    $cacheKey = 'lb_count_country:'.$currentUser->country_acronym.'-'.$beatmap->getKey().'-'.$beatmap->approved.'-'.$legacyMode.'-'.$rulesetId.'-'.$sortedMods;
-                    break;
-            }
+            $cacheKey = match ($type) {
+                'country' => "lb_count_country:{$esFetch->baseParams->getCountryCode()}-",
+                'global' => 'lb_count_global:',
+                default => null,
+            };
 
             if ($cacheKey !== null) {
+                $sortedMods = implode(',', array_sort($mods));
+                $legacyMode = $isLegacy ? '1' : '0';
+                $cacheKey .= "{$beatmap->getKey()}-{$beatmap->approved}-{$legacyMode}-{$rulesetId}-{$sortedMods}";
+
                 $count = get_int(\Cache::get($cacheKey));
 
                 if ($count === null) {
@@ -115,11 +111,11 @@ class BeatmapsController extends Controller
                     // use count as TTL, matches `global-rank-lookup-cache`
                     \Cache::put($cacheKey, $count, max(600, $count));
                 }
-
-                $results['score_count'] = $count;
             } else {
-                $results['score_count'] = UserRank::getCount($esFetch->baseParams);
+                $count = UserRank::getCount($esFetch->baseParams);
             }
+
+            $results['score_count'] = $count;
         }
 
         if (isset($userScore)) {

--- a/app/Http/Controllers/BeatmapsController.php
+++ b/app/Http/Controllers/BeatmapsController.php
@@ -92,27 +92,33 @@ class BeatmapsController extends Controller
         $totalsEnabled = $GLOBALS['cfg']['osu']['scores']['leaderboard_totals_enabled'];
 
         if ($isApi && $totalsEnabled) {
-            $cacheKey = match ($type) {
-                'country' => "lb_count_country:{$esFetch->baseParams->getCountryCode()}-",
-                'global' => 'lb_count_global:',
-                default => null,
-            };
+            $fetchedScoreCount = count($scores);
 
-            if ($cacheKey !== null) {
-                $sortedMods = implode(',', array_sort($mods));
-                $legacyMode = $isLegacy ? '1' : '0';
-                $cacheKey .= "{$beatmap->getKey()}-{$beatmap->approved}-{$legacyMode}-{$rulesetId}-{$sortedMods}";
-
-                $count = get_int(\Cache::get($cacheKey));
-
-                if ($count === null) {
-                    $count = UserRank::getCount($esFetch->baseParams);
-
-                    // use count as TTL, matches `global-rank-lookup-cache`
-                    \Cache::put($cacheKey, $count, max(600, $count));
-                }
+            if ($fetchedScoreCount < $esFetch->baseParams->size) {
+                $count = $fetchedScoreCount;
             } else {
-                $count = UserRank::getCount($esFetch->baseParams);
+                $cacheKey = match ($type) {
+                    'country' => "lb_count_country:{$esFetch->baseParams->getCountryCode()}-",
+                    'global' => 'lb_count_global:',
+                    default => null,
+                };
+
+                if ($cacheKey !== null) {
+                    $sortedMods = implode(',', array_sort($mods));
+                    $legacyMode = $isLegacy ? '1' : '0';
+                    $cacheKey .= "{$beatmap->getKey()}-{$beatmap->approved}-{$legacyMode}-{$rulesetId}-{$sortedMods}";
+
+                    $count = get_int(\Cache::get($cacheKey));
+
+                    if ($count === null) {
+                        $count = UserRank::getCount($esFetch->baseParams);
+
+                        // use count as TTL, matches `global-rank-lookup-cache`
+                        \Cache::put($cacheKey, $count, max(600, $count));
+                    }
+                } else {
+                    $count = UserRank::getCount($esFetch->baseParams);
+                }
             }
 
             $results['score_count'] = $count;


### PR DESCRIPTION
Skip querying in some cases and combine assigning the same key suffix.

Also use fetch param country code instead of current user (technically should always be the same for this section).